### PR TITLE
Fix beta release creation

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -124,6 +124,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download CLI Package
         uses: actions/download-artifact@v4
         with:
@@ -162,7 +165,7 @@ jobs:
 
           **macOS / Linux:**
           \`\`\`bash
-          curl -fLo install.sh https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.sh
+          curl -fLo install.sh https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/install.sh
           chmod +x install.sh
           ./install.sh ${{ needs.version.outputs.tag }}
           \`\`\`
@@ -170,7 +173,7 @@ jobs:
           **Windows (PowerShell):**
           \`\`\`powershell
           \$env:DMTOOLS_VERSION = "${{ needs.version.outputs.tag }}"
-          Invoke-WebRequest -Uri "https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/install.ps1" -OutFile "install.ps1"
+          Invoke-WebRequest -Uri "https://github.com/${{ github.repository }}/releases/download/${{ needs.version.outputs.tag }}/install.ps1" -OutFile "install.ps1"
           .\install.ps1
           \`\`\`
 
@@ -188,15 +191,17 @@ jobs:
 
       - name: Create Beta Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           TAG="${{ needs.version.outputs.tag }}"
           # If the release already exists (e.g. workflow re-run), delete it first so we can recreate with fresh assets
-          if gh release view "$TAG" > /dev/null 2>&1; then
+          if gh release view "$TAG" --repo "$GH_REPO" > /dev/null 2>&1; then
             echo "Release $TAG already exists — deleting so assets can be re-uploaded"
-            gh release delete "$TAG" --yes --cleanup-tag || true
+            gh release delete "$TAG" --repo "$GH_REPO" --yes --cleanup-tag || true
           fi
           gh release create "$TAG" \
+            --repo "$GH_REPO" \
             --title "DMTools Beta $TAG" \
             --notes-file release_notes.md \
             --prerelease \


### PR DESCRIPTION
Fixes the beta release job failing with `fatal: not a git repository`.\n\nChanges:\n- checks out the repository in create-beta-release before release creation\n- passes `--repo`/`GH_REPO` to `gh release view/delete/create`, so the command does not depend on implicit git remote discovery\n- switches beta quick-install links in release notes from raw GitHub URLs to the beta release assets\n- keeps beta releases as prereleases so stable latest remains unaffected\n\nValidated: YAML parses successfully.