### PR TITLE
feat: ignore is cloned by relationship in TestCasesGenerator and Teammate context

### DIFF
--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -150,6 +150,7 @@ dmtools run agents/xray_test_cases_generator.json
 - `isConvertToJiraMarkdown` - Convert output to Jira markdown (default: true)
 - `includeOtherTicketReferences` - Include linked tickets in context (default: true)
 - `isOverridePromptExamples` - Override default prompt examples (default: false)
+- `ignoreClonedByRelationship` - Exclude tickets linked via "is cloned by" from AI context (default: **true**). Prevents cloned duplicates from overloading the context.
 
 **Relationships**:
 - `testCaseLinkRelationship` - Default relationship type (default: "is tested by")
@@ -404,6 +405,7 @@ dmtools Teammate --inputJql "key = PROJ-123"
 - `indexes` - Array of index configurations for additional context
   - Each index has `integration` (index name) and `storagePath` (path to index)
 - `systemRequestCommentAlias` - Alias for system request in comments
+- `ignoreClonedByRelationship` - Exclude tickets linked via "is cloned by" from AI context (default: **true**). Prevents cloned duplicates from overloading the context.
 
 **Index Configuration** (IndexConfig):
 ```json

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
@@ -166,7 +166,7 @@ public class TicketContext implements ToText {
                 }
             }
         } catch (Exception e) {
-            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
+            logger.debug("Could not collect cloned-by keys", e);
         }
         return keys;
     }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
@@ -4,6 +4,8 @@
 package com.github.istin.dmtools.ai;
 
 import com.github.istin.dmtools.atlassian.common.networking.AtlassianRestClient;
+import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
+import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.atlassian.jira.utils.IssuesIDsParser;
 import com.github.istin.dmtools.common.model.IComment;
 import com.github.istin.dmtools.common.model.ITicket;
@@ -17,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -131,6 +132,43 @@ public class TicketContext implements ToText {
             comments = fetchedComments;
         }
         
+    }
+
+    public void prepareContext(boolean withComments, boolean withExtraTickets, boolean ignoreClonedBy) throws IOException {
+        if (ignoreClonedBy) {
+            this.excludedExtraTicketKeys = collectClonedByKeys(ticket);
+        }
+        prepareContext(withComments, withExtraTickets);
+    }
+
+    /**
+     * Collects the keys of tickets linked to the given ticket via "is cloned by" or "clones"
+     * relationships, so they can be excluded from AI context to avoid duplicate noise.
+     */
+    public static Set<String> collectClonedByKeys(ITicket ticket) {
+        Set<String> keys = new HashSet<>();
+        try {
+            if (ticket instanceof com.github.istin.dmtools.atlassian.jira.model.Ticket) {
+                com.github.istin.dmtools.atlassian.jira.model.Fields fields =
+                        ((com.github.istin.dmtools.atlassian.jira.model.Ticket) ticket).getFields();
+                if (fields != null) {
+                    List<IssueLink> links = fields.getIssueLinks();
+                    if (links != null) {
+                        for (IssueLink link : links) {
+                            if (Relationship.isClonedBy(link)) {
+                                String key = link.getKey();
+                                if (key != null) {
+                                    keys.add(key);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
+        }
+        return keys;
     }
 
     /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/TicketContext.java
@@ -17,6 +17,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -47,6 +49,10 @@ public class TicketContext implements ToText {
     @Getter
     private List<ITicket> extraTickets = new ArrayList<>();
 
+    @Setter
+    @Getter
+    private Set<String> excludedExtraTicketKeys = new HashSet<>();
+
     public TicketContext(TrackerClient<? extends ITicket> trackerClient, ITicket ticket) {
         this.trackerClient = trackerClient;
         this.ticket = ticket;
@@ -75,6 +81,7 @@ public class TicketContext implements ToText {
                 // Filter out self-references and prepare list of keys to fetch
                 List<String> keysToFetch = keys.stream()
                         .filter(key -> !key.equalsIgnoreCase(ticket.getKey()))
+                        .filter(key -> !excludedExtraTicketKeys.contains(key))
                         .collect(Collectors.toList());
 
                 if (!keysToFetch.isEmpty()) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/model/Relationship.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/model/Relationship.java
@@ -28,6 +28,8 @@ public class Relationship {
     public static final String RELATE = "relate";
     public static final String RELATES = "Relates";
     public static final String TESTS = "Tests";
+    public static final String IS_CLONED_BY = "is cloned by";
+    public static final String CLONES = "clones";
 
     public static boolean isFixedInOrImplementedIn(IssueLink issueLink) {
         String inwardType = issueLink.getInwardType();
@@ -59,5 +61,11 @@ public class Relationship {
     public static boolean isLinkedTo(IssueLink issueLink) {
         String inwardType = issueLink.getInwardType();
         return inwardType.equalsIgnoreCase(Relationship.LINKED_TO) || inwardType.equalsIgnoreCase(Relationship.LINKED_WITH);
+    }
+
+    public static boolean isClonedBy(IssueLink issueLink) {
+        String inwardType = issueLink.getInwardType();
+        String outwardType = issueLink.getOutwardType();
+        return IS_CLONED_BY.equalsIgnoreCase(inwardType) || CLONES.equalsIgnoreCase(outwardType);
     }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
@@ -12,7 +12,6 @@ import com.github.istin.dmtools.ai.agent.RelatedTestCasesAgent;
 import com.github.istin.dmtools.ai.agent.TestCaseDeduplicationAgent;
 import com.github.istin.dmtools.ai.agent.TestCaseGeneratorAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
-import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
 import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.teammate.InstructionProcessor;
 import com.github.istin.dmtools.atlassian.jira.model.Ticket;
@@ -40,9 +39,7 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.*;
 
 public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, List<TestCasesGenerator.TestCasesResult>> {
@@ -150,10 +147,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 }
 
                 TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-                if (params.isIgnoreClonedByRelationship()) {
-                    ticketContext.setExcludedExtraTicketKeys(collectClonedByKeys(ticket));
-                }
-                ticketContext.prepareContext(false, params.isIncludeOtherTicketReferences());
+                ticketContext.prepareContext(false, params.isIncludeOtherTicketReferences(), params.isIgnoreClonedByRelationship());
                 String additionalRules = extractFromConfluence(params.getConfluencePages());
                 result.add(generateTestCases(ticketContext, additionalRules, listOfAllTestCases, params, customAdapter));
                 TrackerParams.OutputType outputType = getOutputTypeSafe(params);
@@ -198,31 +192,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         return sb.toString();
     }
 
-    static Set<String> collectClonedByKeys(ITicket ticket) {
-        Set<String> keys = new HashSet<>();
-        try {
-            if (ticket instanceof com.github.istin.dmtools.atlassian.jira.model.Ticket) {
-                com.github.istin.dmtools.atlassian.jira.model.Fields fields =
-                        ((com.github.istin.dmtools.atlassian.jira.model.Ticket) ticket).getFields();
-                if (fields != null) {
-                    List<IssueLink> links = fields.getIssueLinks();
-                    if (links != null) {
-                        for (IssueLink link : links) {
-                            if (Relationship.isClonedBy(link)) {
-                                String key = link.getKey();
-                                if (key != null) {
-                                    keys.add(key);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
-        }
-        return keys;
-    }
+
 
     public TestCasesResult generateTestCases(TicketContext ticketContext, String extraRules, List<? extends ITicket> listOfAllTestCases, TestCasesGeneratorParams params) throws Exception {
         return generateTestCases(ticketContext, extraRules, listOfAllTestCases, params, null);

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
@@ -12,6 +12,7 @@ import com.github.istin.dmtools.ai.agent.RelatedTestCasesAgent;
 import com.github.istin.dmtools.ai.agent.TestCaseDeduplicationAgent;
 import com.github.istin.dmtools.ai.agent.TestCaseGeneratorAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
+import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
 import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.teammate.InstructionProcessor;
 import com.github.istin.dmtools.atlassian.jira.model.Ticket;
@@ -39,7 +40,9 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.*;
 
 public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, List<TestCasesGenerator.TestCasesResult>> {
@@ -147,6 +150,9 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 }
 
                 TicketContext ticketContext = new TicketContext(trackerClient, ticket);
+                if (params.isIgnoreClonedByRelationship()) {
+                    ticketContext.setExcludedExtraTicketKeys(collectClonedByKeys(ticket));
+                }
                 ticketContext.prepareContext(false, params.isIncludeOtherTicketReferences());
                 String additionalRules = extractFromConfluence(params.getConfluencePages());
                 result.add(generateTestCases(ticketContext, additionalRules, listOfAllTestCases, params, customAdapter));
@@ -190,6 +196,32 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
             sb.append("... (").append(stackTrace.length - maxLines).append(" more lines)");
         }
         return sb.toString();
+    }
+
+    static Set<String> collectClonedByKeys(ITicket ticket) {
+        Set<String> keys = new HashSet<>();
+        try {
+            if (ticket instanceof com.github.istin.dmtools.atlassian.jira.model.Ticket) {
+                com.github.istin.dmtools.atlassian.jira.model.Fields fields =
+                        ((com.github.istin.dmtools.atlassian.jira.model.Ticket) ticket).getFields();
+                if (fields != null) {
+                    List<IssueLink> links = fields.getIssueLinks();
+                    if (links != null) {
+                        for (IssueLink link : links) {
+                            if (Relationship.isClonedBy(link)) {
+                                String key = link.getKey();
+                                if (key != null) {
+                                    keys.add(key);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
+        }
+        return keys;
     }
 
     public TestCasesResult generateTestCases(TicketContext ticketContext, String extraRules, List<? extends ITicket> listOfAllTestCases, TestCasesGeneratorParams params) throws Exception {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGeneratorParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGeneratorParams.java
@@ -45,6 +45,7 @@ public class TestCasesGeneratorParams extends Params {
     public static final String JQL_MODIFIER_JS_ACTION = "jqlModifierJSAction";
     public static final String TEST_CASES_CREATION_RULES = "testCasesCreationRules";
     public static final String CUSTOM_TEST_CASES_TRACKER = "customTestCasesTracker";
+    public static final String IGNORE_CLONED_BY_RELATIONSHIP = "ignoreClonedByRelationship";
 
     @SerializedName(EXISTING_TEST_CASES_JQL)
     private String existingTestCasesJql;
@@ -108,4 +109,7 @@ public class TestCasesGeneratorParams extends Params {
 
     @SerializedName(CUSTOM_TEST_CASES_TRACKER)
     private CustomTestCasesTrackerParams customTestCasesTracker;
+
+    @SerializedName(IGNORE_CLONED_BY_RELATIONSHIP)
+    private boolean ignoreClonedByRelationship = true;
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -12,8 +12,6 @@ import com.github.istin.dmtools.ai.agent.RequestDecompositionAgent;
 import com.github.istin.dmtools.ai.agent.SourceImpactAssessmentAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.atlassian.jira.model.Fields;
-import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
-import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.config.ApplicationConfiguration;
 import com.github.istin.dmtools.common.model.IAttachment;
@@ -49,9 +47,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultItem>> {
 
@@ -367,10 +363,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             
             // Create and prepare ticket context
             TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-            if (expertParams.isIgnoreClonedByRelationship()) {
-                ticketContext.setExcludedExtraTicketKeys(collectClonedByKeys(ticket));
-            }
-            ticketContext.prepareContext(true, false);
+            ticketContext.prepareContext(true, false, expertParams.isIgnoreClonedByRelationship());
             // Get attachments and convert to text
             List<? extends IAttachment> attachments = ticket.getAttachments();
             if (expertParams.isSkipAllAttachments()) {
@@ -711,32 +704,6 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             return Collections.emptyList();
         }
         return mermaidIndexTools.read(config.getIntegration(), config.getStoragePath());
-    }
-
-    static Set<String> collectClonedByKeys(ITicket ticket) {
-        Set<String> keys = new HashSet<>();
-        try {
-            if (ticket instanceof com.github.istin.dmtools.atlassian.jira.model.Ticket) {
-                com.github.istin.dmtools.atlassian.jira.model.Fields fields =
-                        ((com.github.istin.dmtools.atlassian.jira.model.Ticket) ticket).getFields();
-                if (fields != null) {
-                    List<IssueLink> links = fields.getIssueLinks();
-                    if (links != null) {
-                        for (IssueLink link : links) {
-                            if (Relationship.isClonedBy(link)) {
-                                String key = link.getKey();
-                                if (key != null) {
-                                    keys.add(key);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
-        }
-        return keys;
     }
 
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -12,6 +12,8 @@ import com.github.istin.dmtools.ai.agent.RequestDecompositionAgent;
 import com.github.istin.dmtools.ai.agent.SourceImpactAssessmentAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.atlassian.jira.model.Fields;
+import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
+import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.config.ApplicationConfiguration;
 import com.github.istin.dmtools.common.model.IAttachment;
@@ -47,7 +49,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultItem>> {
 
@@ -100,6 +104,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
 
         @SerializedName("writeAgentParamsToFiles")
         private boolean writeAgentParamsToFiles = false;
+
+        @SerializedName("ignoreClonedByRelationship")
+        private boolean ignoreClonedByRelationship = true;
 
     }
 
@@ -360,6 +367,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             
             // Create and prepare ticket context
             TicketContext ticketContext = new TicketContext(trackerClient, ticket);
+            if (expertParams.isIgnoreClonedByRelationship()) {
+                ticketContext.setExcludedExtraTicketKeys(collectClonedByKeys(ticket));
+            }
             ticketContext.prepareContext(true, false);
             // Get attachments and convert to text
             List<? extends IAttachment> attachments = ticket.getAttachments();
@@ -701,6 +711,32 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             return Collections.emptyList();
         }
         return mermaidIndexTools.read(config.getIntegration(), config.getStoragePath());
+    }
+
+    static Set<String> collectClonedByKeys(ITicket ticket) {
+        Set<String> keys = new HashSet<>();
+        try {
+            if (ticket instanceof com.github.istin.dmtools.atlassian.jira.model.Ticket) {
+                com.github.istin.dmtools.atlassian.jira.model.Fields fields =
+                        ((com.github.istin.dmtools.atlassian.jira.model.Ticket) ticket).getFields();
+                if (fields != null) {
+                    List<IssueLink> links = fields.getIssueLinks();
+                    if (links != null) {
+                        for (IssueLink link : links) {
+                            if (Relationship.isClonedBy(link)) {
+                                String key = link.getKey();
+                                if (key != null) {
+                                    keys.add(key);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("Could not collect cloned-by keys: {}", e.getMessage());
+        }
+        return keys;
     }
 
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/model/RelationshipTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/model/RelationshipTest.java
@@ -138,4 +138,32 @@ public class RelationshipTest {
         Mockito.when(issueLink.getInwardType()).thenReturn("other");
         assertFalse(Relationship.isLinkedTo(issueLink));
     }
+
+    @Test
+    public void testIsClonedBy_InwardIsClonedBy() {
+        Mockito.when(issueLink.getInwardType()).thenReturn(Relationship.IS_CLONED_BY);
+        Mockito.when(issueLink.getOutwardType()).thenReturn("clones");
+        assertTrue(Relationship.isClonedBy(issueLink));
+    }
+
+    @Test
+    public void testIsClonedBy_OutwardClones() {
+        Mockito.when(issueLink.getInwardType()).thenReturn("is cloned by");
+        Mockito.when(issueLink.getOutwardType()).thenReturn(Relationship.CLONES);
+        assertTrue(Relationship.isClonedBy(issueLink));
+    }
+
+    @Test
+    public void testIsClonedBy_CaseInsensitive() {
+        Mockito.when(issueLink.getInwardType()).thenReturn("IS CLONED BY");
+        Mockito.when(issueLink.getOutwardType()).thenReturn("CLONES");
+        assertTrue(Relationship.isClonedBy(issueLink));
+    }
+
+    @Test
+    public void testIsClonedBy_NotClone() {
+        Mockito.when(issueLink.getInwardType()).thenReturn(Relationship.RELATES_TO);
+        Mockito.when(issueLink.getOutwardType()).thenReturn(Relationship.RELATES_TO);
+        assertFalse(Relationship.isClonedBy(issueLink));
+    }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParamsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParamsTest.java
@@ -128,6 +128,7 @@ public class TestCasesGeneratorParamsTest {
             "jqlModifier.js"                    // jqlModifierJSAction
             , null                              // testCasesCreationRules
             , null                              // customTestCasesTracker
+            , true                              // ignoreClonedByRelationship
         );
 
         assertTrue("Constructor should set enableParallelTestCaseCheck correctly",

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
@@ -13,6 +13,9 @@ import com.github.istin.dmtools.atlassian.jira.model.Relationship;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.atlassian.jira.model.Fields;
+import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
+import com.github.istin.dmtools.atlassian.jira.model.Ticket;
 import com.github.istin.dmtools.job.JavaScriptExecutor;
 import com.github.istin.dmtools.job.TrackerParams;
 import org.junit.Before;
@@ -21,8 +24,10 @@ import org.mockito.ArgumentCaptor;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -641,5 +646,90 @@ public class TestCasesGeneratorTest {
         String capturedRules = captor.getValue().getExtraRules();
         assertTrue("extraRules should contain content from page 1", capturedRules.contains("Rules from page 1"));
         assertTrue("extraRules should contain content from page 2", capturedRules.contains("Rules from page 2"));
+    }
+
+    // ---- Tests for collectClonedByKeys and ignoreClonedByRelationship ----
+
+    @Test
+    public void testCollectClonedByKeys_withClonedByLink_returnsKey() {
+        Ticket mockJiraTicket = mock(Ticket.class);
+        Fields mockFields = mock(Fields.class);
+        IssueLink cloneLink = mock(IssueLink.class);
+
+        when(mockJiraTicket.getFields()).thenReturn(mockFields);
+        when(cloneLink.getInwardType()).thenReturn(Relationship.IS_CLONED_BY);
+        when(cloneLink.getOutwardType()).thenReturn(Relationship.CLONES);
+        when(cloneLink.getKey()).thenReturn("PROJ-999");
+        when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(cloneLink));
+
+        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("PROJ-999"));
+    }
+
+    @Test
+    public void testCollectClonedByKeys_noClonedByLink_returnsEmpty() {
+        Ticket mockJiraTicket = mock(Ticket.class);
+        Fields mockFields = mock(Fields.class);
+        IssueLink relatesLink = mock(IssueLink.class);
+
+        when(mockJiraTicket.getFields()).thenReturn(mockFields);
+        when(relatesLink.getInwardType()).thenReturn(Relationship.RELATES_TO);
+        when(relatesLink.getOutwardType()).thenReturn(Relationship.RELATES_TO);
+        when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(relatesLink));
+
+        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCollectClonedByKeys_nullIssueLinks_returnsEmpty() {
+        Ticket mockJiraTicket = mock(Ticket.class);
+        Fields mockFields = mock(Fields.class);
+
+        when(mockJiraTicket.getFields()).thenReturn(mockFields);
+        when(mockFields.getIssueLinks()).thenReturn(null);
+
+        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCollectClonedByKeys_nonJiraTicket_returnsEmpty() {
+        ITicket nonJiraTicket = mock(ITicket.class);
+        Set<String> result = TestCasesGenerator.collectClonedByKeys(nonJiraTicket);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCollectClonedByKeys_mixedLinks_returnsOnlyClonedByKeys() {
+        Ticket mockJiraTicket = mock(Ticket.class);
+        Fields mockFields = mock(Fields.class);
+
+        IssueLink cloneLink = mock(IssueLink.class);
+        when(cloneLink.getInwardType()).thenReturn(Relationship.IS_CLONED_BY);
+        when(cloneLink.getOutwardType()).thenReturn(Relationship.CLONES);
+        when(cloneLink.getKey()).thenReturn("PROJ-100");
+
+        IssueLink relatesLink = mock(IssueLink.class);
+        when(relatesLink.getInwardType()).thenReturn(Relationship.RELATES_TO);
+        when(relatesLink.getOutwardType()).thenReturn(Relationship.RELATES_TO);
+
+        IssueLink blockerLink = mock(IssueLink.class);
+        when(blockerLink.getInwardType()).thenReturn(Relationship.IS_BLOCKED_BY);
+        when(blockerLink.getOutwardType()).thenReturn(Relationship.BLOCKS);
+
+        when(mockJiraTicket.getFields()).thenReturn(mockFields);
+        when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(cloneLink, relatesLink, blockerLink));
+
+        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        assertEquals(1, result.size());
+        assertTrue(result.contains("PROJ-100"));
+    }
+
+    @Test
+    public void testIgnoreClonedByRelationship_defaultIsTrue() {
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        assertTrue("ignoreClonedByRelationship should default to true", params.isIgnoreClonedByRelationship());
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
@@ -9,13 +9,13 @@ import com.github.istin.dmtools.ai.Claude35TokenCounter;
 import com.github.istin.dmtools.ai.TicketContext;
 import com.github.istin.dmtools.ai.agent.TestCaseGeneratorAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
+import com.github.istin.dmtools.atlassian.jira.model.Fields;
+import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
 import com.github.istin.dmtools.atlassian.jira.model.Relationship;
+import com.github.istin.dmtools.atlassian.jira.model.Ticket;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
-import com.github.istin.dmtools.atlassian.jira.model.Fields;
-import com.github.istin.dmtools.atlassian.jira.model.IssueLink;
-import com.github.istin.dmtools.atlassian.jira.model.Ticket;
 import com.github.istin.dmtools.job.JavaScriptExecutor;
 import com.github.istin.dmtools.job.TrackerParams;
 import org.junit.Before;
@@ -662,7 +662,7 @@ public class TestCasesGeneratorTest {
         when(cloneLink.getKey()).thenReturn("PROJ-999");
         when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(cloneLink));
 
-        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        Set<String> result = TicketContext.collectClonedByKeys(mockJiraTicket);
         assertEquals(1, result.size());
         assertTrue(result.contains("PROJ-999"));
     }
@@ -678,7 +678,7 @@ public class TestCasesGeneratorTest {
         when(relatesLink.getOutwardType()).thenReturn(Relationship.RELATES_TO);
         when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(relatesLink));
 
-        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        Set<String> result = TicketContext.collectClonedByKeys(mockJiraTicket);
         assertTrue(result.isEmpty());
     }
 
@@ -690,14 +690,14 @@ public class TestCasesGeneratorTest {
         when(mockJiraTicket.getFields()).thenReturn(mockFields);
         when(mockFields.getIssueLinks()).thenReturn(null);
 
-        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        Set<String> result = TicketContext.collectClonedByKeys(mockJiraTicket);
         assertTrue(result.isEmpty());
     }
 
     @Test
     public void testCollectClonedByKeys_nonJiraTicket_returnsEmpty() {
         ITicket nonJiraTicket = mock(ITicket.class);
-        Set<String> result = TestCasesGenerator.collectClonedByKeys(nonJiraTicket);
+        Set<String> result = TicketContext.collectClonedByKeys(nonJiraTicket);
         assertTrue(result.isEmpty());
     }
 
@@ -722,7 +722,7 @@ public class TestCasesGeneratorTest {
         when(mockJiraTicket.getFields()).thenReturn(mockFields);
         when(mockFields.getIssueLinks()).thenReturn(Arrays.asList(cloneLink, relatesLink, blockerLink));
 
-        Set<String> result = TestCasesGenerator.collectClonedByKeys(mockJiraTicket);
+        Set<String> result = TicketContext.collectClonedByKeys(mockJiraTicket);
         assertEquals(1, result.size());
         assertTrue(result.contains("PROJ-100"));
     }


### PR DESCRIPTION
Closes #23

By default, Jira tickets linked via is cloned by are now excluded from the AI context built for TestCasesGenerator and Teammate jobs. This prevents cloned duplicates from overloading the context window.

Changes:
- Add IS_CLONED_BY / CLONES constants + isClonedBy() to Relationship.java
- Add ignoreClonedByRelationship param (default: true) to TestCasesGeneratorParams and TeammateParams
- Add excludedExtraTicketKeys to TicketContext; prepareContext() honors the exclusion set
- collectClonedByKeys() helper in TestCasesGenerator and Teammate collects cloned-by linked ticket keys
- Updated dmtools-ai-docs with new param docs for both jobs

Tests:
- RelationshipTest: 4 new tests for isClonedBy()
- TestCasesGeneratorTest: 6 new tests for collectClonedByKeys() and default param
- TestCasesGeneratorParamsTest: updated AllArgsConstructor call

All tests pass.