### PR TITLE
fix: use JIRA_EXTRA_FIELDS_PROJECT as primary fallback for field resolution

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -2006,13 +2006,16 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
 
         // If we still couldn't extract a project key, prefer JIRA_EXTRA_FIELDS_PROJECT
         // (set via setProjectContext) as it is the explicitly configured project context.
-        if (projectKey.isEmpty() && getProjectContext() != null && !getProjectContext().isEmpty()) {
-            projectKey = getProjectContext();
+        String projectContext = getProjectContext();
+        if (projectKey.isEmpty() && projectContext != null && !projectContext.isBlank()) {
+            projectKey = projectContext.trim().toUpperCase(Locale.ROOT);
             logger.debug("Could not extract project key from JQL, using projectContext fallback: {}", projectKey);
         }
 
-        // Last resort: pick the first known project key
-        // (getFields calls /field which is a global endpoint, any project key works)
+        // Last resort: pick the first known project key.
+        // getFields(projectKey) usually resolves fields via the global /field endpoint,
+        // but it can fall back to issue/createmeta?projectKeys=..., where the chosen
+        // project key must be valid and accessible.
         if (projectKey.isEmpty()) {
             List<String> knownKeys = getKnownProjectKeys();
             if (!knownKeys.isEmpty()) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -2004,13 +2004,20 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
         // Try to extract project key from JQL query
         String projectKey = extractProjectKeyFromJQL(searchQueryJQL);
 
-        // If we still couldn't extract a project key, use the first known project key
+        // If we still couldn't extract a project key, prefer JIRA_EXTRA_FIELDS_PROJECT
+        // (set via setProjectContext) as it is the explicitly configured project context.
+        if (projectKey.isEmpty() && getProjectContext() != null && !getProjectContext().isEmpty()) {
+            projectKey = getProjectContext();
+            logger.debug("Could not extract project key from JQL, using projectContext fallback: {}", projectKey);
+        }
+
+        // Last resort: pick the first known project key
         // (getFields calls /field which is a global endpoint, any project key works)
         if (projectKey.isEmpty()) {
             List<String> knownKeys = getKnownProjectKeys();
             if (!knownKeys.isEmpty()) {
                 projectKey = knownKeys.get(0);
-                logger.debug("Could not extract project key from JQL, using fallback: {}", projectKey);
+                logger.debug("Could not extract project key from JQL, using first known project key as fallback: {}", projectKey);
             }
         }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientFieldResolutionTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientFieldResolutionTest.java
@@ -704,8 +704,10 @@ public class JiraClientFieldResolutionTest {
     void testResolveFieldNamesForSearch_usesProjectContextBeforeKnownProjectKeys() throws Exception {
         // When JQL contains no extractable project key, projectContext (= JIRA_EXTRA_FIELDS_PROJECT)
         // must be used as the first fallback — not the first entry from getKnownProjectKeys().
+        // "Story Points" exists only in the MYPROJECT mock response, so if it resolves to
+        // customfield_10001 we know MYPROJECT was used and not "OTHER".
         jiraClient.setMockProjectKeys("OTHER");
-        jiraClient.setProjectContext("MYPROJECT");
+        jiraClient.setProjectContext("myproject"); // lowercase to verify trim+toUpperCase
         jiraClient.setMockFieldsResponse("MYPROJECT", """
                 [
                   {"id":"summary","name":"Summary","custom":false},
@@ -713,11 +715,9 @@ public class JiraClientFieldResolutionTest {
                 ]
                 """);
 
-        // JQL has no project key — fallback must pick projectContext "MYPROJECT", not "OTHER"
-        List<String> result = invokeResolveFieldNamesForSearch("filter = 12345", new String[]{"summary"});
+        List<String> result = invokeResolveFieldNamesForSearch("filter = 12345", new String[]{"summary", "Story Points"});
 
         assertNotNull(result);
-        // Verify it resolved using MYPROJECT fields (no exception = correct project was used)
-        assertFalse(result.contains(null));
+        assertEquals(List.of("summary", "customfield_10001"), result);
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientFieldResolutionTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientFieldResolutionTest.java
@@ -699,4 +699,25 @@ public class JiraClientFieldResolutionTest {
         assertNotNull(result);
         assertFalse(result.contains(null));
     }
+
+    @Test
+    void testResolveFieldNamesForSearch_usesProjectContextBeforeKnownProjectKeys() throws Exception {
+        // When JQL contains no extractable project key, projectContext (= JIRA_EXTRA_FIELDS_PROJECT)
+        // must be used as the first fallback — not the first entry from getKnownProjectKeys().
+        jiraClient.setMockProjectKeys("OTHER");
+        jiraClient.setProjectContext("MYPROJECT");
+        jiraClient.setMockFieldsResponse("MYPROJECT", """
+                [
+                  {"id":"summary","name":"Summary","custom":false},
+                  {"id":"customfield_10001","name":"Story Points","custom":true}
+                ]
+                """);
+
+        // JQL has no project key — fallback must pick projectContext "MYPROJECT", not "OTHER"
+        List<String> result = invokeResolveFieldNamesForSearch("filter = 12345", new String[]{"summary"});
+
+        assertNotNull(result);
+        // Verify it resolved using MYPROJECT fields (no exception = correct project was used)
+        assertFalse(result.contains(null));
+    }
 }


### PR DESCRIPTION
## Problem

When JQL doesn't contain an extractable project key (e.g. `filter = 26390`), `resolveFieldNamesForSearch` was falling back to the **first key from `getKnownProjectKeys()`** — which could be any random project the API user has access to (e.g. `TBDDOS` instead of `DIGIX`).

## Fix

Use `projectContext` (populated from `JIRA_EXTRA_FIELDS_PROJECT` env variable via `setProjectContext()`) as the **first fallback** before `getKnownProjectKeys()`.

Priority order:
1. Project key extracted from JQL
2. `projectContext` = `JIRA_EXTRA_FIELDS_PROJECT` ← new
3. First key from `getKnownProjectKeys()` (last resort)

Applies to both `BasicJiraClient` and `XrayClient` since both call `setProjectContext()` in their constructors and both inherit `resolveFieldNamesForSearch` from `JiraClient`.

## Test
`testResolveFieldNamesForSearch_usesProjectContextBeforeKnownProjectKeys` — verifies that when JQL has no extractable project key and `projectContext` is set, it is used instead of the first known project key.