### PR TITLE
DMC-904 javascript-agents.md uses non-canonical agent name StoryProcessor

### DIFF
--- a/dmtools-ai-docs/references/agents/javascript-agents.md
+++ b/dmtools-ai-docs/references/agents/javascript-agents.md
@@ -775,7 +775,7 @@ console.info("Info message");
 
 ```json
 {
-  "name": "StoryProcessor",
+  "name": "Teammate",
   "params": {
     "preprocessJSAction": "agents/js/validateStory.js",
     "postprocessJSAction": "agents/js/updateTickets.js",


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`dmtools-ai-docs/references/agents/javascript-agents.md` contained a stale JSON example with `"name": "StoryProcessor"` under the `Using in Teammate Configuration` section. That identifier is not part of the canonical supported job-name set documented in `teammate-configs.md` and `jobs/README.md`, so the DMC-898 consistency audit correctly failed.

### Fix
Updated the JSON example in `dmtools-ai-docs/references/agents/javascript-agents.md` to use the canonical `Teammate` job identifier. This is the minimal targeted change needed to bring the secondary documentation back in line with the canonical job-reference documentation.

### Test Coverage
- Reproduction test used: `testing/tests/DMC-898/test_dmc_898.py` — `test_dmc_898_documentation_references_stay_consistent`
- Full verification: `python3 -m pytest testing/tests/DMC-898/test_dmc_898.py -q` PASSED; `./gradlew :dmtools-core:compileJava :dmtools-core:test` PASSED

### Notes
- No repo-root `instruction.md` file was present in this checkout, so implementation constraints were derived from the available repository guidance and the ticket context files in `input/DMC-904/`.
