### PR TITLE
feat: beta release workflow — auto pre-release on every merge to main

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -1,0 +1,210 @@
+name: Beta Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  checks: write
+  packages: write
+
+jobs:
+  # ─── Determine beta version (no gradle.properties bump) ───────────────────
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.beta_version.outputs.version }}
+      tag: ${{ steps.beta_version.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine beta version
+        id: beta_version
+        run: |
+          BASE_VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+          BETA_VERSION="${BASE_VERSION}-beta.${{ github.run_number }}"
+          echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v${BETA_VERSION}" >> $GITHUB_OUTPUT
+          echo "📦 Beta version: $BETA_VERSION"
+
+  # ─── Build & test (reuses existing reusable workflow) ─────────────────────
+  build-and-test:
+    needs: version
+    uses: ./.github/workflows/build-and-test.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  # ─── Package CLI ──────────────────────────────────────────────────────────
+  package-cli:
+    needs: [version, build-and-test]
+    uses: ./.github/workflows/package-cli.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  # ─── Package AI skill ─────────────────────────────────────────────────────
+  package-skill:
+    needs: [version, build-and-test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update version in skill metadata
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          if [ -f "dmtools-ai-docs/SKILL.md" ]; then
+            sed -i "s/version: .*/version: $VERSION/" dmtools-ai-docs/SKILL.md
+          fi
+
+      - name: Create skill package
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          DIST_DIR="dist"
+          mkdir -p $DIST_DIR
+
+          cd dmtools-ai-docs
+
+          zip -r ../$DIST_DIR/dmtools-skill-v${VERSION}.zip . \
+            -x "*.git*" -x ".DS_Store" -x "node_modules/*" \
+            -x "*.swp" -x ".cursorrules" -x ".github/*" -x "install.sh"
+
+          tar -czf ../$DIST_DIR/dmtools-skill-v${VERSION}.tar.gz \
+            --exclude='.git*' --exclude='.DS_Store' --exclude='node_modules' \
+            --exclude='.cursorrules' --exclude='.github' --exclude='install.sh' .
+
+          cd ..
+          cp dmtools-ai-docs/install.sh $DIST_DIR/skill-install.sh
+          chmod +x $DIST_DIR/skill-install.sh
+          cp dmtools-ai-docs/skill-install.ps1 $DIST_DIR/skill-install.ps1
+
+          echo "✅ Skill package created:"
+          ls -lh $DIST_DIR/
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum *.zip *.tar.gz > skill-checksums.sha256
+          cat skill-checksums.sha256
+
+      - name: Upload skill artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: skill-package
+          path: |
+            dist/dmtools-skill-*.zip
+            dist/dmtools-skill-*.tar.gz
+            dist/skill-install.sh
+            dist/skill-install.ps1
+            dist/skill-checksums.sha256
+          retention-days: 7
+
+  # ─── Create beta GitHub release (prerelease: true → main stays "latest") ──
+  create-beta-release:
+    needs: [version, package-cli, package-skill]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download CLI Package
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-package
+          path: cli/
+
+      - name: Download Skill Package
+        uses: actions/download-artifact@v4
+        with:
+          name: skill-package
+          path: skill/
+
+      - name: Generate Release Notes
+        run: |
+          VERSION="${{ needs.version.outputs.version }}"
+          SHORT_SHA="${GITHUB_SHA:0:8}"
+
+          cat > release_notes.md << EOF
+          # 🧪 DMTools Beta v${VERSION}
+
+          > **This is a pre-release / beta build** — automatically generated on every merge to \`main\`.
+          > For the latest stable release see the [Releases page](https://github.com/${{ github.repository }}/releases/latest).
+
+          ## 📦 What's Included
+
+          ### 🖥️ DMTools CLI
+          - Executable JAR with all dependencies bundled
+          - Cross-platform install scripts (\`install\`, \`install.sh\`, \`install.bat\`, \`install.ps1\`)
+          - Wrapper script (\`dmtools.sh\`)
+
+          ### 🤖 DMTools Agent Skill
+          - Universal AI assistant skill (Cursor, Claude, Codex, …)
+          - Full DMtools documentation and tool reference
+
+          ## 🎯 Quick Install (this beta)
+
+          **macOS / Linux:**
+          \`\`\`bash
+          curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | bash -s ${{ needs.version.outputs.tag }}
+          \`\`\`
+
+          **Windows (PowerShell):**
+          \`\`\`powershell
+          \$env:DMTOOLS_VERSION = "${{ needs.version.outputs.tag }}"
+          Invoke-RestMethod -Uri "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.ps1" | Invoke-Expression
+          \`\`\`
+
+          ## 📊 Build Info
+
+          | Field | Value |
+          |---|---|
+          | Version | \`${VERSION}\` |
+          | Git commit | \`${SHORT_SHA}\` |
+          | Build date | $(date -u '+%Y-%m-%d %H:%M:%S UTC') |
+          | Triggered by | \`${{ github.event_name }}\` |
+          EOF
+
+          echo "Release notes generated"
+
+      - name: Create Beta Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.version.outputs.tag }}
+          name: "DMTools Beta ${{ needs.version.outputs.tag }}"
+          body_path: release_notes.md
+          draft: false
+          prerelease: true   # ← keeps main stable release as "latest"
+          files: |
+            cli/dmtools-v${{ needs.version.outputs.version }}-all.jar
+            cli/install.sh
+            cli/install
+            cli/install.bat
+            cli/install.ps1
+            cli/dmtools.sh
+            skill/dmtools-skill-v${{ needs.version.outputs.version }}.zip
+            skill/dmtools-skill-v${{ needs.version.outputs.version }}.tar.gz
+            skill/skill-install.sh
+            skill/skill-install.ps1
+            skill/skill-checksums.sha256
+
+      - name: Summary
+        run: |
+          echo "## 🧪 Beta Release Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag:** \`${{ needs.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${GITHUB_SHA:0:8}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> ℹ️ Marked as **pre-release** — stable \`latest\` is unaffected." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  checks: write
-  packages: write
+  contents: read  # least-privilege default; elevated grants are per-job
 
 jobs:
   # ─── Determine beta version (no gradle.properties bump) ───────────────────
@@ -29,9 +27,9 @@ jobs:
         id: beta_version
         run: |
           BASE_VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
-          BETA_VERSION="${BASE_VERSION}-beta.${{ github.run_number }}"
-          echo "version=$BETA_VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v${BETA_VERSION}" >> $GITHUB_OUTPUT
+          BETA_VERSION="${BASE_VERSION}-beta.${{ github.run_number }}.${{ github.run_attempt }}"
+          echo "version=$BETA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v${BETA_VERSION}" >> "$GITHUB_OUTPUT"
           echo "📦 Beta version: $BETA_VERSION"
 
   # ─── Build & test (reuses existing reusable workflow) ─────────────────────
@@ -77,12 +75,16 @@ jobs:
           cd dmtools-ai-docs
 
           zip -r ../$DIST_DIR/dmtools-skill-v${VERSION}.zip . \
-            -x "*.git*" -x ".DS_Store" -x "node_modules/*" \
-            -x "*.swp" -x ".cursorrules" -x ".github/*" -x "install.sh"
+            -x "*.git*" -x "*/.git/*" -x ".DS_Store" -x "node_modules/*" -x "*/node_modules/*" \
+            -x "*.swp" -x ".cursorrules" -x ".github/*" -x "*/.github/*" -x "install.sh"
 
           tar -czf ../$DIST_DIR/dmtools-skill-v${VERSION}.tar.gz \
-            --exclude='.git*' --exclude='.DS_Store' --exclude='node_modules' \
-            --exclude='.cursorrules' --exclude='.github' --exclude='install.sh' .
+            --exclude='.git' --exclude='.git/*' --exclude='*/.git' --exclude='*/.git/*' \
+            --exclude='.DS_Store' \
+            --exclude='node_modules' --exclude='node_modules/*' --exclude='*/node_modules' --exclude='*/node_modules/*' \
+            --exclude='.cursorrules' \
+            --exclude='.github' --exclude='.github/*' --exclude='*/.github' --exclude='*/.github/*' \
+            --exclude='install.sh' .
 
           cd ..
           cp dmtools-ai-docs/install.sh $DIST_DIR/skill-install.sh
@@ -156,13 +158,16 @@ jobs:
 
           **macOS / Linux:**
           \`\`\`bash
-          curl -fsSL https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh | bash -s ${{ needs.version.outputs.tag }}
+          curl -fLo install.sh https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh
+          chmod +x install.sh
+          ./install.sh ${{ needs.version.outputs.tag }}
           \`\`\`
 
           **Windows (PowerShell):**
           \`\`\`powershell
           \$env:DMTOOLS_VERSION = "${{ needs.version.outputs.tag }}"
-          Invoke-RestMethod -Uri "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.ps1" | Invoke-Expression
+          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.ps1" -OutFile "install.ps1"
+          .\install.ps1
           \`\`\`
 
           ## 📊 Build Info


### PR DESCRIPTION
## Summary

Adds `.github/workflows/beta-release.yml` — a workflow that automatically creates a **pre-release** GitHub Release every time something is merged to `main`.

## How it works

| Step | Detail |
|---|---|
| **Trigger** | `push` to `main` (also `workflow_dispatch` for manual runs) |
| **Version** | `{current_version}-beta.{run_number}` — reads from `gradle.properties`, no file bump |
| **Pipeline** | Reuses `build-and-test.yml` → `package-cli.yml` + packages skill in-job |
| **Tag** | `v{beta_version}` (e.g. `v1.7.173-beta.42`) |
| **Release flag** | `prerelease: true` → stable `latest` release is **never displaced** |

## Why `prerelease: true` keeps `latest` safe

GitHub only updates the `latest` pointer when a release has `prerelease: false`. All beta releases are marked as pre-release, so the most recent stable release continues to be returned by the `/releases/latest` API endpoint and shown as **Latest** on the Releases page.