### PR TITLE
DMC-902 Test: Verify upgrade guidance completeness — migration note includes backup, verification, and rollback

### DIFF
--- a/testing/components/services/upgrade_guidance_service.py
+++ b/testing/components/services/upgrade_guidance_service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class SectionAudit:
+    path: Path
+    heading: str
+    content: str
+    missing_requirements: tuple[str, ...]
+
+
+class UpgradeGuidanceService:
+    SECTION_HEADING = "Upgrading from legacy installs"
+
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.candidate_paths = (
+            repository_root / "README.md",
+            repository_root / "dmtools-ai-docs/references/installation/README.md",
+            repository_root / "dmtools-ai-docs/references/installation/troubleshooting.md",
+        )
+
+    def audit_upgrade_guidance_sections(self) -> list[SectionAudit]:
+        audits: list[SectionAudit] = []
+        for path in self.candidate_paths:
+            for section in self._extract_named_sections(path, self.SECTION_HEADING):
+                normalized_section = self._normalize(section)
+                missing_requirements = tuple(
+                    label
+                    for label, checker in self._requirement_checks().items()
+                    if not checker(section, normalized_section)
+                )
+                audits.append(
+                    SectionAudit(
+                        path=path,
+                        heading=self.SECTION_HEADING,
+                        content=section.strip(),
+                        missing_requirements=missing_requirements,
+                    )
+                )
+        return audits
+
+    @staticmethod
+    def format_missing_requirements(audits: list[SectionAudit]) -> str:
+        lines = [
+            "Each visible 'Upgrading from legacy installs' section must include backup, replace, preserve/merge config, path update, verification, and rollback guidance."
+        ]
+        for audit in audits:
+            if not audit.missing_requirements:
+                continue
+            lines.append(f"- {audit.path.as_posix()}: missing {', '.join(audit.missing_requirements)}")
+            lines.append("  Section content:")
+            for section_line in audit.content.splitlines():
+                lines.append(f"    {section_line}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _extract_named_sections(path: Path, heading: str) -> list[str]:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        sections: list[str] = []
+        heading_pattern = re.compile(rf"^(?P<hashes>#+)\s+{re.escape(heading)}\s*$")
+
+        for index, line in enumerate(lines):
+            match = heading_pattern.match(line.strip())
+            if not match:
+                continue
+
+            level = len(match.group("hashes"))
+            collected_lines = [line]
+            for candidate_line in lines[index + 1 :]:
+                stripped_candidate = candidate_line.strip()
+                if stripped_candidate.startswith("#"):
+                    next_heading_match = re.match(r"^(?P<hashes>#+)\s+", stripped_candidate)
+                    if next_heading_match and len(next_heading_match.group("hashes")) <= level:
+                        break
+                collected_lines.append(candidate_line)
+            sections.append("\n".join(collected_lines).strip())
+
+        return sections
+
+    @staticmethod
+    def _normalize(content: str) -> str:
+        return re.sub(r"\s+", " ", content).lower()
+
+    @classmethod
+    def _requirement_checks(cls) -> dict[str, Callable[[str, str], bool]]:
+        return {
+            "backup of ~/.dmtools": cls._has_backup_step,
+            "replace with EPAM release": cls._has_replace_step,
+            "preserve or merge config": cls._has_preserve_step,
+            "update system paths": cls._has_path_update_step,
+            "verification commands": cls._has_verification_step,
+            "rollback using backup copy": cls._has_rollback_step,
+        }
+
+    @staticmethod
+    def _has_backup_step(section: str, normalized_section: str) -> bool:
+        return "~/.dmtools" in section and any(token in normalized_section for token in ("backup", "back up", "copy"))
+
+    @staticmethod
+    def _has_replace_step(section: str, normalized_section: str) -> bool:
+        mentions_epam_release = any(
+            token in normalized_section
+            for token in (
+                "github.com/epam/dm.ai/releases",
+                "epam release",
+                "release asset",
+                "latest/download/install",
+            )
+        )
+        return mentions_epam_release and any(
+            token in normalized_section for token in ("replace", "re-run", "rerun", "switch")
+        )
+
+    @staticmethod
+    def _has_preserve_step(section: str, normalized_section: str) -> bool:
+        return any(
+            token in normalized_section for token in ("preserve", "merge", "keep", "retain")
+        ) and any(
+            token in normalized_section
+            for token in ("config", "configuration", "dmtools.env", "dmtools-local.env")
+        )
+
+    @staticmethod
+    def _has_path_update_step(section: str, normalized_section: str) -> bool:
+        return any(
+            token in normalized_section
+            for token in (
+                "~/.dmtools/bin",
+                "path",
+                "which dmtools",
+                "get-command dmtools",
+                "alias",
+                "wrapper script",
+                "shell profile",
+            )
+        )
+
+    @staticmethod
+    def _has_verification_step(section: str, normalized_section: str) -> bool:
+        return "dmtools --version" in section and "dmtools list" in section
+
+    @staticmethod
+    def _has_rollback_step(section: str, normalized_section: str) -> bool:
+        return any(token in normalized_section for token in ("rollback", "roll back", "restore")) and any(
+            token in normalized_section for token in ("backup", "backup copy", "backup folder")
+        )

--- a/testing/tests/DMC-902/README.md
+++ b/testing/tests/DMC-902/README.md
@@ -1,0 +1,25 @@
+# DMC-902 automated test
+
+This test validates that every visible `Upgrading from legacy installs` section in the tracked installation documentation includes the required migration safeguards: backup, EPAM release replacement, config preservation, path update guidance, verification commands, and rollback.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-902/test_dmc_902.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads repository documentation files directly from this checkout.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-902/config.yaml
+++ b/testing/tests/DMC-902/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-902
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-902/test_dmc_902.py
+++ b/testing/tests/DMC-902/test_dmc_902.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from testing.components.services.upgrade_guidance_service import UpgradeGuidanceService
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_902_upgrade_guidance_is_complete() -> None:
+    service = UpgradeGuidanceService(REPOSITORY_ROOT)
+
+    audits = service.audit_upgrade_guidance_sections()
+
+    assert audits, (
+        "Expected at least one 'Upgrading from legacy installs' section in README.md, "
+        "dmtools-ai-docs/references/installation/README.md, or "
+        "dmtools-ai-docs/references/installation/troubleshooting.md."
+    )
+
+    incomplete_audits = [audit for audit in audits if audit.missing_requirements]
+    assert not incomplete_audits, service.format_missing_requirements(audits)


### PR DESCRIPTION
# DMC-902 automated test result

**Status:** FAILED

**Test command:** `python3 -m pytest testing/tests/DMC-902/test_dmc_902.py -q`

**Result:** The `Upgrading from legacy installs` section was found in `README.md` and `dmtools-ai-docs/references/installation/README.md`, but both sections are incomplete. They include the EPAM release replacement guidance and path cleanup guidance, but they are missing:

- backup of `~/.dmtools`
- preserve or merge config guidance
- verification commands `dmtools --version` and `dmtools list`
- rollback guidance that restores the backup copy

**Step-by-step outcome**

1. Locate the `Upgrading from legacy installs` section. **Passed** — found in `README.md` and `dmtools-ai-docs/references/installation/README.md`.
2. Verify presence of backup `~/.dmtools`, replace artifact with EPAM release, preserve/merge config, and update system paths. **Failed** — replace/path guidance exists, but backup and preserve/merge config guidance do not.
3. Check for verification commands `dmtools --version` and `dmtools list`. **Failed** — neither command is present in either section.
4. Check for a rollback step involving restoration of the backup copy. **Failed** — no rollback or restore-from-backup step is documented.

**Exact pytest failure**

```text
F                                                                        [100%]
=================================== FAILURES ===================================
__________________ test_dmc_902_upgrade_guidance_is_complete ___________________

    def test_dmc_902_upgrade_guidance_is_complete() -> None:
        service = UpgradeGuidanceService(REPOSITORY_ROOT)

        audits = service.audit_upgrade_guidance_sections()

        assert audits, (
            "Expected at least one 'Upgrading from legacy installs' section in README.md, "
            "dmtools-ai-docs/references/installation/README.md, or "
            "dmtools-ai-docs/references/installation/troubleshooting.md."
        )

        incomplete_audits = [audit for audit in audits if audit.missing_requirements]
>       assert not incomplete_audits, service.format_missing_requirements(audits)
E       AssertionError: Each visible 'Upgrading from legacy installs' section must include backup, replace, preserve/merge config, path update, verification, and rollback guidance.
E         - /home/runner/work/dm.ai/dm.ai/README.md: missing backup of ~/.dmtools, preserve or merge config, verification commands, rollback using backup copy
E           Section content:
E             ### Upgrading from legacy installs
E
E             1. Re-run the installer from `https://github.com/epam/dm.ai/releases/latest/download/install.sh` (or `install.bat` / `install.ps1` on Windows) to replace wrappers that still point to `IstiN/dmtools` or raw GitHub URLs.
E             2. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases and wrapper scripts from your shell profile or old CI bootstrap steps.
E             3. For CI caches, refresh any keys tied to legacy install URLs after switching to the release asset path.
E         - /home/runner/work/dm.ai/dm.ai/dmtools-ai-docs/references/installation/README.md: missing backup of ~/.dmtools, preserve or merge config, verification commands, rollback using backup copy
E           Section content:
E             ### Upgrading from legacy installs
E
E             1. Replace any `IstiN/dmtools` or `raw.githubusercontent.com/.../main/install.sh` bootstrap commands with `https://github.com/epam/dm.ai/releases/latest/download/install.sh`.
E             2. Remove stale aliases or wrapper scripts that bypass `~/.dmtools/bin/dmtools` before reinstalling.
E             3. If a CI job caches `~/.dmtools`, update the cache key when switching away from legacy install URLs.
E       assert not [SectionAudit(path=PosixPath('/home/runner/work/dm.ai/dm.ai/README.md'), heading='Upgrading from legacy installs', con...uirements=('backup of ~/.dmtools', 'preserve or merge config', 'verification commands', 'rollback using backup copy'))]

testing/tests/DMC-902/test_dmc_902.py:21: AssertionError
=========================== short test summary info ============================
FAILED testing/tests/DMC-902/test_dmc_902.py::test_dmc_902_upgrade_guidance_is_complete - AssertionError: Each visible 'Upgrading from legacy installs' section must include backup, replace, preserve/merge config, path update, verification, and rollback guidance.
1 failed in 0.02s
```

**Environment**

- Repository paths under test: `README.md`, `dmtools-ai-docs/references/installation/README.md`, `dmtools-ai-docs/references/installation/troubleshooting.md`
- OS: `Linux 6.17.0-1010-azure x86_64`
- Runtime: `Python 3.12.3`
- Browser: `N/A`
- Config: none
- Full log: `outputs/dmc_902_pytest.log`
