### PR TITLE
chore(ci): harden auto-update-prs workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+concurrency:
+  group: auto-update-prs
+  cancel-in-progress: true
+
 jobs:
   update-prs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: write
       pull-requests: write
@@ -17,8 +22,17 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           sleep 15
-          prs=$(gh pr list --repo ${{ github.repository }} --state open --json number,mergeable,headRefName --jq '.[] | select(.mergeable != "CONFLICTING") | .number')
+          prs=$(gh pr list --repo ${{ github.repository }} --state open --base main \
+            --json number,mergeable,mergeStateStatus \
+            --jq '.[] | select(.mergeable == "MERGEABLE" and .mergeStateStatus == "BEHIND") | .number')
+
+          if [ -z "$prs" ]; then
+            echo "No open PRs to update."
+            exit 0
+          fi
+
           for pr in $prs; do
             echo "Updating PR #$pr..."
-            gh pr update-branch $pr --repo ${{ github.repository }} || echo "PR #$pr skipped (up to date or conflict)"
+            gh pr update-branch $pr --repo ${{ github.repository }} \
+              || echo "PR #$pr skipped (already up to date or conflict)"
           done


### PR DESCRIPTION
## Summary

This PR ports improvements to `auto-update-prs.yml` that were developed and battle-tested in a sibling PostNL repository. The changes make the workflow more precise, safer, and easier to observe.

| # | Change | Rationale |
|---|---|---|
| 1 | Add `concurrency` group with `cancel-in-progress: true` | Prevents overlapping runs piling up when several commits land on `main` in quick succession |
| 2 | Add `timeout-minutes: 5` | Safety net against a stuck `gh pr update-branch` call holding a runner indefinitely |
| 3 | Scope `gh pr list` with `--base main` | Avoids touching PRs targeting other base branches (e.g. release branches) |
| 4 | Tighten jq filter: `MERGEABLE + BEHIND` (replacing `!= CONFLICTING`) | `!= CONFLICTING` still processes PRs that are already up-to-date and PRs with `UNKNOWN` mergeability. `MERGEABLE + BEHIND` is the precise signal for "this PR needs a main merge-in" |
| 5 | Early-exit with log message when no PRs need updating | Cleaner run logs; avoids a silent empty `for` loop |

**What is unchanged:** `runs-on: ubuntu-latest`, `secrets.PAT_TOKEN` auth, `permissions`, and the `sleep 15` delay.

## Test plan

- [ ] Merge a commit to `main` and verify the workflow fires and updates any BEHIND PRs
- [ ] Verify the workflow does **not** touch PRs that are already up-to-date
- [ ] Verify the workflow prints "No open PRs to update." when there are none