### PR TITLE
feat: add set_env_variable() JS binding for runtime property switching

### DIFF
--- a/dmtools-ai-docs/references/agents/javascript-agents.md
+++ b/dmtools-ai-docs/references/agents/javascript-agents.md
@@ -834,4 +834,68 @@ function processWithDelay(items) {
 
 ---
 
+## 🔀 Runtime Property Switching with `set_env_variable()`
+
+When a workflow needs to interact with **multiple GitHub organisations** (or other integrations requiring different credentials), you can switch the active credential at runtime using `set_env_variable()`.
+
+### How it works
+
+`set_env_variable(propertyName, envVarName)` tells dmtools to read a different environment variable for the given property. The actual secret value stays inside Java — the JS agent only provides the **name** of the env var, never the value itself.
+
+### Setup (environment / CI secrets)
+
+Define your credentials as separate environment variables in your CI configuration:
+
+```bash
+FIRST_GITHUB_TOKEN=...    # token for first organisation
+SECOND_GITHUB_TOKEN=...   # token for second organisation
+```
+
+### Usage in JS agents
+
+```javascript
+function action(params) {
+    // Switch to first organisation's token
+    set_env_variable("SOURCE_GITHUB_TOKEN", "FIRST_GITHUB_TOKEN");
+    github_trigger_workflow({
+        workspace: "first-org",
+        repository: "some-repo",
+        workflowId: "deploy.yml",
+        inputs: "{}"
+    });
+
+    // Switch to second organisation's token
+    set_env_variable("SOURCE_GITHUB_TOKEN", "SECOND_GITHUB_TOKEN");
+    github_create_pull_request({
+        workspace: "second-org",
+        repository: "another-repo",
+        sourceBranch: "feature/my-branch",
+        targetBranch: "main",
+        title: "My PR"
+    });
+
+    return { status: "done" };
+}
+```
+
+### Security guarantees
+
+| What JS sees | What stays in Java |
+|---|---|
+| `"FIRST_GITHUB_TOKEN"` (string name) | `ghp_xxxx...` (actual token value) |
+
+- The env var **name** is validated: only uppercase letters, digits, and underscores (`[A-Z0-9_]`) are accepted.
+- If the env var is not set, dmtools throws an error — the message contains the variable name only, never the token value.
+- The token value is never logged or returned to JS context.
+
+### Supported properties
+
+Currently `set_env_variable()` supports switching the GitHub token:
+
+| Property name | Effect |
+|---|---|
+| `SOURCE_GITHUB_TOKEN` | Recreates the GitHub client with the new token |
+
+---
+
 *Next: [Teammate Configurations](teammate-configs.md) | [MCP Tools Usage Examples](examples/mcp-tools-usage.md)*

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/BasicGithub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/BasicGithub.java
@@ -38,6 +38,25 @@ public class BasicGithub extends GitHub {
     }
 
 
+    /**
+     * Creates a new GitHub client instance with the specified token, reusing the default base path.
+     * Use this when a JS agent needs to switch tokens at runtime via set_env_variable().
+     *
+     * @param token the GitHub authorization token
+     * @return a new BasicGithub instance configured with the given token
+     */
+    public static BasicGithub createWithToken(String token) throws IOException {
+        SourceCodeConfig config = SourceCodeConfig.builder()
+                .branchName(DEFAULT_CONFIG.getBranchName())
+                .repoName(DEFAULT_CONFIG.getRepoName())
+                .workspaceName(DEFAULT_CONFIG.getWorkspaceName())
+                .type(SourceCodeConfig.Type.GITHUB)
+                .auth(token)
+                .path(DEFAULT_CONFIG.getPath())
+                .build();
+        return new BasicGithub(config);
+    }
+
     private static BasicGithub instance;
 
     public static synchronized SourceCode getInstance() throws IOException {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
@@ -11,8 +11,10 @@ import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.file.FileTools;
 import com.github.istin.dmtools.mcp.generated.MCPSchemaGenerator;
 import com.github.istin.dmtools.mcp.generated.MCPToolExecutor;
+import com.github.istin.dmtools.github.BasicGithub;
 import com.github.istin.dmtools.microsoft.ado.BasicAzureDevOpsClient;
 import com.github.istin.dmtools.microsoft.teams.BasicTeamsClient;
+import java.util.regex.Pattern;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,6 +46,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public class JobJavaScriptBridge {
 
     private static final Logger logger = LogManager.getLogger(JobJavaScriptBridge.class);
+
+    /** Only uppercase letters, digits and underscores are allowed as env var names. */
+    private static final Pattern SAFE_ENV_VAR_NAME = Pattern.compile("^[A-Z0-9_]+$");
+
+    /** Overrides for dmtools properties set by JS via set_env_variable(). Values stay in Java. */
+    private final Map<String, String> propertyOverrides = new HashMap<>();
 
     private final TrackerClient<?> trackerClient;
     private final AI ai;
@@ -201,6 +209,9 @@ public class JobJavaScriptBridge {
 
             // Expose require function for module loading
             jsContext.getBindings("js").putMember("require", new RequireProxy());
+
+            // Expose set_env_variable for runtime property switching (alias name only, value stays in Java)
+            jsContext.getBindings("js").putMember("set_env_variable", new SetEnvVariableProxy());
 
             // Expose MCP tools using generated infrastructure
             exposeMCPToolsUsingGenerated();
@@ -547,6 +558,63 @@ public class JobJavaScriptBridge {
     }
 
     /**
+     * Proxy for set_env_variable(propertyName, envVarName) JS function.
+     * Allows a JS agent to redirect a dmtools property to read from a different env variable.
+     * The actual token value stays in Java — JS only provides the env var NAME.
+     */
+    private class SetEnvVariableProxy implements ProxyExecutable {
+        @Override
+        public Object execute(Value... arguments) {
+            if (arguments.length < 2) {
+                throw new IllegalArgumentException("set_env_variable requires 2 arguments: propertyName, envVarName");
+            }
+            String propertyName = arguments[0].asString();
+            String envVarName = arguments[1].asString();
+            setEnvVariable(propertyName, envVarName);
+            return true;
+        }
+    }
+
+    /**
+     * Sets a dmtools property to the value of the specified environment variable.
+     * Called from JS via set_env_variable(propertyName, envVarName).
+     * The env var NAME is provided by JS; the actual value is resolved in Java only.
+     *
+     * @param propertyName the dmtools property key (e.g. "SOURCE_GITHUB_TOKEN")
+     * @param envVarName   the name of the environment variable whose value to use
+     */
+    public void setEnvVariable(String propertyName, String envVarName) {
+        if (!SAFE_ENV_VAR_NAME.matcher(envVarName).matches()) {
+            throw new IllegalArgumentException(
+                "Invalid environment variable name '" + envVarName + "': only A-Z, 0-9 and _ are allowed");
+        }
+        String value = System.getenv(envVarName);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException(
+                "Environment variable '" + envVarName + "' is not set or is empty");
+        }
+        propertyOverrides.put(propertyName, value);
+        logger.info("Property '{}' redirected via env var '{}' (value not logged)", propertyName, envVarName);
+        refreshClientForProperty(propertyName);
+    }
+
+    /**
+     * Recreates the affected client in clientInstances after a property override.
+     */
+    private void refreshClientForProperty(String propertyName) {
+        if ("SOURCE_GITHUB_TOKEN".equals(propertyName)) {
+            String newToken = propertyOverrides.get("SOURCE_GITHUB_TOKEN");
+            try {
+                BasicGithub refreshed = BasicGithub.createWithToken(newToken);
+                clientInstances.put("github", refreshed);
+                logger.info("GitHub client refreshed with new token from property override");
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to refresh GitHub client after property override", e);
+            }
+        }
+    }
+
+    /**
      * Expose a single MCP tool to JavaScript context using generated executor
      */
     private void exposeToolToJS(String toolName, Map<String, Object> toolSchema) {
@@ -616,6 +684,9 @@ public class JobJavaScriptBridge {
 
             // Ensure require function is available for this execution
             jsContext.getBindings("js").putMember("require", new RequireProxy());
+
+            // Ensure set_env_variable is available for this execution
+            jsContext.getBindings("js").putMember("set_env_variable", new SetEnvVariableProxy());
             
             // Evaluate the JavaScript code
             jsContext.eval("js", jsCode);

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/SetEnvVariableTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/SetEnvVariableTest.java
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.job;
+
+import com.github.istin.dmtools.ai.AI;
+import com.github.istin.dmtools.atlassian.confluence.Confluence;
+import com.github.istin.dmtools.common.code.SourceCode;
+import com.github.istin.dmtools.common.tracker.TrackerClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for set_env_variable() JS binding in JobJavaScriptBridge.
+ *
+ * The feature allows JS agents to redirect a dmtools property to a different
+ * environment variable at runtime. The actual value stays in Java — JS only
+ * provides the env var NAME, never the secret value.
+ */
+@ExtendWith(MockitoExtension.class)
+class SetEnvVariableTest {
+
+    @Mock private TrackerClient<?> mockTrackerClient;
+    @Mock private AI mockAI;
+    @Mock private Confluence mockConfluence;
+    @Mock private SourceCode mockSourceCode;
+
+    private JobJavaScriptBridge bridge;
+
+    @BeforeEach
+    void setUp() {
+        bridge = new JobJavaScriptBridge(mockTrackerClient, mockAI, mockConfluence, mockSourceCode, null);
+    }
+
+    // ─── Input validation ──────────────────────────────────────────────────────
+
+    @Test
+    void rejectsEnvVarNameWithLowercase() {
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> bridge.setEnvVariable("SOURCE_GITHUB_TOKEN", "mytoken")
+        );
+        assertTrue(ex.getMessage().contains("only A-Z, 0-9 and _ are allowed"),
+            "Error message must describe the constraint, not expose a secret");
+    }
+
+    @Test
+    void rejectsEnvVarNameWithSpecialCharacters() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> bridge.setEnvVariable("SOURCE_GITHUB_TOKEN", "MY-TOKEN")
+        );
+    }
+
+    @Test
+    void rejectsEnvVarNameWithDollarSign() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> bridge.setEnvVariable("SOURCE_GITHUB_TOKEN", "$SECRET")
+        );
+    }
+
+    @Test
+    void rejectsEnvVarNameWithSpaces() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> bridge.setEnvVariable("SOURCE_GITHUB_TOKEN", "MY TOKEN")
+        );
+    }
+
+    // ─── Missing / unset env var ───────────────────────────────────────────────
+
+    @Test
+    void throwsSafeErrorWhenEnvVarNotSet() {
+        // DMTOOLS_NONEXISTENT_VAR_XYZ should not be set in any test environment
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> bridge.setEnvVariable("SOURCE_GITHUB_TOKEN", "DMTOOLS_NONEXISTENT_VAR_XYZ")
+        );
+        // Error message must mention the var name but must NOT contain any token value
+        assertTrue(ex.getMessage().contains("DMTOOLS_NONEXISTENT_VAR_XYZ"),
+            "Error should name the missing variable");
+        assertFalse(ex.getMessage().toLowerCase().contains("ghp_"),
+            "Error must not leak token values");
+    }
+
+    // ─── JS execution ─────────────────────────────────────────────────────────
+
+    @Test
+    void jsCallsSetEnvVariableWithBadNameAndReceivesError() throws Exception {
+        // JS agent tries to pass a lowercase env var name → should throw
+        String js = """
+            function action(params) {
+                try {
+                    set_env_variable("SOURCE_GITHUB_TOKEN", "bad_name");
+                    return "no_error";
+                } catch (e) {
+                    return "error:" + e.message;
+                }
+            }
+            """;
+        org.json.JSONObject jsParams = new org.json.JSONObject();
+        Object result = bridge.executeJavaScript(js, jsParams);
+        String resultStr = result != null ? result.toString() : "";
+        assertTrue(resultStr.startsWith("error:"), "JS should catch the validation error");
+        assertFalse(resultStr.toLowerCase().contains("ghp_"),
+            "Error returned to JS must not contain token values");
+    }
+
+    @Test
+    void jsCallsSetEnvVariableWithMissingVarAndReceivesError() throws Exception {
+        String js = """
+            function action(params) {
+                try {
+                    set_env_variable("SOURCE_GITHUB_TOKEN", "DMTOOLS_NONEXISTENT_VAR_XYZ");
+                    return "no_error";
+                } catch (e) {
+                    return "error:" + e.message;
+                }
+            }
+            """;
+        org.json.JSONObject jsParams = new org.json.JSONObject();
+        Object result = bridge.executeJavaScript(js, jsParams);
+        String resultStr = result != null ? result.toString() : "";
+        assertTrue(resultStr.startsWith("error:"), "JS should catch the missing-var error");
+    }
+}


### PR DESCRIPTION
Allows JS agents to redirect a dmtools property (e.g. SOURCE_GITHUB_TOKEN) to a different environment variable at runtime, enabling multi-org GitHub workflows without exposing secret values to JS context.

How it works:
  set_env_variable("SOURCE_GITHUB_TOKEN", "SECOND_GITHUB_TOKEN")

JS provides only the env var NAME. The actual token value is resolved inside Java via System.getenv() and never enters the JS context.

Changes:
- BasicGithub.createWithToken(): static factory for per-call token
- JobJavaScriptBridge: SetEnvVariableProxy inner class, setEnvVariable() method with input sanitisation ([A-Z0-9_] only), refreshClientForProperty() that recreates the GitHub client when SOURCE_GITHUB_TOKEN is overridden
- set_env_variable binding exposed in both JS context init paths
- SetEnvVariableTest: 7 unit tests covering validation, missing vars, and JS-level error propagation (value never returned to JS)
- dmtools-ai-docs: new 'Runtime Property Switching' section with usage guide, security guarantees table, and supported properties