### PR TITLE
fix(ci): remove unreliable mergeStateStatus=BEHIND filter in auto-update-prs

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -23,16 +23,20 @@ jobs:
         run: |
           sleep 15
           prs=$(gh pr list --repo ${{ github.repository }} --state open --base main \
-            --json number,mergeable,mergeStateStatus \
-            --jq '.[] | select(.mergeable == "MERGEABLE" and .mergeStateStatus == "BEHIND") | .number')
+            --json number,mergeable,isDraft,mergeStateStatus \
+            --jq '.[]
+                   | select(.isDraft == false)
+                   | select(.mergeable == "MERGEABLE")
+                   | select(.mergeStateStatus != "DIRTY")
+                   | .number')
 
           if [ -z "$prs" ]; then
-            echo "No open PRs to update."
+            echo "No candidate PRs found."
             exit 0
           fi
 
           for pr in $prs; do
-            echo "Updating PR #$pr..."
-            gh pr update-branch $pr --repo ${{ github.repository }} \
+            echo "Attempting to update PR #$pr..."
+            gh pr update-branch "$pr" --repo ${{ github.repository }} \
               || echo "PR #$pr skipped (already up to date or conflict)"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -93,13 +93,18 @@ cache*/
 data/dmtools-db.lock.db
 data/dmtools-db.mv.db
 data/*.db
-data/*.db
 data/*.lock.db
 data/*.mv.db
 
 # Security files
 cookies.txt
 jwt_token.txt
+
+# ---------------------------------
+# IDE & Editor Configurations
+# ---------------------------------
+.idea/
+.vscode/
 
 # Environment files (contain sensitive API keys and tokens)
 .env


### PR DESCRIPTION
## Summary

- `mergeStateStatus == "BEHIND"` is only returned by GitHub when branch protection enforces *"Require branches to be up to date before merging"*. `epam/dm.ai` has no branch protection on `main`, so behind-main PRs are reported as `CLEAN` and silently skipped by the workflow.
- Replaces the filter with a broader select (non-draft, `MERGEABLE`, not `DIRTY`) and relies on `gh pr update-branch` being a no-op for already-up-to-date branches (the existing `|| echo "... skipped"` handles that).
- Verified live: PR #17 is behind main by 3 commits but reports `mergeStateStatus: CLEAN` — it would never be caught by the old filter.

## Test plan

- [ ] Merge this PR and trigger `auto-update-prs` (push any trivial commit to `main`)
- [ ] Confirm the workflow log shows `Attempting to update PR #N...` for open, mergeable, non-draft PRs
- [ ] For PRs already up to date, confirm `PR #N skipped (already up to date or conflict)` — no hard failure