### PR TITLE
DMC-919 Active install docs still contain legacy raw GitHub URLs and version-pinned installer commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,18 +52,6 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install | bash
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
 ```
 
-**Specific Version (e.g., v1.7.179):**
-
-**macOS / Linux / Git Bash:**
-```bash
-curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install | bash -s -- v1.7.179
-```
-
-**Windows:**
-```cmd
-set DMTOOLS_VERSION=v1.7.179 && curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
-```
-
 **Verify installation:**
 ```bash
 dmtools --version
@@ -80,6 +68,18 @@ See the [installation guide](dmtools-ai-docs/references/installation/README.md) 
 4. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases, wrapper scripts, and outdated PATH entries from your shell profile or CI bootstrap steps.
 5. Verify the migrated install with `dmtools --version` and `dmtools list`, and refresh CI cache keys that still reference legacy install URLs.
 6. If the migration fails, roll back by restoring the backup copy of `~/.dmtools` and re-enabling the previous wrapper or PATH entry.
+
+   Tagged reinstall example for rollback or migration validation:
+
+   **macOS / Linux / Git Bash:**
+   ```bash
+   curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install | bash -s -- v1.7.179
+   ```
+
+   **Windows:**
+   ```cmd
+   set DMTOOLS_VERSION=v1.7.179 && curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
+   ```
 
 ### Deprecated compatibility shims
 

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -20,21 +20,21 @@ Comprehensive knowledge base for DMtools - an AI-powered development toolkit tha
 
 **When a user mentions DMtools or asks to use it, IMMEDIATELY perform these checks:**
 
-### 🚀 Quick Automated Setup (Recommended)
+### 🚀 Quick Installation Bootstrap (Recommended)
 
-Run the automated setup helper that checks and configures everything:
+Install or refresh DMtools from the latest release first, then continue with the configuration checks below:
 
 ```bash
-# Download and run setup helper
-curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/dmtools-ai-docs/setup-dmtools.sh | bash
+# Install or update DMtools from the latest release
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 ```
 
-**This script will:**
-1. ✓ Check if DMtools is installed (and install if missing)
-2. ✓ Create dmtools.env template if missing
-3. ✓ Add dmtools files to .gitignore
+**Then make sure to:**
+1. ✓ Check whether `dmtools` is available
+2. ✓ Create `dmtools.env` if missing
+3. ✓ Add DMtools files to `.gitignore`
 4. ✓ Verify Java installation
-5. ✓ Test DMtools functionality
+5. ✓ Test DMtools functionality with `dmtools list`
 
 **OR follow manual steps below:**
 
@@ -462,8 +462,8 @@ I'll help you configure it. First, which integrations do you need?
 ### Example: Automated Setup Flow
 
 ```bash
-# Step 1: Run automated setup
-curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/dmtools-ai-docs/setup-dmtools.sh | bash
+# Step 1: Install or update DMtools
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 
 # Step 2: If dmtools.env needs credentials, guide user:
 # "I've created dmtools.env. You need to add your credentials:

--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -28,10 +28,9 @@ This script will:
 ```bash
 # Latest stable version
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
-
-# Specific version
-curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
 ```
+
+If you need a tagged reinstall for rollback or migration validation, use the example in [Upgrading from legacy installs](#upgrading-from-legacy-installs).
 
 ## Install Only the Skills You Need
 
@@ -77,6 +76,14 @@ irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | i
 4. Remove stale aliases, wrapper scripts, or PATH entries that bypass `~/.dmtools/bin/dmtools`, and confirm `which dmtools` / `Get-Command dmtools` resolve to the new install.
 5. Verify the migrated installation with `dmtools --version` and `dmtools list`, and update CI cache keys that still reference legacy install URLs.
 6. If anything fails, roll back by restoring the backup copy of `~/.dmtools` and reactivating the previous wrapper or PATH configuration.
+
+#### Tagged reinstall example
+
+Use a tagged installer only when you need to validate or roll back to a previously deployed release during migration work:
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
+```
 
 ### Method 2: Local Development Installation
 
@@ -384,10 +391,7 @@ docker run -it dmtools --version
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 ```
 
-### Update to Specific Version
-```bash
-curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
-```
+For tagged reinstall or rollback guidance, use the example in [Upgrading from legacy installs](#upgrading-from-legacy-installs).
 
 ### Check Current Version
 ```bash


### PR DESCRIPTION
## Issues/Notes

- **Root Cause:** `dmtools-ai-docs/SKILL.md` still exposed raw GitHub bootstrap commands in active setup guidance, and both `README.md` and `dmtools-ai-docs/references/installation/README.md` kept tagged installer examples in active install/update sections instead of limiting them to the deprecated `Upgrading from legacy installs` flow.
- **Broader suite status:** `testing/tests` still has unrelated failures in DMC-893, DMC-896, DMC-897, DMC-898, and DMC-899. Those were not touched by this fix.

## Approach

- Reproduced DMC-900 with `PYTHONPATH=. python3 -m pytest testing/tests/DMC-900/test_dmc_900.py -q -r a`.
- Updated `dmtools-ai-docs/SKILL.md` so the recommended setup path uses the latest release installer instead of raw GitHub bootstrap commands.
- Removed tagged installer examples from active install/update sections in `README.md` and `dmtools-ai-docs/references/installation/README.md`.
- Preserved the canonical tagged installer examples by moving them under `Upgrading from legacy installs`, which keeps DMC-901 coverage intact while satisfying DMC-900.

## Files Modified

- `README.md`
- `dmtools-ai-docs/SKILL.md`
- `dmtools-ai-docs/references/installation/README.md`
- `outputs/rca.md`

## Test Coverage

- Reproduction test: `testing/tests/DMC-900/test_dmc_900.py` — passed after the fix.
- Related regression coverage: `testing/tests/DMC-900/test_dmc_900.py testing/tests/DMC-901/test_dmc_901.py testing/tests/DMC-902/test_dmc_902.py` — **7 passed**.
- Broader suite: `PYTHONPATH=. python3 -m pytest testing/tests -q -r a` — **8 unrelated failures remain** (`DMC-893`, `DMC-896`, `DMC-897`, `DMC-898`, `DMC-899`).
