### PR TITLE
DMC-912 Installation docs lack required backlinks to README installation section

### DIFF
--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -1,5 +1,7 @@
 # DMtools Installation Guide
 
+[Back to README installation](../../../README.md#installation)
+
 ## 🚀 Quick Installation
 
 The fastest way to install DMtools:

--- a/dmtools-ai-docs/references/installation/troubleshooting.md
+++ b/dmtools-ai-docs/references/installation/troubleshooting.md
@@ -1,5 +1,7 @@
 # DMtools Installation Troubleshooting
 
+[Back to README installation](../../../README.md#installation)
+
 ## 🔍 Common Installation Issues
 
 ### Issue: "Java version not found" or "Java 17+ required"


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The detailed installation guides under `dmtools-ai-docs/references/installation/` did not include any markdown link resolving back to `README.md#installation`. The root `README.md` already linked into those guides, so the broken behavior was the missing return path that `testing/tests/DMC-903/test_dmc_903.py` validates.

### Fix
Added explicit backlinks at the top of both `dmtools-ai-docs/references/installation/README.md` and `dmtools-ai-docs/references/installation/troubleshooting.md` pointing to `../../../README.md#installation`. This is the minimum targeted change needed to satisfy the required bidirectional navigation without altering any other installation content.

### Test Coverage
- Reproduction test used: `testing/tests/DMC-903/test_dmc_903.py` — `test_dmc_903_installation_cross_links_are_bidirectional`
- Related regression boundary: `testing/tests/DMC-902/test_dmc_902.py`, `testing/tests/DMC-903/test_dmc_903.py`, `testing/tests/DMC-906/test_dmc_906.py` — all passed
- Full Python ticket suite: `python3 -m pytest testing/tests -q` → **8 failures, 10 passed**. Failures are pre-existing and unrelated to this change (`DMC-893`, `DMC-896`, `DMC-897`, `DMC-898`, `DMC-899`)

### Notes
- `instruction.md` was not present at the repository root, so implementation proceeded from the ticket bundle in `input/DMC-912/`.
- Test execution required installing the repository’s existing Python dependency from `testing/requirements.txt` because `pytest` was not preinstalled in the runner.
