### PR TITLE
feat: beta release workflow — auto pre-release on every merge to main

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,7 +7,9 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read  # least-privilege default; elevated grants are per-job
+  contents: read    # least-privilege default; create-beta-release overrides to write
+  checks: write     # required by the build-and-test reusable workflow
+  packages: write   # required by the build-and-test reusable workflow
 
 jobs:
   # ─── Determine beta version (no gradle.properties bump) ───────────────────

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read    # least-privilege default; create-beta-release overrides to write
-  checks: write     # required by the build-and-test reusable workflow
-  packages: write   # required by the build-and-test reusable workflow
+  contents: read  # least-privilege default; elevated grants are per-job
 
 jobs:
   # ─── Determine beta version (no gradle.properties bump) ───────────────────
@@ -37,6 +35,10 @@ jobs:
   # ─── Build & test (reuses existing reusable workflow) ─────────────────────
   build-and-test:
     needs: version
+    permissions:
+      checks: write    # required by build-and-test nested job
+      packages: write  # required by build-and-test nested job
+      contents: read
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Adds `.github/workflows/beta-release.yml` — a workflow that automatically creates a **pre-release** GitHub Release every time something is merged to `main`.

## How it works

| Step | Detail |
|---|---|
| **Trigger** | `push` to `main` (also `workflow_dispatch` for manual runs) |
| **Version** | `{current_version}-beta.{run_number}.{run_attempt}` — reads from `gradle.properties`, no file bump |
| **Pipeline** | Reuses `build-and-test.yml` → `package-cli.yml` + packages skill in-job |
| **Tag** | `v{beta_version}` (e.g. `v1.7.173-beta.42.1`) |
| **Release flag** | `prerelease: true` → stable `latest` release is **never displaced** |

## Permissions

Top-level: `contents: read` (default), `checks: write` + `packages: write` (required by `build-and-test` reusable workflow). Only the `create-beta-release` job overrides to `contents: write`.

## Why `prerelease: true` keeps `latest` safe

GitHub only updates the `latest` pointer when a release has `prerelease: false`. All beta releases are marked as pre-release, so the most recent stable release continues to be returned by the `/releases/latest` API endpoint.