### PR TITLE
fix: remove duplicate additionalInstructions block in .dmtools/config.js

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -58,26 +58,3 @@ IMPORTANT SCOPE CONSTRAINTS:
         ]
     }
 };
-        story_description: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/11665485/Template+Story'
-        ],
-        story_acceptance_criterias: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/11665485/Template+Story'
-        ],
-        story_questions: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/11665581/Template+Q',
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/18186241/Template+Jira+Markdown'
-        ],
-        story_solution: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/56754177/Template+Solution+Design',
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/18186241/Template+Jira+Markdown'
-        ],
-        solution_description: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/56754177/Template+Solution+Design',
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/18186241/Template+Jira+Markdown'
-        ],
-        bug_creation: [
-            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/18186241/Template+Jira+Markdown'
-        ]
-    }
-};


### PR DESCRIPTION
## Problem

The SM agent was failing with:
```
configLoader: Failed to evaluate .dmtools/config.js: Expected ; but found :
configLoader: No project config found, using defaults
❌ Repository owner and repo are required
```

## Root Cause

`.dmtools/config.js` had the entire `additionalInstructions` block duplicated **after** the closing `};` of `module.exports`. The GraalVM JS engine couldn't parse the file, fell back to empty defaults, and the agent exited immediately with `"Missing owner or repo"`.

## Fix

Removed the stray duplicate block (lines 61–83) that appeared after the proper `};` closing.