### PR TITLE
feat: prepend agent name to CI run trace comments

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/expert/Expert.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/expert/Expert.java
@@ -247,7 +247,7 @@ public class Expert extends AbstractJob<ExpertParams, List<ResultItem>> {
                 if (shouldPostComments(expertParams)) {
                     try {
                         logger.info("Tracing CI run URL to ticket {}: {}", ticket.getTicketKey(), ciRunUrl);
-                        trackerClient.postComment(ticket.getTicketKey(), "Processing started. CI Run: " + ciRunUrl);
+                        trackerClient.postComment(ticket.getTicketKey(), agentNamePrefix(expertParams) + "Processing started. CI Run: " + ciRunUrl);
                     } catch (Exception e) {
                         logger.warn("Failed to post CI run trace comment for ticket {} — continuing. Error: {}",
                                 ticket.getTicketKey(), e.getMessage());

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/AbstractJob.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/AbstractJob.java
@@ -4,6 +4,7 @@
 package com.github.istin.dmtools.job;
 
 import com.github.istin.dmtools.ai.AI;
+import com.github.istin.dmtools.ai.model.Metadata;
 import com.github.istin.dmtools.di.ServerManagedIntegrationsModule;
 import dagger.Component;
 import lombok.Getter;
@@ -156,6 +157,20 @@ public abstract class AbstractJob<Params, Result> implements Job<Params, Result>
      */
     protected JavaScriptExecutor js(String jsCode) {
         return new JavaScriptExecutor(jsCode);
+    }
+
+    protected static String agentNamePrefix(TrackerParams params) {
+        Metadata metadata = params.getMetadata();
+        if (metadata != null) {
+            String name = metadata.getContextId();
+            if (name == null || name.isEmpty()) {
+                name = metadata.getAgentId();
+            }
+            if (name != null && !name.isEmpty()) {
+                return "[" + name + "] ";
+            }
+        }
+        return "";
     }
 
     /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -337,7 +337,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                 if (shouldPostComments(expertParams)) {
                     try {
                         logger.info("Tracing CI run URL to ticket {}: {}", ticket.getTicketKey(), ciRunUrl);
-                        trackerClient.postComment(ticket.getTicketKey(), "Processing started. CI Run: " + ciRunUrl);
+                        trackerClient.postComment(ticket.getTicketKey(), agentNamePrefix(expertParams) + "Processing started. CI Run: " + ciRunUrl);
                     } catch (Exception e) {
                         logger.warn("Failed to post CI run trace comment for ticket {} — continuing. Error: {}",
                                 ticket.getTicketKey(), e.getMessage());


### PR DESCRIPTION
## Summary
- Adds `agentNamePrefix()` helper to `AbstractJob` that resolves the agent label from `metadata.contextId` (e.g. `pr_review`) with fallback to `metadata.agentId` (e.g. `Teammate`)
- Applies the prefix in both `Teammate` and `Expert` when posting the \"Processing started. CI Run: ...\" comment
- Result: comments now read `[pr_review] Processing started. CI Run: https://...`, making it immediately clear which agent triggered the run

## Test plan
- [x] Config with `"metadata": {"contextId": "pr_review"}` → comment starts with `[pr_review]`
- [ ] Config without `contextId` → falls back to `[Teammate]` / `[Expert]`
- [ ] Config without `metadata` block → comment is unchanged (`Processing started. CI Run: ...`)
- [ ] Run unit tests: `./gradlew :dmtools-core:test`