### PR TITLE
DMC-923 Secondary docs have summary drift for Teammate and JSRunner

### DIFF
--- a/dmtools-ai-docs/references/agents/cli-integration.md
+++ b/dmtools-ai-docs/references/agents/cli-integration.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Teammate supports integration with external CLI agents (Cursor, Claude, Copilot, Codex, Gemini CLI, etc.) for advanced code generation and analysis tasks that require full workspace context.
+Teammate orchestrates ticket context, AI instructions, and optional CLI or JS hooks for end-to-end workflow automation.
 
 ## ⚠️ CRITICAL: When to Use CLI Integration
 

--- a/dmtools-ai-docs/references/agents/javascript-agents.md
+++ b/dmtools-ai-docs/references/agents/javascript-agents.md
@@ -516,7 +516,7 @@ function action(params) {
 
 ### The Recommended Approach: JSRunner
 
-**JSRunner is the primary way to test JS agents** — it runs the script inside the real GraalJS environment with live MCP tools, real Jira/Confluence connections, and the exact same `params` structure your agent will receive in production.
+JSRunner executes one GraalJS script with DMtools context for isolated automation, debugging, and JS agent testing.
 
 ```bash
 # Run agent with no params (useful for scripts that read their own config)


### PR DESCRIPTION
# Fix Summary

## RCA
- DMC-898 was failing because two secondary documentation sections used paraphrased descriptions instead of the canonical job summaries.
- The mismatches were in:
  - `dmtools-ai-docs/references/agents/cli-integration.md` (`Teammate` overview)
  - `dmtools-ai-docs/references/agents/javascript-agents.md` (`JSRunner` testing section)
- The canonical tables in `teammate-configs.md` and `jobs/README.md` were already correct; only the mirrored narrative text had drifted.

## Fix
- Replaced the `cli-integration.md` overview sentence with the exact canonical `Teammate` summary.
- Replaced the `javascript-agents.md` JSRunner introduction sentence with the exact canonical `JSRunner` summary.
- Left the rest of the documents unchanged.

## Test Coverage
- Installed the documented Python dependency from `testing/requirements.txt`.
- Ran `python3 -m pytest testing/tests/DMC-898/test_dmc_898.py -q`
- Ran `python3 -m pytest testing/tests/DMC-898 -q`
- Ran `./gradlew :dmtools-core:compileJava --no-daemon`

## Notes
- The repo-root `instruction.md` referenced by the task bundle was not present in this checkout, so implementation followed the ticket inputs plus the repository’s existing build and testing conventions.
