### PR TITLE
chore: update agents submodule + .dmtools prompt packs

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -24,15 +24,27 @@ module.exports = {
 
     agentConfigsDir: 'agents',
 
-    customInstructions: `
-IMPORTANT SCOPE CONSTRAINTS:
-- This repository is the dmtools CLI module (dmtools-core) ONLY.
-- API module (dmtools-server) and UI module are OUT OF SCOPE - do NOT implement, modify, or create tickets for them.
-- All implementation work must target dmtools-core/src/main/java only.
-- When creating subtasks, only create [CORE] subtasks. Do NOT create [API], [UI], or [SD API] subtasks.
-- All new MCP tools must follow the @MCPTool / @MCPParam annotation pattern in dmtools-core.
-- Do NOT suggest or reference Spring Boot, REST endpoints, or frontend changes.
-`,
+    cliPrompts: {
+        story_development: [
+            './.dmtools/instructions/architecture/dmtools_core_scope.md',
+            './.dmtools/prompts/development_focus.md'
+        ],
+        bug_development: [
+            './.dmtools/instructions/architecture/dmtools_core_scope.md',
+            './.dmtools/prompts/development_focus.md'
+        ],
+        bug_rca: [
+            './.dmtools/instructions/architecture/dmtools_core_scope.md'
+        ],
+        pr_review: [
+            './.dmtools/instructions/architecture/dmtools_core_scope.md',
+            './.dmtools/prompts/review_focus.md'
+        ],
+        pr_rework: [
+            './.dmtools/instructions/architecture/dmtools_core_scope.md',
+            './.dmtools/prompts/rework_focus.md'
+        ]
+    },
 
     additionalInstructions: {
         po_refinement: [

--- a/.dmtools/instructions/architecture/dmtools_core_scope.md
+++ b/.dmtools/instructions/architecture/dmtools_core_scope.md
@@ -1,0 +1,8 @@
+# dmtools Core Scope
+
+- Work only in the dmtools CLI/core module.
+- Keep API/server/UI work out of scope.
+- Target `dmtools-core/src/main/java` unless the ticket explicitly names another core path.
+- Create only `[CORE]` subtasks. Do not create `[API]`, `[UI]`, or `[SD API]` subtasks.
+- New MCP tools must follow the existing `@MCPTool` / `@MCPParam` annotation pattern.
+- Do not propose Spring Boot endpoints, REST API work, or frontend changes.

--- a/.dmtools/prompts/development_focus.md
+++ b/.dmtools/prompts/development_focus.md
@@ -1,0 +1,6 @@
+# Development Focus
+
+- Preserve existing DMtools job/agent configuration contracts.
+- Prefer small, composable Java changes with explicit error messages.
+- Reuse existing MCP tool, job, and provider patterns before introducing new abstractions.
+- Keep generated artifacts and credentials out of source control.

--- a/.dmtools/prompts/review_focus.md
+++ b/.dmtools/prompts/review_focus.md
@@ -1,0 +1,6 @@
+# Review Focus
+
+- Check CLI/job config compatibility first.
+- Verify MCP tool annotations, parameter names, and provider wiring.
+- Flag changes that broaden scope into API/UI/server work.
+- Prioritize correctness, security, and backward compatibility over style.

--- a/.dmtools/prompts/rework_focus.md
+++ b/.dmtools/prompts/rework_focus.md
@@ -1,0 +1,6 @@
+# Rework Focus
+
+- Address requested review findings only.
+- Keep fixes inside dmtools core scope.
+- Do not rewrite unrelated agent/job behavior.
+- Preserve public config names and existing runtime contracts.


### PR DESCRIPTION
## Summary

- Updated agents submodule to `bd39610` (dmtools-agents PR #8: prompt architecture skill + config loader improvements)
- Extracted inline scope rules to `.dmtools/instructions/architecture/dmtools_core_scope.md`
- Added `.dmtools/prompts/{development,review,rework}_focus.md` for modular cliPrompts composition
- Wired project context via `cliPrompts` in `.dmtools/config.js`

> Note: `.claude/` is gitignored in this repo (dm.ai is the skill source).