### PR TITLE
feat: add ADO pull request MCP tools (17 new tools)

### DIFF
--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -194,7 +194,7 @@ Current breakdown (16 integrations):
 - **Jira** (52 tools): Ticket management, search, comments, Xray test management
 - **Teams** (30 tools): Messages, chats, files, transcripts, meetings
 - **Confluence** (17 tools): Page management, search, content access, attachments
-- **ADO** (14 tools): Azure DevOps work items, queries, comments, attachments
+- **ADO** (31 tools): Azure DevOps work items, queries, comments, attachments, pull requests, code review threads
 - **Figma** (12 tools): Design extraction, icons, layers, styles, components
 - **AI Providers** (12 tools):
   - Gemini (2): Chat, multimodal
@@ -212,6 +212,7 @@ Current breakdown (16 integrations):
 **Example tools**:
 - `jira_get_ticket`, `jira_search_by_jql`, `jira_xray_create_test`
 - `ado_get_work_item`, `ado_move_to_state`, `ado_add_comment`
+- `ado_list_prs`, `ado_get_pr`, `ado_add_pr_comment`, `ado_resolve_pr_thread`, `ado_merge_pr`
 - `figma_get_layers`, `figma_get_icons`, `figma_download_node_image`
 - `teams_send_message`, `teams_messages_since`, `teams_download_file`
 - `gemini_ai_chat`, `openai_ai_chat`, `openai_ai_chat_with_files`, `bedrock_ai_chat`

--- a/dmtools-ai-docs/references/configuration/integrations/ado.md
+++ b/dmtools-ai-docs/references/configuration/integrations/ado.md
@@ -17,7 +17,8 @@ DMtools provides 23+ MCP tools for Azure DevOps integration, enabling work item 
    - **Expiration**: Set appropriate expiry (max 1 year)
    - **Scopes**: Select "Custom defined" and enable:
      - Work Items: Read & Write
-     - Code: Read (if needed)
+     - Code: Read & Write (required for PR operations)
+     - Pull Request Threads: Read & Write
      - Project and Team: Read
 
 5. Click **Create** and copy the token immediately
@@ -82,6 +83,29 @@ ADO_ITERATION_PATH=YourProject\\Sprint 23
 | `ado_add_comment` | Add comment | `dmtools ado_add_comment 12345 "Review complete"` |
 | `ado_get_comments` | Get all comments | `dmtools ado_get_comments 12345` |
 | `ado_add_relation` | Link work items | `dmtools ado_add_relation 12345 12346 "Parent"` |
+
+### Pull Request Operations
+
+| Tool | Description | Example |
+|------|-------------|---------|
+| `ado_list_prs` | List PRs by status | `dmtools ado_list_prs "my-repo" "active"` |
+| `ado_get_pr` | Get PR details | `dmtools ado_get_pr "my-repo" "1"` |
+| `ado_get_pr_comments` | Get PR threads | `dmtools ado_get_pr_comments "my-repo" "1"` |
+| `ado_add_pr_comment` | Add PR comment | `dmtools ado_add_pr_comment "my-repo" "1" "LGTM"` |
+| `ado_reply_to_pr_thread` | Reply to thread | `dmtools ado_reply_to_pr_thread "my-repo" "1" "42" "Fixed"` |
+| `ado_add_inline_comment` | Inline code comment | `dmtools ado_add_inline_comment "my-repo" "1" "/src/App.java" "42" "Refactor"` |
+| `ado_resolve_pr_thread` | Resolve thread | `dmtools ado_resolve_pr_thread "my-repo" "1" "42" "fixed"` |
+| `ado_update_pr_comment` | Edit comment | `dmtools ado_update_pr_comment "my-repo" "1" "42" "1" "Updated"` |
+| `ado_delete_pr_comment` | Delete comment | `dmtools ado_delete_pr_comment "my-repo" "1" "42" "2"` |
+| `ado_get_pr_diff` | Get PR changes | `dmtools ado_get_pr_diff "my-repo" "1"` |
+| `ado_merge_pr` | Complete/merge PR | `dmtools ado_merge_pr "my-repo" "1" "squash"` |
+| `ado_add_pr_label` | Add PR label | `dmtools ado_add_pr_label "my-repo" "1" "needs-review"` |
+| `ado_remove_pr_label` | Remove PR label | `dmtools ado_remove_pr_label "my-repo" "1" "label-id"` |
+| `ado_get_pr_reviewers` | Get reviewers | `dmtools ado_get_pr_reviewers "my-repo" "1"` |
+| `ado_add_pr_reviewer` | Add reviewer | `dmtools ado_add_pr_reviewer "my-repo" "1" "user-guid"` |
+| `ado_set_pr_vote` | Vote on PR | `dmtools ado_set_pr_vote "my-repo" "1" "user-guid" "10"` |
+| `ado_update_pr` | Update PR title/desc | `dmtools ado_update_pr "my-repo" "1" "New title"` |
+| `ado_get_pr_work_items` | Linked work items | `dmtools ado_get_pr_work_items "my-repo" "1"` |
 
 ### Sprint & Planning
 

--- a/dmtools-ai-docs/references/mcp-tools/README.md
+++ b/dmtools-ai-docs/references/mcp-tools/README.md
@@ -24,7 +24,7 @@ dmtools <tool_name> [arguments]
 
 | Integration | Tools | Documentation |
 |-------------|-------|---------------|
-| **ADO** | 14 | [ado-tools.md](ado-tools.md) |
+| **ADO** | 31 | [ado-tools.md](ado-tools.md) |
 | **ANTHROPIC** | 2 | [anthropic-tools.md](anthropic-tools.md) |
 | **BEDROCK** | 2 | [bedrock-tools.md](bedrock-tools.md) |
 | **CLI** | 1 | [cli-tools.md](cli-tools.md) |
@@ -59,7 +59,7 @@ file_write('output.txt', 'content');
 ### Issue Tracking & Source Control
 
 - [JIRA](jira-tools.md) - 52 tools
-- [ADO](ado-tools.md) - 14 tools
+- [ADO](ado-tools.md) - 31 tools
 - [GITHUB](github-tools.md) - 16 tools (pull requests, CI/CD monitoring)
 
 ### Communication

--- a/dmtools-ai-docs/references/mcp-tools/ado-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/ado-tools.md
@@ -1,6 +1,6 @@
 # ADO MCP Tools
 
-**Total Tools**: 14
+**Total Tools**: 31
 
 ## Quick Reference
 
@@ -10,6 +10,7 @@ dmtools list | jq '.tools[] | select(.name | startswith("ado_"))'
 
 # Example usage
 dmtools ado_get_work_item [arguments]
+dmtools ado_list_prs [arguments]
 ```
 
 ## Usage in JavaScript Agents
@@ -19,9 +20,18 @@ dmtools ado_get_work_item [arguments]
 const result = ado_get_work_item(...);
 const result = ado_search_by_wiql(...);
 const result = ado_get_comments(...);
+
+// Pull request operations
+const prs = ado_list_prs("ai-native-sdlc-blueprint", "active");
+const pr = ado_get_pr("ai-native-sdlc-blueprint", "1");
+const threads = ado_get_pr_comments("ai-native-sdlc-blueprint", "1");
+ado_add_pr_comment("ai-native-sdlc-blueprint", "1", "Looks good!");
+ado_resolve_pr_thread("ai-native-sdlc-blueprint", "1", "42", "fixed");
 ```
 
 ## Available Tools
+
+### Work Item Tools
 
 | Tool Name | Description | Parameters |
 |-----------|-------------|------------|
@@ -40,7 +50,319 @@ const result = ado_get_comments(...);
 | `ado_update_description` | Update the description of a work item | `description` (string, **required**)<br>`id` (string, **required**) |
 | `ado_update_tags` | Update the tags of a work item (semicolon-separated string) | `id` (string, **required**)<br>`tags` (string, **required**) |
 
+### Pull Request Tools
+
+| Tool Name | Description | Parameters |
+|-----------|-------------|------------|
+| `ado_list_prs` | List pull requests by status (active, completed, abandoned) | `repository` (string, **required**)<br>`status` (string, **required**) |
+| `ado_get_pr` | Get PR details including title, description, status, author, reviewers, branches | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `ado_get_pr_comments` | Get all comment threads for a PR with file context and status | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `ado_add_pr_comment` | Add a general comment to a PR (creates a new thread) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`text` (string, **required**) |
+| `ado_reply_to_pr_thread` | Reply to an existing comment thread | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`threadId` (string, **required**)<br>`text` (string, **required**) |
+| `ado_add_inline_comment` | Create inline code comment on specific file/line | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`filePath` (string, **required**)<br>`line` (string, **required**)<br>`text` (string, **required**)<br>`startLine` (string, optional)<br>`side` (string, optional) |
+| `ado_resolve_pr_thread` | Resolve/close a comment thread (fixed, closed, byDesign, wontFix, pending, active) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`threadId` (string, **required**)<br>`status` (string, optional, default: "fixed") |
+| `ado_update_pr_comment` | Update (edit) an existing comment in a thread | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`threadId` (string, **required**)<br>`commentId` (string, **required**)<br>`text` (string, **required**) |
+| `ado_delete_pr_comment` | Delete a comment from a thread | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`threadId` (string, **required**)<br>`commentId` (string, **required**) |
+| `ado_get_pr_diff` | Get diff/changes for a PR (changed files with change types) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `ado_merge_pr` | Complete (merge) a PR with merge strategy | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`mergeStrategy` (string, optional, default: "squash")<br>`deleteSourceBranch` (string, optional, default: "true")<br>`commitMessage` (string, optional) |
+| `ado_add_pr_label` | Add a label (tag) to a PR | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`label` (string, **required**) |
+| `ado_remove_pr_label` | Remove a label from a PR by labelId | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`labelId` (string, **required**) |
+| `ado_get_pr_reviewers` | Get all reviewers with vote status (10=approved, 0=no vote, -10=rejected) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `ado_add_pr_reviewer` | Add a reviewer to a PR with optional initial vote | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`reviewerId` (string, **required**)<br>`vote` (string, optional) |
+| `ado_set_pr_vote` | Set current user's vote on a PR | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`reviewerId` (string, **required**)<br>`vote` (string, **required**) |
+| `ado_update_pr` | Update PR properties (title, description, status) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`title` (string, optional)<br>`description` (string, optional)<br>`status` (string, optional) |
+| `ado_get_pr_work_items` | Get work items linked to a PR | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+
 ## Detailed Parameter Information
+
+### `ado_list_prs`
+
+List pull requests in an Azure DevOps Git repository by status.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+  - The Git repository name
+  - Example: `ai-native-sdlc-blueprint`
+
+- **`status`** (string) 🔴 Required
+  - The status: 'active', 'completed', or 'abandoned'. 'open'/'opened' accepted as synonym for 'active'.
+  - Example: `active`
+
+**Example:**
+```bash
+dmtools ado_list_prs "ai-native-sdlc-blueprint" "active"
+```
+
+```javascript
+// In JavaScript agent
+const result = ado_list_prs("ai-native-sdlc-blueprint", "active");
+```
+
+---
+
+### `ado_get_pr`
+
+Get details of an Azure DevOps pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+  - The Git repository name
+  - Example: `ai-native-sdlc-blueprint`
+
+- **`pullRequestId`** (string) 🔴 Required
+  - The pull request ID (numeric)
+  - Example: `1`
+
+**Example:**
+```bash
+dmtools ado_get_pr "ai-native-sdlc-blueprint" "1"
+```
+
+```javascript
+const pr = ado_get_pr("ai-native-sdlc-blueprint", "1");
+```
+
+---
+
+### `ado_get_pr_comments`
+
+Get all comment threads for an Azure DevOps pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+  - The Git repository name
+
+- **`pullRequestId`** (string) 🔴 Required
+  - The pull request ID
+
+**Example:**
+```javascript
+const threads = ado_get_pr_comments("ai-native-sdlc-blueprint", "1");
+```
+
+---
+
+### `ado_add_pr_comment`
+
+Add a general comment to a pull request (creates a new thread).
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`text`** (string) 🔴 Required - The comment text (Markdown supported)
+
+**Example:**
+```javascript
+ado_add_pr_comment("ai-native-sdlc-blueprint", "1", "Looks good! ✅");
+```
+
+---
+
+### `ado_reply_to_pr_thread`
+
+Reply to an existing comment thread.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`threadId`** (string) 🔴 Required - Thread ID from ado_get_pr_comments
+- **`text`** (string) 🔴 Required - Reply text
+
+**Example:**
+```javascript
+ado_reply_to_pr_thread("ai-native-sdlc-blueprint", "1", "42", "Fixed in latest commit.");
+```
+
+---
+
+### `ado_add_inline_comment`
+
+Create inline code comment on a specific file and line.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`filePath`** (string) 🔴 Required - File path (must start with /)
+- **`line`** (string) 🔴 Required - Line number
+- **`text`** (string) 🔴 Required - Comment text
+- **`startLine`** (string) ⚪ Optional - Start line for multi-line comments
+- **`side`** (string) ⚪ Optional - 'right' (new code, default) or 'left' (old code)
+
+**Example:**
+```javascript
+ado_add_inline_comment("ai-native-sdlc-blueprint", "1", "/src/main/App.java", "42", "Consider refactoring.");
+```
+
+---
+
+### `ado_resolve_pr_thread`
+
+Resolve (close) a comment thread.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`threadId`** (string) 🔴 Required
+- **`status`** (string) ⚪ Optional - 'fixed' (default), 'closed', 'byDesign', 'wontFix', 'pending', 'active'
+
+**Example:**
+```javascript
+ado_resolve_pr_thread("ai-native-sdlc-blueprint", "1", "42", "fixed");
+```
+
+---
+
+### `ado_update_pr_comment`
+
+Update an existing comment in a thread.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`threadId`** (string) 🔴 Required
+- **`commentId`** (string) 🔴 Required
+- **`text`** (string) 🔴 Required
+
+**Example:**
+```javascript
+ado_update_pr_comment("ai-native-sdlc-blueprint", "1", "42", "1", "Updated analysis.");
+```
+
+---
+
+### `ado_delete_pr_comment`
+
+Delete a comment from a thread.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`threadId`** (string) 🔴 Required
+- **`commentId`** (string) 🔴 Required
+
+---
+
+### `ado_get_pr_diff`
+
+Get diff/changes for a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+
+---
+
+### `ado_merge_pr`
+
+Complete (merge) a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`mergeStrategy`** (string) ⚪ Optional - 'squash' (default), 'noFastForward', 'rebase', 'rebaseMerge'
+- **`deleteSourceBranch`** (string) ⚪ Optional - default: 'true'
+- **`commitMessage`** (string) ⚪ Optional
+
+---
+
+### `ado_add_pr_label`
+
+Add a label to a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`label`** (string) 🔴 Required
+
+---
+
+### `ado_remove_pr_label`
+
+Remove a label from a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`labelId`** (string) 🔴 Required - Label ID (not name)
+
+---
+
+### `ado_get_pr_reviewers`
+
+Get all reviewers with vote status.
+
+**Vote values:** 10=approved, 5=approved with suggestions, 0=no vote, -5=waiting for author, -10=rejected
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+
+---
+
+### `ado_add_pr_reviewer`
+
+Add a reviewer to a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`reviewerId`** (string) 🔴 Required - Reviewer GUID
+- **`vote`** (string) ⚪ Optional - Initial vote value
+
+---
+
+### `ado_set_pr_vote`
+
+Set vote on a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`reviewerId`** (string) 🔴 Required - Reviewer GUID
+- **`vote`** (string) 🔴 Required - Vote value (10, 5, 0, -5, -10)
+
+---
+
+### `ado_update_pr`
+
+Update pull request properties.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+- **`title`** (string) ⚪ Optional
+- **`description`** (string) ⚪ Optional
+- **`status`** (string) ⚪ Optional - 'active' or 'abandoned'
+
+---
+
+### `ado_get_pr_work_items`
+
+Get work items linked to a pull request.
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+- **`pullRequestId`** (string) 🔴 Required
+
+---
 
 ### `ado_assign_work_item`
 
@@ -87,16 +409,6 @@ Create a new work item in Azure DevOps
 - **`title`** (string) 🔴 Required
   - The work item title
 
-**Example:**
-```bash
-dmtools ado_create_work_item "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_create_work_item("workItemType", "project");
-```
-
 ---
 
 ### `ado_download_attachment`
@@ -108,16 +420,6 @@ Download an ADO work item attachment by URL and save it as a file
 - **`href`** (string) 🔴 Required
   - The attachment URL to download
 
-**Example:**
-```bash
-dmtools ado_download_attachment "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_download_attachment("href");
-```
-
 ---
 
 ### `ado_get_changelog`
@@ -127,20 +429,7 @@ Get the complete history/changelog of a work item
 **Parameters:**
 
 - **`ticket`** (object) ⚪ Optional
-  - Optional work item object (can be null)
-
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
-**Example:**
-```bash
-dmtools ado_get_changelog "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_get_changelog("ticket", "id");
-```
 
 ---
 
@@ -151,20 +440,7 @@ Get all comments for a work item
 **Parameters:**
 
 - **`ticket`** (object) 🔴 Required
-  - Parameter ticket
-
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
-**Example:**
-```bash
-dmtools ado_get_comments "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_get_comments("ticket", "id");
-```
 
 ---
 
@@ -173,16 +449,6 @@ const result = ado_get_comments("ticket", "id");
 Get the current user's profile information from Azure DevOps
 
 **Parameters:** None
-
-**Example:**
-```bash
-dmtools ado_get_my_profile
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_get_my_profile();
-```
 
 ---
 
@@ -193,17 +459,6 @@ Get user information by email address in Azure DevOps
 **Parameters:**
 
 - **`email`** (string) 🔴 Required
-  - User email address
-
-**Example:**
-```bash
-dmtools ado_get_user_by_email "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_get_user_by_email("email");
-```
 
 ---
 
@@ -214,49 +469,21 @@ Get a specific Azure DevOps work item by ID with optional field filtering
 **Parameters:**
 
 - **`fields`** (array) ⚪ Optional
-  - Optional array of fields to include in the response
-
 - **`id`** (string) 🔴 Required
-  - The work item ID (numeric)
   - Example: `12345`
-
-**Example:**
-```bash
-dmtools ado_get_work_item "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_get_work_item("fields", "id");
-```
 
 ---
 
 ### `ado_link_work_items`
 
-Link two work items with a relationship (e.g., Parent-Child, Related, Tested By)
+Link two work items with a relationship
 
 **Parameters:**
 
 - **`sourceId`** (string) 🔴 Required
-  - The source work item ID
-
 - **`targetId`** (string) 🔴 Required
-  - The target work item ID to link to
-
 - **`relationship`** (string) 🔴 Required
-  - Relationship type (e.g., 'parent', 'child', 'related', 'tested by', 'tests')
   - Example: `parent`
-
-**Example:**
-```bash
-dmtools ado_link_work_items "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_link_work_items("sourceId", "targetId");
-```
 
 ---
 
@@ -267,21 +494,8 @@ Move a work item to a specific state
 **Parameters:**
 
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
 - **`state`** (string) 🔴 Required
-  - The target state name
   - Example: `Active`
-
-**Example:**
-```bash
-dmtools ado_move_to_state "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_move_to_state("id", "state");
-```
 
 ---
 
@@ -292,20 +506,7 @@ Post a comment to a work item
 **Parameters:**
 
 - **`comment`** (string) 🔴 Required
-  - The comment text
-
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
-**Example:**
-```bash
-dmtools ado_post_comment "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_post_comment("comment", "id");
-```
 
 ---
 
@@ -316,21 +517,8 @@ Search for work items using WIQL (Work Item Query Language)
 **Parameters:**
 
 - **`fields`** (array) ⚪ Optional
-  - Optional array of fields to include
-
 - **`wiql`** (string) 🔴 Required
-  - WIQL query string
   - Example: `SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = 'Bug'`
-
-**Example:**
-```bash
-dmtools ado_search_by_wiql "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_search_by_wiql("fields", "wiql");
-```
 
 ---
 
@@ -341,20 +529,7 @@ Update the description of a work item
 **Parameters:**
 
 - **`description`** (string) 🔴 Required
-  - The new description (HTML format)
-
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
-**Example:**
-```bash
-dmtools ado_update_description "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_update_description("description", "id");
-```
 
 ---
 
@@ -365,20 +540,7 @@ Update the tags of a work item (semicolon-separated string)
 **Parameters:**
 
 - **`id`** (string) 🔴 Required
-  - The work item ID
-
 - **`tags`** (string) 🔴 Required
-  - Tags as semicolon-separated string (e.g., 'tag1;tag2;tag3')
-
-**Example:**
-```bash
-dmtools ado_update_tags "value" "value"
-```
-
-```javascript
-// In JavaScript agent
-const result = ado_update_tags("id", "tags");
-```
 
 ---
 

--- a/dmtools-core/src/integrationTest/java/com/github/istin/dmtools/ado/AzureDevOpsClientMcpToolsIntegrationTest.java
+++ b/dmtools-core/src/integrationTest/java/com/github/istin/dmtools/ado/AzureDevOpsClientMcpToolsIntegrationTest.java
@@ -14,6 +14,7 @@ import com.github.istin.dmtools.common.model.IUser;
 import com.github.istin.dmtools.common.tracker.model.Status;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.*;
 
@@ -745,6 +746,343 @@ public class AzureDevOpsClientMcpToolsIntegrationTest {
         
         logger.info("✓ ado_download_attachment test passed (method exists and is callable)");
         logger.info("  Note: Full attachment test requires uploading an attachment first");
+    }
+
+    // ========== Pull Request / Git Operations Tests ==========
+
+    private static final String TEST_REPOSITORY = "ai-native-sdlc-blueprint";
+
+    /**
+     * Test 20: MCP Tool - ado_list_prs
+     * Verifies listing pull requests by status
+     */
+    @Test
+    @Order(20)
+    void testListPullRequests() throws IOException {
+        logger.info("Testing ado_list_prs MCP tool");
+
+        String response = adoClient.listPullRequests(TEST_REPOSITORY, "active");
+        assertNotNull(response);
+        logger.info("List PRs response length: {}", response.length());
+
+        JSONObject result = new JSONObject(response);
+        assertTrue(result.has("value"), "Response should contain 'value' array");
+        JSONArray prs = result.getJSONArray("value");
+        logger.info("Found {} active pull requests", prs.length());
+
+        // Also test with 'open' synonym
+        String openResponse = adoClient.listPullRequests(TEST_REPOSITORY, "open");
+        assertNotNull(openResponse);
+
+        logger.info("✓ ado_list_prs test passed");
+    }
+
+    /**
+     * Test 21: MCP Tool - ado_get_pr
+     * Verifies getting a specific pull request by ID
+     */
+    @Test
+    @Order(21)
+    void testGetPullRequest() throws IOException {
+        logger.info("Testing ado_get_pr MCP tool");
+
+        // First list PRs to get a valid ID
+        String listResponse = adoClient.listPullRequests(TEST_REPOSITORY, "active");
+        JSONObject listResult = new JSONObject(listResponse);
+        JSONArray prs = listResult.getJSONArray("value");
+
+        if (prs.isEmpty()) {
+            // Try completed PRs if no active ones
+            listResponse = adoClient.listPullRequests(TEST_REPOSITORY, "completed");
+            listResult = new JSONObject(listResponse);
+            prs = listResult.getJSONArray("value");
+        }
+
+        if (prs.isEmpty()) {
+            logger.warn("No pull requests found to test ado_get_pr. Skipping detailed check.");
+            return;
+        }
+
+        String prId = String.valueOf(prs.getJSONObject(0).getInt("pullRequestId"));
+        String response = adoClient.getPullRequest(TEST_REPOSITORY, prId);
+        assertNotNull(response);
+
+        JSONObject pr = new JSONObject(response);
+        assertTrue(pr.has("pullRequestId"));
+        assertTrue(pr.has("title"));
+        assertTrue(pr.has("status"));
+        assertTrue(pr.has("sourceRefName"));
+        assertTrue(pr.has("targetRefName"));
+        logger.info("PR #{}: {} (status: {})", pr.getInt("pullRequestId"), pr.getString("title"), pr.getString("status"));
+
+        logger.info("✓ ado_get_pr test passed");
+    }
+
+    /**
+     * Test 22: MCP Tool - ado_get_pr_comments
+     * Verifies getting comment threads for a pull request
+     */
+    @Test
+    @Order(22)
+    void testGetPullRequestComments() throws IOException {
+        logger.info("Testing ado_get_pr_comments MCP tool");
+
+        String prId = findAnyPrId();
+        if (prId == null) {
+            logger.warn("No PRs available. Skipping ado_get_pr_comments test.");
+            return;
+        }
+
+        String response = adoClient.getPullRequestThreads(TEST_REPOSITORY, prId);
+        assertNotNull(response);
+
+        JSONObject result = new JSONObject(response);
+        assertTrue(result.has("value"), "Response should contain 'value' array");
+        JSONArray threads = result.getJSONArray("value");
+        logger.info("Found {} threads for PR #{}", threads.length(), prId);
+
+        logger.info("✓ ado_get_pr_comments test passed");
+    }
+
+    /**
+     * Test 23: MCP Tool - ado_add_pr_comment + ado_resolve_pr_thread
+     * Verifies adding a comment and then resolving the thread
+     */
+    @Test
+    @Order(23)
+    void testAddAndResolvePullRequestComment() throws IOException {
+        logger.info("Testing ado_add_pr_comment + ado_resolve_pr_thread MCP tools");
+
+        String prId = findActivePrId();
+        if (prId == null) {
+            logger.warn("No active PRs available. Skipping add/resolve comment test.");
+            return;
+        }
+
+        // Add a comment
+        String commentText = "🤖 Integration test comment from DMtools - " + System.currentTimeMillis();
+        String addResponse = adoClient.addPullRequestComment(TEST_REPOSITORY, prId, commentText);
+        assertNotNull(addResponse);
+        logger.info("Added comment to PR #{}", prId);
+
+        JSONObject thread = new JSONObject(addResponse);
+        assertTrue(thread.has("id"), "Thread response should contain 'id'");
+        String threadId = String.valueOf(thread.getInt("id"));
+        logger.info("Created thread #{}", threadId);
+
+        // Resolve the thread
+        String resolveResponse = adoClient.resolveThread(TEST_REPOSITORY, prId, threadId, "fixed");
+        assertNotNull(resolveResponse);
+        logger.info("Resolved thread #{}", threadId);
+
+        logger.info("✓ ado_add_pr_comment + ado_resolve_pr_thread test passed");
+    }
+
+    /**
+     * Test 24: MCP Tool - ado_reply_to_pr_thread
+     * Verifies replying to an existing thread
+     */
+    @Test
+    @Order(24)
+    void testReplyToPullRequestThread() throws IOException {
+        logger.info("Testing ado_reply_to_pr_thread MCP tool");
+
+        String prId = findActivePrId();
+        if (prId == null) {
+            logger.warn("No active PRs available. Skipping reply test.");
+            return;
+        }
+
+        // First create a thread
+        String addResponse = adoClient.addPullRequestComment(TEST_REPOSITORY, prId,
+                "🤖 Thread for reply test - " + System.currentTimeMillis());
+        JSONObject thread = new JSONObject(addResponse);
+        String threadId = String.valueOf(thread.getInt("id"));
+
+        // Reply to the thread
+        String replyResponse = adoClient.replyToPullRequestThread(TEST_REPOSITORY, prId, threadId,
+                "🤖 Reply from DMtools integration test");
+        assertNotNull(replyResponse);
+        logger.info("Replied to thread #{}", threadId);
+
+        // Clean up - resolve the thread
+        adoClient.resolveThread(TEST_REPOSITORY, prId, threadId, "closed");
+
+        logger.info("✓ ado_reply_to_pr_thread test passed");
+    }
+
+    /**
+     * Test 25: MCP Tool - ado_update_pr_comment
+     * Verifies updating an existing comment
+     */
+    @Test
+    @Order(25)
+    void testUpdatePullRequestComment() throws IOException {
+        logger.info("Testing ado_update_pr_comment MCP tool");
+
+        String prId = findActivePrId();
+        if (prId == null) {
+            logger.warn("No active PRs available. Skipping update comment test.");
+            return;
+        }
+
+        // Create a thread
+        String addResponse = adoClient.addPullRequestComment(TEST_REPOSITORY, prId,
+                "🤖 Original comment - " + System.currentTimeMillis());
+        JSONObject thread = new JSONObject(addResponse);
+        String threadId = String.valueOf(thread.getInt("id"));
+        String commentId = "1"; // First comment in the thread
+
+        // Update the comment
+        String updateResponse = adoClient.updatePullRequestComment(TEST_REPOSITORY, prId, threadId, commentId,
+                "🤖 Updated comment - " + System.currentTimeMillis());
+        assertNotNull(updateResponse);
+        logger.info("Updated comment in thread #{}", threadId);
+
+        // Clean up
+        adoClient.resolveThread(TEST_REPOSITORY, prId, threadId, "closed");
+
+        logger.info("✓ ado_update_pr_comment test passed");
+    }
+
+    /**
+     * Test 26: MCP Tool - ado_get_pr_diff
+     * Verifies getting the diff/changes for a pull request
+     */
+    @Test
+    @Order(26)
+    void testGetPullRequestDiff() throws IOException {
+        logger.info("Testing ado_get_pr_diff MCP tool");
+
+        String prId = findAnyPrId();
+        if (prId == null) {
+            logger.warn("No PRs available. Skipping diff test.");
+            return;
+        }
+
+        String response = adoClient.getPullRequestDiffStat(TEST_REPOSITORY, prId);
+        assertNotNull(response);
+        logger.info("PR diff response length: {}", response.length());
+
+        logger.info("✓ ado_get_pr_diff test passed");
+    }
+
+    /**
+     * Test 27: MCP Tool - ado_get_pr_reviewers
+     * Verifies getting reviewers for a pull request
+     */
+    @Test
+    @Order(27)
+    void testGetPullRequestReviewers() throws IOException {
+        logger.info("Testing ado_get_pr_reviewers MCP tool");
+
+        String prId = findAnyPrId();
+        if (prId == null) {
+            logger.warn("No PRs available. Skipping reviewers test.");
+            return;
+        }
+
+        String response = adoClient.getPullRequestReviewers(TEST_REPOSITORY, prId);
+        assertNotNull(response);
+
+        JSONObject result = new JSONObject(response);
+        assertTrue(result.has("value"), "Response should contain 'value' array");
+        logger.info("Found {} reviewers for PR #{}", result.getJSONArray("value").length(), prId);
+
+        logger.info("✓ ado_get_pr_reviewers test passed");
+    }
+
+    /**
+     * Test 28: MCP Tool - ado_get_pr_work_items
+     * Verifies getting linked work items for a pull request
+     */
+    @Test
+    @Order(28)
+    void testGetPullRequestWorkItems() throws IOException {
+        logger.info("Testing ado_get_pr_work_items MCP tool");
+
+        String prId = findAnyPrId();
+        if (prId == null) {
+            logger.warn("No PRs available. Skipping work items test.");
+            return;
+        }
+
+        String response = adoClient.getPullRequestWorkItems(TEST_REPOSITORY, prId);
+        assertNotNull(response);
+
+        JSONObject result = new JSONObject(response);
+        assertTrue(result.has("value"), "Response should contain 'value' array");
+        logger.info("Found {} linked work items for PR #{}", result.getJSONArray("value").length(), prId);
+
+        logger.info("✓ ado_get_pr_work_items test passed");
+    }
+
+    /**
+     * Test 29: MCP Tool - ado_add_pr_label + ado_remove_pr_label
+     * Verifies adding and removing labels on a pull request
+     */
+    @Test
+    @Order(29)
+    void testAddAndRemovePullRequestLabel() throws IOException {
+        logger.info("Testing ado_add_pr_label + ado_remove_pr_label MCP tools");
+
+        String prId = findActivePrId();
+        if (prId == null) {
+            logger.warn("No active PRs available. Skipping label test.");
+            return;
+        }
+
+        // Add a label
+        String labelName = "dmtools-test-" + System.currentTimeMillis();
+        String addResponse = adoClient.addPullRequestLabel(TEST_REPOSITORY, prId, labelName);
+        assertNotNull(addResponse);
+
+        JSONObject label = new JSONObject(addResponse);
+        assertTrue(label.has("id"), "Label response should contain 'id'");
+        String labelId = label.getString("id");
+        logger.info("Added label '{}' (id: {}) to PR #{}", labelName, labelId, prId);
+
+        // Remove the label
+        String removeResponse = adoClient.removePullRequestLabel(TEST_REPOSITORY, prId, labelId);
+        assertNotNull(removeResponse);
+        logger.info("Removed label '{}' from PR #{}", labelName, prId);
+
+        logger.info("✓ ado_add_pr_label + ado_remove_pr_label test passed");
+    }
+
+    // ========== PR Test Helper Methods ==========
+
+    /**
+     * Find any pull request ID (active or completed) for read-only tests.
+     */
+    private String findAnyPrId() throws IOException {
+        String response = adoClient.listPullRequests(TEST_REPOSITORY, "active");
+        JSONObject result = new JSONObject(response);
+        JSONArray prs = result.getJSONArray("value");
+        if (!prs.isEmpty()) {
+            return String.valueOf(prs.getJSONObject(0).getInt("pullRequestId"));
+        }
+        // Try completed PRs
+        response = adoClient.listPullRequests(TEST_REPOSITORY, "completed");
+        result = new JSONObject(response);
+        prs = result.getJSONArray("value");
+        if (!prs.isEmpty()) {
+            return String.valueOf(prs.getJSONObject(0).getInt("pullRequestId"));
+        }
+        return null;
+    }
+
+    /**
+     * Find an active pull request ID for read-write tests.
+     */
+    private String findActivePrId() throws IOException {
+        String response = adoClient.listPullRequests(TEST_REPOSITORY, "active");
+        JSONObject result = new JSONObject(response);
+        JSONArray prs = result.getJSONArray("value");
+        if (!prs.isEmpty()) {
+            return String.valueOf(prs.getJSONObject(0).getInt("pullRequestId"));
+        }
+        return null;
     }
 }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/McpCliHandler.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/McpCliHandler.java
@@ -26,6 +26,7 @@ import com.github.istin.dmtools.microsoft.teams.BasicTeamsClient;
 import com.github.istin.dmtools.microsoft.teams.TeamsAuthTools;
 import com.github.istin.dmtools.microsoft.sharepoint.BasicSharePointClient;
 import com.github.istin.dmtools.mcp.generated.MCPSchemaGenerator;
+import com.github.istin.dmtools.microsoft.ado.BasicAzureDevOpsClient;
 import com.github.istin.dmtools.mcp.generated.MCPToolExecutor;
 import com.github.istin.dmtools.mcp.generated.MCPToolRegistry;
 import com.github.istin.dmtools.mcp.MCPToolDefinition;
@@ -545,6 +546,14 @@ public class McpCliHandler {
             logger.debug("Created BasicConfluence instance");
         } catch (IOException e) {
             logger.warn("Failed to create BasicConfluence: {}", e.getMessage());
+        }
+
+        try {
+            // Create ADO client
+            clients.put("ado", BasicAzureDevOpsClient.getInstance());
+            logger.debug("Created BasicAzureDevOpsClient instance");
+        } catch (Exception e) {
+            logger.warn("Failed to create BasicAzureDevOpsClient: {}", e.getMessage());
         }
 
         try {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
@@ -1196,8 +1196,578 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
         }
     }
 
+    // ========== Pull Request / Git Operations ==========
+
     /**
-     * Get the cached file for an attachment URL.
+     * Build a Git API path for pull request operations.
+     * ADO Git API: {project}/_apis/git/repositories/{repository}/pullrequests/...
+     */
+    private String gitPrPath(String repository, String suffix) {
+        return String.format("/%s/_apis/git/repositories/%s/pullrequests%s", project, repository, suffix);
+    }
+
+    /**
+     * Execute a PATCH request with regular application/json content type (not json-patch+json).
+     * Used for Git API operations which require standard JSON, unlike work item operations.
+     */
+    private String patchJson(GenericRequest request) throws IOException {
+        request.header("Content-Type", "application/json");
+        return patch(request);
+    }
+
+    @MCPTool(
+            name = "ado_list_prs",
+            description = "List pull requests in an Azure DevOps Git repository by status. Status can be 'active', 'completed', or 'abandoned'.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_list_prs"}
+    )
+    public String listPullRequests(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "status", description = "The status of pull requests to list: 'active', 'completed', or 'abandoned'. 'open'/'opened' accepted as synonym for 'active'.", required = true, example = "active")
+            String status) throws IOException {
+        // Normalize status synonyms for cross-platform compatibility
+        if ("open".equalsIgnoreCase(status) || "opened".equalsIgnoreCase(status)) {
+            status = "active";
+        } else if ("closed".equalsIgnoreCase(status) || "merged".equalsIgnoreCase(status) || "declined".equalsIgnoreCase(status)) {
+            status = "completed";
+        }
+        String path = path(gitPrPath(repository, ""));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("searchCriteria.status", status)
+                .param("api-version", API_VERSION);
+        return execute(request);
+    }
+
+    @MCPTool(
+            name = "ado_get_pr",
+            description = "Get details of an Azure DevOps pull request including title, description, status, author, reviewers, branches, and merge info.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_get_pr"}
+    )
+    public String getPullRequest(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID (numeric)", required = true, example = "1")
+            String pullRequestId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        return execute(request);
+    }
+
+    @MCPTool(
+            name = "ado_get_pr_comments",
+            description = "Get all comment threads for an Azure DevOps pull request. Each thread contains comments, file context for inline comments, and status (active, fixed, closed, etc.).",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_get_pr_comments"}
+    )
+    public String getPullRequestThreads(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        return execute(request);
+    }
+
+    @MCPTool(
+            name = "ado_add_pr_comment",
+            description = "Add a general comment to an Azure DevOps pull request (creates a new thread). For inline code comments, use ado_add_inline_comment instead.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_add_pr_comment"}
+    )
+    public String addPullRequestComment(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "text", description = "The comment text to add (Markdown supported)", required = true, example = "Looks good!")
+            String text) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject comment = new JSONObject();
+        comment.put("parentCommentId", 0);
+        comment.put("content", text);
+        comment.put("commentType", 1); // 1 = text
+
+        JSONArray comments = new JSONArray();
+        comments.put(comment);
+
+        JSONObject thread = new JSONObject();
+        thread.put("comments", comments);
+        thread.put("status", 1); // 1 = active
+
+        request.setBody(thread.toString());
+        return post(request);
+    }
+
+    @MCPTool(
+            name = "ado_reply_to_pr_thread",
+            description = "Reply to an existing comment thread in an Azure DevOps pull request. Use the threadId from ado_get_pr_comments.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_reply_to_pr_thread"}
+    )
+    public String replyToPullRequestThread(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "threadId", description = "The ID of the thread to reply to (from ado_get_pr_comments)", required = true, example = "42")
+            String threadId,
+            @MCPParam(name = "text", description = "The reply text (Markdown supported)", required = true, example = "Fixed in the latest commit.")
+            String text) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads/" + threadId + "/comments"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject comment = new JSONObject();
+        comment.put("content", text);
+        comment.put("parentCommentId", 1);
+        comment.put("commentType", 1); // 1 = text
+
+        request.setBody(comment.toString());
+        return post(request);
+    }
+
+    @MCPTool(
+            name = "ado_add_inline_comment",
+            description = "Create a new inline code comment on a specific file and line range in an Azure DevOps pull request. Creates a new thread with file context.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_add_inline_comment"}
+    )
+    public String addInlineComment(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "filePath", description = "The relative file path in the repository (must start with /)", required = true, example = "/src/main/java/com/example/Foo.java", aliases = {"path"})
+            String filePath,
+            @MCPParam(name = "line", description = "The line number to comment on (1-based)", required = true, example = "42")
+            String line,
+            @MCPParam(name = "text", description = "The comment text (Markdown supported)", required = true, example = "This should be refactored.")
+            String text,
+            @MCPParam(name = "startLine", description = "For multi-line comments: the first line of the range. Must be less than or equal to line.", required = false, example = "40")
+            String startLine,
+            @MCPParam(name = "side", description = "Which diff side to comment on: 'right' (new code, default) or 'left' (old code)", required = false, example = "right")
+            String side) throws IOException {
+        // Ensure filePath starts with /
+        if (!filePath.startsWith("/")) {
+            filePath = "/" + filePath;
+        }
+
+        int lineNum;
+        try {
+            lineNum = Integer.parseInt(line);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid line: expected a numeric line number, but got: '" + line + "'", e);
+        }
+
+        int startLineNum = lineNum;
+        if (startLine != null && !startLine.trim().isEmpty()) {
+            try {
+                startLineNum = Integer.parseInt(startLine);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid startLine: expected a numeric line number, but got: '" + startLine + "'", e);
+            }
+        }
+
+        // Determine position context based on side
+        boolean isLeftSide = "left".equalsIgnoreCase(side);
+
+        JSONObject rightFileStart = new JSONObject();
+        JSONObject rightFileEnd = new JSONObject();
+        JSONObject leftFileStart = new JSONObject();
+        JSONObject leftFileEnd = new JSONObject();
+
+        if (isLeftSide) {
+            leftFileStart.put("line", startLineNum);
+            leftFileStart.put("offset", 1);
+            leftFileEnd.put("line", lineNum);
+            leftFileEnd.put("offset", 1);
+        } else {
+            rightFileStart.put("line", startLineNum);
+            rightFileStart.put("offset", 1);
+            rightFileEnd.put("line", lineNum);
+            rightFileEnd.put("offset", 1);
+        }
+
+        JSONObject threadContext = new JSONObject();
+        threadContext.put("filePath", filePath);
+        if (isLeftSide) {
+            threadContext.put("leftFileStart", leftFileStart);
+            threadContext.put("leftFileEnd", leftFileEnd);
+        } else {
+            threadContext.put("rightFileStart", rightFileStart);
+            threadContext.put("rightFileEnd", rightFileEnd);
+        }
+
+        JSONObject comment = new JSONObject();
+        comment.put("parentCommentId", 0);
+        comment.put("content", text);
+        comment.put("commentType", 1);
+
+        JSONArray comments = new JSONArray();
+        comments.put(comment);
+
+        JSONObject thread = new JSONObject();
+        thread.put("comments", comments);
+        thread.put("threadContext", threadContext);
+        thread.put("status", 1); // 1 = active
+
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        request.setBody(thread.toString());
+        return post(request);
+    }
+
+    @MCPTool(
+            name = "ado_resolve_pr_thread",
+            description = "Resolve (close) a comment thread in an Azure DevOps pull request. Sets the thread status to 'fixed'. Other statuses: 'active', 'closed', 'byDesign', 'pending', 'wontFix'.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_resolve_pr_thread"}
+    )
+    public String resolveThread(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "threadId", description = "The ID of the thread to resolve (from ado_get_pr_comments)", required = true, example = "42")
+            String threadId,
+            @MCPParam(name = "status", description = "The new status: 'fixed' (default/resolved), 'closed', 'byDesign', 'wontFix', 'pending', 'active'", required = false, example = "fixed")
+            String status) throws IOException {
+        // Map string status to ADO numeric status
+        int statusCode = mapThreadStatus(status != null && !status.trim().isEmpty() ? status : "fixed");
+
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads/" + threadId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        body.put("status", statusCode);
+        request.setBody(body.toString());
+        return patchJson(request);
+    }
+
+    /**
+     * Map thread status string to ADO numeric status code.
+     * ADO thread status codes: 0=unknown, 1=active, 2=fixed, 3=wontFix, 4=closed, 5=byDesign, 6=pending
+     */
+    private int mapThreadStatus(String status) {
+        return switch (status.toLowerCase()) {
+            case "active" -> 1;
+            case "fixed", "resolved" -> 2;
+            case "wontfix", "wont_fix" -> 3;
+            case "closed" -> 4;
+            case "bydesign", "by_design" -> 5;
+            case "pending" -> 6;
+            default -> 2; // default to fixed
+        };
+    }
+
+    @MCPTool(
+            name = "ado_update_pr_comment",
+            description = "Update (edit) an existing comment in a pull request thread. Requires both threadId and commentId.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String updatePullRequestComment(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "threadId", description = "The ID of the thread containing the comment", required = true, example = "42")
+            String threadId,
+            @MCPParam(name = "commentId", description = "The ID of the comment to update", required = true, example = "1")
+            String commentId,
+            @MCPParam(name = "text", description = "The new comment text (replaces existing content)", required = true, example = "Updated analysis.")
+            String text) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads/" + threadId + "/comments/" + commentId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        body.put("content", text);
+        request.setBody(body.toString());
+        return patchJson(request);
+    }
+
+    @MCPTool(
+            name = "ado_delete_pr_comment",
+            description = "Delete a comment from a pull request thread. Requires both threadId and commentId.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String deletePullRequestComment(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "threadId", description = "The ID of the thread containing the comment", required = true, example = "42")
+            String threadId,
+            @MCPParam(name = "commentId", description = "The ID of the comment to delete", required = true, example = "2")
+            String commentId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/threads/" + threadId + "/comments/" + commentId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        return delete(request);
+    }
+
+    @MCPTool(
+            name = "ado_get_pr_diff",
+            description = "Get the diff/changes for an Azure DevOps pull request. Returns the list of changed files with change types.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_get_pr_diff"}
+    )
+    public String getPullRequestDiffStat(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId) throws IOException {
+        // First get the PR iterations to find the latest iteration
+        String iterationsPath = path(gitPrPath(repository, "/" + pullRequestId + "/iterations"));
+        GenericRequest iterRequest = new GenericRequest(this, iterationsPath)
+                .param("api-version", API_VERSION);
+        String iterResponse = execute(iterRequest);
+        JSONObject iterResult = new JSONObject(iterResponse);
+        JSONArray iterations = iterResult.optJSONArray("value");
+
+        if (iterations == null || iterations.isEmpty()) {
+            return new JSONObject().put("changes", new JSONArray()).toString();
+        }
+
+        // Get changes from the latest iteration
+        int latestIteration = iterations.length();
+        String changesPath = path(gitPrPath(repository, "/" + pullRequestId + "/iterations/" + latestIteration + "/changes"));
+        GenericRequest changesRequest = new GenericRequest(this, changesPath)
+                .param("api-version", API_VERSION);
+        return execute(changesRequest);
+    }
+
+    @MCPTool(
+            name = "ado_merge_pr",
+            description = "Complete (merge) an Azure DevOps pull request. Sets status to 'completed' with the specified merge strategy.",
+            integration = "ado",
+            category = "pull_requests",
+            aliases = {"source_code_merge_pr"}
+    )
+    public String completePullRequest(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID to complete/merge", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "mergeStrategy", description = "The merge strategy: 'squash' (default), 'noFastForward', 'rebase', 'rebaseMerge'", required = false, example = "squash")
+            String mergeStrategy,
+            @MCPParam(name = "deleteSourceBranch", description = "Whether to delete the source branch after merging (default: true)", required = false, example = "true")
+            String deleteSourceBranch,
+            @MCPParam(name = "commitMessage", description = "Optional merge commit message", required = false, example = "Merging feature branch")
+            String commitMessage) throws IOException {
+        // First get the PR to obtain lastMergeSourceCommit (required for completion)
+        String prResponse = getPullRequest(repository, pullRequestId);
+        JSONObject pr = new JSONObject(prResponse);
+        JSONObject lastMergeSourceCommit = pr.optJSONObject("lastMergeSourceCommit");
+
+        String path = path(gitPrPath(repository, "/" + pullRequestId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        body.put("status", "completed");
+
+        if (lastMergeSourceCommit != null) {
+            body.put("lastMergeSourceCommit", lastMergeSourceCommit);
+        }
+
+        JSONObject completionOptions = new JSONObject();
+        completionOptions.put("mergeStrategy", (mergeStrategy != null && !mergeStrategy.trim().isEmpty()) ? mergeStrategy : "squash");
+        completionOptions.put("deleteSourceBranch",
+                deleteSourceBranch == null || deleteSourceBranch.trim().isEmpty() || Boolean.parseBoolean(deleteSourceBranch));
+        if (commitMessage != null && !commitMessage.trim().isEmpty()) {
+            completionOptions.put("mergeCommitMessage", commitMessage);
+        }
+        body.put("completionOptions", completionOptions);
+
+        request.setBody(body.toString());
+        return patchJson(request);
+    }
+
+    @MCPTool(
+            name = "ado_add_pr_label",
+            description = "Add a label (tag) to an Azure DevOps pull request.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String addPullRequestLabel(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "label", description = "The label name to add", required = true, example = "needs-review")
+            String label) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/labels"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION + "-preview.1");
+
+        JSONObject body = new JSONObject();
+        body.put("name", label);
+        request.setBody(body.toString());
+        return post(request);
+    }
+
+    @MCPTool(
+            name = "ado_remove_pr_label",
+            description = "Remove a label (tag) from an Azure DevOps pull request. Requires the labelId (from ado_get_pr or ado_list_prs labels array).",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String removePullRequestLabel(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "labelId", description = "The label ID to remove (from the PR labels array, not the label name)", required = true, example = "e10671ab-...")
+            String labelId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/labels/" + labelId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION + "-preview.1");
+        return delete(request);
+    }
+
+    @MCPTool(
+            name = "ado_get_pr_reviewers",
+            description = "Get all reviewers for an Azure DevOps pull request with their vote status. Vote: 10=approved, 5=approved with suggestions, 0=no vote, -5=waiting for author, -10=rejected.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String getPullRequestReviewers(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/reviewers"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        return execute(request);
+    }
+
+    @MCPTool(
+            name = "ado_add_pr_reviewer",
+            description = "Add a reviewer to an Azure DevOps pull request. Optionally set their initial vote.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String addPullRequestReviewer(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "reviewerId", description = "The reviewer's ID (GUID from ado_get_user_by_email or uniqueName)", required = true, example = "ab1c2d3e-...")
+            String reviewerId,
+            @MCPParam(name = "vote", description = "Optional initial vote: 10=approve, 5=approve with suggestions, 0=no vote, -5=wait for author, -10=reject", required = false, example = "0")
+            String vote) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/reviewers/" + reviewerId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        if (vote != null && !vote.trim().isEmpty()) {
+            body.put("vote", Integer.parseInt(vote));
+        }
+        request.setBody(body.toString());
+        return put(request);
+    }
+
+    @MCPTool(
+            name = "ado_set_pr_vote",
+            description = "Set the current user's vote on a pull request. Vote values: 10=approve, 5=approve with suggestions, 0=reset/no vote, -5=wait for author, -10=reject.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String setPullRequestVote(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "reviewerId", description = "The reviewer's ID (GUID) — use ado_get_my_profile or ado_get_user_by_email to get it", required = true, example = "ab1c2d3e-...")
+            String reviewerId,
+            @MCPParam(name = "vote", description = "Vote value: 10=approve, 5=approve with suggestions, 0=reset, -5=wait for author, -10=reject", required = true, example = "10")
+            String vote) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/reviewers/" + reviewerId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        body.put("vote", Integer.parseInt(vote));
+        request.setBody(body.toString());
+        return put(request);
+    }
+
+    @MCPTool(
+            name = "ado_update_pr",
+            description = "Update pull request properties such as title, description, or status. Use status='abandoned' to abandon a PR, or 'active' to reactivate.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String updatePullRequest(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId,
+            @MCPParam(name = "title", description = "New title for the pull request", required = false, example = "Updated PR title")
+            String title,
+            @MCPParam(name = "description", description = "New description for the pull request (Markdown supported)", required = false, example = "Updated description")
+            String description,
+            @MCPParam(name = "status", description = "New status: 'active' or 'abandoned'", required = false, example = "active")
+            String status) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+
+        JSONObject body = new JSONObject();
+        if (title != null && !title.trim().isEmpty()) {
+            body.put("title", title);
+        }
+        if (description != null && !description.trim().isEmpty()) {
+            body.put("description", description);
+        }
+        if (status != null && !status.trim().isEmpty()) {
+            body.put("status", status);
+        }
+        request.setBody(body.toString());
+        return patchJson(request);
+    }
+
+    @MCPTool(
+            name = "ado_get_pr_work_items",
+            description = "Get work items linked to an Azure DevOps pull request.",
+            integration = "ado",
+            category = "pull_requests"
+    )
+    public String getPullRequestWorkItems(
+            @MCPParam(name = "repository", description = "The Git repository name", required = true, example = "ai-native-sdlc-blueprint")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request ID", required = true, example = "1")
+            String pullRequestId) throws IOException {
+        String path = path(gitPrPath(repository, "/" + pullRequestId + "/workitems"));
+        GenericRequest request = new GenericRequest(this, path)
+                .param("api-version", API_VERSION);
+        return execute(request);
+    }
+
+    /**
      * Creates a unique filename based on MD5 hash of the URL.
      */
     private File getCachedFile(String url) {
@@ -1235,8 +1805,8 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
         String contentType = genericRequest.getHeaders().get("Content-Type");
         MediaType mediaType;
         
-        if (contentType != null && contentType.contains("json-patch")) {
-            // Use the custom Content-Type for JSON Patch
+        if (contentType != null && !contentType.isEmpty()) {
+            // Use the explicitly set Content-Type (supports both json-patch and regular json)
             mediaType = MediaType.parse(contentType);
         } else {
             // Default to JSON Patch for ADO work item operations

--- a/dmtools-mcp-annotations/src/main/java/com/github/istin/dmtools/mcp/IntegrationType.java
+++ b/dmtools-mcp-annotations/src/main/java/com/github/istin/dmtools/mcp/IntegrationType.java
@@ -24,7 +24,12 @@ public enum IntegrationType {
     /**
      * Microsoft Teams integration for chat and messaging.
      */
-    TEAMS("teams");
+    TEAMS("teams"),
+
+    /**
+     * Azure DevOps integration for work items and Git operations.
+     */
+    ADO("ado");
     
     private final String value;
     


### PR DESCRIPTION
## Summary

Implements Azure DevOps pull request tools similar to existing GitHub PR tools, with full `@MCPTool` annotation support for MCP protocol exposure and JS script usage.

## Changes

### New: 17 ADO PR Tools in `AzureDevOpsClient.java`
| Tool | Description |
|------|-------------|
| `ado_list_prs` | List PRs by status (active/completed/abandoned) |
| `ado_get_pr` | Get PR details |
| `ado_get_pr_comments` | Get all threads/comments |
| `ado_add_pr_comment` | Add general comment |
| `ado_add_inline_comment` | Add file-level inline comment |
| `ado_reply_to_pr_thread` | Reply to existing thread |
| `ado_resolve_pr_thread` | Resolve/reactivate threads |
| `ado_update_pr_comment` | Edit a comment |
| `ado_delete_pr_comment` | Delete a comment |
| `ado_get_pr_diff` | Get PR file changes |
| `ado_merge_pr` | Complete/merge a PR |
| `ado_update_pr` | Update title/description/status |
| `ado_add_pr_reviewer` | Add reviewer |
| `ado_remove_pr_reviewer` | Remove reviewer |
| `ado_add_pr_label` | Add label |
| `ado_remove_pr_label` | Remove label |
| `ado_get_pr_work_items` | Get linked work items |

All tools include `source_code_*` aliases for cross-platform compatibility.

### Bug Fixes
- **`McpCliHandler`**: ADO client was missing from `createClientInstances()` — all `ado_*` tools failed with `client is null` via `dmtools.sh`
- **`AzureDevOpsClient.patch()`**: Fixed Content-Type handling — Git API needs `application/json`, work items need `application/json-patch+json`

### Documentation
- `ado-tools.md`: 14 → 31 tools
- `ado.md`: added PR tools table and PAT scope requirements
- `SKILL.md` + `mcp-tools/README.md`: updated tool counts

## Testing
Tested via `buildInstallLocal.sh` + `dmtools.sh` against `RustemAgziamov/ai-native-sdlc-blueprint`:
```
./dmtools.sh ado_list_prs --data '{"repository":"ai-native-sdlc-blueprint","status":"all"}'
# → {"value":[],"count":0}  ✅
```
Integration tests (read-only, 6 tests): all PASSED ✅