### PR TITLE
fix: handle null priorities in test_case_generator.xml template

### DIFF
--- a/dmtools-core/src/main/resources/ftl/prompts/agents/test_case_generator.xml
+++ b/dmtools-core/src/main/resources/ftl/prompts/agents/test_case_generator.xml
@@ -17,9 +17,11 @@
             ${global.storyDescription}
             Ensure your feedback is constructive and professional.
         </story_description>
+        <#if global.priorities?? && global.priorities?has_content>
         <priorities>
             ${global.priorities}
         </priorities>
+        </#if>
         <existing_test_cases>
             ⚠️⚠️⚠️ CRITICAL WARNING ⚠️⚠️⚠️
 


### PR DESCRIPTION
## Problem
When `testCasesPriorities` is not configured in job params (e.g. PostNL), the FreeMarker template `test_case_generator.xml` throws `InvalidReferenceException` because `${global.priorities}` evaluates to null/missing.

## Root Cause

## Fix
Wrap the `<priorities>` block in a FreeMarker conditional so it's only rendered when priorities is non-null and non-empty:
```xml
<#if global.priorities?? && global.priorities?has_content>
<priorities>
    ${global.priorities}
</priorities>
</#if>
```