### PR TITLE
fix: propagate JSON envVariables overrides to CLI subprocess env

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -44,6 +44,17 @@ public class PropertyReader {
   }
 
   /**
+   * Get the current per-thread environment variable overrides.
+   * Used by CliExecutionHelper to propagate envVariables from JSON config into subprocess env.
+   *
+   * @return unmodifiable view of current overrides, or empty map if none set
+   */
+  public static Map<String, String> getOverrides() {
+    Map<String, String> overrides = THREAD_LOCAL_OVERRIDES.get();
+    return overrides != null ? Collections.unmodifiableMap(overrides) : Collections.emptyMap();
+  }
+
+  /**
    * Resets the cached property state for testing purposes.
    * Package-private to restrict use to unit tests in the same package.
    * Do NOT call from production code.

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -9,6 +9,7 @@ import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -245,6 +246,16 @@ public class CliExecutionHelper {
             if (envVars.containsKey("CURSOR_API_KEY")) {
                 logger.info("CURSOR_API_KEY found in environment (length: {})", envVars.get("CURSOR_API_KEY").length());
             }
+        }
+
+        // Merge per-job envVariables overrides (from JSON config) into the subprocess env.
+        // These take priority over dmtools.env so that e.g. COPILOT_MODEL set in a JSON
+        // agent config actually reaches run-agent.sh.
+        Map<String, String> jobOverrides = PropertyReader.getOverrides();
+        if (!jobOverrides.isEmpty()) {
+            logger.info("Merging {} per-job envVariables override(s) into subprocess environment", jobOverrides.size());
+            envVars = new java.util.HashMap<>(envVars);
+            envVars.putAll(jobOverrides);
         }
         
         // Convert Path to File for ProcessBuilder - safer than changing system properties


### PR DESCRIPTION
## Problem

When a Teammate job has `envVariables` in its JSON config (e.g. `COPILOT_MODEL: claude-opus-4.6`), `JobRunner` applies them as Java thread-local overrides via `PropertyReader.setOverrides()`. However, `CliExecutionHelper.executeCliCommands()` only passed variables from `dmtools.env` file to the subprocess — the thread-local overrides were never forwarded.

As a result, environment variables like `COPILOT_MODEL` set in a JSON agent config never reached `run-agent.sh`, making it impossible to override the Copilot model (or any other env var) per-agent via config.

Symptoms visible in logs:
```
[INFO] CommandLineUtils - AI Agent Provider: copilot
[INFO] CommandLineUtils - Copilot Configuration:
[INFO] CommandLineUtils -   Model: claude-sonnet-4.6   ← always the dmtools.env default, never the config override
```

## Fix

**`PropertyReader.java`** — added `public static getOverrides()` to expose the current thread-local overrides map.

**`CliExecutionHelper.java`** — after loading `dmtools.env`, merges the per-job overrides (higher priority) into the envVars map before spawning the subprocess, so variables like `COPILOT_MODEL` actually reach the shell script.

## Impact

Any `envVariables` declared in a JSON agent config now correctly take effect for all CLI agent providers (Copilot, Cursor, CodeMie).