### PR TITLE
DMC-856 Document per-skill installation options in dmtools-ai-docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,33 +181,107 @@ jobs:
         run: |
           VERSION="${{ needs.version-and-tag.outputs.version }}"
           DIST_DIR="dist"
-          mkdir -p $DIST_DIR
+          mkdir -p "$DIST_DIR" "$DIST_DIR/staging"
 
-          # Create the skill package
-          echo "📦 Creating DMtools Agent Skill package..."
-          cd dmtools-ai-docs
+          copy_skill_doc() {
+            local source_file="$1"
+            local target_root="$2"
+            mkdir -p "$target_root/$(dirname "$source_file")"
+            cp "dmtools-ai-docs/$source_file" "$target_root/$source_file"
+          }
 
-          # Create ZIP archive (exclude install.sh - it's a separate release asset)
-          zip -r ../$DIST_DIR/dmtools-skill-v${VERSION}.zip . \
-            -x "*.git*" \
-            -x ".DS_Store" \
-            -x "node_modules/*" \
-            -x "*.swp" \
-            -x ".cursorrules" \
-            -x ".github/*" \
-            -x "install.sh"
+          create_skill_manifest() {
+            local target_root="$1"
+            local skill_name="$2"
+            local title="$3"
+            local description="$4"
+            cat > "$target_root/SKILL.md" <<EOF
+          ---
+          name: $skill_name
+          description: $description
+          license: Apache-2.0
+          compatibility:
+            - Java 17+
+            - macOS, Linux, Windows (WSL)
+          metadata:
+            version: skill-v$VERSION
+            author: DMtools Team
+            repository: https://github.com/epam/dm.ai
+            documentation: https://github.com/epam/dm.ai/tree/main/dmtools-ai-docs
+          ---
 
-          # Create tarball for *nix systems (exclude install.sh - it's a separate release asset)
-          tar -czf ../$DIST_DIR/dmtools-skill-v${VERSION}.tar.gz \
-            --exclude='.git*' \
-            --exclude='.DS_Store' \
-            --exclude='node_modules' \
-            --exclude='.cursorrules' \
-            --exclude='.github' \
-            --exclude='install.sh' \
-            .
+          # $title
 
-          cd ..
+          Install instructions: [references/installation/README.md#install-only-the-skills-you-need](references/installation/README.md#install-only-the-skills-you-need)
+
+          Use the focused configuration and MCP reference pages included in this package:
+          EOF
+          }
+
+          package_directory() {
+            local source_dir="$1"
+            local base_name="$2"
+            local output_dir="$PWD/$DIST_DIR"
+            (
+              cd "$source_dir"
+              zip -rq "$output_dir/${base_name}-v${VERSION}.zip" .
+              tar -czf "$output_dir/${base_name}-v${VERSION}.tar.gz" .
+            )
+            cp "$DIST_DIR/${base_name}-v${VERSION}.zip" "$DIST_DIR/${base_name}.zip"
+            cp "$DIST_DIR/${base_name}-v${VERSION}.tar.gz" "$DIST_DIR/${base_name}.tar.gz"
+          }
+
+          echo "📦 Creating DMtools Agent Skill packages..."
+
+          package_directory "dmtools-ai-docs" "dmtools-skill"
+
+          mkdir -p "$DIST_DIR/staging/jira"
+          create_skill_manifest "$DIST_DIR/staging/jira" "dmtools-jira" "DMtools Jira Skill" "Focused DMtools skill for Jira setup, Jira MCP tools, and Xray-backed workflows."
+          cat >> "$DIST_DIR/staging/jira/SKILL.md" <<'EOF'
+          - [Jira configuration](references/configuration/integrations/jira.md)
+          - [Jira MCP tools](references/mcp-tools/jira-tools.md)
+          - [Xray manual generation](references/test-generation/xray-manual.md)
+          EOF
+          copy_skill_doc "references/installation/README.md" "$DIST_DIR/staging/jira"
+          copy_skill_doc "references/configuration/integrations/jira.md" "$DIST_DIR/staging/jira"
+          copy_skill_doc "references/mcp-tools/jira-tools.md" "$DIST_DIR/staging/jira"
+          copy_skill_doc "references/test-generation/xray-manual.md" "$DIST_DIR/staging/jira"
+          package_directory "$DIST_DIR/staging/jira" "dmtools-jira-skill"
+
+          mkdir -p "$DIST_DIR/staging/github"
+          create_skill_manifest "$DIST_DIR/staging/github" "dmtools-github" "DMtools GitHub Skill" "Focused DMtools skill for GitHub configuration and pull request tooling."
+          cat >> "$DIST_DIR/staging/github/SKILL.md" <<'EOF'
+          - [GitHub configuration](references/configuration/integrations/github.md)
+          - [GitHub MCP tools](references/mcp-tools/github-tools.md)
+          EOF
+          copy_skill_doc "references/installation/README.md" "$DIST_DIR/staging/github"
+          copy_skill_doc "references/configuration/integrations/github.md" "$DIST_DIR/staging/github"
+          copy_skill_doc "references/mcp-tools/github-tools.md" "$DIST_DIR/staging/github"
+          package_directory "$DIST_DIR/staging/github" "dmtools-github-skill"
+
+          mkdir -p "$DIST_DIR/staging/ado"
+          create_skill_manifest "$DIST_DIR/staging/ado" "dmtools-ado" "DMtools Azure DevOps Skill" "Focused DMtools skill for Azure DevOps configuration, work item automation, and PR tooling."
+          cat >> "$DIST_DIR/staging/ado/SKILL.md" <<'EOF'
+          - [ADO configuration](references/configuration/integrations/ado.md)
+          - [ADO MCP tools](references/mcp-tools/ado-tools.md)
+          EOF
+          copy_skill_doc "references/installation/README.md" "$DIST_DIR/staging/ado"
+          copy_skill_doc "references/configuration/integrations/ado.md" "$DIST_DIR/staging/ado"
+          copy_skill_doc "references/mcp-tools/ado-tools.md" "$DIST_DIR/staging/ado"
+          package_directory "$DIST_DIR/staging/ado" "dmtools-ado-skill"
+
+          mkdir -p "$DIST_DIR/staging/testrail"
+          create_skill_manifest "$DIST_DIR/staging/testrail" "dmtools-testrail" "DMtools TestRail Skill" "Focused DMtools skill for TestRail configuration and generated test case workflows."
+          cat >> "$DIST_DIR/staging/testrail/SKILL.md" <<'EOF'
+          - [TestRail configuration](references/configuration/integrations/testrail.md)
+          - [TestRail MCP tools](references/mcp-tools/testrail-tools.md)
+          - [TestRail manual generation](references/test-generation/testrail-manual.md)
+          EOF
+          copy_skill_doc "references/installation/README.md" "$DIST_DIR/staging/testrail"
+          copy_skill_doc "references/configuration/integrations/testrail.md" "$DIST_DIR/staging/testrail"
+          copy_skill_doc "references/mcp-tools/testrail-tools.md" "$DIST_DIR/staging/testrail"
+          copy_skill_doc "references/test-generation/testrail-manual.md" "$DIST_DIR/staging/testrail"
+          package_directory "$DIST_DIR/staging/testrail" "dmtools-testrail-skill"
 
           # Copy install scripts (bash + PowerShell)
           cp dmtools-ai-docs/install.sh $DIST_DIR/skill-install.sh
@@ -230,6 +304,14 @@ jobs:
           path: |
             dist/dmtools-skill-*.zip
             dist/dmtools-skill-*.tar.gz
+            dist/dmtools-jira-skill*.zip
+            dist/dmtools-jira-skill*.tar.gz
+            dist/dmtools-github-skill*.zip
+            dist/dmtools-github-skill*.tar.gz
+            dist/dmtools-ado-skill*.zip
+            dist/dmtools-ado-skill*.tar.gz
+            dist/dmtools-testrail-skill*.zip
+            dist/dmtools-testrail-skill*.tar.gz
             dist/skill-install.sh
             dist/skill-install.ps1
             dist/skill-checksums.sha256
@@ -337,15 +419,24 @@ jobs:
           irm https://github.com/${{ github.repository }}/releases/download/v${VERSION}/skill-install.ps1 | iex
           \`\`\`
 
+          **Focused skill install:**
+          \`\`\`bash
+          DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${VERSION}/skill-install.sh | bash
+          \`\`\`
+
+          **Focused packages:**
+          - \`dmtools-jira-skill.zip\` → \`/dmtools-jira\`
+          - \`dmtools-github-skill.zip\` → \`/dmtools-github\`
+          - \`dmtools-ado-skill.zip\` → \`/dmtools-ado\`
+          - \`dmtools-testrail-skill.zip\` → \`/dmtools-testrail\`
+
           **Manual Installation:**
-          1. Download \`dmtools-skill-v${VERSION}.zip\` or \`dmtools-skill-v${VERSION}.tar.gz\`
+          1. Download \`dmtools-skill.zip\` or a focused package such as \`dmtools-jira-skill.zip\`
           2. Extract to one of these directories:
              - \`.cursor/skills/\` (project-level Cursor)
              - \`.claude/skills/\` (project-level Claude)
-             - \`~/.cursor/skills/\` (global Cursor)
              - \`~/.claude/skills/\` (global Claude)
-             - \`~/.codex/skills/\` (global Codex)
-             - \`%USERPROFILE%\.claude\skills\` (global Claude on Windows)
+             - \`.codex/skills/\` (project-level Codex)
 
           ### Install Specific Version (v${VERSION})
 
@@ -414,6 +505,24 @@ jobs:
             cli/dmtools.sh
             skill/dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.zip
             skill/dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
+            skill/dmtools-skill.zip
+            skill/dmtools-skill.tar.gz
+            skill/dmtools-jira-skill-v${{ needs.version-and-tag.outputs.version }}.zip
+            skill/dmtools-jira-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
+            skill/dmtools-jira-skill.zip
+            skill/dmtools-jira-skill.tar.gz
+            skill/dmtools-github-skill-v${{ needs.version-and-tag.outputs.version }}.zip
+            skill/dmtools-github-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
+            skill/dmtools-github-skill.zip
+            skill/dmtools-github-skill.tar.gz
+            skill/dmtools-ado-skill-v${{ needs.version-and-tag.outputs.version }}.zip
+            skill/dmtools-ado-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
+            skill/dmtools-ado-skill.zip
+            skill/dmtools-ado-skill.tar.gz
+            skill/dmtools-testrail-skill-v${{ needs.version-and-tag.outputs.version }}.zip
+            skill/dmtools-testrail-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
+            skill/dmtools-testrail-skill.zip
+            skill/dmtools-testrail-skill.tar.gz
             skill/skill-install.sh
             skill/skill-install.ps1
             skill/skill-checksums.sha256
@@ -438,6 +547,7 @@ jobs:
           echo "**Agent Skill:**" >> $GITHUB_STEP_SUMMARY
           echo "- Skill ZIP (dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.zip)" >> $GITHUB_STEP_SUMMARY
           echo "- Skill TAR (dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz)" >> $GITHUB_STEP_SUMMARY
+          echo "- Focused packages: dmtools-jira-skill, dmtools-github-skill, dmtools-ado-skill, dmtools-testrail-skill" >> $GITHUB_STEP_SUMMARY
           echo "- skill-install.sh (automatic installer, macOS/Linux)"  >> $GITHUB_STEP_SUMMARY
           echo "- skill-install.ps1 (automatic installer, Windows PowerShell)" >> $GITHUB_STEP_SUMMARY
           echo "- skill-checksums.sha256 (checksums)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -421,7 +421,7 @@ jobs:
 
           **Focused skill install:**
           \`\`\`bash
-          DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${VERSION}/skill-install.sh | bash
+          curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${VERSION}/skill-install.sh | bash -s -- --skills jira,github
           \`\`\`
 
           **Focused packages:**

--- a/dmtools-ai-docs/README.md
+++ b/dmtools-ai-docs/README.md
@@ -43,8 +43,43 @@ INSTALL_LOCATION=2 bash install.sh    # Second location (.claude)
 # Install to all locations (explicit)
 bash install.sh --all
 
+# Install only selected focused skills
+DMTOOLS_SKILLS=jira,github bash install.sh
+bash install.sh --skills jira,github
+
 # Show help
 bash install.sh --help
+```
+
+## Install Only the Skills You Need
+
+Use focused packages when you want dedicated slash commands such as `/dmtools-jira` or `/dmtools-github` instead of the full `/dmtools` bundle.
+
+| Skill | Slash command | Latest package | Latest tarball |
+|------|------|------|------|
+| Full DMtools | `/dmtools` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-skill.tar.gz` |
+| Jira | `/dmtools-jira` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-jira-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-jira-skill.tar.gz` |
+| GitHub | `/dmtools-github` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-github-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-github-skill.tar.gz` |
+| Azure DevOps | `/dmtools-ado` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-ado-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-ado-skill.tar.gz` |
+| TestRail | `/dmtools-testrail` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-testrail-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-testrail-skill.tar.gz` |
+
+### Installer Selection Examples
+
+```bash
+# Install only Jira
+DMTOOLS_SKILLS=jira curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+
+# Install Jira + GitHub together
+DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+
+# Local installer usage
+bash install.sh --skills ado,testrail
+```
+
+```powershell
+# PowerShell installer usage
+$env:DMTOOLS_SKILLS = "jira,github"
+irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | iex
 ```
 
 ## 📦 Manual Installation

--- a/dmtools-ai-docs/README.md
+++ b/dmtools-ai-docs/README.md
@@ -67,10 +67,10 @@ Use focused packages when you want dedicated slash commands such as `/dmtools-ji
 
 ```bash
 # Install only Jira
-DMTOOLS_SKILLS=jira curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira
 
 # Install Jira + GitHub together
-DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira,github
 
 # Local installer usage
 bash install.sh --skills ado,testrail

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -38,6 +38,8 @@ curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/dmtools-ai-docs/set
 
 **OR follow manual steps below:**
 
+**Focused skill packages:** install only the integrations you need with `DMTOOLS_SKILLS=jira,github` and the skill installer described in [references/installation/README.md#install-only-the-skills-you-need](references/installation/README.md#install-only-the-skills-you-need).
+
 ### Step 1: Check if DMtools is installed
 ```bash
 # Check if dmtools command is available

--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -9,19 +9,30 @@
 #   curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
 #   # When piped (non-interactive): installs to ALL detected locations automatically
 #
+#   DMTOOLS_SKILLS=jira,github bash install.sh  # Install focused skills only
 #   INSTALL_LOCATION=1 bash install.sh          # Install to first detected location only
 #   bash install.sh --all                       # Install to all detected locations
+#   bash install.sh --skills jira,github        # Select packages explicitly
 #   bash install.sh                             # Interactive mode: ask user to choose
 
 set -e
 
-# Parse command line arguments
 INSTALL_ALL=false
-for arg in "$@"; do
-    case $arg in
+SELECTED_SKILLS="${DMTOOLS_SKILLS:-}"
+POSITIONAL_ARGS=()
+while [ $# -gt 0 ]; do
+    case "$1" in
         --all|-a)
             INSTALL_ALL=true
             shift
+            ;;
+        --skills|-s)
+            if [ -z "${2:-}" ]; then
+                echo "Missing value for $1" >&2
+                exit 1
+            fi
+            SELECTED_SKILLS="$2"
+            shift 2
             ;;
         --help|-h)
             echo "DMtools Agent Skill Installer"
@@ -31,14 +42,19 @@ for arg in "$@"; do
             echo ""
             echo "Options:"
             echo "  --all, -a     Install to all detected locations"
+            echo "  --skills, -s  Comma-separated package list (dmtools,jira,github,ado,testrail)"
             echo "  --help, -h    Show this help message"
             echo ""
             echo "Environment Variables:"
             echo "  INSTALL_LOCATION  Set to number (1,2,3...) to select specific location"
+            echo "  DMTOOLS_SKILLS   Comma-separated package list for non-interactive installs"
             echo ""
             echo "Examples:"
             echo "  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash"
             echo "    → Non-interactive mode: installs to ALL detected locations automatically"
+            echo ""
+            echo "  DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash"
+            echo "    → Install only /dmtools-jira and /dmtools-github"
             echo ""
             echo "  bash install.sh"
             echo "    → Interactive mode: shows menu to choose location"
@@ -49,34 +65,31 @@ for arg in "$@"; do
             echo "  bash install.sh --all"
             echo "    → Install to all locations"
             echo ""
+            echo "  bash install.sh --skills jira,github"
+            echo "    → Install only focused Jira and GitHub packages"
+            echo ""
             echo "Note: Installs to project-level and global (~/.claude/skills) directories"
             echo "      Run this command from your project root directory."
             exit 0
             ;;
+        *)
+            POSITIONAL_ARGS+=("$1")
+            shift
+            ;;
     esac
 done
+set -- "${POSITIONAL_ARGS[@]}"
 
-# Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 CYAN='\033[0;36m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Configuration
-SKILL_NAME="dmtools"
 GITHUB_REPO="epam/dm.ai"
 TEMP_DIR=$(mktemp -d)
 
-# Skill directories to check
-SKILL_DIRS=(
-    ".cursor/skills"
-    ".claude/skills"
-    ".codex/skills"
-)
-
-# Functions
 print_header() {
     echo "" >&2
     echo -e "${CYAN}╔════════════════════════════════════════════╗${NC}" >&2
@@ -97,11 +110,75 @@ print_info() {
     echo -e "${YELLOW}ℹ${NC} $1" >&2
 }
 
-# Detect available skill directories (project-level + global ~/.claude)
+skill_asset_name() {
+    case "$1" in
+        dmtools) echo "dmtools-skill.zip" ;;
+        jira) echo "dmtools-jira-skill.zip" ;;
+        github) echo "dmtools-github-skill.zip" ;;
+        ado) echo "dmtools-ado-skill.zip" ;;
+        testrail) echo "dmtools-testrail-skill.zip" ;;
+        *)
+            print_error "Unsupported skill package: $1"
+            return 1
+            ;;
+    esac
+}
+
+skill_install_name() {
+    case "$1" in
+        dmtools) echo "dmtools" ;;
+        jira) echo "dmtools-jira" ;;
+        github) echo "dmtools-github" ;;
+        ado) echo "dmtools-ado" ;;
+        testrail) echo "dmtools-testrail" ;;
+        *)
+            print_error "Unsupported skill package: $1"
+            return 1
+            ;;
+    esac
+}
+
+skill_command_name() {
+    case "$1" in
+        dmtools) echo "/dmtools" ;;
+        jira) echo "/dmtools-jira" ;;
+        github) echo "/dmtools-github" ;;
+        ado) echo "/dmtools-ado" ;;
+        testrail) echo "/dmtools-testrail" ;;
+        *)
+            print_error "Unsupported skill package: $1"
+            return 1
+            ;;
+    esac
+}
+
+normalize_skills() {
+    local raw="${1:-dmtools}"
+    local normalized=()
+    IFS=',' read -r -a requested <<< "$raw"
+    for skill in "${requested[@]}"; do
+        local trimmed
+        trimmed=$(echo "$skill" | tr '[:upper:]' '[:lower:]' | xargs)
+        [ -z "$trimmed" ] && continue
+        case "$trimmed" in
+            dmtools|jira|github|ado|testrail)
+                normalized+=("$trimmed")
+                ;;
+            *)
+                print_error "Unsupported skill package: $trimmed"
+                return 1
+                ;;
+        esac
+    done
+    if [ ${#normalized[@]} -eq 0 ]; then
+        normalized=("dmtools")
+    fi
+    printf '%s\n' "${normalized[@]}"
+}
+
 detect_skill_dirs() {
     local found_dirs=()
 
-    # Check project-level directories
     if [ -d ".cursor/skills" ] || [ -d ".cursor" ]; then
         found_dirs+=(".cursor/skills")
     fi
@@ -112,10 +189,8 @@ detect_skill_dirs() {
         found_dirs+=(".codex/skills")
     fi
 
-    # Check global directories (e.g. ~/.claude used by Claude Code / Copilot CLI)
     local home_claude="$HOME/.claude"
     if [ -d "$home_claude/skills" ] || [ -d "$home_claude" ]; then
-        # Only add if not already covered by project-level .claude
         local already_added=false
         for d in "${found_dirs[@]}"; do
             if [ "$d" = ".claude/skills" ]; then
@@ -128,209 +203,213 @@ detect_skill_dirs() {
         fi
     fi
 
-    # If no directories found, default to .cursor/skills in current directory
     if [ ${#found_dirs[@]} -eq 0 ]; then
         found_dirs+=(".cursor/skills")
     fi
 
-    # Return found directories via stdout (not stderr!)
     echo "${found_dirs[@]}"
 }
 
-# Download skill package
 download_skill() {
-    print_info "Downloading DMtools skill..."
+    local skill_key="$1"
+    local asset_name
+    asset_name=$(skill_asset_name "$skill_key") || return 1
+    local asset_path="$TEMP_DIR/$asset_name"
+    local extract_dir="$TEMP_DIR/$skill_key"
 
-    # Get latest release download URL from GitHub API
-    local API_URL="https://api.github.com/repos/$GITHUB_REPO/releases/latest"
-    local DOWNLOAD_URL=$(curl -s "$API_URL" | grep "browser_download_url.*\.zip" | head -1 | cut -d '"' -f 4)
-    local FALLBACK_URL="https://github.com/$GITHUB_REPO/archive/refs/heads/main.zip"
+    print_info "Downloading $(skill_install_name "$skill_key") package..."
 
-    # Try latest release first
-    if [ -n "$DOWNLOAD_URL" ] && curl -L -f -o "$TEMP_DIR/dmtools-skill.zip" "$DOWNLOAD_URL" 2>/dev/null; then
-        print_success "Downloaded latest release"
-    else
-        # Fallback to main branch
-        print_info "Downloading from main branch..."
-        if curl -L -f -o "$TEMP_DIR/dmtools-skill.zip" "$FALLBACK_URL" 2>/dev/null; then
-            print_success "Downloaded from repository"
+    local release_url="https://github.com/$GITHUB_REPO/releases/latest/download/$asset_name"
+    if curl -L -f -o "$asset_path" "$release_url" 2>/dev/null; then
+        print_success "Downloaded $asset_name"
+    elif [ "$skill_key" = "dmtools" ]; then
+        local fallback_url="https://github.com/$GITHUB_REPO/archive/refs/heads/main.zip"
+        print_info "Falling back to repository archive for dmtools..."
+        if curl -L -f -o "$asset_path" "$fallback_url" 2>/dev/null; then
+            print_success "Downloaded dmtools from repository"
         else
-            print_error "Failed to download skill"
+            print_error "Failed to download $asset_name"
             return 1
         fi
-    fi
-
-    # Extract
-    print_info "Extracting skill package..."
-    unzip -q "$TEMP_DIR/dmtools-skill.zip" -d "$TEMP_DIR"
-
-    # Find the skill directory
-    local SKILL_SOURCE=""
-    if [ -f "$TEMP_DIR/SKILL.md" ]; then
-        # Direct extraction (from release ZIP)
-        SKILL_SOURCE="$TEMP_DIR"
-    elif [ -f "$TEMP_DIR/dmtools-main/dmtools-ai-docs/SKILL.md" ]; then
-        # From GitHub main branch archive
-        SKILL_SOURCE="$TEMP_DIR/dmtools-main/dmtools-ai-docs"
-    elif [ -f "$TEMP_DIR/dmtools-ai-docs/SKILL.md" ]; then
-        # Legacy: direct dmtools-ai-docs folder
-        SKILL_SOURCE="$TEMP_DIR/dmtools-ai-docs"
     else
-        # Debug: show what we found
-        print_error "SKILL.md not found in package"
-        print_info "Contents of temp dir:"
-        ls -la "$TEMP_DIR" >&2 | head -10
+        print_error "Failed to download $asset_name"
+        print_info "Focused skill packages are published from release assets only."
         return 1
     fi
 
-    # Return the skill source path via stdout (not stderr!)
-    echo "$SKILL_SOURCE"
-}
+    print_info "Extracting $asset_name..."
+    mkdir -p "$extract_dir"
+    unzip -q "$asset_path" -d "$extract_dir"
 
-# Install skill to a directory
-install_to_directory() {
-    local SKILL_SOURCE="$1"
-    local TARGET_DIR="$2"
-
-    # Create target directory
-    mkdir -p "$TARGET_DIR"
-
-    # Remove old version if exists
-    if [ -d "$TARGET_DIR/$SKILL_NAME" ]; then
-        print_info "Removing old version..."
-        rm -rf "$TARGET_DIR/$SKILL_NAME"
+    local skill_source=""
+    if [ -f "$extract_dir/SKILL.md" ]; then
+        skill_source="$extract_dir"
+    elif [ -f "$extract_dir/dmtools-main/dmtools-ai-docs/SKILL.md" ]; then
+        skill_source="$extract_dir/dmtools-main/dmtools-ai-docs"
+    elif [ -f "$extract_dir/dmtools-ai-docs/SKILL.md" ]; then
+        skill_source="$extract_dir/dmtools-ai-docs"
+    else
+        print_error "SKILL.md not found in $asset_name"
+        print_info "Contents of extract dir:"
+        ls -la "$extract_dir" >&2 | head -10
+        return 1
     fi
 
-    # Copy skill files (exclude installation artifacts)
-    mkdir -p "$TARGET_DIR/$SKILL_NAME"
-
-    # Copy only necessary files
-    for item in "$SKILL_SOURCE"/*; do
-        item_name=$(basename "$item")
-        # Skip installation artifacts
-        if [ "$item_name" = "install.sh" ] || [ "$item_name" = "dmtools-skill.zip" ] || [[ "$item_name" == *.tar.gz ]]; then
-            continue
-        fi
-        cp -r "$item" "$TARGET_DIR/$SKILL_NAME/"
-    done
-
-    print_success "Installed to $TARGET_DIR/$SKILL_NAME"
+    echo "$skill_source"
 }
 
-# Main installation
+install_to_directory() {
+    local skill_source="$1"
+    local target_dir="$2"
+    local skill_name="$3"
+
+    mkdir -p "$target_dir"
+
+    if [ -d "$target_dir/$skill_name" ]; then
+        print_info "Removing old version..."
+        rm -rf "$target_dir/$skill_name"
+    fi
+
+    mkdir -p "$target_dir/$skill_name"
+
+    for item in "$skill_source"/*; do
+        local item_name
+        item_name=$(basename "$item")
+        if [ "$item_name" = "install.sh" ] || [ "$item_name" = "skill-install.ps1" ] || [[ "$item_name" == *.zip ]] || [[ "$item_name" == *.tar.gz ]]; then
+            continue
+        fi
+        cp -r "$item" "$target_dir/$skill_name/"
+    done
+
+    print_success "Installed to $target_dir/$skill_name"
+}
+
 main() {
     print_header
 
-    # Download skill
-    local SKILL_SOURCE=$(download_skill)
-    if [ -z "$SKILL_SOURCE" ]; then
-        print_error "Failed to download skill"
-        exit 1
+    local requested_skills=()
+    while IFS= read -r skill_key; do
+        requested_skills+=("$skill_key")
+    done < <(normalize_skills "$SELECTED_SKILLS")
+    if [ ${#requested_skills[@]} -eq 0 ]; then
+        requested_skills=("dmtools")
     fi
 
-    # Detect available directories
     print_info "Detecting skill directories..."
-    local DIRS=($(detect_skill_dirs))
+    local dirs
+    dirs=($(detect_skill_dirs))
 
-    if [ ${#DIRS[@]} -eq 0 ]; then
+    if [ ${#dirs[@]} -eq 0 ]; then
         print_error "No skill directories found"
         exit 1
     fi
 
-    # Show found directories
     echo "" >&2
     echo "Found skill directories:" >&2
-    for i in "${!DIRS[@]}"; do
-        echo "  $((i+1)). ${DIRS[$i]}" >&2
+    for i in "${!dirs[@]}"; do
+        echo "  $((i+1)). ${dirs[$i]}" >&2
+    done
+    echo "" >&2
+    echo "Selected skill packages:" >&2
+    for skill_key in "${requested_skills[@]}"; do
+        echo "  - $(skill_install_name "$skill_key") ($(skill_command_name "$skill_key"))" >&2
     done
 
-    # Determine installation choice
     echo "" >&2
-    local CHOICE=""
+    local choice=""
+    local selected_dir=""
 
-    if [ ${#DIRS[@]} -eq 1 ]; then
-        # Only one option, install directly
-        local SELECTED_DIR="${DIRS[0]}"
-        echo "Installing to: $SELECTED_DIR" >&2
-        install_to_directory "$SKILL_SOURCE" "$SELECTED_DIR"
+    if [ ${#dirs[@]} -eq 1 ]; then
+        selected_dir="${dirs[0]}"
+        echo "Installing to: $selected_dir" >&2
     else
-        # Multiple options - check for non-interactive mode
         if [ "$INSTALL_ALL" = true ] || [ "${INSTALL_LOCATION}" = "all" ] || [ "${INSTALL_LOCATION}" = "ALL" ]; then
-            CHOICE="all"
+            choice="all"
         elif [ -n "${INSTALL_LOCATION}" ]; then
-            # Use environment variable
-            CHOICE="${INSTALL_LOCATION}"
+            choice="${INSTALL_LOCATION}"
         elif [ ! -t 0 ]; then
-            # Non-interactive (piped input) - install to all locations
             print_info "Non-interactive mode detected, installing to all detected locations"
-            CHOICE="all"
+            choice="all"
         else
-            # Interactive mode - ask user
             echo "Where would you like to install? (Enter number or 'all' for all locations)" >&2
-            read -r CHOICE
+            read -r choice
         fi
 
-        if [ "$CHOICE" = "all" ] || [ "$CHOICE" = "ALL" ]; then
-            # Install to all directories
+        if [ "$choice" = "all" ] || [ "$choice" = "ALL" ]; then
             echo "Installing to all locations..." >&2
-            for DIR in "${DIRS[@]}"; do
-                install_to_directory "$SKILL_SOURCE" "$DIR"
-            done
-            SELECTED_DIR="multiple locations"
+            selected_dir="multiple locations"
         else
-            # Install to selected directory
-            local INDEX=$((CHOICE - 1))
-            if [ $INDEX -ge 0 ] && [ $INDEX -lt ${#DIRS[@]} ]; then
-                SELECTED_DIR="${DIRS[$INDEX]}"
-                # Create directory if needed
-                mkdir -p "$SELECTED_DIR"
-                install_to_directory "$SKILL_SOURCE" "$SELECTED_DIR"
+            local index=$((choice - 1))
+            if [ $index -ge 0 ] && [ $index -lt ${#dirs[@]} ]; then
+                selected_dir="${dirs[$index]}"
+                mkdir -p "$selected_dir"
             else
-                print_error "Invalid choice: $CHOICE"
+                print_error "Invalid choice: $choice"
                 exit 1
             fi
         fi
     fi
 
-    # Cleanup
+    local target_dirs=()
+    if [ "$selected_dir" = "multiple locations" ]; then
+        target_dirs=("${dirs[@]}")
+    else
+        target_dirs=("$selected_dir")
+    fi
+
+    local installed_commands=()
+    for skill_key in "${requested_skills[@]}"; do
+        local skill_source
+        skill_source=$(download_skill "$skill_key")
+        if [ -z "$skill_source" ]; then
+            print_error "Failed to download $(skill_install_name "$skill_key")"
+            exit 1
+        fi
+        local install_name
+        install_name=$(skill_install_name "$skill_key")
+        installed_commands+=("$(skill_command_name "$skill_key")")
+        for dir in "${target_dirs[@]}"; do
+            install_to_directory "$skill_source" "$dir" "$install_name"
+        done
+    done
+
     rm -rf "$TEMP_DIR"
 
-    # Success message
     echo "" >&2
     echo -e "${GREEN}════════════════════════════════════════════════════${NC}" >&2
     echo -e "${GREEN}        DMtools Skill Installed Successfully!       ${NC}" >&2
     echo -e "${GREEN}════════════════════════════════════════════════════${NC}" >&2
     echo "" >&2
-    echo "The DMtools skill is now available in your AI assistant!" >&2
+    echo "The selected DMtools skills are now available in your AI assistant!" >&2
     echo "" >&2
     echo -e "${CYAN}You can now:${NC}" >&2
-    echo "  • Type /dmtools in chat to invoke the skill" >&2
-    echo "  • Ask about DMtools and the assistant will use the skill automatically" >&2
+    for command_name in "${installed_commands[@]}"; do
+        echo "  • Type $command_name in chat to invoke the skill" >&2
+    done
+    echo "  • Ask about the installed DMtools areas and the assistant will use the matching skill automatically" >&2
     echo "" >&2
     echo -e "${BLUE}Example questions:${NC}" >&2
     echo "  • How do I install DMtools?" >&2
     echo "  • Help me configure Jira integration" >&2
-    echo "  • Show me how to create JavaScript agents" >&2
+    echo "  • Review GitHub pull requests with DMtools" >&2
     echo "  • Generate test cases from user story PROJ-123" >&2
     echo "" >&2
 
-    # Platform-specific instructions
-    if [[ "$SELECTED_DIR" == *"cursor"* ]]; then
+    if [[ "$selected_dir" == *"cursor"* ]]; then
         echo -e "${YELLOW}For Cursor:${NC}" >&2
         echo "  • Open Cursor Settings (Cmd+Shift+J or Ctrl+Shift+J)" >&2
         echo "  • Navigate to Rules → Agent Decides" >&2
-        echo "  • You should see 'dmtools' in the skills list" >&2
-    elif [[ "$SELECTED_DIR" == *"claude"* ]]; then
+        echo "  • You should see the selected dmtools skills in the skills list" >&2
+    elif [[ "$selected_dir" == *"claude"* ]]; then
         echo -e "${YELLOW}For Claude:${NC}" >&2
-        echo "  • The skill is available in your Claude desktop app" >&2
-        echo "  • Type /dmtools or mention DMtools in your questions" >&2
+        echo "  • The selected skills are available in your Claude desktop app" >&2
+        echo "  • Type the installed /dmtools* command or mention the matching integration in your questions" >&2
     fi
 
     echo "" >&2
     echo "For more information: https://github.com/epam/dm.ai" >&2
 }
 
-# Handle arguments
 case "${1:-install}" in
     install)
         main
@@ -338,19 +417,20 @@ case "${1:-install}" in
     --help|-h)
         echo "DMtools Agent Skill Installer"
         echo ""
-        echo "Usage: $0 [install|--help]"
+        echo "Usage: $0 [install] [--all] [--skills jira,github]"
         echo ""
         echo "This script installs the DMtools skill for AI assistants that"
         echo "support the Agent Skills standard (Cursor, Claude, Codex, etc.)"
         echo ""
         echo "The installer will:"
         echo "  1. Detect skill directories (.cursor, .claude, .codex, ~/.claude)"
-        echo "  2. Download the latest DMtools skill"
+        echo "  2. Download the selected DMtools skill package(s)"
         echo "  3. Install to ALL detected locations (when piped) or ask you to choose"
         echo ""
         echo "Behavior:"
         echo "  - Piped (curl | bash): Installs to ALL detected locations automatically"
         echo "  - Interactive: Shows menu to choose specific location(s)"
+        echo "  - Focused installs: pass --skills jira,github or set DMTOOLS_SKILLS=jira,github"
         echo ""
         echo "      Run from your project root directory."
         echo ""

--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -53,7 +53,7 @@ while [ $# -gt 0 ]; do
             echo "  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash"
             echo "    → Non-interactive mode: installs to ALL detected locations automatically"
             echo ""
-            echo "  DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash"
+            echo "  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira,github"
             echo "    → Install only /dmtools-jira and /dmtools-github"
             echo ""
             echo "  bash install.sh"

--- a/dmtools-ai-docs/references/configuration/integrations/ado.md
+++ b/dmtools-ai-docs/references/configuration/integrations/ado.md
@@ -4,6 +4,8 @@
 
 DMtools provides 23+ MCP tools for Azure DevOps integration, enabling work item management, sprint planning, and cross-platform synchronization with Jira.
 
+If you only need the Azure DevOps-focused AI assistant package, install `/dmtools-ado` with the instructions in [../../installation/README.md#install-only-the-skills-you-need](../../installation/README.md#install-only-the-skills-you-need).
+
 ## 🔑 Personal Access Token (PAT) Setup
 
 ### Step 1: Create Personal Access Token

--- a/dmtools-ai-docs/references/configuration/integrations/github.md
+++ b/dmtools-ai-docs/references/configuration/integrations/github.md
@@ -4,6 +4,8 @@
 
 DMtools provides 8 MCP tools for GitHub integration, focused on pull request management: listing PRs, getting details, reading comments and review conversations, adding comments/labels, and getting diffs.
 
+If you only need the GitHub-focused AI assistant package, install `/dmtools-github` with the instructions in [../../installation/README.md#install-only-the-skills-you-need](../../installation/README.md#install-only-the-skills-you-need).
+
 ## Authentication
 
 ### Generate a Personal Access Token

--- a/dmtools-ai-docs/references/configuration/integrations/jira.md
+++ b/dmtools-ai-docs/references/configuration/integrations/jira.md
@@ -4,6 +4,8 @@
 
 DMtools provides 52 MCP tools for Jira integration, enabling automated ticket management, test case generation, and workflow automation.
 
+If you only need the Jira-focused AI assistant package, install `/dmtools-jira` with the instructions in [../../installation/README.md#install-only-the-skills-you-need](../../installation/README.md#install-only-the-skills-you-need).
+
 ## 🔑 API Token Generation
 
 ### Step 1: Create Atlassian API Token

--- a/dmtools-ai-docs/references/configuration/integrations/testrail.md
+++ b/dmtools-ai-docs/references/configuration/integrations/testrail.md
@@ -4,6 +4,8 @@
 
 DMtools provides 15 MCP tools for TestRail integration, enabling automated test case creation, requirement linking, and test management directly from Jira/ADO stories.
 
+If you only need the TestRail-focused AI assistant package, install `/dmtools-testrail` with the instructions in [../../installation/README.md#install-only-the-skills-you-need](../../installation/README.md#install-only-the-skills-you-need).
+
 ## 🔑 API Key Generation
 
 ### Step 1: Create TestRail API Key

--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -8,6 +8,8 @@ The fastest way to install DMtools:
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 ```
 
+If you only need focused AI assistant skills, see [Install Only the Skills You Need](#install-only-the-skills-you-need).
+
 This script will:
 1. ✅ Check for Java 17+ (install if missing)
 2. ✅ Download the latest DMtools release
@@ -28,6 +30,42 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | b
 # Specific version
 curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
 ```
+
+## Install Only the Skills You Need
+
+Use the focused skill packages when you want integration-specific slash commands in your AI assistant instead of the full `/dmtools` bundle.
+
+| Skill | Slash command | Latest ZIP | Latest TAR |
+|------|------|------|------|
+| Full DMtools | `/dmtools` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-skill.tar.gz` |
+| Jira | `/dmtools-jira` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-jira-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-jira-skill.tar.gz` |
+| GitHub | `/dmtools-github` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-github-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-github-skill.tar.gz` |
+| Azure DevOps | `/dmtools-ado` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-ado-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-ado-skill.tar.gz` |
+| TestRail | `/dmtools-testrail` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-testrail-skill.zip` | `https://github.com/epam/dm.ai/releases/latest/download/dmtools-testrail-skill.tar.gz` |
+
+### Skill Installer Examples
+
+```bash
+# Install only Jira
+DMTOOLS_SKILLS=jira curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+
+# Install Jira + GitHub together
+DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+
+# Run the installer locally and pass the package list directly
+bash install.sh --skills ado,testrail
+```
+
+```powershell
+$env:DMTOOLS_SKILLS = "jira,github"
+irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | iex
+```
+
+### Manual Focused Package Installation
+
+1. Download the ZIP or TAR for the skill you need.
+2. Extract it into `.cursor/skills/`, `.claude/skills/`, or `.codex/skills/`.
+3. The extracted folder name becomes the slash command, for example `dmtools-jira` → `/dmtools-jira`.
 
 ### Upgrading from legacy installs
 

--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -47,10 +47,10 @@ Use the focused skill packages when you want integration-specific slash commands
 
 ```bash
 # Install only Jira
-DMTOOLS_SKILLS=jira curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira
 
 # Install Jira + GitHub together
-DMTOOLS_SKILLS=jira,github curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira,github
 
 # Run the installer locally and pass the package list directly
 bash install.sh --skills ado,testrail

--- a/dmtools-ai-docs/skill-install.ps1
+++ b/dmtools-ai-docs/skill-install.ps1
@@ -7,18 +7,15 @@
 #   irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | iex
 #   # When piped (non-interactive): installs to ALL detected locations automatically
 #
-#   $env:INSTALL_LOCATION = "1"; irm .../skill-install.ps1 | iex   # Install to first location only
-#   # Interactive: runs menu to choose location
+#   $env:DMTOOLS_SKILLS = "jira,github"; irm .../skill-install.ps1 | iex
+#   $env:INSTALL_LOCATION = "1"; irm .../skill-install.ps1 | iex
 
 $ErrorActionPreference = "Stop"
 
-# Configuration
-$SKILL_NAME   = "dmtools"
-$GITHUB_REPO  = "epam/dm.ai"
-$TEMP_DIR     = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid().ToString())
+$GITHUB_REPO = "epam/dm.ai"
+$TEMP_DIR = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.Guid]::NewGuid().ToString())
 New-Item -ItemType Directory -Path $TEMP_DIR | Out-Null
 
-# ── Output helpers ────────────────────────────────────────────────────────────
 function Write-Header {
     Write-Host ""
     Write-Host "╔════════════════════════════════════════════╗" -ForegroundColor Cyan
@@ -26,90 +23,161 @@ function Write-Header {
     Write-Host "╚════════════════════════════════════════════╝" -ForegroundColor Cyan
     Write-Host ""
 }
-function Write-Ok($msg)   { Write-Host "✓ $msg" -ForegroundColor Green  }
-function Write-Err($msg)  { Write-Host "✗ $msg" -ForegroundColor Red    }
-function Write-Info($msg) { Write-Host "ℹ $msg" -ForegroundColor Yellow }
 
-# ── Detect skill directories ──────────────────────────────────────────────────
+function Write-Ok($msg) {
+    Write-Host "✓ $msg" -ForegroundColor Green
+}
+
+function Write-Err($msg) {
+    Write-Host "✗ $msg" -ForegroundColor Red
+}
+
+function Write-Info($msg) {
+    Write-Host "ℹ $msg" -ForegroundColor Yellow
+}
+
+function Get-SkillAssetName($skillKey) {
+    switch ($skillKey.ToLowerInvariant()) {
+        "dmtools" { "dmtools-skill.zip" }
+        "jira" { "dmtools-jira-skill.zip" }
+        "github" { "dmtools-github-skill.zip" }
+        "ado" { "dmtools-ado-skill.zip" }
+        "testrail" { "dmtools-testrail-skill.zip" }
+        default { throw "Unsupported skill package: $skillKey" }
+    }
+}
+
+function Get-SkillInstallName($skillKey) {
+    switch ($skillKey.ToLowerInvariant()) {
+        "dmtools" { "dmtools" }
+        "jira" { "dmtools-jira" }
+        "github" { "dmtools-github" }
+        "ado" { "dmtools-ado" }
+        "testrail" { "dmtools-testrail" }
+        default { throw "Unsupported skill package: $skillKey" }
+    }
+}
+
+function Get-SkillCommandName($skillKey) {
+    switch ($skillKey.ToLowerInvariant()) {
+        "dmtools" { "/dmtools" }
+        "jira" { "/dmtools-jira" }
+        "github" { "/dmtools-github" }
+        "ado" { "/dmtools-ado" }
+        "testrail" { "/dmtools-testrail" }
+        default { throw "Unsupported skill package: $skillKey" }
+    }
+}
+
+function Get-RequestedSkills {
+    $raw = $env:DMTOOLS_SKILLS
+    if ([string]::IsNullOrWhiteSpace($raw)) {
+        return @("dmtools")
+    }
+
+    $normalized = @()
+    foreach ($skill in $raw.Split(",")) {
+        $name = $skill.Trim().ToLowerInvariant()
+        if ([string]::IsNullOrWhiteSpace($name)) {
+            continue
+        }
+
+        switch ($name) {
+            "dmtools" { $normalized += $name }
+            "jira" { $normalized += $name }
+            "github" { $normalized += $name }
+            "ado" { $normalized += $name }
+            "testrail" { $normalized += $name }
+            default { throw "Unsupported skill package: $name" }
+        }
+    }
+
+    if ($normalized.Count -eq 0) {
+        return @("dmtools")
+    }
+    return $normalized
+}
+
 function Get-SkillDirs {
     $dirs = @()
-    $cwd  = (Get-Location).Path
+    $cwd = (Get-Location).Path
 
     foreach ($sub in @(".cursor", ".claude", ".codex")) {
         $path = Join-Path $cwd $sub
-        if (Test-Path $path) { $dirs += Join-Path $path "skills" }
+        if (Test-Path $path) {
+            $dirs += Join-Path $path "skills"
+        }
     }
 
     $globalClaude = Join-Path $env:USERPROFILE ".claude"
     if (Test-Path $globalClaude) {
         $globalSkills = Join-Path $globalClaude "skills"
-        # Add only if not already covered by project-level .claude
         $alreadyAdded = $dirs | Where-Object { $_ -eq (Join-Path $cwd ".claude\skills") }
-        if (-not $alreadyAdded) { $dirs += $globalSkills }
+        if (-not $alreadyAdded) {
+            $dirs += $globalSkills
+        }
     }
 
-    if ($dirs.Count -eq 0) { $dirs += Join-Path $cwd ".cursor\skills" }
+    if ($dirs.Count -eq 0) {
+        $dirs += Join-Path $cwd ".cursor\skills"
+    }
     return $dirs
 }
 
-# ── Download skill package ────────────────────────────────────────────────────
-function Get-SkillPackage {
-    Write-Info "Fetching latest release information..."
+function Get-SkillPackage($skillKey) {
+    $assetName = Get-SkillAssetName $skillKey
+    $zipPath = Join-Path $TEMP_DIR $assetName
+    $extractPath = Join-Path $TEMP_DIR $skillKey
+    New-Item -ItemType Directory -Path $extractPath | Out-Null
 
-    $zipPath = Join-Path $TEMP_DIR "dmtools-skill.zip"
+    Write-Info "Downloading $(Get-SkillInstallName $skillKey) package..."
 
     try {
-        $apiUrl   = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
-        $release  = Invoke-RestMethod -Uri $apiUrl -TimeoutSec 30
-        $asset    = $release.assets | Where-Object { $_.name -like "dmtools-skill-*.zip" } | Select-Object -First 1
-        if ($asset) {
-            Write-Info "Downloading $($asset.name)..."
-            Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zipPath -UseBasicParsing
-            Write-Ok "Downloaded latest release"
-        } else {
-            throw "No skill ZIP found in release assets"
-        }
+        $releaseUrl = "https://github.com/$GITHUB_REPO/releases/latest/download/$assetName"
+        Invoke-WebRequest -Uri $releaseUrl -OutFile $zipPath -UseBasicParsing
+        Write-Ok "Downloaded $assetName"
     } catch {
-        Write-Info "Falling back to main branch archive..."
+        if ($skillKey -ne "dmtools") {
+            Write-Err "Failed to download $assetName"
+            throw "Focused skill packages are published from release assets only."
+        }
+
+        Write-Info "Falling back to main branch archive for dmtools..."
         $fallback = "https://github.com/$GITHUB_REPO/archive/refs/heads/main.zip"
         Invoke-WebRequest -Uri $fallback -OutFile $zipPath -UseBasicParsing
-        Write-Ok "Downloaded from main branch"
+        Write-Ok "Downloaded dmtools from main branch"
     }
 
-    Write-Info "Extracting skill package..."
-    Expand-Archive -Path $zipPath -DestinationPath $TEMP_DIR -Force
+    Write-Info "Extracting $assetName..."
+    Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
 
-    # Locate SKILL.md
-    $skillMd = Get-ChildItem -Path $TEMP_DIR -Recurse -Filter "SKILL.md" | Select-Object -First 1
+    $skillMd = Get-ChildItem -Path $extractPath -Recurse -Filter "SKILL.md" | Select-Object -First 1
     if (-not $skillMd) {
         Write-Err "SKILL.md not found in package"
-        throw "Invalid skill package"
+        throw "Invalid skill package: $assetName"
     }
     return $skillMd.DirectoryName
 }
 
-# ── Install to a single directory ────────────────────────────────────────────
-function Install-ToDirectory($skillSource, $targetDir) {
-    $dest = Join-Path $targetDir $SKILL_NAME
+function Install-ToDirectory($skillSource, $targetDir, $skillName) {
+    $dest = Join-Path $targetDir $skillName
     if (Test-Path $dest) {
         Write-Info "Removing old version..."
         Remove-Item -Recurse -Force $dest
     }
     New-Item -ItemType Directory -Path $dest | Out-Null
 
-    # Copy everything except installer artifacts
-    $skip = @("install.sh", "skill-install.ps1", "dmtools-skill.zip")
+    $skip = @("install.sh", "skill-install.ps1")
     Get-ChildItem -Path $skillSource | Where-Object { $_.Name -notin $skip } | ForEach-Object {
         Copy-Item -Path $_.FullName -Destination $dest -Recurse -Force
     }
     Write-Ok "Installed to $dest"
 }
 
-# ── Main ──────────────────────────────────────────────────────────────────────
 function Main {
     Write-Header
 
-    $skillSource = Get-SkillPackage
+    $requestedSkills = Get-RequestedSkills
     Write-Info "Detecting skill directories..."
     $dirs = Get-SkillDirs
 
@@ -119,8 +187,12 @@ function Main {
         Write-Host "  $($i+1). $($dirs[$i])"
     }
     Write-Host ""
+    Write-Host "Selected skill packages:" -ForegroundColor Cyan
+    foreach ($skill in $requestedSkills) {
+        Write-Host "  - $(Get-SkillInstallName $skill) ($(Get-SkillCommandName $skill))"
+    }
+    Write-Host ""
 
-    # Determine choice
     $choice = $env:INSTALL_LOCATION
     if (-not $choice) {
         if ($dirs.Count -eq 1) {
@@ -133,21 +205,31 @@ function Main {
         }
     }
 
+    $targetDirs = @()
     if ($choice -eq "all" -or $choice -eq "ALL") {
-        foreach ($dir in $dirs) { Install-ToDirectory $skillSource $dir }
+        $targetDirs = $dirs
     } else {
         $idx = [int]$choice - 1
         if ($idx -ge 0 -and $idx -lt $dirs.Count) {
             $selectedDir = $dirs[$idx]
             New-Item -ItemType Directory -Path $selectedDir -Force | Out-Null
-            Install-ToDirectory $skillSource $selectedDir
+            $targetDirs = @($selectedDir)
         } else {
             Write-Err "Invalid choice: $choice"
             exit 1
         }
     }
 
-    # Cleanup
+    $installedCommands = @()
+    foreach ($skill in $requestedSkills) {
+        $skillSource = Get-SkillPackage $skill
+        $skillName = Get-SkillInstallName $skill
+        $installedCommands += Get-SkillCommandName $skill
+        foreach ($dir in $targetDirs) {
+            Install-ToDirectory $skillSource $dir $skillName
+        }
+    }
+
     Remove-Item -Recurse -Force $TEMP_DIR -ErrorAction SilentlyContinue
 
     Write-Host ""
@@ -155,16 +237,18 @@ function Main {
     Write-Host "        DMtools Skill Installed Successfully!       " -ForegroundColor Green
     Write-Host "════════════════════════════════════════════════════" -ForegroundColor Green
     Write-Host ""
-    Write-Host "The DMtools skill is now available in your AI assistant!" -ForegroundColor White
+    Write-Host "The selected DMtools skills are now available in your AI assistant!" -ForegroundColor White
     Write-Host ""
     Write-Host "You can now:" -ForegroundColor Cyan
-    Write-Host "  • Type /dmtools in chat to invoke the skill"
-    Write-Host "  • Ask about DMtools and the assistant will use the skill automatically"
+    foreach ($commandName in $installedCommands) {
+        Write-Host "  • Type $commandName in chat to invoke the skill"
+    }
+    Write-Host "  • Ask about the installed DMtools areas and the assistant will use the matching skill automatically"
     Write-Host ""
     Write-Host "Example questions:" -ForegroundColor Blue
     Write-Host "  • How do I install DMtools?"
     Write-Host "  • Help me configure Jira integration"
-    Write-Host "  • Show me how to create JavaScript agents"
+    Write-Host "  • Review GitHub pull requests with DMtools"
     Write-Host "  • Generate test cases from user story PROJ-123"
     Write-Host ""
     Write-Host "For more information: https://github.com/epam/dm.ai" -ForegroundColor DarkGray


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present at the repository root, so implementation followed the ticket payload from `input/DMC-856` and existing repo conventions.
- No dmtools-core Java sources required changes; the ticket was satisfied in the AI skill docs, installer scripts, and release packaging flow.
- No new Java unit tests were added because the modified files are documentation, shell/PowerShell installers, and GitHub Actions packaging logic rather than unit-testable core classes.

## Approach

- Added focused installation guidance for per-skill packages, including stable `latest/download/...` asset URLs and examples for selecting packages during install.
- Extended both skill installers to support focused installs via `DMTOOLS_SKILLS` and, for Bash, `--skills`, while preserving the existing location-selection flow.
- Updated the release workflow to build and publish versioned and versionless focused skill assets (`dmtools-jira`, `dmtools-github`, `dmtools-ado`, `dmtools-testrail`) so the documented endpoints are real release artifacts.
- Added backlinks from integration-specific skill pages to the shared installer instructions.

## Files Modified

- `.github/workflows/release.yml` — generates focused skill ZIP/TAR assets, attaches stable latest-download names, and updates release notes/release artifact lists.
- `dmtools-ai-docs/install.sh` — adds focused package selection support and installs named skill folders/commands such as `/dmtools-jira`.
- `dmtools-ai-docs/skill-install.ps1` — mirrors focused package selection for PowerShell installs.
- `dmtools-ai-docs/README.md` — documents per-skill packages, asset endpoints, and installer examples.
- `dmtools-ai-docs/references/installation/README.md` — adds the canonical “install only the skills you need” section and focused package examples.
- `dmtools-ai-docs/SKILL.md` — points main skill users to the focused-skill installation path.
- `dmtools-ai-docs/references/configuration/integrations/jira.md` — links Jira readers back to focused installer instructions.
- `dmtools-ai-docs/references/configuration/integrations/github.md` — links GitHub readers back to focused installer instructions.
- `dmtools-ai-docs/references/configuration/integrations/ado.md` — links Azure DevOps readers back to focused installer instructions.
- `dmtools-ai-docs/references/configuration/integrations/testrail.md` — links TestRail readers back to focused installer instructions.

## Test Coverage

- Ran `./gradlew :dmtools-core:test --no-daemon`.
- Ran `bash -n dmtools-ai-docs/install.sh`.
- Parsed `dmtools-ai-docs/skill-install.ps1` with PowerShell’s parser.
- Built a local focused `dmtools-jira` package smoke test to confirm the generated ZIP contains the expected `SKILL.md` and linked docs.
