### PR TITLE
DMC-924 Per-skill catalogue index is missing from dmtools-ai-docs

### DIFF
--- a/dmtools-ai-docs/per-skill-packages/index.md
+++ b/dmtools-ai-docs/per-skill-packages/index.md
@@ -1,0 +1,15 @@
+# Per-Skill Package Catalogue
+
+This page is the canonical catalogue for the approved focused DMtools skill packages.
+
+| Skill | Slash command | Java package | Artifact alias |
+| --- | --- | --- | --- |
+| `dmtools-jira` | `/dmtools-jira` | `com.github.istin.dmtools.atlassian.jira` | `com.github.istin:dmtools-jira` |
+| `dmtools-confluence` | `/dmtools-confluence` | `com.github.istin.dmtools.atlassian.confluence` | `com.github.istin:dmtools-confluence` |
+| `dmtools-github` | `/dmtools-github` | `com.github.istin.dmtools.github` | `com.github.istin:dmtools-github` |
+| `dmtools-gitlab` | `/dmtools-gitlab` | `com.github.istin.dmtools.gitlab` | `com.github.istin:dmtools-gitlab` |
+| `dmtools-ado` | `/dmtools-ado` | `com.github.istin.dmtools.microsoft.ado` | `com.github.istin:dmtools-ado` |
+| `dmtools-figma` | `/dmtools-figma` | `com.github.istin.dmtools.figma` | `com.github.istin:dmtools-figma` |
+| `dmtools-testrail` | `/dmtools-testrail` | `com.github.istin.dmtools.testrail` | `com.github.istin:dmtools-testrail` |
+| `dmtools-teams` | `/dmtools-teams` | `com.github.istin.dmtools.microsoft.teams` | `com.github.istin:dmtools-teams` |
+| `dmtools-report` | `/dmtools-report` | `com.github.istin.dmtools.report` | `com.github.istin:dmtools-report` |


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The canonical per-skill catalogue file expected at `dmtools-ai-docs/per-skill-packages/index.md` did not exist in the repository. Because `testing/components/services/per_skill_catalog_service.py` validates that exact path first, the linked regression failed before any skill mapping content could be checked.

### Fix
Added `dmtools-ai-docs/per-skill-packages/index.md` as the canonical catalogue for the 9 approved focused skills. Each row now includes the exact skill name, `/dmtools-<name>` slash command, canonical Java package identifier, and `com.github.istin:dmtools-<name>` artifact alias required by the validator and ticket.

### Test Coverage
- Reproduction test added: existing linked regression `testing/tests/DMC-914/test_dmc_914.py` — `test_dmc_914_per_skill_catalog_lists_all_canonical_skill_rows`
- Linked pytest suite: PASSED (`python3 -m pytest testing/tests/DMC-914/test_dmc_914.py -q`)
- Full core validation: PASSED (`./gradlew :dmtools-core:compileJava :dmtools-core:test --no-daemon`)

### Notes
The fix is documentation-only and intentionally limited to the missing canonical catalogue artifact.
