### PR TITLE
DMC-927 Test: Handle invalid skills in normal and strict mode — skip with warning or fail run

### DIFF
--- a/testing/components/factories/installer_script_factory.py
+++ b/testing/components/factories/installer_script_factory.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.installer_script_service import InstallerScriptService
+from testing.core.interfaces.installer_script import InstallerScript
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_installer_script(repository_root: Path) -> InstallerScript:
+    return InstallerScriptService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+    )

--- a/testing/components/services/installer_script_service.py
+++ b/testing/components/services/installer_script_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from testing.core.interfaces.installer_script import InstallerScript
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+class InstallerScriptService(InstallerScript):
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+    ) -> None:
+        self.repository_root = repository_root
+        self.install_script_path = repository_root / "install.sh"
+        self.runner = runner
+
+    def run_main(
+        self,
+        args: Sequence[str] = (),
+        extra_env: Mapping[str, str] | None = None,
+        post_script: str = "",
+    ) -> ProcessExecutionResult:
+        with tempfile.TemporaryDirectory(prefix="dmtools-installer-") as temp_dir:
+            install_dir = Path(temp_dir) / "home" / ".dmtools"
+            bin_dir = install_dir / "bin"
+            installer_env_path = bin_dir / "dmtools-installer.env"
+
+            env = {
+                "DMTOOLS_INSTALLER_TEST_MODE": "true",
+                "DMTOOLS_INSTALL_DIR": str(install_dir),
+                "DMTOOLS_BIN_DIR": str(bin_dir),
+                "DMTOOLS_INSTALLER_ENV_PATH": str(installer_env_path),
+            }
+            if extra_env:
+                env.update(extra_env)
+
+            command = textwrap.dedent(
+                f"""
+                set -e
+                source "{self.install_script_path}"
+
+                check_java() {{
+                    info "stubbed check_java"
+                }}
+
+                get_latest_version() {{
+                    echo "v0.0.0-test"
+                }}
+
+                download_dmtools() {{
+                    local version="$1"
+                    info "stubbed download_dmtools $version"
+                    mkdir -p "$(dirname "$JAR_PATH")"
+                    printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+                }}
+
+                update_shell_config() {{
+                    info "stubbed update_shell_config"
+                }}
+
+                verify_installation() {{
+                    info "stubbed verify_installation"
+                }}
+
+                print_instructions() {{
+                    info "stubbed print_instructions"
+                }}
+
+                main "$@"
+                {post_script}
+                """
+            ).strip()
+
+            return self.runner.run(
+                ["bash", "-lc", command, "bash", *args],
+                cwd=self.repository_root,
+                env=env,
+            )

--- a/testing/core/interfaces/installer_script.py
+++ b/testing/core/interfaces/installer_script.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Mapping, Protocol, Sequence
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+class InstallerScript(Protocol):
+    def run_main(
+        self,
+        args: Sequence[str] = (),
+        extra_env: Mapping[str, str] | None = None,
+        post_script: str = "",
+    ) -> ProcessExecutionResult:
+        raise NotImplementedError

--- a/testing/tests/DMC-927/README.md
+++ b/testing/tests/DMC-927/README.md
@@ -1,0 +1,22 @@
+# DMC-927 automated test
+
+This test exercises the real installer argument parsing and skill-selection flow for invalid
+skill handling while stubbing download and system-mutation steps.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-927/test_dmc_927.py -q
+```
+
+## Environment
+
+No credentials are required. The test executes the repository `install.sh` locally, isolates
+installer output in a temporary directory, and stubs Java/download verification steps so the
+assertions stay focused on user-visible invalid-skill behavior.

--- a/testing/tests/DMC-927/config.yaml
+++ b/testing/tests/DMC-927/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-927
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-927/conftest.py
+++ b/testing/tests/DMC-927/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def installer_script() -> InstallerScript:
+    return create_installer_script(REPOSITORY_ROOT)

--- a/testing/tests/DMC-927/test_dmc_927.py
+++ b/testing/tests/DMC-927/test_dmc_927.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.core.interfaces.installer_script import InstallerScript  # noqa: E402
+
+
+def test_dmc_927_normal_mode_skips_unknown_skills_and_keeps_valid_selection(
+    installer_script: InstallerScript,
+) -> None:
+    execution = installer_script.run_main(
+        extra_env={"DMTOOLS_SKILLS": "jira,unknown_skill"},
+        post_script="""
+printf 'installer_env_path=%s\\n' "$INSTALLER_ENV_PATH"
+cat "$INSTALLER_ENV_PATH"
+""",
+    )
+
+    assert execution.returncode == 0, (
+        "Normal installer mode should continue when at least one known skill remains.\n"
+        f"stdout:\n{execution.stdout}\n\nstderr:\n{execution.stderr}"
+    )
+    assert "Warning: Skipping unknown skills: unknown_skill" in execution.stdout
+    assert "Effective skills: jira (source: env)" in execution.stdout
+    assert "Effective integrations: ai,cli,file,kb,mermaid,jira" in execution.stdout
+    assert 'DMTOOLS_SKILLS="jira"' in execution.stdout
+    assert 'DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"' in execution.stdout
+
+
+def test_dmc_927_strict_mode_rejects_invalid_skills_with_invalid_skill_error(
+    installer_script: InstallerScript,
+) -> None:
+    execution = installer_script.run_main(args=("--skills=invalid", "--strict"))
+
+    assert execution.returncode != 0, "Strict installer mode must fail for invalid skills."
+    assert "No valid skills selected. Unknown skills: invalid." in execution.stderr
+    assert "Allowed skills:" in execution.stderr


### PR DESCRIPTION
## Test Automation Result

**Status:** ❌ FAILED  
**Test Case:** DMC-927 — Handle invalid skills in normal and strict mode — skip with warning or fail run

## What was automated
- Executed the real `install.sh` main flow with Java/download/shell-update steps stubbed so the test stayed focused on installer argument parsing, invalid-skill handling, terminal logs, and generated installer config.
- Verified normal mode with `DMTOOLS_SKILLS='jira,unknown_skill'`.
- Verified strict mode with `--skills=invalid --strict`.

## Human-style verification
- Checked the visible terminal messages a user would actually see, not just internal variables.
- Confirmed normal mode showed `Warning: Skipping unknown skills: unknown_skill`, preserved `jira`, and wrote `DMTOOLS_SKILLS="jira"` plus `DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"`.
- Observed strict mode exit with code `1`, but the user-facing error was `Error: Unknown installer option: --strict`.

## Result
- Normal mode matched the expected result.
- Strict mode did **not** match the expected result.
- Expected: the installer should fail because `invalid` is not a valid skill and report that invalid-skill problem.
- Actual: the installer fails earlier because `--strict` is treated as an unsupported option, so the strict invalid-skill path is never reached.

## Failure output
```text
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0 -- /bin/python3
cachedir: .pytest_cache
rootdir: /home/runner/work/dm.ai/dm.ai
collecting ... collected 2 items

testing/tests/DMC-927/test_dmc_927.py::test_dmc_927_normal_mode_skips_unknown_skills_and_keeps_valid_selection PASSED
testing/tests/DMC-927/test_dmc_927.py::test_dmc_927_strict_mode_rejects_invalid_skills_with_invalid_skill_error FAILED

E       assert 'No valid skills selected. Unknown skills: invalid.' in '\x1b[0;31mError: Unknown installer option: --strict\x1b[0m\n'
```

## How to run
```bash
python3 -m pytest testing/tests/DMC-927/test_dmc_927.py -q
```
