### PR TITLE
DMC-860 Remove deprecated 'codegenerator' agent from codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ java -jar dmtools-appengine.jar
 - **Base**: `AbstractJob<Params, Result>` - Thread-local context support
 - **Runner**: `JobRunner` - Factory-based instantiation, prevents race conditions
 - **Context**: `JobContext` - Thread-local configuration and attributes
-- 20+ specialized jobs: BA (RequirementsCollector, UserStoryGenerator), Dev (CodeGenerator, UnitTestsGenerator), QA (TestCasesGenerator), Reporting (DevProductivityReport)
+- 20+ specialized jobs: BA (RequirementsCollector, UserStoryGenerator), Dev (CodeGenerator compatibility shim, UnitTestsGenerator), QA (TestCasesGenerator), Reporting (DevProductivityReport)
 
 #### 2. MCP Tools System
 Three-component architecture:
@@ -153,7 +153,7 @@ com.github.istin.dmtools/
 ├── di/              # Dagger dependency injection (46+ components)
 ├── ba/              # Business Analysis jobs
 ├── qa/              # QA jobs (TestCasesGenerator)
-├── dev/             # Development jobs (CodeGenerator, UnitTestsGenerator)
+├── dev/             # Development jobs (CodeGenerator compatibility shim, UnitTestsGenerator)
 ├── report/          # Productivity reporting
 ├── documentation/   # Documentation generation
 ├── diagram/         # Mermaid diagram generation
@@ -605,7 +605,7 @@ function action(params) {
 | Size | Small (~100-200 lines) | Can be larger |
 | AI Interaction | One prompt, one call | Multiple agent calls |
 | Reusability | High - used by multiple jobs | Lower - specific workflow |
-| Examples | TestCaseGeneratorAgent, RequestDecompositionAgent | TestCasesGenerator, CodeGenerator |
+| Examples | TestCaseGeneratorAgent, RequestDecompositionAgent | TestCasesGenerator, CodeGenerator compatibility shim |
 
 **Example Flow**:
 ```

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ See the [installation guide](dmtools-ai-docs/references/installation/README.md) 
 2. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases and wrapper scripts from your shell profile or old CI bootstrap steps.
 3. For CI caches, refresh any keys tied to legacy install URLs after switching to the release asset path.
 
+### Deprecated compatibility shims
+
+- `CodeGenerator` is deprecated and kept only as a compatibility shim for one release. Invocations now log a warning and return a no-op response; migrate affected automation before `v1.8.0`.
+
 ### Configuration
 
 ```bash

--- a/dmtools-ai-docs/CHANGELOG.md
+++ b/dmtools-ai-docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [skill-v1.0.28] - 2026-05-01
+
+### Changed
+
+- Marked `CodeGenerator` as a deprecated compatibility shim across job/configuration docs
+- Added migration guidance that the shim is no-op, logs a deprecation warning, and is scheduled for removal before `v1.8.0`
+
 ## [skill-v1.0.27] - 2026-03-26
 
 ### Added
@@ -270,4 +277,3 @@ All notable changes to the DMtools Agent Skill will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-

--- a/dmtools-ai-docs/references/configuration/json-config-rules.md
+++ b/dmtools-ai-docs/references/configuration/json-config-rules.md
@@ -82,7 +82,7 @@ The `"name"` field in JSON configuration **MUST** exactly match the Java Job cla
 | `TestCasesGenerator` | Generate test cases from stories |
 | `Teammate` | AI teammate for ticket analysis |
 | `Expert` | Domain expert Q&A |
-| `CodeGenerator` | Generate code from stories |
+| `CodeGenerator` | Deprecated compatibility shim. Accepted for one release, logs a warning, and performs no generation. |
 | `UnitTestsGenerator` | Generate unit tests |
 | `DocumentationGenerator` | Generate documentation |
 | `DiagramsCreator` | Create Mermaid diagrams |

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -2,6 +2,8 @@
 
 Complete reference for all 23 available jobs in DMtools. Jobs are specialized workflows that orchestrate MCP tools, AI agents, and data processing.
 
+> **Deprecation notice:** `CodeGenerator` is no longer a supported development workflow. The CLI entry remains as a compatibility shim for one release, logs a deprecation warning, and performs no generation. Migrate to `Teammate`-driven development flows or other supported jobs before `v1.8.0`.
+
 ---
 
 ## ⚠️ CRITICAL: The "name" Field is NOT User-Defined
@@ -49,7 +51,6 @@ The `"name"` field is a **technical identifier** that maps to a Java class in DM
 - [QAProductivityReport](#qaproductivityreport) - QA team productivity metrics
 
 ### Development (Dev)
-- [CodeGenerator](#codegenerator) - Generate code from user stories
 - [UnitTestsGenerator](#unittestsgenerator) - Generate unit tests for code
 - [DevProductivityReport](#devproductivityreport) - Dev team productivity metrics
 - [CommitsTriage](#commitstriage) - Analyze and categorize commits

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGenerator.java
@@ -4,31 +4,31 @@
 package com.github.istin.dmtools.dev;
 
 import com.github.istin.dmtools.ai.AI;
-import com.github.istin.dmtools.ai.ConversationObserver;
-import com.github.istin.dmtools.ai.JAssistant;
-import com.github.istin.dmtools.ai.TicketContext;
-import com.github.istin.dmtools.atlassian.confluence.BasicConfluence;
-import com.github.istin.dmtools.atlassian.jira.BasicJiraClient;
-import com.github.istin.dmtools.common.code.SourceCode;
-import com.github.istin.dmtools.common.model.ITicket;
-import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.job.AbstractJob;
 import com.github.istin.dmtools.job.ResultItem;
-import com.github.istin.dmtools.ai.dial.BasicDialAI;
-import com.github.istin.dmtools.prompt.PromptManager;
-import com.github.istin.dmtools.report.freemarker.GenericCell;
-import com.github.istin.dmtools.report.freemarker.GenericReport;
-import com.github.istin.dmtools.report.freemarker.GenericRow;
-import org.json.JSONArray;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class CodeGenerator extends AbstractJob<CodeGeneratorParams, List<ResultItem>> {
 
+    public static final String REMOVAL_VERSION = "v1.8.0";
+    private final Logger logger;
+
+    public CodeGenerator() {
+        this(LogManager.getLogger(CodeGenerator.class));
+    }
+
+    CodeGenerator(Logger logger) {
+        this.logger = logger;
+    }
+
     @Override
-    public List<ResultItem> runJob(CodeGeneratorParams params) throws Exception {
-        return runJob(params.getConfluenceRootPage(), params.getEachPagePrefix(), params.getInputJQL(), params.getInitiator(), params.getRole(), params.getSources());
+    public List<ResultItem> runJob(CodeGeneratorParams params) {
+        logger.warn(getDeprecationMessage());
+        return Collections.singletonList(new ResultItem(getName(), getCompatibilityResponse()));
     }
 
     @Override
@@ -36,50 +36,13 @@ public class CodeGenerator extends AbstractJob<CodeGeneratorParams, List<ResultI
         return null;
     }
 
-    public static List<ResultItem> runJob(String confluenceRootPage, String eachPagePrefix, String inputJQL, String initiator, String role, JSONArray sources) throws Exception {
-        BasicConfluence confluence = BasicConfluence.getInstance();
-
-        TrackerClient<? extends ITicket> trackerClient = BasicJiraClient.getInstance();
-        List<SourceCode> basicSourceCodes = SourceCode.Impl.getConfiguredSourceCodes(sources);
-        ConversationObserver conversationObserver = new ConversationObserver();
-        BasicDialAI ai = new BasicDialAI(conversationObserver);
-        PromptManager promptManager = new PromptManager();
-
-        JAssistant jAssistant = new JAssistant(trackerClient, basicSourceCodes, ai, promptManager);
-
-        List<ResultItem> resultItems = new ArrayList<>();
-        trackerClient.searchAndPerform(ticket -> {
-            TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-            ticketContext.prepareContext();
-            String response = generateCode(confluenceRootPage, eachPagePrefix, role, ticketContext, jAssistant, conversationObserver, confluence, basicSourceCodes);
-            trackerClient.postCommentIfNotExists(ticket.getTicketKey(), trackerClient.tag(initiator) + ", code is prepared.");
-            resultItems.add(new ResultItem(ticket.getKey(), response));
-            return false;
-        }, inputJQL, trackerClient.getExtendedQueryFields());
-        return resultItems;
+    public static String getDeprecationMessage() {
+        return "CodeGenerator is deprecated and now runs as a compatibility shim. "
+                + "No code will be generated. Migrate to supported workflows before " + REMOVAL_VERSION + ".";
     }
 
-    public static String generateCode(String confluenceRootPage, String eachPagePrefix, String role, TicketContext ticketContext, JAssistant jAssistant, ConversationObserver conversationObserver, BasicConfluence confluence, List<SourceCode> basicSourceCode) throws Exception {
-        String response = jAssistant.generateCode(role, ticketContext);
-        List<ConversationObserver.Message> messages = conversationObserver.getMessages();
-        if (confluenceRootPage == null || eachPagePrefix == null || confluenceRootPage.isEmpty() || eachPagePrefix.isEmpty()) {
-            messages.clear();
-            return "";
-        }
-
-        if (!messages.isEmpty()) {
-            GenericReport genericReport = new GenericReport();
-            genericReport.setIsNotWiki(false);
-            genericReport.setName(eachPagePrefix + " " + ticketContext.getTicket().getKey());
-            for (ConversationObserver.Message message : messages) {
-                GenericRow row = new GenericRow(false);
-                row.getCells().add(new GenericCell("<b>" + message.getAuthor() + "</b>"));
-                row.getCells().add(new GenericCell(message.getText()));
-                genericReport.getRows().add(row);
-            }
-            conversationObserver.printAndClear();
-            confluence.publishPageToDefaultSpace(confluenceRootPage, eachPagePrefix, genericReport);
-        }
-        return response;
+    public static String getCompatibilityResponse() {
+        return "CodeGenerator compatibility shim executed successfully. "
+                + "No action was taken and no code artifacts were produced.";
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java
@@ -3,56 +3,33 @@
 
 package com.github.istin.dmtools.dev;
 
-import com.github.istin.dmtools.ai.ConversationObserver;
-import com.github.istin.dmtools.ai.JAssistant;
-import com.github.istin.dmtools.ai.TicketContext;
-import com.github.istin.dmtools.atlassian.confluence.BasicConfluence;
-import com.github.istin.dmtools.common.code.SourceCode;
-import com.github.istin.dmtools.common.model.ITicket;
-import com.github.istin.dmtools.common.tracker.TrackerClient;
-import com.github.istin.dmtools.ai.dial.BasicDialAI;
-import com.github.istin.dmtools.prompt.PromptManager;
-import org.junit.Before;
+import com.github.istin.dmtools.job.ResultItem;
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class CodeGeneratorTest {
 
-    private CodeGenerator codeGenerator;
-    private CodeGeneratorParams params;
-    private BasicConfluence confluence;
-    private TrackerClient<ITicket> trackerClient;
-    private List<SourceCode> basicSourceCodes;
-    private ConversationObserver conversationObserver;
-    private BasicDialAI dialAI;
-    private PromptManager promptManager;
-    private JAssistant jAssistant;
-
-    @Before
-    public void setUp() {
-        codeGenerator = new CodeGenerator();
-        params = mock(CodeGeneratorParams.class);
-        confluence = mock(BasicConfluence.class);
-        trackerClient = mock(TrackerClient.class);
-        basicSourceCodes = mock(List.class);
-        conversationObserver = mock(ConversationObserver.class);
-        dialAI = mock(BasicDialAI.class);
-        promptManager = mock(PromptManager.class);
-        jAssistant = mock(JAssistant.class);
-    }
-
-
     @Test
-    public void testGenerateCode() throws Exception {
-        TicketContext ticketContext = mock(TicketContext.class);
-        when(ticketContext.getTicket()).thenReturn(mock(ITicket.class));
+    public void testRunJobReturnsCompatibilityResponseAndLogsDeprecationWarning() {
+        Logger logger = mock(Logger.class);
+        CodeGenerator codeGenerator = new CodeGenerator(logger);
 
-        CodeGenerator.generateCode("rootPage", "prefix", "role", ticketContext, jAssistant, conversationObserver, confluence, basicSourceCodes);
+        List<ResultItem> resultItems = codeGenerator.runJob(null);
 
-        verify(jAssistant, times(1)).generateCode(eq("role"), eq(ticketContext));
-        verify(conversationObserver, times(1)).getMessages();
+        assertEquals(1, resultItems.size());
+        assertEquals("CodeGenerator", resultItems.get(0).getKey());
+        assertEquals(CodeGenerator.getCompatibilityResponse(), resultItems.get(0).getResult());
+        assertNull(codeGenerator.getAi());
+        assertTrue(CodeGenerator.getDeprecationMessage().contains("deprecated"));
+        assertTrue(CodeGenerator.getDeprecationMessage().contains(CodeGenerator.REMOVAL_VERSION));
+        verify(logger).warn(CodeGenerator.getDeprecationMessage());
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobRunnerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobRunnerTest.java
@@ -3,18 +3,22 @@
 
 package com.github.istin.dmtools.job;
 
+import com.github.istin.dmtools.dev.CodeGenerator;
 import com.github.istin.dmtools.kb.KBProcessingJob;
 import com.github.istin.dmtools.reporting.ReportGeneratorJob;
 import com.github.istin.dmtools.reporting.ReportVisualizerJob;
 import org.junit.Test;
+import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.lang.reflect.Method;
 import java.util.Base64;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -55,6 +59,13 @@ public class JobRunnerTest {
     }
 
     @Test
+    public void testCodeGeneratorCompatibilityShimRemainsRegistered() throws Exception {
+        assertTrue(invokeCreateJobInstance("CodeGenerator") instanceof CodeGenerator);
+        assertTrue(invokeCreateJobInstance("codegenerator") instanceof CodeGenerator);
+        assertTrue(invokeListJobs().contains("- CodeGenerator"));
+    }
+
+    @Test
     public void testKBProcessingJobUsesCliFacingNameInListingAndValidation() throws Exception {
         assertEquals("KBProcessingJob", new KBProcessingJob().getName());
 
@@ -69,6 +80,23 @@ public class JobRunnerTest {
             assertTrue(e.getMessage().contains("KBProcessingJob"));
             assertFalse(e.getMessage().contains("KBProcessing,"));
         }
+    }
+
+    @Test
+    public void testRunSupportsCodeGeneratorCompatibilityShim() throws Exception {
+        JobParams jobParams = new JobParams();
+        jobParams.setName("CodeGenerator");
+        jobParams.set(JobParams.PARAMS, new JSONObject());
+
+        Object result = new JobRunner().run(jobParams);
+
+        assertNotNull(result);
+        assertTrue(result instanceof List);
+        List<?> items = (List<?>) result;
+        assertEquals(1, items.size());
+        ResultItem item = (ResultItem) items.get(0);
+        assertEquals("CodeGenerator", item.getKey());
+        assertEquals(CodeGenerator.getCompatibilityResponse(), item.getResult());
     }
 
     private Object invokeCreateJobInstance(String jobName) throws Exception {


### PR DESCRIPTION
## Issues/Notes

- No `instruction.md` was present at the repository root, so implementation followed the ticket payload under `input/DMC-860/`.
- `CodeGenerator` is intentionally **not** hard-removed yet. The class and `JobRunner` registration remain as a one-release compatibility shim that logs a deprecation warning and returns a deterministic no-op result.
- No in-repo external consumers of `codegenerator` were found beyond the updated code/docs references.
- Rollback is low risk: restore the previous `CodeGenerator` implementation and revert the documentation deprecation notes if consumers cannot migrate during the compatibility window.

## Approach

- Replaced the legacy `CodeGenerator` implementation with a small compatibility shim in `dmtools-core` while preserving the existing `CodeGenerator` / `codegenerator` lookup path in `JobRunner`.
- The shim now emits a clear deprecation warning mentioning the planned removal version (`v1.8.0`) and returns a successful, non-empty compatibility response instead of invoking Jira/Confluence/AI generation flows.
- Kept `CodeGeneratorParams` unchanged so existing job payloads continue to deserialize without contract changes.
- Updated the dev/job documentation to stop advertising `CodeGenerator` as an active workflow and to document the migration/deprecation window instead.

## Files Modified

- `dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGenerator.java` — removed the old generation workflow and replaced it with the compatibility shim.
- `dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java` — added focused unit coverage for the shim response and deprecation logging.
- `dmtools-core/src/test/java/com/github/istin/dmtools/job/JobRunnerTest.java` — verified the shim stays registered in `JobRunner`, appears in job listings, and executes successfully through the runtime entry point.
- `README.md` — added a root-level deprecation note for the compatibility shim.
- `dmtools-ai-docs/references/jobs/README.md` — removed `CodeGenerator` from the supported development jobs list and added a migration/deprecation notice.
- `dmtools-ai-docs/references/configuration/json-config-rules.md` — marked `CodeGenerator` as a deprecated accepted name rather than a supported generation workflow.
- `dmtools-ai-docs/CHANGELOG.md` — recorded the documentation-side migration note for the shim window.
- `CLAUDE.md` — updated internal contributor guidance to reflect that `CodeGenerator` is now only a compatibility shim.

## Test Coverage

- Added unit coverage that calls the shim directly, verifies the no-op compatibility payload, and asserts that the deprecation warning message is logged.
- Added runtime coverage for `JobRunner` registration and execution so the preserved `CodeGenerator` / `codegenerator` entry point remains safe for existing callers.
- Verification run:
  - `./gradlew :dmtools-core:compileJava :dmtools-core:test`
