### PR TITLE
fix: strip Confluence/Jira smart-link suffix from GitHub URLs in parseUris

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -1600,7 +1600,11 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
 
         // Pattern to match GitHub URLs in the format:
         // https://github.com/{owner}/{repo}/blob/{branch}/{path}
-        String pattern = "https://github\\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+?)(?=[\\s\"'<>]|$)";
+        // The lookahead stops at whitespace, quotes, angle brackets, pipes and square
+        // brackets so that Confluence/Jira smart-link suffixes like
+        //   |https://...|smart-link]
+        // are not included in the matched URL.
+        String pattern = "https://github\\.com/([^/]+)/([^/]+)/blob/([^/]+)/(.+?)(?=[\\s\"'<>|\\[\\]]|$)";
 
         Pattern r = Pattern.compile(pattern);
         Matcher m = r.matcher(object);
@@ -1619,6 +1623,12 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
     public Object uriToObject(String uri) throws Exception {
         if (uri == null || uri.isEmpty()) {
             return null;
+        }
+
+        // Strip Confluence/Jira smart-link suffix: url|display-text|smart-link]
+        // e.g. https://github.com/.../file.md|https://github.com/.../file.md|smart-link]
+        if (uri.contains("|")) {
+            uri = uri.substring(0, uri.indexOf('|'));
         }
 
         // Check if the URI is a GitHub file URL

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubTest.java
@@ -9,9 +9,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for GitHub class that test functionality without external API calls.
@@ -78,5 +78,61 @@ public class GitHubTest {
     public void testGetDefaultWorkspace() {
         String workspace = gitHub.getDefaultWorkspace();
         assertEquals("testWorkspace", workspace);
+    }
+
+    // ── parseUris tests ──────────────────────────────────────────────────────
+
+    @Test
+    public void testParseUris_plainUrl() throws Exception {
+        String input = "See https://github.com/epam/dm.ai/blob/main/README.md for details.";
+        Set<String> uris = gitHub.parseUris(input);
+        assertEquals(1, uris.size());
+        assertEquals("https://github.com/epam/dm.ai/blob/main/README.md", uris.iterator().next());
+    }
+
+    @Test
+    public void testParseUris_smartLinkSuffix_doesNotPollutePath() throws Exception {
+        // Jira/Confluence smart-link format:
+        // [url|display-text|smart-link]
+        String input = "[[https://github.com/epam/dm.ai/blob/main/agents/js/smAgent.js" +
+                "|https://github.com/epam/dm.ai/blob/main/agents/js/smAgent.js|smart-link]]";
+        Set<String> uris = gitHub.parseUris(input);
+        assertEquals(1, uris.size());
+        String parsed = uris.iterator().next();
+        assertFalse("URL must not contain pipe character", parsed.contains("|"));
+        assertEquals("https://github.com/epam/dm.ai/blob/main/agents/js/smAgent.js", parsed);
+    }
+
+    @Test
+    public void testParseUris_multipleSmartLinks() throws Exception {
+        String input = "See [[https://github.com/epam/dm.ai/blob/main/README.md" +
+                "|https://github.com/epam/dm.ai/blob/main/README.md|smart-link]] " +
+                "and [[https://github.com/epam/dm.ai/blob/main/CONTRIBUTING.md" +
+                "|https://github.com/epam/dm.ai/blob/main/CONTRIBUTING.md|smart-link]]";
+        Set<String> uris = gitHub.parseUris(input);
+        assertEquals(2, uris.size());
+        for (String uri : uris) {
+            assertFalse("URL must not contain pipe character", uri.contains("|"));
+        }
+        assertTrue(uris.contains("https://github.com/epam/dm.ai/blob/main/README.md"));
+        assertTrue(uris.contains("https://github.com/epam/dm.ai/blob/main/CONTRIBUTING.md"));
+    }
+
+    @Test
+    public void testParseUris_emptyInput() throws Exception {
+        Set<String> uris = gitHub.parseUris("");
+        assertTrue(uris.isEmpty());
+    }
+
+    @Test
+    public void testParseUris_nullInput() throws Exception {
+        Set<String> uris = gitHub.parseUris(null);
+        assertTrue(uris.isEmpty());
+    }
+
+    @Test
+    public void testParseUris_noGithubUrls() throws Exception {
+        Set<String> uris = gitHub.parseUris("Just some text without any GitHub links.");
+        assertTrue(uris.isEmpty());
     }
 }


### PR DESCRIPTION
## Problem

When Jira/Confluence tickets contain GitHub links in **smart-link format**:
```
[[https://github.com/epam/dm.ai/blob/main/agents/js/smAgent.js|https://github.com/epam/dm.ai/blob/main/agents/js/smAgent.js|smart-link]]
```
dmtools was making a GitHub API call with the entire suffix included in the path:
```
GET /repos/epam/dm.ai/contents/agents/js/smAgent.js|epam/dm.ai/blob/main/...|smart-link]
→ 404 Not Found
```

## Root Cause

The `parseUris` regex lookahead `(?=[\s"'<>]|$)` did not include `|` as a terminator, so the pipe-delimited smart-link suffix was captured as part of the file path.

## Fix

Two layers of protection:

1. **`parseUris`** — added `|`, `[`, `]` to the regex lookahead so the match stops at the first pipe character.
2. **`uriToObject`** — defensive strip of any `|...` suffix before calling `getFileContent()`.

## Tests

Added 6 new unit tests in `GitHubTest`:
- Plain URL parsed correctly
- Single smart-link suffix stripped
- Multiple smart-links in one string all stripped  
- Empty / null / no-URL inputs