### PR TITLE
fix(ci): replace sleep 15 with mergeability-wait retry loop in auto-update-prs

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 concurrency:
   group: auto-update-prs
@@ -21,7 +22,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          sleep 15
+          # After a push to main, GitHub invalidates cached mergeability for all open PRs
+          # and recomputes asynchronously — returning "UNKNOWN" until ready. Retry until
+          # no PRs are stuck in UNKNOWN (up to ~90s) so the MERGEABLE filter doesn't miss them.
+          for attempt in $(seq 1 6); do
+            unknown=$(gh pr list --repo ${{ github.repository }} --state open --base main \
+              --json number,mergeable \
+              --jq '[.[] | select(.mergeable == "UNKNOWN")] | length')
+            echo "Attempt $attempt: $unknown PR(s) still in UNKNOWN mergeability state"
+            [ "$unknown" -eq 0 ] && break
+            sleep 15
+          done
+
           prs=$(gh pr list --repo ${{ github.repository }} --state open --base main \
             --json number,mergeable,isDraft,mergeStateStatus \
             --jq '.[]


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `sleep 15` with a retry loop (up to 6×15s = 90s) that polls until no open PRs remain in `UNKNOWN` mergeability state before running the update loop
- Adds `workflow_dispatch` trigger for manual runs

## Why
After a push to `main`, GitHub asynchronously recomputes mergeability for all open PRs, returning `UNKNOWN` during that window. The old `sleep 15` was too short — PRs still in `UNKNOWN` were silently excluded by the `select(.mergeable == "MERGEABLE")` filter, causing them to miss the auto-update. Ported from the same fix in `Postnl-Production/api-client-sdk` (run [#24775348949](https://github.com/Postnl-Production/api-client-sdk/actions/runs/24775348949/job/72492019125)).

## Test plan
- [ ] Merge a commit to `main` with one or more open PRs — confirm the workflow waits for mergeability resolution and successfully updates eligible PRs
- [ ] Trigger manually via `workflow_dispatch` and confirm it runs without errors