### PR TITLE
DMC-920 Test: Follow backlink from troubleshooting guide — navigation returns to root README installation

### DIFF
--- a/testing/tests/DMC-920/README.md
+++ b/testing/tests/DMC-920/README.md
@@ -1,0 +1,20 @@
+# DMC-920 automated test
+
+This test validates that `dmtools-ai-docs/references/installation/troubleshooting.md` exposes a visible backlink to the root `README.md#installation` anchor and that the link resolves to the installation section users expect to return to.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-920/test_dmc_920.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads markdown files directly from this repository checkout.
+

--- a/testing/tests/DMC-920/config.yaml
+++ b/testing/tests/DMC-920/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-920
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-920/test_dmc_920.py
+++ b/testing/tests/DMC-920/test_dmc_920.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+from testing.components.services.documentation_cross_link_service import (
+    DocumentationCrossLinkService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_920_troubleshooting_backlink_returns_to_root_readme_installation() -> None:
+    service = DocumentationCrossLinkService(REPOSITORY_ROOT)
+    markdown = service.troubleshooting_guide_path.read_text(encoding="utf-8")
+    readme_links = [
+        link
+        for link in service.parse_markdown_links(markdown)
+        if service.resolve_target(service.troubleshooting_guide_path, link.target)[0]
+        == service.readme_path.resolve()
+    ]
+    backlinks = [
+        link
+        for link in readme_links
+        if service.resolve_target(service.troubleshooting_guide_path, link.target)[1]
+        == "installation"
+    ]
+
+    assert backlinks, service.format_missing_backlink(
+        service.troubleshooting_guide_path,
+        readme_links,
+    )
+
+    backlink = backlinks[0]
+    resolved_path, fragment = service.resolve_target(
+        service.troubleshooting_guide_path,
+        backlink.target,
+    )
+
+    assert backlink.text == "Back to README installation", (
+        "The troubleshooting guide should expose a clear user-facing backlink label. "
+        f"Found {backlink.text!r}."
+    )
+    assert resolved_path == service.readme_path.resolve(), service.format_invalid_target(
+        service.troubleshooting_guide_path,
+        backlink,
+        resolved_path,
+        fragment,
+    )
+    assert fragment == "installation", service.format_invalid_target(
+        service.troubleshooting_guide_path,
+        backlink,
+        resolved_path,
+        fragment,
+    )
+    assert fragment in service.anchors_for(resolved_path), service.format_invalid_target(
+        service.troubleshooting_guide_path,
+        backlink,
+        resolved_path,
+        fragment,
+    )
+
+    service.section_content(resolved_path, "### Installation")
+
+    first_section_line = next(
+        index
+        for index, line in enumerate(markdown.splitlines(), start=1)
+        if line.startswith("## ")
+    )
+    assert backlink.line_number < first_section_line, (
+        "The backlink should appear before the troubleshooting sections so users can "
+        "return to the README installation instructions immediately. "
+        f"Found backlink on line {backlink.line_number} and first section on line "
+        f"{first_section_line}."
+    )


### PR DESCRIPTION
## Test Automation Result

**PASSED** — DMC-920 automation confirms the troubleshooting guide backlink returns users to the root README installation section.

**Ticket:** `DMC-920`  
**Automated test:** `testing/tests/DMC-920/test_dmc_920.py`  
**Command:** `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest testing/tests/DMC-920/test_dmc_920.py -q`  
**Result:** `1 passed in 0.02s`

### What automation verified
1. Opened `dmtools-ai-docs/references/installation/troubleshooting.md`.
2. Located a backlink targeting `README.md#installation`.
3. Verified the link resolves to the repository root `README.md` and that the `### Installation` anchor exists.
4. Verified the visible backlink label is `Back to README installation`.
5. Verified the backlink is placed before the first troubleshooting section, so users encounter it immediately.

### Real human-style verification
- Observed the visible text `Back to README installation` at the top of the troubleshooting guide.
- Observed that following the link would return a user to the root README installation section because the target resolves to `README.md#installation` and the installation heading exists in `README.md`.
- Observed behavior matched the expected result.

