### PR TITLE
Update agents story acceptance criteria template

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -61,6 +61,11 @@ module.exports = {
             './.dmtools/instructions/product/po_domain_knowledge.md',
             'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/11665485/Template+Story'
         ],
+        story_acceptance_criteria: [
+            './.dmtools/instructions/product/po_domain_knowledge.md',
+            './agents/instructions/common/investigate_before_answer.md',
+            'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/11665485/Template+Story'
+        ],
         story_acceptance_criterias: [
             './.dmtools/instructions/product/po_domain_knowledge.md',
             './agents/instructions/common/investigate_before_answer.md',

--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -17,6 +17,7 @@ module.exports = {
         project: 'DMC',
         parentTicket: 'DMC-101',
         questions: {
+            fetchJql: 'parent = {ticketKey} AND issuetype = Subtask ORDER BY created ASC',
             answerField: 'Answer'
         },
         fields: {


### PR DESCRIPTION
## Summary
- update the agents submodule to latest main b19313d with the singular story_acceptance_criteria agent and enhanced Jira story template
- keep the existing DM.AI PO/domain acceptance criteria extension by adding the new story_acceptance_criteria config key while preserving legacy story_acceptance_criterias compatibility

## Validation
- node config load for .dmtools/config.js
- dmtools run /tmp/dmtools_changed_tests.json passed: 93 passed, 0 failed
