### PR TITLE
Customize DM.AI test case generation rules

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -91,5 +91,14 @@ module.exports = {
         bug_creation: [
             'https://dmtools.atlassian.net/wiki/spaces/AINA/pages/18186241/Template+Jira+Markdown'
         ]
+    },
+
+    jobParamPatches: {
+        test_cases_generator: {
+            confluencePages: [
+                './agents/instructions/test_cases/test_case_creation_rules.md',
+                './.dmtools/instructions/test_cases/dm_ai_functional_test_case_rules.md'
+            ]
+        }
     }
 };

--- a/.dmtools/instructions/test_cases/dm_ai_functional_test_case_rules.md
+++ b/.dmtools/instructions/test_cases/dm_ai_functional_test_case_rules.md
@@ -1,0 +1,72 @@
+# DM.AI Functional Test Case Rules
+
+Use these rules when generating Test Case tickets for the DM.AI project.
+
+## Goal
+
+Generate test cases that validate the real product behavior a user or maintainer depends on, not only that files were edited.
+
+For documentation stories, a good test case must prove that the documentation is correct by checking it against the implementation, CLI behavior, generated artifacts, or repository workflows.
+
+## Prefer functional evidence
+
+Each test case should include at least one concrete evidence source:
+
+- a `dmtools` CLI command and expected output;
+- a source-of-truth implementation file or config that defines the behavior;
+- a generated documentation artifact that users consume;
+- a GitHub workflow, install script, or release artifact used by users;
+- a Jira/GitHub integration result visible to users.
+
+Avoid test cases that only say "open the document and inspect it" unless the expected result names exact entries, exact files, and how they are verified.
+
+## DM.AI documentation stories
+
+When the story updates `teammate-configs.md`, `dmtools-ai-docs`, agent names, or agent descriptions:
+
+1. Verify each documented agent against implementation/discovery sources, for example:
+   - `./dmtools.sh list`
+   - `dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java`
+   - agent JSON configs under `agents/`
+   - generated docs under `dmtools-ai-docs/`
+2. Validate concrete user-facing content:
+   - public agent name;
+   - short description;
+   - whether it is active or deprecated;
+   - replacement/migration path for deprecated aliases;
+   - working usage example link.
+3. Split cases by behavior, not by broad document section:
+   - "agent registry names match CLI discovery";
+   - "usage links resolve and show executable examples";
+   - "deprecated aliases point to replacement public agents";
+   - "generated skill docs include updated agent summaries".
+4. Do not create cases that require checking unrelated files such as `CHANGELOG.md` unless the story explicitly asks for them.
+
+## Step quality
+
+Steps must be executable by a human or automatable by `test_case_automation`:
+
+- include exact command or file path;
+- include exact expected text/pattern where possible;
+- define failure conditions clearly;
+- avoid vague words like "correct", "relevant", "updated", or "proper" unless followed by measurable criteria.
+
+## Expected result quality
+
+Expected results must be specific enough to fail when documentation is misleading.
+
+Good:
+`./dmtools.sh list` contains `TestCasesGenerator`, and `dmtools-ai-docs/references/agents/teammate-configs.md` documents the same name with a usage link to `agents/test_cases_generator.json`.
+
+Bad:
+All docs are accurate and links are relevant.
+
+## Coverage balance
+
+For small documentation stories, prefer 3-5 high-signal cases over many broad cases:
+
+1. registry/source-of-truth consistency;
+2. user-facing documentation content;
+3. usage example links or commands;
+4. generated docs/skill package consistency if generation is part of the workflow;
+5. deprecated alias migration only when obsolete names are actually present.


### PR DESCRIPTION
Updates agents to IstiN/dmtools-agents@ec82729 and adds DM.AI-specific TestCasesGenerator rules.

Analysis from DMC-857 generated cases:
- existing cases were broad documentation inspections rather than functional checks;
- some expected unrelated files/scripts like CHANGELOG updates;
- expected results used vague criteria such as “relevant” or “correct” without source-of-truth verification;
- cases did not consistently validate user-facing behavior via `dmtools` CLI discovery, implementation registry, generated docs, or usage examples.

Changes:
- adds generic agents support for `jobParamPatches`, allowing project config to patch top-level params for Java-backed jobs such as `TestCasesGenerator`;
- adds `.dmtools/instructions/test_cases/dm_ai_functional_test_case_rules.md`;
- wires these rules only for DM.AI `test_cases_generator` via `.dmtools/config.js`.

The new DM.AI rules require test cases to validate real product behavior with concrete evidence: CLI commands, implementation source-of-truth files, generated docs, GitHub workflows/install artifacts, or Jira/GitHub integration results.

Validated agents focused suite: `91 passed, 0 failed`.