### PR TITLE
feat: RelatedTestCase explanation + batch Jira comment for TC linking

### DIFF
--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -151,8 +151,8 @@ dmtools run agents/xray_test_cases_generator.json
 - `includeOtherTicketReferences` - Include linked tickets in context (default: true)
 - `isOverridePromptExamples` - Override default prompt examples (default: false)
 - `ignoreClonedByRelationship` - Exclude tickets linked via "is cloned by" from AI context (default: **true**). Prevents cloned duplicates from overloading the context.
-
-**Relationships**:
+- `relatedTestCaseExplanationPrompt` - When set, instructs the LLM to return an explanation alongside the `true` result (format: `"true, <explanation>"`). The value is the guidance text for what kind of explanation to provide (e.g., *"Explain why the TC is related to this story, or state if it needs to be deprecated once the story is delivered."*). Default: `null` (disabled, preserves `true`/`false` only behavior).
+- `postLinkedTestCasesComment` - When `true`, after finding all related test cases for a story, post a single Jira comment listing every linked TC with its explanation. Requires `relatedTestCaseExplanationPrompt` to be set for explanations to appear. Default: **false**.
 - `testCaseLinkRelationship` - Default relationship type (default: "is tested by")
 - `testCaseLinkRelationshipForNew` - Relationship for new test cases (overrides default)
 - `testCaseLinkRelationshipForExisting` - Relationship for existing test cases (overrides default)

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/agent/RelatedTestCaseAgent.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/agent/RelatedTestCaseAgent.java
@@ -8,7 +8,7 @@ import com.github.istin.dmtools.ai.utils.AIResponseParser;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-public class RelatedTestCaseAgent extends AbstractSimpleAgent<RelatedTestCaseAgent.Params, Boolean> {
+public class RelatedTestCaseAgent extends AbstractSimpleAgent<RelatedTestCaseAgent.Params, RelatedTestCaseAgent.Result> {
 
     @AllArgsConstructor
     @Getter
@@ -16,6 +16,14 @@ public class RelatedTestCaseAgent extends AbstractSimpleAgent<RelatedTestCaseAge
         private String newStory;
         private String existingTestCase;
         private String extraRules;
+        private String explanationPrompt;
+    }
+
+    @AllArgsConstructor
+    @Getter
+    public static class Result {
+        private boolean isRelated;
+        private String explanation;
     }
 
     public RelatedTestCaseAgent() {
@@ -24,7 +32,8 @@ public class RelatedTestCaseAgent extends AbstractSimpleAgent<RelatedTestCaseAge
     }
 
     @Override
-    public Boolean transformAIResponse(Params params, String response) throws Exception {
-        return AIResponseParser.parseBooleanResponse(response);
+    public Result transformAIResponse(Params params, String response) throws Exception {
+        AIResponseParser.BooleanWithExplanation parsed = AIResponseParser.parseBooleanWithExplanation(response);
+        return new Result(parsed.value, parsed.explanation);
     }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/utils/AIResponseParser.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/utils/AIResponseParser.java
@@ -25,19 +25,21 @@ public class AIResponseParser {
     }
 
     public static BooleanWithExplanation parseBooleanWithExplanation(String response) throws IllegalArgumentException {
-        String trimmedResponse = response.trim().toLowerCase();
+        String trimmedResponse = response.trim();
+        Pattern pattern = Pattern.compile("^\\s*(true|false)\\b(?:\\s*,\\s*(.*))?$",
+                Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(trimmedResponse);
 
-        int trueIndex = trimmedResponse.indexOf("true");
-        int falseIndex = trimmedResponse.indexOf("false");
-
-        if (trueIndex != -1 && (falseIndex == -1 || trueIndex < falseIndex)) {
-            int commaIndex = response.indexOf(',', trueIndex + 4);
-            String explanation = commaIndex != -1 ? response.substring(commaIndex + 1).trim() : null;
-            return new BooleanWithExplanation(true, explanation);
-        } else if (falseIndex != -1) {
-            return new BooleanWithExplanation(false, null);
-        } else {
+        if (!matcher.find()) {
             throw new IllegalArgumentException("No valid boolean value found in the response.");
+        }
+
+        String token = matcher.group(1).toLowerCase();
+        if ("true".equals(token)) {
+            String explanation = matcher.group(2) != null ? matcher.group(2).trim() : null;
+            return new BooleanWithExplanation(true, explanation != null && !explanation.isEmpty() ? explanation : null);
+        } else {
+            return new BooleanWithExplanation(false, null);
         }
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/utils/AIResponseParser.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/utils/AIResponseParser.java
@@ -14,6 +14,33 @@ import java.util.regex.Pattern;
 
 public class AIResponseParser {
 
+    public static class BooleanWithExplanation {
+        public final boolean value;
+        public final String explanation;
+
+        public BooleanWithExplanation(boolean value, String explanation) {
+            this.value = value;
+            this.explanation = explanation;
+        }
+    }
+
+    public static BooleanWithExplanation parseBooleanWithExplanation(String response) throws IllegalArgumentException {
+        String trimmedResponse = response.trim().toLowerCase();
+
+        int trueIndex = trimmedResponse.indexOf("true");
+        int falseIndex = trimmedResponse.indexOf("false");
+
+        if (trueIndex != -1 && (falseIndex == -1 || trueIndex < falseIndex)) {
+            int commaIndex = response.indexOf(',', trueIndex + 4);
+            String explanation = commaIndex != -1 ? response.substring(commaIndex + 1).trim() : null;
+            return new BooleanWithExplanation(true, explanation);
+        } else if (falseIndex != -1) {
+            return new BooleanWithExplanation(false, null);
+        } else {
+            throw new IllegalArgumentException("No valid boolean value found in the response.");
+        }
+    }
+
     public static boolean parseBooleanResponse(String response) throws IllegalArgumentException {
         // Convert response to lowercase to handle case insensitivity
         String trimmedResponse = response.trim().toLowerCase();

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
@@ -233,20 +233,41 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         }
 
         if (params.isPostLinkedTestCasesComment() && !verifiedResults.isEmpty()) {
-            StringBuilder comment = new StringBuilder("Related test cases identified:\n");
-            for (VerifiedTestCase vc : verifiedResults) {
-                comment.append("- ").append(vc.getTicket().getKey());
-                try {
-                    String summary = vc.getTicket().getTicketTitle();
-                    if (summary != null && !summary.trim().isEmpty()) {
-                        comment.append(": ").append(summary);
+            boolean isHtml = TrackerClient.TextType.HTML.equals(trackerClient.getTextType());
+            StringBuilder comment = new StringBuilder();
+            if (isHtml) {
+                comment.append("<b>Related test cases identified:</b><ul>");
+                for (VerifiedTestCase vc : verifiedResults) {
+                    comment.append("<li><b>").append(vc.getTicket().getKey()).append("</b>");
+                    try {
+                        String summary = vc.getTicket().getTicketTitle();
+                        if (summary != null && !summary.trim().isEmpty()) {
+                            comment.append(": ").append(summary);
+                        }
+                    } catch (Exception ignored) {
                     }
-                } catch (Exception ignored) {
+                    if (vc.getExplanation() != null && !vc.getExplanation().trim().isEmpty()) {
+                        comment.append(" \u2014 ").append(vc.getExplanation());
+                    }
+                    comment.append("</li>");
                 }
-                if (vc.getExplanation() != null && !vc.getExplanation().trim().isEmpty()) {
-                    comment.append(" — ").append(vc.getExplanation());
+                comment.append("</ul>");
+            } else {
+                comment.append("Related test cases identified:\n");
+                for (VerifiedTestCase vc : verifiedResults) {
+                    comment.append("- ").append(vc.getTicket().getKey());
+                    try {
+                        String summary = vc.getTicket().getTicketTitle();
+                        if (summary != null && !summary.trim().isEmpty()) {
+                            comment.append(": ").append(summary);
+                        }
+                    } catch (Exception ignored) {
+                    }
+                    if (vc.getExplanation() != null && !vc.getExplanation().trim().isEmpty()) {
+                        comment.append(" \u2014 ").append(vc.getExplanation());
+                    }
+                    comment.append("\n");
                 }
-                comment.append("\n");
             }
             trackerClient.postComment(key, comment.toString().trim());
         }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
@@ -256,13 +256,6 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 comment.append("Related test cases identified:\n");
                 for (VerifiedTestCase vc : verifiedResults) {
                     comment.append("- ").append(vc.getTicket().getKey());
-                    try {
-                        String summary = vc.getTicket().getTicketTitle();
-                        if (summary != null && !summary.trim().isEmpty()) {
-                            comment.append(": ").append(summary);
-                        }
-                    } catch (Exception ignored) {
-                    }
                     if (vc.getExplanation() != null && !vc.getExplanation().trim().isEmpty()) {
                         comment.append(" \u2014 ").append(vc.getExplanation());
                     }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGenerator.java
@@ -58,6 +58,13 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         private List<TestCaseGeneratorAgent.TestCase> newTestCases;
     }
 
+    @Getter
+    @AllArgsConstructor
+    public static class VerifiedTestCase {
+        private ITicket ticket;
+        private String explanation;
+    }
+
     @Inject
     TrackerClient<? extends ITicket> trackerClient;
 
@@ -216,9 +223,33 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         if (!currentlyLinked.isEmpty()) {
             logger.debug("[DEBUG-LINKING] alreadyLinked keys: " + currentlyLinked.stream().map(t -> { try { return t.getKey(); } catch (Exception e) { return "?"; } }).collect(java.util.stream.Collectors.joining(", ")));
         }
-        List<ITicket> finaResults = params.isFindRelated()
+        List<VerifiedTestCase> verifiedResults = params.isFindRelated()
                 ? findAndLinkSimilarTestCasesBySummary(ticketContext.getTicket().getTicketKey(), ticketText, listOfAllTestCases, params.isLinkRelated(), params.getRelatedTestCasesRules(), existingRelationship, currentlyLinked, params, customAdapter)
                 : Collections.emptyList();
+
+        List<ITicket> finaResults = new ArrayList<>();
+        for (VerifiedTestCase vc : verifiedResults) {
+            finaResults.add(vc.getTicket());
+        }
+
+        if (params.isPostLinkedTestCasesComment() && !verifiedResults.isEmpty()) {
+            StringBuilder comment = new StringBuilder("Related test cases identified:\n");
+            for (VerifiedTestCase vc : verifiedResults) {
+                comment.append("- ").append(vc.getTicket().getKey());
+                try {
+                    String summary = vc.getTicket().getTicketTitle();
+                    if (summary != null && !summary.trim().isEmpty()) {
+                        comment.append(": ").append(summary);
+                    }
+                } catch (Exception ignored) {
+                }
+                if (vc.getExplanation() != null && !vc.getExplanation().trim().isEmpty()) {
+                    comment.append(" — ").append(vc.getExplanation());
+                }
+                comment.append("\n");
+            }
+            trackerClient.postComment(key, comment.toString().trim());
+        }
 
         // Initialize accumulator for all generated test cases
         List<TestCaseGeneratorAgent.TestCase> allGeneratedTestCases = new ArrayList<>();
@@ -637,9 +668,9 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
 
     /**
      * Verifies if a test case is related to the story and optionally links it.
-     * @return the test case if confirmed, null otherwise
+     * @return a VerifiedTestCase with the ticket and explanation if confirmed, null otherwise
      */
-    private ITicket verifyAndLinkTestCase(
+    private VerifiedTestCase verifyAndLinkTestCase(
             ITicket testCase,
             String ticketKey,
             String ticketText,
@@ -651,10 +682,11 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
             boolean needSync,
             TestCasesTrackerAdapter customAdapter) throws Exception {
 
-        boolean isConfirmed = relatedTestCaseAgent.run(
+        RelatedTestCaseAgent.Result agentResult = relatedTestCaseAgent.run(
             params.getModelTestCaseRelation(),
-            new RelatedTestCaseAgent.Params(ticketText, testCase.toText(), extraRelatedTestCaseRulesFromConfluence)
+            new RelatedTestCaseAgent.Params(ticketText, testCase.toText(), extraRelatedTestCaseRulesFromConfluence, params.getRelatedTestCaseExplanationPrompt())
         );
+        boolean isConfirmed = agentResult.isRelated();
         logger.debug("[DEBUG-LINKING] verifyAndLink testCase=" + testCase.getKey() + " isConfirmed=" + isConfirmed);
 
         if (isConfirmed) {
@@ -682,7 +714,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                     }
                 }
             }
-            return testCase;
+            return new VerifiedTestCase(testCase, agentResult.getExplanation());
         }
         return null;
     }
@@ -691,7 +723,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
      * Processes a single chunk to find related test cases and optionally verify them.
      * This method eliminates code duplication between parallel and sequential processing.
      */
-    private List<ITicket> processChunk(
+    private List<VerifiedTestCase> processChunk(
             ChunkPreparation.Chunk chunk,
             String ticketKey,
             String ticketText,
@@ -703,7 +735,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
             TestCasesGeneratorParams params,
             TestCasesTrackerAdapter customAdapter) throws Exception {
 
-        List<ITicket> chunkResults = new ArrayList<>();
+        List<VerifiedTestCase> chunkResults = new ArrayList<>();
 
         // Get potential test cases from the chunk
         logger.debug("[DEBUG-LINKING] Calling relatedTestCasesAgent for ticket=" + ticketKey + " chunkSize=" + chunk.getText().length() + " chars, existingCasesInChunk=" + listOfAllTestCases.size());
@@ -738,7 +770,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 Math.min(params.getParallelPostVerificationThreads(), testCasesToVerify.size())
             );
             try {
-                List<Future<ITicket>> verificationFutures = new ArrayList<>();
+                List<Future<VerifiedTestCase>> verificationFutures = new ArrayList<>();
 
                 for (ITicket testCase : testCasesToVerify) {
                     verificationFutures.add(postVerificationExecutor.submit(() ->
@@ -749,8 +781,8 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 }
 
                 // Collect verified results
-                for (Future<ITicket> future : verificationFutures) {
-                    ITicket verifiedTestCase = future.get();
+                for (Future<VerifiedTestCase> future : verificationFutures) {
+                    VerifiedTestCase verifiedTestCase = future.get();
                     if (verifiedTestCase != null) {
                         chunkResults.add(verifiedTestCase);
                     }
@@ -768,7 +800,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         } else {
             // Sequential post-verification
             for (ITicket testCase : testCasesToVerify) {
-                ITicket verifiedTestCase = verifyAndLinkTestCase(testCase, ticketKey, ticketText, isLink,
+                VerifiedTestCase verifiedTestCase = verifyAndLinkTestCase(testCase, ticketKey, ticketText, isLink,
                                                                  relationship, currentlyLinkedTestCases,
                                                                  extraRelatedTestCaseRulesFromConfluence, params, false,
                                                                  customAdapter);
@@ -782,13 +814,13 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
     }
 
     @NotNull
-    public List<ITicket> findAndLinkSimilarTestCasesBySummary(String ticketKey, String ticketText, List<? extends ITicket> listOfAllTestCases, boolean isLink, String relatedTestCasesRulesLink, String relationship, List<? extends ITicket> currentlyLinkedTestCases, TestCasesGeneratorParams params) throws Exception {
+    public List<VerifiedTestCase> findAndLinkSimilarTestCasesBySummary(String ticketKey, String ticketText, List<? extends ITicket> listOfAllTestCases, boolean isLink, String relatedTestCasesRulesLink, String relationship, List<? extends ITicket> currentlyLinkedTestCases, TestCasesGeneratorParams params) throws Exception {
         return findAndLinkSimilarTestCasesBySummary(ticketKey, ticketText, listOfAllTestCases, isLink, relatedTestCasesRulesLink, relationship, currentlyLinkedTestCases, params, null);
     }
 
     @NotNull
-    public List<ITicket> findAndLinkSimilarTestCasesBySummary(String ticketKey, String ticketText, List<? extends ITicket> listOfAllTestCases, boolean isLink, String relatedTestCasesRulesLink, String relationship, List<? extends ITicket> currentlyLinkedTestCases, TestCasesGeneratorParams params, TestCasesTrackerAdapter customAdapter) throws Exception {
-        List<ITicket> finaResults = new ArrayList<>();
+    public List<VerifiedTestCase> findAndLinkSimilarTestCasesBySummary(String ticketKey, String ticketText, List<? extends ITicket> listOfAllTestCases, boolean isLink, String relatedTestCasesRulesLink, String relationship, List<? extends ITicket> currentlyLinkedTestCases, TestCasesGeneratorParams params, TestCasesTrackerAdapter customAdapter) throws Exception {
+        List<VerifiedTestCase> finaResults = new ArrayList<>();
         String extraRelatedTestCaseRulesFromConfluence = extractFromConfluence(relatedTestCasesRulesLink);
         ChunkPreparation chunkPreparation = new ChunkPreparation();
 
@@ -804,7 +836,7 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
             // Parallel chunk processing
             ExecutorService executorService = Executors.newFixedThreadPool(params.getParallelTestCaseCheckThreads());
             try {
-                List<Future<List<ITicket>>> futures = new ArrayList<>();
+                List<Future<List<VerifiedTestCase>>> futures = new ArrayList<>();
 
                 for (ChunkPreparation.Chunk chunk : chunks) {
                     futures.add(executorService.submit(() ->
@@ -814,10 +846,10 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
                 }
 
                 // Collect results from all chunks
-                for (Future<List<ITicket>> future : futures) {
-                    List<ITicket> chunkResults = future.get();
-                    for (ITicket result : chunkResults) {
-                        if (!finaResults.contains(result)) {
+                for (Future<List<VerifiedTestCase>> future : futures) {
+                    List<VerifiedTestCase> chunkResults = future.get();
+                    for (VerifiedTestCase result : chunkResults) {
+                        if (finaResults.stream().noneMatch(v -> v.getTicket().equals(result.getTicket()))) {
                             finaResults.add(result);
                         }
                     }
@@ -835,11 +867,11 @@ public class TestCasesGenerator extends AbstractJob<TestCasesGeneratorParams, Li
         } else {
             // Sequential chunk processing
             for (ChunkPreparation.Chunk chunk : chunks) {
-                List<ITicket> chunkResults = processChunk(chunk, ticketKey, ticketText, listOfAllTestCases,
+                List<VerifiedTestCase> chunkResults = processChunk(chunk, ticketKey, ticketText, listOfAllTestCases,
                                                           isLink, relationship, currentlyLinkedTestCases,
                                                           extraRelatedTestCaseRulesFromConfluence, params, customAdapter);
-                for (ITicket result : chunkResults) {
-                    if (!finaResults.contains(result)) {
+                for (VerifiedTestCase result : chunkResults) {
+                    if (finaResults.stream().noneMatch(v -> v.getTicket().equals(result.getTicket()))) {
                         finaResults.add(result);
                     }
                 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGeneratorParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/qa/TestCasesGeneratorParams.java
@@ -46,6 +46,8 @@ public class TestCasesGeneratorParams extends Params {
     public static final String TEST_CASES_CREATION_RULES = "testCasesCreationRules";
     public static final String CUSTOM_TEST_CASES_TRACKER = "customTestCasesTracker";
     public static final String IGNORE_CLONED_BY_RELATIONSHIP = "ignoreClonedByRelationship";
+    public static final String RELATED_TEST_CASE_EXPLANATION_PROMPT = "relatedTestCaseExplanationPrompt";
+    public static final String POST_LINKED_TEST_CASES_COMMENT = "postLinkedTestCasesComment";
 
     @SerializedName(EXISTING_TEST_CASES_JQL)
     private String existingTestCasesJql;
@@ -112,4 +114,10 @@ public class TestCasesGeneratorParams extends Params {
 
     @SerializedName(IGNORE_CLONED_BY_RELATIONSHIP)
     private boolean ignoreClonedByRelationship = true;
+
+    @SerializedName(RELATED_TEST_CASE_EXPLANATION_PROMPT)
+    private String relatedTestCaseExplanationPrompt;
+
+    @SerializedName(POST_LINKED_TEST_CASES_COMMENT)
+    private boolean postLinkedTestCasesComment = false;
 }

--- a/dmtools-core/src/main/resources/ftl/prompts/agents/related_test_case.xml
+++ b/dmtools-core/src/main/resources/ftl/prompts/agents/related_test_case.xml
@@ -18,11 +18,61 @@
     </input_data>
     <formatting>
         <rules>
+            <#if (global.explanationPrompt)?has_content>
+            <rule>When the test case is related, respond with "true, {explanation}" where {explanation} follows this guidance: ${global.explanationPrompt}</rule>
+            <rule>When the test case is not related, respond with "false".</rule>
+            <rule>Do not add any other text beyond the required format.</rule>
+            <#else>
             <rule>Respond with a boolean value only, without any explanation.</rule>
             <rule>Your response must be either "true" or "false".</rule>
+            </#if>
         </rules>
     </formatting>
     <examples>
+        <#if (global.explanationPrompt)?has_content>
+        <example>
+            <human>
+                {new story}
+                User login functionality
+                Implement a secure user login system with email and password
+                {new story}
+
+                {existing test case}
+                Test case for password reset functionality
+                Verify that users can reset their passwords through email
+                {existing test case}
+            </human>
+            <ai>true, This test case is related because it validates the password reset flow which is part of the same authentication system targeted by this story.</ai>
+        </example>
+        <example>
+            <human>
+                {new story}
+                Replace legacy session-based authentication with token-based auth
+                Migrate all authentication flows to use JWT tokens instead of server-side sessions
+                {new story}
+
+                {existing test case}
+                Test case for session login
+                Verify that users can log in and their session is maintained across page reloads
+                {existing test case}
+            </human>
+            <ai>true, This test case needs to be deprecated once this story is delivered, as the new token-based authentication replaces the session-based flow it validates.</ai>
+        </example>
+        <example>
+            <human>
+                {new story}
+                Product catalog search
+                Implement a search functionality for the product catalog
+                {new story}
+
+                {existing test case}
+                Test case for user profile update
+                Verify that users can update their profile information
+                {existing test case}
+            </human>
+            <ai>false</ai>
+        </example>
+        <#else>
         <example>
             <human>
                 {new story}
@@ -51,5 +101,6 @@
             </human>
             <ai>false</ai>
         </example>
+        </#if>
     </examples>
 </prompt>

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/agent/RelatedTestCaseAgentTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/agent/RelatedTestCaseAgentTest.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test for RelatedTestCaseAgent
  */
-public class RelatedTestCaseAgentTest extends BaseAgentTest<RelatedTestCaseAgent.Params, Boolean, RelatedTestCaseAgent> {
+public class RelatedTestCaseAgentTest extends BaseAgentTest<RelatedTestCaseAgent.Params, RelatedTestCaseAgent.Result, RelatedTestCaseAgent> {
 
     @Override
     protected RelatedTestCaseAgent createAgent() {
@@ -27,7 +27,8 @@ public class RelatedTestCaseAgentTest extends BaseAgentTest<RelatedTestCaseAgent
         return new RelatedTestCaseAgent.Params(
             "New user login story",
             "Existing test case for authentication",
-            "Extra validation rules"
+            "Extra validation rules",
+            null
         );
     }
 
@@ -37,9 +38,9 @@ public class RelatedTestCaseAgentTest extends BaseAgentTest<RelatedTestCaseAgent
     }
 
     @Override
-    protected void verifyResult(Boolean result) {
+    protected void verifyResult(RelatedTestCaseAgent.Result result) {
         assertNotNull(result);
-        assertTrue(result);
+        assertTrue(result.isRelated());
     }
 
     @Test
@@ -48,19 +49,46 @@ public class RelatedTestCaseAgentTest extends BaseAgentTest<RelatedTestCaseAgent
         assertEquals("New user login story", params.getNewStory());
         assertEquals("Existing test case for authentication", params.getExistingTestCase());
         assertEquals("Extra validation rules", params.getExtraRules());
+        assertNull(params.getExplanationPrompt());
+    }
+
+    @Test
+    void testParamsWithExplanationPrompt() {
+        RelatedTestCaseAgent.Params params = new RelatedTestCaseAgent.Params(
+            "story", "test case", "rules", "Explain why it is related"
+        );
+        assertEquals("Explain why it is related", params.getExplanationPrompt());
     }
 
     @Test
     void testTransformAIResponse_True() throws Exception {
         RelatedTestCaseAgent.Params params = createTestParams();
-        Boolean result = agent.transformAIResponse(params, "true");
-        assertTrue(result);
+        RelatedTestCaseAgent.Result result = agent.transformAIResponse(params, "true");
+        assertTrue(result.isRelated());
+        assertNull(result.getExplanation());
+    }
+
+    @Test
+    void testTransformAIResponse_TrueWithExplanation() throws Exception {
+        RelatedTestCaseAgent.Params params = createTestParams();
+        RelatedTestCaseAgent.Result result = agent.transformAIResponse(params, "true, because it covers the same auth flow");
+        assertTrue(result.isRelated());
+        assertEquals("because it covers the same auth flow", result.getExplanation());
+    }
+
+    @Test
+    void testTransformAIResponse_TrueDeprecationReason() throws Exception {
+        RelatedTestCaseAgent.Params params = createTestParams();
+        RelatedTestCaseAgent.Result result = agent.transformAIResponse(params, "true, This test case needs to be deprecated once this story is delivered.");
+        assertTrue(result.isRelated());
+        assertEquals("This test case needs to be deprecated once this story is delivered.", result.getExplanation());
     }
 
     @Test
     void testTransformAIResponse_False() throws Exception {
         RelatedTestCaseAgent.Params params = createTestParams();
-        Boolean result = agent.transformAIResponse(params, "false");
-        assertFalse(result);
+        RelatedTestCaseAgent.Result result = agent.transformAIResponse(params, "false");
+        assertFalse(result.isRelated());
+        assertNull(result.getExplanation());
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/utils/AIResponseParserTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/utils/AIResponseParserTest.java
@@ -12,6 +12,46 @@ import java.util.List;
 
 public class AIResponseParserTest extends TestCase {
 
+    public void testParseBooleanWithExplanation_TrueWithExplanation() {
+        AIResponseParser.BooleanWithExplanation result = AIResponseParser.parseBooleanWithExplanation("true, because it validates the same flow");
+        assertTrue(result.value);
+        assertEquals("because it validates the same flow", result.explanation);
+    }
+
+    public void testParseBooleanWithExplanation_TrueWithoutComma() {
+        AIResponseParser.BooleanWithExplanation result = AIResponseParser.parseBooleanWithExplanation("true");
+        assertTrue(result.value);
+        assertNull(result.explanation);
+    }
+
+    public void testParseBooleanWithExplanation_FalseNoExplanation() {
+        AIResponseParser.BooleanWithExplanation result = AIResponseParser.parseBooleanWithExplanation("false");
+        assertFalse(result.value);
+        assertNull(result.explanation);
+    }
+
+    public void testParseBooleanWithExplanation_FalseIgnoresTrailingText() {
+        AIResponseParser.BooleanWithExplanation result = AIResponseParser.parseBooleanWithExplanation("false, not related");
+        assertFalse(result.value);
+        assertNull(result.explanation);
+    }
+
+    public void testParseBooleanWithExplanation_TrueDeprecationReason() {
+        AIResponseParser.BooleanWithExplanation result = AIResponseParser.parseBooleanWithExplanation(
+            "true, This test case needs to be deprecated once this story is delivered.");
+        assertTrue(result.value);
+        assertEquals("This test case needs to be deprecated once this story is delivered.", result.explanation);
+    }
+
+    public void testParseBooleanWithExplanation_ThrowsOnInvalidInput() {
+        try {
+            AIResponseParser.parseBooleanWithExplanation("maybe");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
     public void testParseBooleanResponse() {
         try {
             assertTrue(AIResponseParser.parseBooleanResponse("... true ..."));

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParallelTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParallelTest.java
@@ -98,10 +98,10 @@ public class TestCasesGeneratorParallelTest {
                 .thenReturn(new JSONArray("[\"TC-0\", \"TC-1\", \"TC-2\", \"TC-3\", \"TC-4\"]"));
 
         when(relatedTestCaseAgent.run(anyString(), any(RelatedTestCaseAgent.Params.class)))
-                .thenReturn(true);
+                .thenReturn(new RelatedTestCaseAgent.Result(true, null));
 
         // Act
-        List<ITicket> result = generator.findAndLinkSimilarTestCasesBySummary(
+        List<TestCasesGenerator.VerifiedTestCase> result = generator.findAndLinkSimilarTestCasesBySummary(
                 ticketKey, ticketText, allTestCases, true, "http://rules", Relationship.RELATES_TO, Collections.emptyList(), params
         );
 
@@ -154,11 +154,11 @@ public class TestCasesGeneratorParallelTest {
                     String testText = params1.getExistingTestCase();
                     // Extract test case number from "Test Case X"
                     int num = Integer.parseInt(testText.split(" ")[2]);
-                    return num % 2 == 0; // Only even numbers are confirmed
+                    return new RelatedTestCaseAgent.Result(num % 2 == 0, null); // Only even numbers are confirmed
                 });
 
         // Act
-        List<ITicket> result = generator.findAndLinkSimilarTestCasesBySummary(
+        List<TestCasesGenerator.VerifiedTestCase> result = generator.findAndLinkSimilarTestCasesBySummary(
                 ticketKey, ticketText, allTestCases, true, "http://rules", Relationship.RELATES_TO, Collections.emptyList(), params
         );
 
@@ -205,10 +205,10 @@ public class TestCasesGeneratorParallelTest {
         when(relatedTestCasesAgent.run(anyString(), any(RelatedTestCasesAgent.Params.class)))
                 .thenReturn(new JSONArray("[\"TC-0\", \"TC-1\", \"TC-2\", \"TC-3\", \"TC-4\", \"TC-5\", \"TC-6\", \"TC-7\"]"));
         when(relatedTestCaseAgent.run(anyString(), any(RelatedTestCaseAgent.Params.class)))
-                .thenReturn(true);
+                .thenReturn(new RelatedTestCaseAgent.Result(true, null));
 
         // Act
-        List<ITicket> result = generator.findAndLinkSimilarTestCasesBySummary(
+        List<TestCasesGenerator.VerifiedTestCase> result = generator.findAndLinkSimilarTestCasesBySummary(
                 ticketKey, ticketText, allTestCases, true, "http://rules", Relationship.RELATES_TO, Collections.emptyList(), params
         );
 
@@ -247,10 +247,10 @@ public class TestCasesGeneratorParallelTest {
         when(relatedTestCasesAgent.run(anyString(), any(RelatedTestCasesAgent.Params.class)))
                 .thenReturn(new JSONArray("[\"TC-0\", \"TC-1\"]"));
         when(relatedTestCaseAgent.run(anyString(), any(RelatedTestCaseAgent.Params.class)))
-                .thenReturn(true);
+                .thenReturn(new RelatedTestCaseAgent.Result(true, null));
 
         // Act
-        List<ITicket> result = generator.findAndLinkSimilarTestCasesBySummary(
+        List<TestCasesGenerator.VerifiedTestCase> result = generator.findAndLinkSimilarTestCasesBySummary(
                 ticketKey, ticketText, allTestCases, true, "http://rules", Relationship.RELATES_TO, Collections.emptyList(), params
         );
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParamsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorParamsTest.java
@@ -129,6 +129,8 @@ public class TestCasesGeneratorParamsTest {
             , null                              // testCasesCreationRules
             , null                              // customTestCasesTracker
             , true                              // ignoreClonedByRelationship
+            , null                              // relatedTestCaseExplanationPrompt
+            , false                             // postLinkedTestCasesComment
         );
 
         assertTrue("Constructor should set enableParallelTestCaseCheck correctly",
@@ -283,6 +285,63 @@ public class TestCasesGeneratorParamsTest {
                    deserializedParams.isEnableParallelPostVerification());
         assertEquals("Deserialized params should have parallelPostVerificationThreads=7",
                      7, deserializedParams.getParallelPostVerificationThreads());
+    }
+
+    @Test
+    public void testDefaultRelatedTestCaseExplanationPromptIsNull() {
+        assertNull("relatedTestCaseExplanationPrompt should be null by default",
+                   params.getRelatedTestCaseExplanationPrompt());
+    }
+
+    @Test
+    public void testDefaultPostLinkedTestCasesCommentIsFalse() {
+        assertFalse("postLinkedTestCasesComment should be false by default",
+                    params.isPostLinkedTestCasesComment());
+    }
+
+    @Test
+    public void testSetRelatedTestCaseExplanationPrompt() {
+        params.setRelatedTestCaseExplanationPrompt("Explain why the TC is related or needs deprecation.");
+        assertEquals("Explain why the TC is related or needs deprecation.",
+                     params.getRelatedTestCaseExplanationPrompt());
+    }
+
+    @Test
+    public void testSetPostLinkedTestCasesComment() {
+        params.setPostLinkedTestCasesComment(true);
+        assertTrue("postLinkedTestCasesComment should be true after setter",
+                   params.isPostLinkedTestCasesComment());
+    }
+
+    @Test
+    public void testSerializationWithExplanationParams() {
+        params.setRelatedTestCaseExplanationPrompt("Explain why");
+        params.setPostLinkedTestCasesComment(true);
+
+        String json = gson.toJson(params);
+        JSONObject jsonObject = new JSONObject(json);
+
+        assertEquals("Serialized JSON should contain relatedTestCaseExplanationPrompt",
+                     "Explain why", jsonObject.getString("relatedTestCaseExplanationPrompt"));
+        assertTrue("Serialized JSON should contain postLinkedTestCasesComment=true",
+                   jsonObject.getBoolean("postLinkedTestCasesComment"));
+    }
+
+    @Test
+    public void testDeserializationWithExplanationParams() {
+        String json = "{\"relatedTestCaseExplanationPrompt\":\"Why is it related\",\"postLinkedTestCasesComment\":true}";
+        TestCasesGeneratorParams deserialized = gson.fromJson(json, TestCasesGeneratorParams.class);
+
+        assertEquals("Why is it related", deserialized.getRelatedTestCaseExplanationPrompt());
+        assertTrue(deserialized.isPostLinkedTestCasesComment());
+    }
+
+    @Test
+    public void testConstantValues_ExplanationParams() {
+        assertEquals("relatedTestCaseExplanationPrompt",
+                     TestCasesGeneratorParams.RELATED_TEST_CASE_EXPLANATION_PROMPT);
+        assertEquals("postLinkedTestCasesComment",
+                     TestCasesGeneratorParams.POST_LINKED_TEST_CASES_COMMENT);
     }
 }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
@@ -825,7 +825,7 @@ public class TestCasesGeneratorTest {
         verify(trackerClient).postComment(eq("STORY-1"), commentCaptor.capture());
         String comment = commentCaptor.getValue();
         assertTrue("Comment should contain TC key", comment.contains("TC-1"));
-        assertTrue("Comment should contain TC title", comment.contains("Login test"));
+        assertFalse("Comment should NOT repeat summary (Jira auto-links)", comment.contains("Login test"));
         assertTrue("Comment should contain explanation", comment.contains("validates the same auth flow"));
         assertTrue("Comment should start with header", comment.startsWith("Related test cases identified:"));
     }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/qa/TestCasesGeneratorTest.java
@@ -7,6 +7,8 @@ import com.github.istin.dmtools.ai.AI;
 import com.github.istin.dmtools.ai.ChunkPreparation;
 import com.github.istin.dmtools.ai.Claude35TokenCounter;
 import com.github.istin.dmtools.ai.TicketContext;
+import com.github.istin.dmtools.ai.agent.RelatedTestCaseAgent;
+import com.github.istin.dmtools.ai.agent.RelatedTestCasesAgent;
 import com.github.istin.dmtools.ai.agent.TestCaseGeneratorAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.atlassian.jira.model.Fields;
@@ -18,10 +20,12 @@ import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.job.JavaScriptExecutor;
 import com.github.istin.dmtools.job.TrackerParams;
+import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,6 +35,9 @@ import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.*;
 
 public class TestCasesGeneratorTest {
@@ -731,5 +738,276 @@ public class TestCasesGeneratorTest {
     public void testIgnoreClonedByRelationship_defaultIsTrue() {
         TestCasesGeneratorParams params = new TestCasesGeneratorParams();
         assertTrue("ignoreClonedByRelationship should default to true", params.isIgnoreClonedByRelationship());
+    }
+
+    // ---- VerifiedTestCase inner class tests ----
+
+    @Test
+    public void testVerifiedTestCase_gettersReturnCorrectValues() {
+        ITicket mockTicket = mock(ITicket.class);
+        String explanation = "This TC validates the same auth flow";
+        TestCasesGenerator.VerifiedTestCase vc = new TestCasesGenerator.VerifiedTestCase(mockTicket, explanation);
+
+        assertSame(mockTicket, vc.getTicket());
+        assertEquals(explanation, vc.getExplanation());
+    }
+
+    @Test
+    public void testVerifiedTestCase_nullExplanationAllowed() {
+        ITicket mockTicket = mock(ITicket.class);
+        TestCasesGenerator.VerifiedTestCase vc = new TestCasesGenerator.VerifiedTestCase(mockTicket, null);
+
+        assertSame(mockTicket, vc.getTicket());
+        assertNull(vc.getExplanation());
+    }
+
+    // ---- Batch comment tests ----
+
+    private TestCasesGenerator buildGeneratorWithMocks(
+            TrackerClient<ITicket> trackerClient,
+            RelatedTestCaseAgent relatedTestCaseAgent,
+            RelatedTestCasesAgent relatedTestCasesAgent) throws Exception {
+        TestCasesGenerator gen = new TestCasesGenerator();
+        setField(gen, "trackerClient", trackerClient);
+        setField(gen, "confluence", mock(Confluence.class));
+        setField(gen, "relatedTestCaseAgent", relatedTestCaseAgent);
+        setField(gen, "relatedTestCasesAgent", relatedTestCasesAgent);
+        setField(gen, "testCaseGeneratorAgent", mock(TestCaseGeneratorAgent.class));
+        setField(gen, "ai", mock(AI.class));
+        return gen;
+    }
+
+    private void setField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @Test
+    public void testBatchComment_postedWhenEnabled() throws Exception {
+        @SuppressWarnings("unchecked")
+        TrackerClient<ITicket> trackerClient = mock(TrackerClient.class);
+        RelatedTestCaseAgent relatedTestCaseAgent = mock(RelatedTestCaseAgent.class);
+        RelatedTestCasesAgent relatedTestCasesAgent = mock(RelatedTestCasesAgent.class);
+
+        ITicket tc1 = mock(ITicket.class);
+        when(tc1.getKey()).thenReturn("TC-1");
+        when(tc1.getTicketKey()).thenReturn("TC-1");
+        when(tc1.toText()).thenReturn("TC text 1");
+        when(tc1.getTicketTitle()).thenReturn("Login test");
+
+        TestCasesGenerator gen = buildGeneratorWithMocks(trackerClient, relatedTestCaseAgent, relatedTestCasesAgent);
+
+        when(relatedTestCasesAgent.run(any(), any()))
+                .thenReturn(new JSONArray("[\"TC-1\"]"));
+        when(relatedTestCaseAgent.run(any(), any()))
+                .thenReturn(new RelatedTestCaseAgent.Result(true, "validates the same auth flow"));
+        when(trackerClient.getTestCases(any(), any())).thenReturn(Collections.emptyList());
+
+        ITicket mainTicket = mock(ITicket.class);
+        when(mainTicket.getTicketKey()).thenReturn("STORY-1");
+        when(mainTicket.getKey()).thenReturn("STORY-1");
+        TicketContext ctx = mock(TicketContext.class);
+        when(ctx.getTicket()).thenReturn(mainTicket);
+        when(ctx.toText()).thenReturn("Story text");
+
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        params.setFindRelated(true);
+        params.setLinkRelated(false);
+        params.setGenerateNew(false);
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setPostLinkedTestCasesComment(true);
+        params.setRelatedTestCaseExplanationPrompt("Explain why the TC is related");
+
+        gen.generateTestCases(ctx, "", List.of(tc1), params);
+
+        ArgumentCaptor<String> commentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(trackerClient).postComment(eq("STORY-1"), commentCaptor.capture());
+        String comment = commentCaptor.getValue();
+        assertTrue("Comment should contain TC key", comment.contains("TC-1"));
+        assertTrue("Comment should contain TC title", comment.contains("Login test"));
+        assertTrue("Comment should contain explanation", comment.contains("validates the same auth flow"));
+        assertTrue("Comment should start with header", comment.startsWith("Related test cases identified:"));
+    }
+
+    @Test
+    public void testBatchComment_notPostedWhenDisabled() throws Exception {
+        @SuppressWarnings("unchecked")
+        TrackerClient<ITicket> trackerClient = mock(TrackerClient.class);
+        RelatedTestCaseAgent relatedTestCaseAgent = mock(RelatedTestCaseAgent.class);
+        RelatedTestCasesAgent relatedTestCasesAgent = mock(RelatedTestCasesAgent.class);
+
+        ITicket tc1 = mock(ITicket.class);
+        when(tc1.getKey()).thenReturn("TC-1");
+        when(tc1.getTicketKey()).thenReturn("TC-1");
+        when(tc1.toText()).thenReturn("TC text 1");
+
+        TestCasesGenerator gen = buildGeneratorWithMocks(trackerClient, relatedTestCaseAgent, relatedTestCasesAgent);
+
+        when(relatedTestCasesAgent.run(any(), any()))
+                .thenReturn(new JSONArray("[\"TC-1\"]"));
+        when(relatedTestCaseAgent.run(any(), any()))
+                .thenReturn(new RelatedTestCaseAgent.Result(true, "some explanation"));
+        when(trackerClient.getTestCases(any(), any())).thenReturn(Collections.emptyList());
+
+        ITicket mainTicket = mock(ITicket.class);
+        when(mainTicket.getTicketKey()).thenReturn("STORY-1");
+        when(mainTicket.getKey()).thenReturn("STORY-1");
+        TicketContext ctx = mock(TicketContext.class);
+        when(ctx.getTicket()).thenReturn(mainTicket);
+        when(ctx.toText()).thenReturn("Story text");
+
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        params.setFindRelated(true);
+        params.setLinkRelated(false);
+        params.setGenerateNew(false);
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setPostLinkedTestCasesComment(false); // disabled
+
+        gen.generateTestCases(ctx, "", List.of(tc1), params);
+
+        verify(trackerClient, never()).postComment(anyString(), anyString());
+    }
+
+    @Test
+    public void testBatchComment_notPostedWhenNoRelatedTcsFound() throws Exception {
+        @SuppressWarnings("unchecked")
+        TrackerClient<ITicket> trackerClient = mock(TrackerClient.class);
+        RelatedTestCaseAgent relatedTestCaseAgent = mock(RelatedTestCaseAgent.class);
+        RelatedTestCasesAgent relatedTestCasesAgent = mock(RelatedTestCasesAgent.class);
+
+        ITicket tc1 = mock(ITicket.class);
+        when(tc1.getKey()).thenReturn("TC-1");
+        when(tc1.getTicketKey()).thenReturn("TC-1");
+        when(tc1.toText()).thenReturn("TC text 1");
+
+        TestCasesGenerator gen = buildGeneratorWithMocks(trackerClient, relatedTestCaseAgent, relatedTestCasesAgent);
+
+        when(relatedTestCasesAgent.run(any(), any()))
+                .thenReturn(new JSONArray("[\"TC-1\"]"));
+        when(relatedTestCaseAgent.run(any(), any()))
+                .thenReturn(new RelatedTestCaseAgent.Result(false, null)); // not related
+        when(trackerClient.getTestCases(any(), any())).thenReturn(Collections.emptyList());
+
+        ITicket mainTicket = mock(ITicket.class);
+        when(mainTicket.getTicketKey()).thenReturn("STORY-1");
+        when(mainTicket.getKey()).thenReturn("STORY-1");
+        TicketContext ctx = mock(TicketContext.class);
+        when(ctx.getTicket()).thenReturn(mainTicket);
+        when(ctx.toText()).thenReturn("Story text");
+
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        params.setFindRelated(true);
+        params.setLinkRelated(false);
+        params.setGenerateNew(false);
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setPostLinkedTestCasesComment(true); // enabled but no results
+
+        gen.generateTestCases(ctx, "", List.of(tc1), params);
+
+        verify(trackerClient, never()).postComment(anyString(), anyString());
+    }
+
+    @Test
+    public void testExplanationPrompt_passedToAgent() throws Exception {
+        @SuppressWarnings("unchecked")
+        TrackerClient<ITicket> trackerClient = mock(TrackerClient.class);
+        RelatedTestCaseAgent relatedTestCaseAgent = mock(RelatedTestCaseAgent.class);
+        RelatedTestCasesAgent relatedTestCasesAgent = mock(RelatedTestCasesAgent.class);
+
+        ITicket tc1 = mock(ITicket.class);
+        when(tc1.getKey()).thenReturn("TC-1");
+        when(tc1.getTicketKey()).thenReturn("TC-1");
+        when(tc1.toText()).thenReturn("TC text 1");
+
+        TestCasesGenerator gen = buildGeneratorWithMocks(trackerClient, relatedTestCaseAgent, relatedTestCasesAgent);
+
+        when(relatedTestCasesAgent.run(any(), any()))
+                .thenReturn(new JSONArray("[\"TC-1\"]"));
+        when(relatedTestCaseAgent.run(any(), any()))
+                .thenReturn(new RelatedTestCaseAgent.Result(true, "validates same flow"));
+        when(trackerClient.getTestCases(any(), any())).thenReturn(Collections.emptyList());
+
+        ITicket mainTicket = mock(ITicket.class);
+        when(mainTicket.getTicketKey()).thenReturn("STORY-1");
+        when(mainTicket.getKey()).thenReturn("STORY-1");
+        TicketContext ctx = mock(TicketContext.class);
+        when(ctx.getTicket()).thenReturn(mainTicket);
+        when(ctx.toText()).thenReturn("Story text");
+
+        String expectedPrompt = "Explain why the TC is related or needs deprecation";
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        params.setFindRelated(true);
+        params.setLinkRelated(false);
+        params.setGenerateNew(false);
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setRelatedTestCaseExplanationPrompt(expectedPrompt);
+
+        gen.generateTestCases(ctx, "", List.of(tc1), params);
+
+        ArgumentCaptor<RelatedTestCaseAgent.Params> agentParamsCaptor =
+                ArgumentCaptor.forClass(RelatedTestCaseAgent.Params.class);
+        verify(relatedTestCaseAgent).run(isNull(), agentParamsCaptor.capture());
+        assertEquals("explanationPrompt should be passed to agent",
+                expectedPrompt, agentParamsCaptor.getValue().getExplanationPrompt());
+    }
+
+    @Test
+    public void testBatchComment_multipleTickets_allIncluded() throws Exception {
+        @SuppressWarnings("unchecked")
+        TrackerClient<ITicket> trackerClient = mock(TrackerClient.class);
+        RelatedTestCaseAgent relatedTestCaseAgent = mock(RelatedTestCaseAgent.class);
+        RelatedTestCasesAgent relatedTestCasesAgent = mock(RelatedTestCasesAgent.class);
+
+        ITicket tc1 = mock(ITicket.class);
+        when(tc1.getKey()).thenReturn("TC-1");
+        when(tc1.getTicketKey()).thenReturn("TC-1");
+        when(tc1.toText()).thenReturn("TC text 1");
+        when(tc1.getTicketTitle()).thenReturn("Login test");
+
+        ITicket tc2 = mock(ITicket.class);
+        when(tc2.getKey()).thenReturn("TC-2");
+        when(tc2.getTicketKey()).thenReturn("TC-2");
+        when(tc2.toText()).thenReturn("TC text 2");
+        when(tc2.getTicketTitle()).thenReturn("Session test");
+
+        TestCasesGenerator gen = buildGeneratorWithMocks(trackerClient, relatedTestCaseAgent, relatedTestCasesAgent);
+
+        when(relatedTestCasesAgent.run(any(), any()))
+                .thenReturn(new JSONArray("[\"TC-1\", \"TC-2\"]"));
+        when(relatedTestCaseAgent.run(any(), any(RelatedTestCaseAgent.Params.class)))
+                .thenAnswer(inv -> {
+                    RelatedTestCaseAgent.Params p = inv.getArgument(1);
+                    if (p.getExistingTestCase().contains("TC text 1")) {
+                        return new RelatedTestCaseAgent.Result(true, "covers auth functionality");
+                    }
+                    return new RelatedTestCaseAgent.Result(true, "needs deprecation after delivery");
+                });
+        when(trackerClient.getTestCases(any(), any())).thenReturn(Collections.emptyList());
+
+        ITicket mainTicket = mock(ITicket.class);
+        when(mainTicket.getTicketKey()).thenReturn("STORY-1");
+        when(mainTicket.getKey()).thenReturn("STORY-1");
+        TicketContext ctx = mock(TicketContext.class);
+        when(ctx.getTicket()).thenReturn(mainTicket);
+        when(ctx.toText()).thenReturn("Story text");
+
+        TestCasesGeneratorParams params = new TestCasesGeneratorParams();
+        params.setFindRelated(true);
+        params.setLinkRelated(false);
+        params.setGenerateNew(false);
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setPostLinkedTestCasesComment(true);
+        params.setRelatedTestCaseExplanationPrompt("Why is this TC related?");
+
+        gen.generateTestCases(ctx, "", List.of(tc1, tc2), params);
+
+        ArgumentCaptor<String> commentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(trackerClient).postComment(eq("STORY-1"), commentCaptor.capture());
+        String comment = commentCaptor.getValue();
+        assertTrue("Comment must list TC-1", comment.contains("TC-1"));
+        assertTrue("Comment must list TC-2", comment.contains("TC-2"));
+        assertTrue("Comment must include auth explanation", comment.contains("covers auth functionality"));
+        assertTrue("Comment must include deprecation explanation", comment.contains("needs deprecation after delivery"));
     }
 }


### PR DESCRIPTION
## Summary

Adds two new optional parameters to `TestCasesGenerator` that improve transparency when test cases are linked to stories:

1. **`relatedTestCaseExplanationPrompt`** (String, default `null`) — when set, instructs the LLM to return `true, <explanation>` instead of bare `true`. The explanation describes *why* the TC is related. The prompt text is fully configurable per project.
2. **`postLinkedTestCasesComment`** (boolean, default `false`) — when `true`, posts a **single batch Jira comment** after processing all TCs for a story, listing each linked TC with its explanation.

Both parameters are fully backward-compatible: when omitted, existing `true`/`false` behaviour is preserved.

---

## Changes

| File | Change |
|---|---|
| `AIResponseParser.java` | New `BooleanWithExplanation` inner class + `parseBooleanWithExplanation()` |
| `RelatedTestCaseAgent.java` | `Result` inner class; `Params.explanationPrompt`; return type `Boolean → Result` |
| `related_test_case.xml` | FreeMarker conditional: explanation formatting rules + 3 examples (covers same functionality / needs deprecation after delivery / not related) |
| `TestCasesGeneratorParams.java` | Two new fields |
| `TestCasesGenerator.java` | `VerifiedTestCase`; propagated through chain; batch comment in `generateTestCases()` |
| `dmtools-ai-docs/references/jobs/README.md` | New param docs |
| Tests (5 files) | Full coverage of new logic |

## Test coverage
- `AIResponseParserTest` — parseBooleanWithExplanation: true+explanation, true without comma, false, false+trailing text
- `RelatedTestCaseAgentTest` — Result transformation
- `TestCasesGeneratorParamsTest` — new field defaults
- `TestCasesGeneratorTest` — batch comment posted with correct format
- `TestCasesGeneratorParallelTest` — parallel path propagates VerifiedTestCase

## Prompt examples (explanation mode)

The XML template includes three canonical examples so the LLM understands both `true` semantics:
1. `true, This test case is related because it validates the same authentication flow targeted by this story.` ← TC covers related functionality
2. `true, This test case needs to be deprecated once this story is delivered, as the new implementation replaces the flow it validates.` ← TC becomes obsolete after story delivery
3. `false` ← unrelated