### PR TITLE
fix: null-safe override merging + unit tests for CLI subprocess env propagation

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -259,15 +259,16 @@ public class CliExecutionHelper {
                 String key = entry.getKey();
                 String value = entry.getValue();
                 if (key == null || key.isBlank() || value == null) {
-                    logger.warn("Skipping invalid envVariables entry: key={}, value={}", key, value);
+                    logger.warn("Skipping invalid envVariables entry: key={}, keyBlank={}, valueNull={}",
+                            key, key != null && key.isBlank(), value == null);
                     skipped++;
                     continue;
                 }
                 merged.put(key, value);
             }
-            int merged_count = jobOverrides.size() - skipped;
+            int mergedCount = jobOverrides.size() - skipped;
             logger.info("Merging {} per-job envVariables override(s) into subprocess environment ({} skipped due to null/blank key or null value)",
-                    merged_count, skipped);
+                    mergedCount, skipped);
             envVars = merged;
         }
         

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -253,9 +253,22 @@ public class CliExecutionHelper {
         // agent config actually reaches run-agent.sh.
         Map<String, String> jobOverrides = PropertyReader.getOverrides();
         if (!jobOverrides.isEmpty()) {
-            logger.info("Merging {} per-job envVariables override(s) into subprocess environment", jobOverrides.size());
-            envVars = new java.util.HashMap<>(envVars);
-            envVars.putAll(jobOverrides);
+            java.util.HashMap<String, String> merged = new java.util.HashMap<>(envVars);
+            int skipped = 0;
+            for (Map.Entry<String, String> entry : jobOverrides.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                if (key == null || key.isBlank() || value == null) {
+                    logger.warn("Skipping invalid envVariables entry: key={}, value={}", key, value);
+                    skipped++;
+                    continue;
+                }
+                merged.put(key, value);
+            }
+            int merged_count = jobOverrides.size() - skipped;
+            logger.info("Merging {} per-job envVariables override(s) into subprocess environment ({} skipped due to null/blank key or null value)",
+                    merged_count, skipped);
+            envVars = merged;
         }
         
         // Convert Path to File for ProcessBuilder - safer than changing system properties

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -24,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -792,5 +793,96 @@ public class CliExecutionHelperTest {
     void testIsVideoFile_NullOrEmpty_ReturnsFalse() {
         assertFalse(CliExecutionHelper.isVideoFile(null));
         assertFalse(CliExecutionHelper.isVideoFile(""));
+    }
+
+    // ── PropertyReader envVariables propagation ─────────────────────────────
+
+    @Test
+    void testExecuteCliCommands_JobOverridesPropagatedToSubprocess() {
+        // Arrange: set a per-job override that should reach the subprocess env
+        com.github.istin.dmtools.common.utils.PropertyReader.setOverrides(
+                Map.of("COPILOT_MODEL", "claude-opus-4.6", "AI_AGENT_PROVIDER", "copilot")
+        );
+        try {
+            String[] commands = {"run-agent.sh prompt"};
+            try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+                mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                        .thenReturn(Map.of("AI_AGENT_PROVIDER", "cursor")); // dmtools.env has old value
+                mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class)))
+                        .thenReturn("ok");
+
+                cliHelper.executeCliCommands(commands, null, "dmtools.env");
+
+                // Verify subprocess received merged env where job override wins over dmtools.env
+                mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                        anyString(),
+                        isNull(),
+                        argThat((Map<String, String> env) ->
+                                "claude-opus-4.6".equals(env.get("COPILOT_MODEL"))
+                                && "copilot".equals(env.get("AI_AGENT_PROVIDER")) // override beats dmtools.env
+                        )
+                ));
+            }
+        } finally {
+            com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testExecuteCliCommands_NoJobOverrides_UsesOnlyDmtoolsEnv() {
+        // Arrange: no per-job overrides — should just use dmtools.env vars
+        com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        String[] commands = {"echo hello"};
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                    .thenReturn(Map.of("COPILOT_MODEL", "gpt-5-mini"));
+            mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class)))
+                    .thenReturn("hello");
+
+            cliHelper.executeCliCommands(commands, null, "dmtools.env");
+
+            mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                    anyString(),
+                    isNull(),
+                    argThat((Map<String, String> env) -> "gpt-5-mini".equals(env.get("COPILOT_MODEL")))
+            ));
+        }
+    }
+
+    @Test
+    void testExecuteCliCommands_NullOrBlankKeysInOverridesAreSkipped() {
+        // Arrange: overrides contain null key, blank key, null value — all should be skipped safely
+        java.util.HashMap<String, String> badOverrides = new java.util.HashMap<>();
+        badOverrides.put(null, "some-value");   // null key
+        badOverrides.put("  ", "other-value");  // blank key
+        badOverrides.put("VALID_KEY", null);    // null value
+        badOverrides.put("COPILOT_MODEL", "claude-opus-4.6"); // only this survives
+        com.github.istin.dmtools.common.utils.PropertyReader.setOverrides(badOverrides);
+        try {
+            String[] commands = {"echo test"};
+            try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+                mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                        .thenReturn(new java.util.HashMap<>());
+                mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class)))
+                        .thenReturn("test");
+
+                // Should NOT throw NullPointerException
+                assertDoesNotThrow(() -> cliHelper.executeCliCommands(commands, null, "dmtools.env"));
+
+                // Valid entry must be present; invalid ones must be absent
+                mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                        anyString(),
+                        isNull(),
+                        argThat((Map<String, String> env) ->
+                                "claude-opus-4.6".equals(env.get("COPILOT_MODEL"))
+                                && !env.containsKey(null)
+                                && !env.containsKey("  ")
+                                && !env.containsKey("VALID_KEY")
+                        )
+                ));
+            }
+        } finally {
+            com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -24,7 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
Follow-up to #7 addressing Copilot AI review comments.

## Changes

### 1. Null safety in `CliExecutionHelper`

`processBuilder.environment().putAll()` throws `NullPointerException` if any key or value is `null`. JSON config parsing can produce such entries (mis-typed keys, explicit nulls). Now filters them out with a warning log instead of crashing.

**Before:**
```java
envVars.putAll(jobOverrides); // NPE if null key/value
```

**After:** iterates entries, skips nulls/blank keys, logs a warning per skipped entry, only adds valid ones.

### 2. Unit tests — 3 new cases in `CliExecutionHelperTest`

| Test | What it verifies |
|------|-----------------|
| `testExecuteCliCommands_JobOverridesPropagatedToSubprocess` | `COPILOT_MODEL` from JSON `envVariables` reaches subprocess and wins over `dmtools.env` value |
| `testExecuteCliCommands_NoJobOverrides_UsesOnlyDmtoolsEnv` | Without overrides, `dmtools.env` values pass through unchanged |
| `testExecuteCliCommands_NullOrBlankKeysInOverridesAreSkipped` | Null key, blank key, null value are silently dropped without NPE; valid entry still propagates |

All 48 tests pass (45 existing + 3 new).