### PR TITLE
DMC-906 Upgrade guidance docs omit backup, config-merge, verification, and rollback steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ See the [installation guide](dmtools-ai-docs/references/installation/README.md) 
 
 ### Upgrading from legacy installs
 
-1. Re-run the installer from `https://github.com/epam/dm.ai/releases/latest/download/install.sh` (or `install.bat` / `install.ps1` on Windows) to replace wrappers that still point to `IstiN/dmtools` or raw GitHub URLs.
-2. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases and wrapper scripts from your shell profile or old CI bootstrap steps.
-3. For CI caches, refresh any keys tied to legacy install URLs after switching to the release asset path.
+1. Back up `~/.dmtools` before changing anything so you can restore the current wrapper, JAR, and local state if the migration goes wrong.
+2. Re-run the installer from `https://github.com/epam/dm.ai/releases/latest/download/install.sh` (or `install.bat` / `install.ps1` on Windows) to replace any `IstiN/dmtools` or raw GitHub bootstrap paths with the EPAM release asset path.
+3. Preserve or merge your existing `dmtools.env`, `dmtools-local.env`, and any other local configuration instead of overwriting them during the reinstall.
+4. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases, wrapper scripts, and outdated PATH entries from your shell profile or CI bootstrap steps.
+5. Verify the migrated install with `dmtools --version` and `dmtools list`, and refresh CI cache keys that still reference legacy install URLs.
+6. If the migration fails, roll back by restoring the backup copy of `~/.dmtools` and re-enabling the previous wrapper or PATH entry.
 
 ### Configuration
 

--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -31,9 +31,12 @@ curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh |
 
 ### Upgrading from legacy installs
 
-1. Replace any `IstiN/dmtools` or `raw.githubusercontent.com/.../main/install.sh` bootstrap commands with `https://github.com/epam/dm.ai/releases/latest/download/install.sh`.
-2. Remove stale aliases or wrapper scripts that bypass `~/.dmtools/bin/dmtools` before reinstalling.
-3. If a CI job caches `~/.dmtools`, update the cache key when switching away from legacy install URLs.
+1. Back up `~/.dmtools` before starting so you can restore the current installation, local cache, and wrapper scripts if the migration needs to be rolled back.
+2. Replace any `IstiN/dmtools` or `raw.githubusercontent.com/.../main/install.sh` bootstrap commands with `https://github.com/epam/dm.ai/releases/latest/download/install.sh` so the install points to the EPAM release asset path.
+3. Preserve or merge your existing `dmtools.env`, `dmtools-local.env`, and other local configuration files instead of replacing them blindly during reinstall.
+4. Remove stale aliases, wrapper scripts, or PATH entries that bypass `~/.dmtools/bin/dmtools`, and confirm `which dmtools` / `Get-Command dmtools` resolve to the new install.
+5. Verify the migrated installation with `dmtools --version` and `dmtools list`, and update CI cache keys that still reference legacy install URLs.
+6. If anything fails, roll back by restoring the backup copy of `~/.dmtools` and reactivating the previous wrapper or PATH configuration.
 
 ### Method 2: Local Development Installation
 

--- a/testing/tests/DMC-906/test_dmc_906.py
+++ b/testing/tests/DMC-906/test_dmc_906.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+from testing.components.services.upgrade_guidance_service import UpgradeGuidanceService
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+VISIBLE_GUIDANCE_PATHS = {
+    "README.md",
+    "dmtools-ai-docs/references/installation/README.md",
+}
+
+
+def test_dmc_906_visible_upgrade_sections_include_complete_migration_safeguards() -> None:
+    service = UpgradeGuidanceService(REPOSITORY_ROOT)
+
+    audits_by_path = {
+        audit.path.relative_to(REPOSITORY_ROOT).as_posix(): audit
+        for audit in service.audit_upgrade_guidance_sections()
+    }
+
+    missing_sections = sorted(VISIBLE_GUIDANCE_PATHS.difference(audits_by_path))
+    assert not missing_sections, (
+        "Expected visible upgrade guidance sections for "
+        + ", ".join(sorted(VISIBLE_GUIDANCE_PATHS))
+        + f"; missing {', '.join(missing_sections)}"
+    )
+
+    incomplete_sections = {
+        path: audits_by_path[path].missing_requirements
+        for path in sorted(VISIBLE_GUIDANCE_PATHS)
+        if audits_by_path[path].missing_requirements
+    }
+    assert not incomplete_sections, (
+        "Visible upgrade guidance sections are missing required migration safeguards: "
+        + ", ".join(
+            f"{path} -> {', '.join(requirements)}"
+            for path, requirements in incomplete_sections.items()
+        )
+    )


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The visible `Upgrading from legacy installs` sections in `README.md` and `dmtools-ai-docs/references/installation/README.md` only covered switching away from legacy install URLs and stale wrappers. They did not include the backup, config-preservation, verification, and rollback steps required by the existing upgrade guidance audit, so the linked documentation regression failed.

### Fix
Updated both visible upgrade sections to document the full six-step migration flow: back up `~/.dmtools`, switch to the EPAM release installer, preserve or merge local config, clean up stale PATH and wrapper entries, verify with `dmtools --version` and `dmtools list`, and roll back by restoring the backup copy if needed.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-906/test_dmc_906.py` — `test_dmc_906_visible_upgrade_sections_include_complete_migration_safeguards`
- Linked regression test: `testing/tests/DMC-902/test_dmc_902.py` — PASSED
- Full test suite: `python3 -m pytest testing/tests -q` — 7 failures remain, all in pre-existing documentation audit tickets (`DMC-893`, `DMC-896`, `DMC-897`) unrelated to this change

### Notes
`instruction.md` was not present at the repository root, so the implementation used the ticket files available under `input/DMC-906/`.
