### PR TITLE
feat(ado): add pipeline MCP tools (list, trigger, runs, logs)

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -190,8 +190,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ needs.version.outputs.tag }}" \
-            --title "DMTools Beta ${{ needs.version.outputs.tag }}" \
+          TAG="${{ needs.version.outputs.tag }}"
+          # If the release already exists (e.g. workflow re-run), delete it first so we can recreate with fresh assets
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists — deleting so assets can be re-uploaded"
+            gh release delete "$TAG" --yes --cleanup-tag || true
+          fi
+          gh release create "$TAG" \
+            --title "DMTools Beta $TAG" \
             --notes-file release_notes.md \
             --prerelease \
             cli/dmtools-v${{ needs.version.outputs.version }}-all.jar \

--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -187,26 +187,23 @@ jobs:
           echo "Release notes generated"
 
       - name: Create Beta Release
-        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.version.outputs.tag }}
-          name: "DMTools Beta ${{ needs.version.outputs.tag }}"
-          body_path: release_notes.md
-          draft: false
-          prerelease: true   # ← keeps main stable release as "latest"
-          files: |
-            cli/dmtools-v${{ needs.version.outputs.version }}-all.jar
-            cli/install.sh
-            cli/install
-            cli/install.bat
-            cli/install.ps1
-            cli/dmtools.sh
-            skill/dmtools-skill-v${{ needs.version.outputs.version }}.zip
-            skill/dmtools-skill-v${{ needs.version.outputs.version }}.tar.gz
-            skill/skill-install.sh
-            skill/skill-install.ps1
+        run: |
+          gh release create "${{ needs.version.outputs.tag }}" \
+            --title "DMTools Beta ${{ needs.version.outputs.tag }}" \
+            --notes-file release_notes.md \
+            --prerelease \
+            cli/dmtools-v${{ needs.version.outputs.version }}-all.jar \
+            cli/install.sh \
+            cli/install \
+            cli/install.bat \
+            cli/install.ps1 \
+            cli/dmtools.sh \
+            skill/dmtools-skill-v${{ needs.version.outputs.version }}.zip \
+            skill/dmtools-skill-v${{ needs.version.outputs.version }}.tar.gz \
+            skill/skill-install.sh \
+            skill/skill-install.ps1 \
             skill/skill-checksums.sha256
 
       - name: Summary

--- a/dmtools-ai-docs/references/mcp-tools/ado-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/ado-tools.md
@@ -1,6 +1,6 @@
 # ADO MCP Tools
 
-**Total Tools**: 31
+**Total Tools**: 36
 
 ## Quick Reference
 
@@ -27,6 +27,12 @@ const pr = ado_get_pr("ai-native-sdlc-blueprint", "1");
 const threads = ado_get_pr_comments("ai-native-sdlc-blueprint", "1");
 ado_add_pr_comment("ai-native-sdlc-blueprint", "1", "Looks good!");
 ado_resolve_pr_thread("ai-native-sdlc-blueprint", "1", "42", "fixed");
+// Pipeline operations
+const pipelines = ado_list_pipelines();
+const run = ado_trigger_pipeline(9, "main", null);
+const runs = ado_list_pipeline_runs(9, 10);
+const runDetail = ado_get_pipeline_run(9, run.id);
+const logs = ado_get_pipeline_logs(run.id, null, 200);
 ```
 
 ## Available Tools
@@ -72,6 +78,16 @@ ado_resolve_pr_thread("ai-native-sdlc-blueprint", "1", "42", "fixed");
 | `ado_set_pr_vote` | Set current user's vote on a PR | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`reviewerId` (string, **required**)<br>`vote` (string, **required**) |
 | `ado_update_pr` | Update PR properties (title, description, status) | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`title` (string, optional)<br>`description` (string, optional)<br>`status` (string, optional) |
 | `ado_get_pr_work_items` | Get work items linked to a PR | `repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+
+### Pipeline Management Tools
+
+| Tool Name | Description | Parameters |
+|-----------|-------------|------------|
+| `ado_list_pipelines` | List all pipelines defined in the ADO project | None |
+| `ado_trigger_pipeline` | Trigger a pipeline run (equiv. `github_trigger_workflow`) | `pipelineId` (int, **required**)<br>`branch` (string, optional — accepts `main` or `refs/heads/main`)<br>`variables` (string JSON, optional — e.g. `{"myVar":"value"}`) |
+| `ado_list_pipeline_runs` | List recent runs of a pipeline (equiv. `github_list_workflow_runs`) | `pipelineId` (int, **required**)<br>`top` (int, optional, default: 10) |
+| `ado_get_pipeline_run` | Get details of a specific pipeline run (state, result, timestamps) | `pipelineId` (int, **required**)<br>`runId` (int, **required**) |
+| `ado_get_pipeline_logs` | Get combined task logs for a pipeline run (equiv. `github_get_job_logs`) | `buildId` (int, **required**)<br>`taskName` (string, optional — case-insensitive filter)<br>`tailLines` (int, optional, default: 200, 0 = all) |
 
 ## Detailed Parameter Information
 
@@ -544,3 +560,89 @@ Update the tags of a work item (semicolon-separated string)
 
 ---
 
+
+## Pipeline Management Tools
+
+### `ado_list_pipelines`
+
+List all pipelines defined in the ADO project.
+
+**Parameters:** None
+
+---
+
+### `ado_trigger_pipeline`
+
+Trigger a pipeline run. Equivalent to `github_trigger_workflow`.
+
+**Parameters:**
+
+- **`pipelineId`** (int) 🔴 Required
+  - The pipeline ID to trigger
+  - Example: `9`
+
+- **`branch`** (string) ⚪ Optional
+  - Branch to run the pipeline on. Accepts both short name (`main`) and fully-qualified ref (`refs/heads/main`) — the prefix is normalized automatically.
+  - Example: `main`
+
+- **`variables`** (string JSON) ⚪ Optional
+  - Pipeline variables as a JSON object. Each key becomes a non-secret variable.
+  - Example: `{"workItemId":"42","env":"staging"}`
+
+---
+
+### `ado_list_pipeline_runs`
+
+List recent runs of a pipeline. Equivalent to `github_list_workflow_runs`.
+
+**Parameters:**
+
+- **`pipelineId`** (int) 🔴 Required
+  - The pipeline ID
+  - Example: `9`
+
+- **`top`** (int) ⚪ Optional
+  - Number of runs to return. Default: `10`
+  - Example: `20`
+
+---
+
+### `ado_get_pipeline_run`
+
+Get details of a specific pipeline run including state (`inProgress`, `completed`) and result (`succeeded`, `failed`, `canceled`).
+
+**Parameters:**
+
+- **`pipelineId`** (int) 🔴 Required
+  - The pipeline ID
+  - Example: `9`
+
+- **`runId`** (int) 🔴 Required
+  - The run ID (returned by `ado_trigger_pipeline` or `ado_list_pipeline_runs`)
+  - Example: `42`
+
+---
+
+### `ado_get_pipeline_logs`
+
+Get combined logs for all tasks in a pipeline run. Uses the build timeline API to discover task log IDs, then fetches each log. Equivalent to `github_get_job_logs`.
+
+**Parameters:**
+
+- **`buildId`** (int) 🔴 Required
+  - The build/run ID (same as the `id` from `ado_trigger_pipeline` or `ado_list_pipeline_runs`)
+  - Example: `42`
+
+- **`taskName`** (string) ⚪ Optional
+  - Case-insensitive substring filter — only tasks whose name contains this string are included.
+  - Example: `PowerShell`
+
+- **`tailLines`** (int) ⚪ Optional
+  - Lines to return from the end of each task log. Default: `200`. Use `0` for full logs.
+  - Example: `100`
+
+**Notes:**
+- `Stage` and `Checkpoint` records are automatically skipped (they have no useful log content).
+- Output is formatted as sections: `=== Task: <name> ===`
+
+---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
@@ -1788,8 +1788,10 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             category = "pipeline_management"
     )
     public JSONObject listPipelines() throws IOException {
-        String path = String.format("/%s/_apis/pipelines?api-version=%s", project, API_VERSION);
-        String response = execute(new GenericRequest(this, path(path)));
+        String path = String.format("/%s/_apis/pipelines", project);
+        GenericRequest request = new GenericRequest(this, path(path))
+                .param("api-version", API_VERSION);
+        String response = execute(request);
         return new JSONObject(response);
     }
 
@@ -1808,15 +1810,20 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             @MCPParam(name = "branch", description = "The branch to run the pipeline on (e.g. 'main')", required = false) String branch,
             @MCPParam(name = "variables", description = "JSON object of pipeline variables, e.g. {\"myVar\":\"value\"}", required = false) String variablesJson
     ) throws IOException {
-        String path = String.format("/%s/_apis/pipelines/%d/runs?api-version=%s", project, pipelineId, API_VERSION);
+        String path = String.format("/%s/_apis/pipelines/%d/runs", project, pipelineId);
 
         JSONObject body = new JSONObject();
 
         if (branch != null && !branch.isBlank()) {
+            // Accept both "main" and "refs/heads/main" formats
+            String normalizedBranch = branch.trim();
+            if (!normalizedBranch.startsWith("refs/heads/")) {
+                normalizedBranch = "refs/heads/" + normalizedBranch;
+            }
             body.put("resources", new JSONObject()
                     .put("repositories", new JSONObject()
                             .put("self", new JSONObject()
-                                    .put("refName", "refs/heads/" + branch))));
+                                    .put("refName", normalizedBranch))));
         }
 
         if (variablesJson != null && !variablesJson.isBlank()) {
@@ -1828,7 +1835,8 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             body.put("variables", variables);
         }
 
-        GenericRequest triggerRequest = new GenericRequest(this, path(path));
+        GenericRequest triggerRequest = new GenericRequest(this, path(path))
+                .param("api-version", API_VERSION);
         triggerRequest.setBody(body.toString());
         String response = triggerRequest.post();
         return new JSONObject(response);
@@ -1849,9 +1857,11 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             @MCPParam(name = "top", description = "Number of runs to return (default 10)", required = false) Integer top
     ) throws IOException {
         int limit = (top != null && top > 0) ? top : 10;
-        String path = String.format("/%s/_apis/pipelines/%d/runs?api-version=%s&$top=%d",
-                project, pipelineId, API_VERSION, limit);
-        String response = execute(new GenericRequest(this, path(path)));
+        String path = String.format("/%s/_apis/pipelines/%d/runs", project, pipelineId);
+        GenericRequest request = new GenericRequest(this, path(path))
+                .param("api-version", API_VERSION)
+                .param("$top", limit);
+        String response = execute(request);
         return new JSONObject(response);
     }
 
@@ -1868,9 +1878,10 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             @MCPParam(name = "pipelineId", description = "The pipeline ID", required = true) int pipelineId,
             @MCPParam(name = "runId", description = "The run ID", required = true) int runId
     ) throws IOException {
-        String path = String.format("/%s/_apis/pipelines/%d/runs/%d?api-version=%s",
-                project, pipelineId, runId, API_VERSION);
-        String response = execute(new GenericRequest(this, path(path)));
+        String path = String.format("/%s/_apis/pipelines/%d/runs/%d", project, pipelineId, runId);
+        GenericRequest request = new GenericRequest(this, path(path))
+                .param("api-version", API_VERSION);
+        String response = execute(request);
         return new JSONObject(response);
     }
 
@@ -1890,9 +1901,9 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             @MCPParam(name = "taskName", description = "Optional: filter logs to a specific task name (case-insensitive substring match)", required = false) String taskName,
             @MCPParam(name = "tailLines", description = "Lines to return from the end of each task log (default 200, 0 = all)", required = false) Integer tailLines
     ) throws IOException {
-        String timelinePath = String.format("/%s/_apis/build/builds/%d/timeline?api-version=%s",
-                project, buildId, API_VERSION);
-        String timelineResponse = execute(new GenericRequest(this, path(timelinePath)));
+        String timelinePath = String.format("/%s/_apis/build/builds/%d/timeline", project, buildId);
+        String timelineResponse = execute(new GenericRequest(this, path(timelinePath))
+                .param("api-version", API_VERSION));
         JSONObject timeline = new JSONObject(timelineResponse);
         JSONArray records = timeline.optJSONArray("records");
 
@@ -1921,10 +1932,10 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
             int logId = log.optInt("id", -1);
             if (logId < 0) continue;
 
-            String logPath = String.format("/%s/_apis/build/builds/%d/logs/%d?api-version=%s",
-                    project, buildId, logId, API_VERSION);
+            String logPath = String.format("/%s/_apis/build/builds/%d/logs/%d", project, buildId, logId);
             try {
-                GenericRequest logRequest = new GenericRequest(this, path(logPath));
+                GenericRequest logRequest = new GenericRequest(this, path(logPath))
+                        .param("api-version", API_VERSION);
                 String logContent = execute(logRequest);
 
                 if (logContent == null || logContent.isBlank()) continue;

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsClient.java
@@ -1776,6 +1776,175 @@ public abstract class AzureDevOpsClient extends AbstractRestClient implements Tr
         return new File(getCacheFolderName() + "/" + value + imageExtension);
     }
 
+    // ========== Pipeline Operations ==========
+
+    /**
+     * List all pipelines in the project.
+     */
+    @MCPTool(
+            name = "ado_list_pipelines",
+            description = "List all pipelines defined in the ADO project.",
+            integration = "ado",
+            category = "pipeline_management"
+    )
+    public JSONObject listPipelines() throws IOException {
+        String path = String.format("/%s/_apis/pipelines?api-version=%s", project, API_VERSION);
+        String response = execute(new GenericRequest(this, path(path)));
+        return new JSONObject(response);
+    }
+
+    /**
+     * Trigger a pipeline run.
+     * Equivalent to github_trigger_workflow.
+     */
+    @MCPTool(
+            name = "ado_trigger_pipeline",
+            description = "Trigger a pipeline run in ADO. Equivalent to github_trigger_workflow.",
+            integration = "ado",
+            category = "pipeline_management"
+    )
+    public JSONObject triggerPipeline(
+            @MCPParam(name = "pipelineId", description = "The pipeline ID to trigger", required = true) int pipelineId,
+            @MCPParam(name = "branch", description = "The branch to run the pipeline on (e.g. 'main')", required = false) String branch,
+            @MCPParam(name = "variables", description = "JSON object of pipeline variables, e.g. {\"myVar\":\"value\"}", required = false) String variablesJson
+    ) throws IOException {
+        String path = String.format("/%s/_apis/pipelines/%d/runs?api-version=%s", project, pipelineId, API_VERSION);
+
+        JSONObject body = new JSONObject();
+
+        if (branch != null && !branch.isBlank()) {
+            body.put("resources", new JSONObject()
+                    .put("repositories", new JSONObject()
+                            .put("self", new JSONObject()
+                                    .put("refName", "refs/heads/" + branch))));
+        }
+
+        if (variablesJson != null && !variablesJson.isBlank()) {
+            JSONObject rawVars = new JSONObject(variablesJson);
+            JSONObject variables = new JSONObject();
+            for (String key : rawVars.keySet()) {
+                variables.put(key, new JSONObject().put("value", rawVars.get(key).toString()).put("isSecret", false));
+            }
+            body.put("variables", variables);
+        }
+
+        GenericRequest triggerRequest = new GenericRequest(this, path(path));
+        triggerRequest.setBody(body.toString());
+        String response = triggerRequest.post();
+        return new JSONObject(response);
+    }
+
+    /**
+     * List runs of a specific pipeline.
+     * Equivalent to github_list_workflow_runs.
+     */
+    @MCPTool(
+            name = "ado_list_pipeline_runs",
+            description = "List recent runs of a pipeline. Equivalent to github_list_workflow_runs.",
+            integration = "ado",
+            category = "pipeline_management"
+    )
+    public JSONObject listPipelineRuns(
+            @MCPParam(name = "pipelineId", description = "The pipeline ID", required = true) int pipelineId,
+            @MCPParam(name = "top", description = "Number of runs to return (default 10)", required = false) Integer top
+    ) throws IOException {
+        int limit = (top != null && top > 0) ? top : 10;
+        String path = String.format("/%s/_apis/pipelines/%d/runs?api-version=%s&$top=%d",
+                project, pipelineId, API_VERSION, limit);
+        String response = execute(new GenericRequest(this, path(path)));
+        return new JSONObject(response);
+    }
+
+    /**
+     * Get details of a specific pipeline run.
+     */
+    @MCPTool(
+            name = "ado_get_pipeline_run",
+            description = "Get details of a specific pipeline run including state and result.",
+            integration = "ado",
+            category = "pipeline_management"
+    )
+    public JSONObject getPipelineRun(
+            @MCPParam(name = "pipelineId", description = "The pipeline ID", required = true) int pipelineId,
+            @MCPParam(name = "runId", description = "The run ID", required = true) int runId
+    ) throws IOException {
+        String path = String.format("/%s/_apis/pipelines/%d/runs/%d?api-version=%s",
+                project, pipelineId, runId, API_VERSION);
+        String response = execute(new GenericRequest(this, path(path)));
+        return new JSONObject(response);
+    }
+
+    /**
+     * Get combined logs for all tasks in a pipeline build run.
+     * Uses the build timeline to discover task log IDs, then fetches each log.
+     * Equivalent to github_get_job_logs.
+     */
+    @MCPTool(
+            name = "ado_get_pipeline_logs",
+            description = "Get combined logs for all tasks in a pipeline run (build ID). Equivalent to github_get_job_logs.",
+            integration = "ado",
+            category = "pipeline_management"
+    )
+    public String getPipelineLogs(
+            @MCPParam(name = "buildId", description = "The build/run ID returned by ado_trigger_pipeline or ado_list_pipeline_runs", required = true) int buildId,
+            @MCPParam(name = "taskName", description = "Optional: filter logs to a specific task name (case-insensitive substring match)", required = false) String taskName,
+            @MCPParam(name = "tailLines", description = "Lines to return from the end of each task log (default 200, 0 = all)", required = false) Integer tailLines
+    ) throws IOException {
+        String timelinePath = String.format("/%s/_apis/build/builds/%d/timeline?api-version=%s",
+                project, buildId, API_VERSION);
+        String timelineResponse = execute(new GenericRequest(this, path(timelinePath)));
+        JSONObject timeline = new JSONObject(timelineResponse);
+        JSONArray records = timeline.optJSONArray("records");
+
+        if (records == null || records.isEmpty()) {
+            return "(no timeline records found for build " + buildId + ")";
+        }
+
+        int tail = (tailLines != null && tailLines >= 0) ? tailLines : 200;
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < records.length(); i++) {
+            JSONObject record = records.getJSONObject(i);
+            String type = record.optString("type", "");
+            String name = record.optString("name", "");
+
+            // Stage/Checkpoint records don't carry meaningful log content
+            if ("Stage".equals(type) || "Checkpoint".equals(type)) continue;
+
+            if (taskName != null && !taskName.isBlank()
+                    && !name.toLowerCase(Locale.ROOT).contains(taskName.toLowerCase(Locale.ROOT))) {
+                continue;
+            }
+
+            JSONObject log = record.optJSONObject("log");
+            if (log == null) continue;
+            int logId = log.optInt("id", -1);
+            if (logId < 0) continue;
+
+            String logPath = String.format("/%s/_apis/build/builds/%d/logs/%d?api-version=%s",
+                    project, buildId, logId, API_VERSION);
+            try {
+                GenericRequest logRequest = new GenericRequest(this, path(logPath));
+                String logContent = execute(logRequest);
+
+                if (logContent == null || logContent.isBlank()) continue;
+
+                String[] lines = logContent.split("\n");
+                String[] slice = (tail > 0 && lines.length > tail)
+                        ? Arrays.copyOfRange(lines, lines.length - tail, lines.length)
+                        : lines;
+
+                sb.append("=== ").append(type).append(": ").append(name).append(" ===\n");
+                for (String line : slice) sb.append(line).append("\n");
+                sb.append("\n");
+            } catch (Exception e) {
+                logger.warn("Failed to fetch log {} for build {}: {}", logId, buildId, e.getMessage());
+            }
+        }
+
+        return sb.length() > 0 ? sb.toString() : "(no logs found for build " + buildId + ")";
+    }
+
     // ========== Helper Methods ==========
 
     /**

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsPipelineToolsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsPipelineToolsTest.java
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.microsoft.ado;
+
+import com.github.istin.dmtools.common.networking.GenericRequest;
+import org.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for AzureDevOpsClient pipeline operations:
+ * listPipelines, triggerPipeline, listPipelineRuns, getPipelineRun, getPipelineLogs
+ */
+public class AzureDevOpsPipelineToolsTest {
+
+    private TestableAzureDevOpsClient client;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        client = new TestableAzureDevOpsClient("TestOrg", "TestProject", "fake-pat");
+    }
+
+    // ---- listPipelines ----
+
+    @Test
+    void testListPipelines_returnsJsonFromApi() throws IOException {
+        String fakeResponse = "{\"count\":2,\"value\":[{\"id\":1,\"name\":\"pipeline-a\"},{\"id\":2,\"name\":\"pipeline-b\"}]}";
+        client.setMockResponse("/TestProject/_apis/pipelines", fakeResponse);
+
+        JSONObject result = client.listPipelines();
+
+        assertEquals(2, result.getInt("count"));
+        assertEquals("pipeline-a", result.getJSONArray("value").getJSONObject(0).getString("name"));
+    }
+
+    // ---- triggerPipeline ----
+
+    @Test
+    void testTriggerPipeline_noOptionalParams_postsMinimalBody() throws IOException {
+        String fakeResponse = "{\"id\":42,\"state\":\"inProgress\"}";
+        client.setMockPostResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        JSONObject result = client.triggerPipeline(9, null, null);
+
+        assertEquals(42, result.getInt("id"));
+        assertEquals("inProgress", result.getString("state"));
+        // Verify an empty body was posted (no branch, no variables)
+        String postedBody = client.getLastPostedBody("/TestProject/_apis/pipelines/9/runs");
+        JSONObject posted = new JSONObject(postedBody);
+        assertFalse(posted.has("resources"), "No resources key expected when branch is null");
+        assertFalse(posted.has("variables"), "No variables key expected when variablesJson is null");
+    }
+
+    @Test
+    void testTriggerPipeline_withBranch_includesBranchInBody() throws IOException {
+        String fakeResponse = "{\"id\":43,\"state\":\"inProgress\"}";
+        client.setMockPostResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        client.triggerPipeline(9, "feature/my-branch", null);
+
+        String postedBody = client.getLastPostedBody("/TestProject/_apis/pipelines/9/runs");
+        JSONObject posted = new JSONObject(postedBody);
+        assertTrue(posted.has("resources"), "Should include resources when branch is set");
+        String refName = posted.getJSONObject("resources")
+                .getJSONObject("repositories")
+                .getJSONObject("self")
+                .getString("refName");
+        assertEquals("refs/heads/feature/my-branch", refName);
+    }
+
+    @Test
+    void testTriggerPipeline_withVariables_includesVariablesInBody() throws IOException {
+        String fakeResponse = "{\"id\":44,\"state\":\"inProgress\"}";
+        client.setMockPostResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        client.triggerPipeline(9, null, "{\"myVar\":\"hello\"}");
+
+        String postedBody = client.getLastPostedBody("/TestProject/_apis/pipelines/9/runs");
+        JSONObject posted = new JSONObject(postedBody);
+        assertTrue(posted.has("variables"), "Should include variables");
+        JSONObject vars = posted.getJSONObject("variables");
+        assertTrue(vars.has("myVar"));
+        assertEquals("hello", vars.getJSONObject("myVar").getString("value"));
+        assertFalse(vars.getJSONObject("myVar").getBoolean("isSecret"));
+    }
+
+    // ---- listPipelineRuns ----
+
+    @Test
+    void testListPipelineRuns_defaultsToTop10() throws IOException {
+        String fakeResponse = "{\"count\":1,\"value\":[{\"id\":8,\"state\":\"completed\"}]}";
+        client.setMockResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        JSONObject result = client.listPipelineRuns(9, null);
+
+        assertEquals(1, result.getInt("count"));
+        // Verify $top=10 was appended in the URL called
+        assertTrue(client.getLastCalledUrl().contains("$top=10"),
+                "Expected $top=10 in URL, got: " + client.getLastCalledUrl());
+    }
+
+    @Test
+    void testListPipelineRuns_customTop() throws IOException {
+        String fakeResponse = "{\"count\":0,\"value\":[]}";
+        client.setMockResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        client.listPipelineRuns(9, 25);
+
+        assertTrue(client.getLastCalledUrl().contains("$top=25"),
+                "Expected $top=25 in URL, got: " + client.getLastCalledUrl());
+    }
+
+    // ---- getPipelineRun ----
+
+    @Test
+    void testGetPipelineRun_returnsRunDetails() throws IOException {
+        String fakeResponse = "{\"id\":8,\"state\":\"completed\",\"result\":\"succeeded\"}";
+        client.setMockResponse("/TestProject/_apis/pipelines/9/runs/8", fakeResponse);
+
+        JSONObject result = client.getPipelineRun(9, 8);
+
+        assertEquals(8, result.getInt("id"));
+        assertEquals("succeeded", result.getString("result"));
+    }
+
+    // ---- getPipelineLogs ----
+
+    @Test
+    void testGetPipelineLogs_noRecords_returnsNoLogsMessage() throws IOException {
+        String timelineResponse = "{\"records\":[]}";
+        client.setMockResponse("/TestProject/_apis/build/builds/8/timeline", timelineResponse);
+
+        String result = client.getPipelineLogs(8, null, null);
+
+        assertTrue(result.contains("no timeline records found"), "Got: " + result);
+    }
+
+    @Test
+    void testGetPipelineLogs_skipsStageAndCheckpointRecords() throws IOException {
+        String timelineResponse = "{\"records\":["
+                + "{\"type\":\"Stage\",\"name\":\"__default\",\"state\":\"completed\",\"log\":{\"id\":1}},"
+                + "{\"type\":\"Checkpoint\",\"name\":\"cp\",\"state\":\"completed\",\"log\":{\"id\":2}}"
+                + "]}";
+        client.setMockResponse("/TestProject/_apis/build/builds/8/timeline", timelineResponse);
+
+        String result = client.getPipelineLogs(8, null, null);
+
+        assertEquals("(no logs found for build 8)", result);
+    }
+
+    @Test
+    void testGetPipelineLogs_includesJobAndTaskLogs() throws IOException {
+        String timelineResponse = "{\"records\":["
+                + "{\"type\":\"Job\",\"name\":\"My Job\",\"state\":\"completed\",\"log\":{\"id\":10}},"
+                + "{\"type\":\"Task\",\"name\":\"Run Tests\",\"state\":\"completed\",\"log\":{\"id\":11}}"
+                + "]}";
+        client.setMockResponse("/TestProject/_apis/build/builds/8/timeline", timelineResponse);
+        client.setMockResponse("/TestProject/_apis/build/builds/8/logs/10", "line1\nline2\nline3\n");
+        client.setMockResponse("/TestProject/_apis/build/builds/8/logs/11", "test output\n");
+
+        String result = client.getPipelineLogs(8, null, null);
+
+        assertTrue(result.contains("=== Job: My Job ==="), "Got: " + result);
+        assertTrue(result.contains("=== Task: Run Tests ==="), "Got: " + result);
+        assertTrue(result.contains("line1"), "Got: " + result);
+        assertTrue(result.contains("test output"), "Got: " + result);
+    }
+
+    @Test
+    void testGetPipelineLogs_taskNameFilter_onlyMatchingTask() throws IOException {
+        String timelineResponse = "{\"records\":["
+                + "{\"type\":\"Task\",\"name\":\"Initialize job\",\"state\":\"completed\",\"log\":{\"id\":4}},"
+                + "{\"type\":\"Task\",\"name\":\"PowerShell\",\"state\":\"completed\",\"log\":{\"id\":7}}"
+                + "]}";
+        client.setMockResponse("/TestProject/_apis/build/builds/8/timeline", timelineResponse);
+        client.setMockResponse("/TestProject/_apis/build/builds/8/logs/7", "ps output\n");
+
+        String result = client.getPipelineLogs(8, "powershell", null);
+
+        assertTrue(result.contains("=== Task: PowerShell ==="), "Got: " + result);
+        assertFalse(result.contains("Initialize job"), "Should not include Initialize job, got: " + result);
+    }
+
+    @Test
+    void testGetPipelineLogs_tailLines_truncatesLongLogs() throws IOException {
+        String timelineResponse = "{\"records\":["
+                + "{\"type\":\"Task\",\"name\":\"Build\",\"state\":\"completed\",\"log\":{\"id\":5}}"
+                + "]}";
+        client.setMockResponse("/TestProject/_apis/build/builds/8/timeline", timelineResponse);
+
+        // Build a 10-line log
+        StringBuilder logContent = new StringBuilder();
+        for (int i = 1; i <= 10; i++) {
+            logContent.append("line").append(i).append("\n");
+        }
+        client.setMockResponse("/TestProject/_apis/build/builds/8/logs/5", logContent.toString());
+
+        // Request only last 3 lines
+        String result = client.getPipelineLogs(8, null, 3);
+
+        assertTrue(result.contains("line8"), "Got: " + result);
+        assertTrue(result.contains("line9"), "Got: " + result);
+        assertTrue(result.contains("line10"), "Got: " + result);
+        assertFalse(result.contains("line1\n"), "Should not include line1 with tail=3, got: " + result);
+    }
+
+    // ---- Testable subclass ----
+
+    private static class TestableAzureDevOpsClient extends AzureDevOpsClient {
+
+        /** URL-keyed GET responses (partial path match) */
+        private final Map<String, String> getResponses = new HashMap<>();
+        /** URL-keyed POST responses (partial path match) */
+        private final Map<String, String> postResponses = new HashMap<>();
+        /** Last posted body per path */
+        private final Map<String, String> postedBodies = new HashMap<>();
+        private String lastCalledUrl = "";
+
+        TestableAzureDevOpsClient(String org, String project, String pat) throws IOException {
+            super(org, project, pat);
+        }
+
+        void setMockResponse(String pathFragment, String response) {
+            getResponses.put(pathFragment, response);
+        }
+
+        void setMockPostResponse(String pathFragment, String response) {
+            postResponses.put(pathFragment, response);
+        }
+
+        String getLastPostedBody(String pathFragment) {
+            return postedBodies.get(pathFragment);
+        }
+
+        String getLastCalledUrl() {
+            return lastCalledUrl;
+        }
+
+        @Override
+        public String execute(GenericRequest request) throws IOException {
+            String url = request.url();
+            lastCalledUrl = url;
+            for (Map.Entry<String, String> entry : getResponses.entrySet()) {
+                if (url.contains(entry.getKey())) {
+                    return entry.getValue();
+                }
+            }
+            throw new IOException("No mock GET response configured for URL: " + url);
+        }
+
+        @Override
+        public String post(GenericRequest request) throws IOException {
+            String url = request.url();
+            lastCalledUrl = url;
+            for (Map.Entry<String, String> entry : postResponses.entrySet()) {
+                if (url.contains(entry.getKey())) {
+                    postedBodies.put(entry.getKey(), request.getBody());
+                    return entry.getValue();
+                }
+            }
+            throw new IOException("No mock POST response configured for URL: " + url);
+        }
+
+        // Legacy method kept for completeness — not needed for current tests
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsPipelineToolsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/ado/AzureDevOpsPipelineToolsTest.java
@@ -76,6 +76,23 @@ public class AzureDevOpsPipelineToolsTest {
     }
 
     @Test
+    void testTriggerPipeline_withFullRefBranch_doesNotDoublePrefixRefs() throws IOException {
+        String fakeResponse = "{\"id\":45,\"state\":\"inProgress\"}";
+        client.setMockPostResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);
+
+        // Pass an already-qualified ref — should NOT become refs/heads/refs/heads/main
+        client.triggerPipeline(9, "refs/heads/main", null);
+
+        String postedBody = client.getLastPostedBody("/TestProject/_apis/pipelines/9/runs");
+        JSONObject posted = new JSONObject(postedBody);
+        String refName = posted.getJSONObject("resources")
+                .getJSONObject("repositories")
+                .getJSONObject("self")
+                .getString("refName");
+        assertEquals("refs/heads/main", refName, "refs/heads/ prefix must not be duplicated");
+    }
+
+    @Test
     void testTriggerPipeline_withVariables_includesVariablesInBody() throws IOException {
         String fakeResponse = "{\"id\":44,\"state\":\"inProgress\"}";
         client.setMockPostResponse("/TestProject/_apis/pipelines/9/runs", fakeResponse);


### PR DESCRIPTION
## What

### 1. ADO Pipeline MCP Tools (5 new tools)

Add 5 new ADO pipeline MCP tools to `AzureDevOpsClient`, completing the ADO equivalents of the GitHub pipeline/workflow API:

| New ADO Tool | GitHub Equivalent |
|---|---|
| `ado_list_pipelines` | — (no direct equivalent) |
| `ado_trigger_pipeline` | `github_trigger_workflow` |
| `ado_list_pipeline_runs` | `github_list_workflow_runs` |
| `ado_get_pipeline_run` | `github_get_workflow_run` |
| `ado_get_pipeline_logs` | `github_get_job_logs` |

### 2. Beta Release Workflow Fix (idempotency)

`gh release create` fails if the tag already exists (e.g. workflow re-run). Fixed by checking if the release exists first and deleting it before recreating — making re-runs idempotent.

## Details

### `ado_trigger_pipeline(pipelineId, branch?, variables?)`
- Accepts both short branch name (`main`) and fully-qualified ref (`refs/heads/main`) — normalized automatically to avoid double-prefixing.
- Optional JSON variables object.

### `ado_list_pipeline_runs(pipelineId, top?)`
Defaults to 10, configurable via `top`.

### `ado_get_pipeline_run(pipelineId, runId)`
Returns state (`inProgress`, `completed`) and result (`succeeded`, `failed`, `canceled`).

### `ado_get_pipeline_logs(buildId, taskName?, tailLines?)`
- Uses build timeline API to discover task log IDs, fetches each log.
- Supports `taskName` (case-insensitive substring filter) and `tailLines` (default 200).
- Skips `Stage`/`Checkpoint` records automatically.

## Tests

13 unit tests in `AzureDevOpsPipelineToolsTest`:
- All 5 methods covered
- Branch normalization: `refs/heads/main` input stays `refs/heads/main`
- `$top` param, tailLines truncation, task name filter, Stage/Checkpoint skipping

## Docs

Updated `dmtools-ai-docs/references/mcp-tools/ado-tools.md`:
- Added Pipeline Management Tools section (Quick Reference, Available Tools table, detailed params)
- Bumped total tools count 31 → 36
