### PR TITLE
fix: correct Acceptance Criteria field name in story_acceptance_criterias agent

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -15,7 +15,10 @@ module.exports = {
 
     jira: {
         project: 'DMC',
-        parentTicket: 'DMC-101'
+        parentTicket: 'DMC-101',
+        fields: {
+            acceptanceCriteria: 'Acceptance Criteria'
+        }
     },
 
     git: {
@@ -69,3 +72,4 @@ IMPORTANT SCOPE CONSTRAINTS:
         ]
     }
 };
+


### PR DESCRIPTION
## What
Updates `agents` submodule to fix the `fieldName` in `story_acceptance_criterias.json` from `"Acceptance Criterias"` to `"Acceptance Criteria"`.

## Why
"Acceptance Criterias" is grammatically incorrect ("criteria" is already plural) and doesn't match the actual Jira field name `Acceptance Criteria` in the DMC project. This caused the BA agent output to be written to a non-existent field.