### PR TITLE
DMC-926 Test: Install with missing or empty selection — all skills installed by default

### DIFF
--- a/testing/components/services/installer_full_install_audit_service.py
+++ b/testing/components/services/installer_full_install_audit_service.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import re
+import textwrap
+from typing import Mapping
+
+from testing.core.interfaces.installer_script import InstallerScript
+from testing.core.models.installer_full_install_observation import (
+    InstallerFullInstallObservation,
+)
+
+
+class InstallerFullInstallAuditService:
+    ALL_SKILLS = (
+        "dmtools,jira,confluence,github,gitlab,figma,teams,"
+        "sharepoint,ado,testrail,xray"
+    )
+    ALL_INTEGRATIONS = (
+        "ai,cli,file,kb,mermaid,jira,confluence,github,gitlab,figma,"
+        "teams,teams_auth,sharepoint,ado,testrail,jira_xray"
+    )
+
+    _ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+    _PROBE_PREFIX = "__DMTOOLS_PROBE__:"
+    _INSTALLER_ENV_LINE_KEY = "installer_env_line"
+
+    def __init__(self, installer_script: InstallerScript) -> None:
+        self.installer_script = installer_script
+
+    def observe(
+        self,
+        extra_env: Mapping[str, str | None] | None = None,
+    ) -> InstallerFullInstallObservation:
+        execution = self.installer_script.run_main(
+            extra_env=extra_env,
+            post_script=self._probe_script(),
+        )
+
+        probe_values: dict[str, str] = {}
+        installer_env: dict[str, str] = {}
+        visible_stdout_lines: list[str] = []
+
+        for line in self._strip_ansi(execution.stdout).splitlines():
+            if not line.startswith(self._PROBE_PREFIX):
+                visible_stdout_lines.append(line)
+                continue
+
+            key, _, value = line[len(self._PROBE_PREFIX) :].partition("=")
+            if key == self._INSTALLER_ENV_LINE_KEY:
+                env_key, _, env_value = value.partition("=")
+                if env_key:
+                    installer_env[env_key] = env_value.strip().strip('"')
+                continue
+
+            probe_values[key] = value
+
+        return InstallerFullInstallObservation(
+            execution=execution,
+            stdout="\n".join(visible_stdout_lines).strip(),
+            stderr=self._strip_ansi(execution.stderr).strip(),
+            install_root_exists=probe_values.get("install_root_exists") == "true",
+            bin_dir_exists=probe_values.get("bin_dir_exists") == "true",
+            jar_exists=probe_values.get("jar_exists") == "true",
+            script_exists=probe_values.get("script_exists") == "true",
+            script_is_executable=probe_values.get("script_is_executable") == "true",
+            installer_env=installer_env,
+        )
+
+    @classmethod
+    def _probe_script(cls) -> str:
+        return textwrap.dedent(
+            f"""
+            if [ -d "$INSTALL_DIR" ]; then
+                printf '{cls._PROBE_PREFIX}install_root_exists=true\\n'
+            else
+                printf '{cls._PROBE_PREFIX}install_root_exists=false\\n'
+            fi
+            if [ -d "$BIN_DIR" ]; then
+                printf '{cls._PROBE_PREFIX}bin_dir_exists=true\\n'
+            else
+                printf '{cls._PROBE_PREFIX}bin_dir_exists=false\\n'
+            fi
+            if [ -s "$JAR_PATH" ]; then
+                printf '{cls._PROBE_PREFIX}jar_exists=true\\n'
+            else
+                printf '{cls._PROBE_PREFIX}jar_exists=false\\n'
+            fi
+            if [ -f "$SCRIPT_PATH" ]; then
+                printf '{cls._PROBE_PREFIX}script_exists=true\\n'
+            else
+                printf '{cls._PROBE_PREFIX}script_exists=false\\n'
+            fi
+            if [ -x "$SCRIPT_PATH" ]; then
+                printf '{cls._PROBE_PREFIX}script_is_executable=true\\n'
+            else
+                printf '{cls._PROBE_PREFIX}script_is_executable=false\\n'
+            fi
+            if [ -f "$INSTALLER_ENV_PATH" ]; then
+                while IFS= read -r line || [ -n "$line" ]; do
+                    printf '{cls._PROBE_PREFIX}{cls._INSTALLER_ENV_LINE_KEY}=%s\\n' "$line"
+                done < "$INSTALLER_ENV_PATH"
+            fi
+            """
+        ).strip()
+
+    @classmethod
+    def _strip_ansi(cls, value: str) -> str:
+        return cls._ANSI_ESCAPE_PATTERN.sub("", value)

--- a/testing/components/services/installer_script_service.py
+++ b/testing/components/services/installer_script_service.py
@@ -23,7 +23,7 @@ class InstallerScriptService(InstallerScript):
     def run_main(
         self,
         args: Sequence[str] = (),
-        extra_env: Mapping[str, str] | None = None,
+        extra_env: Mapping[str, str | None] | None = None,
         post_script: str = "",
     ) -> ProcessExecutionResult:
         with tempfile.TemporaryDirectory(prefix="dmtools-installer-") as temp_dir:
@@ -31,11 +31,12 @@ class InstallerScriptService(InstallerScript):
             bin_dir = install_dir / "bin"
             installer_env_path = bin_dir / "dmtools-installer.env"
 
-            env = {
+            env: dict[str, str | None] = {
                 "DMTOOLS_INSTALLER_TEST_MODE": "true",
                 "DMTOOLS_INSTALL_DIR": str(install_dir),
                 "DMTOOLS_BIN_DIR": str(bin_dir),
                 "DMTOOLS_INSTALLER_ENV_PATH": str(installer_env_path),
+                "DMTOOLS_SKILLS": None,
             }
             if extra_env:
                 env.update(extra_env)
@@ -56,8 +57,13 @@ class InstallerScriptService(InstallerScript):
                 download_dmtools() {{
                     local version="$1"
                     info "stubbed download_dmtools $version"
-                    mkdir -p "$(dirname "$JAR_PATH")"
+                    mkdir -p "$(dirname "$JAR_PATH")" "$BIN_DIR"
                     printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+                    cat > "$SCRIPT_PATH" <<'EOF'
+#!/bin/bash
+echo "dmtools stub"
+EOF
+                    chmod +x "$SCRIPT_PATH"
                 }}
 
                 update_shell_config() {{

--- a/testing/core/interfaces/installer_script.py
+++ b/testing/core/interfaces/installer_script.py
@@ -9,7 +9,7 @@ class InstallerScript(Protocol):
     def run_main(
         self,
         args: Sequence[str] = (),
-        extra_env: Mapping[str, str] | None = None,
+        extra_env: Mapping[str, str | None] | None = None,
         post_script: str = "",
     ) -> ProcessExecutionResult:
         raise NotImplementedError

--- a/testing/core/interfaces/process_runner.py
+++ b/testing/core/interfaces/process_runner.py
@@ -11,7 +11,7 @@ class ProcessRunner(Protocol):
         self,
         args: Sequence[str],
         cwd: Path,
-        env: Mapping[str, str] | None = None,
+        env: Mapping[str, str | None] | None = None,
         trace_network: bool = False,
     ) -> ProcessExecutionResult:
         raise NotImplementedError

--- a/testing/core/models/installer_full_install_observation.py
+++ b/testing/core/models/installer_full_install_observation.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+@dataclass(frozen=True)
+class InstallerFullInstallObservation:
+    execution: ProcessExecutionResult
+    stdout: str
+    stderr: str
+    install_root_exists: bool
+    bin_dir_exists: bool
+    jar_exists: bool
+    script_exists: bool
+    script_is_executable: bool
+    installer_env: Mapping[str, str]

--- a/testing/frameworks/api/rest/subprocess_process_runner.py
+++ b/testing/frameworks/api/rest/subprocess_process_runner.py
@@ -15,14 +15,18 @@ class SubprocessProcessRunner:
         self,
         args: Sequence[str],
         cwd: Path,
-        env: Mapping[str, str] | None = None,
+        env: Mapping[str, str | None] | None = None,
         trace_network: bool = False,
     ) -> ProcessExecutionResult:
         trace_path: Path | None = None
         command = list(args)
         merged_env = os.environ.copy()
         if env:
-            merged_env.update(env)
+            for key, value in env.items():
+                if value is None:
+                    merged_env.pop(key, None)
+                else:
+                    merged_env[key] = value
 
         if trace_network:
             strace_path = shutil.which("strace")

--- a/testing/tests/DMC-926/README.md
+++ b/testing/tests/DMC-926/README.md
@@ -1,0 +1,28 @@
+# DMC-926 automated test
+
+This test covers the installer's backward-compatible full-install flow when the skill selection is
+missing, empty, or explicitly set to `all`.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-926/test_dmc_926.py -q
+```
+
+## Environment
+
+No credentials are required. The test runs the repository `install.sh` locally, stubs download and
+system-mutation steps through the shared installer test service, and inspects the persisted
+installer-managed skill configuration from the isolated test run.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-926/config.yaml
+++ b/testing/tests/DMC-926/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-926
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-926/conftest.py
+++ b/testing/tests/DMC-926/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.components.services.installer_full_install_audit_service import (
+    InstallerFullInstallAuditService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def installer_full_install_audit_service() -> InstallerFullInstallAuditService:
+    return InstallerFullInstallAuditService(create_installer_script(REPOSITORY_ROOT))

--- a/testing/tests/DMC-926/test_dmc_926.py
+++ b/testing/tests/DMC-926/test_dmc_926.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+INSTALL_SCRIPT = REPOSITORY_ROOT / "install.sh"
+ALL_SKILLS = (
+    "dmtools,jira,confluence,github,gitlab,figma,teams,"
+    "sharepoint,ado,testrail,xray"
+)
+ALL_INTEGRATIONS = (
+    "ai,cli,file,kb,mermaid,jira,confluence,github,gitlab,figma,"
+    "teams,teams_auth,sharepoint,ado,testrail,jira_xray"
+)
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(value: str) -> str:
+    return ANSI_ESCAPE_PATTERN.sub("", value)
+
+
+def parse_installer_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, raw_value = line.partition("=")
+        values[key] = raw_value.strip().strip('"')
+    return values
+
+
+def run_installer_with_stubbed_runtime(
+    temp_dir: Path,
+    *,
+    args: tuple[str, ...] = (),
+    env_overrides: dict[str, str | None] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    install_dir = temp_dir / "install-root"
+    bin_dir = install_dir / "bin"
+    installer_env_path = bin_dir / "dmtools-installer.env"
+
+    env = os.environ.copy()
+    env["DMTOOLS_INSTALLER_TEST_MODE"] = "true"
+    env["DMTOOLS_INSTALL_DIR"] = str(install_dir)
+    env["DMTOOLS_BIN_DIR"] = str(bin_dir)
+    env["DMTOOLS_INSTALLER_ENV_PATH"] = str(installer_env_path)
+    env.pop("DMTOOLS_SKILLS", None)
+    if env_overrides:
+        for key, value in env_overrides.items():
+            if value is None:
+                env.pop(key, None)
+            else:
+                env[key] = value
+
+    script = f"""
+set -e
+source "{INSTALL_SCRIPT}"
+
+check_java() {{
+    info "check_java stub"
+}}
+
+get_latest_version() {{
+    printf '%s' 'v9.9.9'
+}}
+
+download_dmtools() {{
+    local version="$1"
+    progress "Downloading DMTools $version (stub)"
+    mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+    printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+    cat > "$SCRIPT_PATH" <<'EOF'
+#!/bin/bash
+echo "dmtools stub"
+EOF
+    chmod +x "$SCRIPT_PATH"
+}}
+
+update_shell_config() {{
+    info "update_shell_config stub"
+}}
+
+verify_installation() {{
+    [ -s "$JAR_PATH" ] || error "Expected installer to create $JAR_PATH"
+    [ -x "$SCRIPT_PATH" ] || error "Expected installer to create executable $SCRIPT_PATH"
+    info "verify_installation stub"
+}}
+
+print_instructions() {{
+    info "print_instructions stub"
+}}
+
+main "$@"
+"""
+
+    return subprocess.run(
+        ["bash", "-lc", script, "installer-test", *args],
+        cwd=REPOSITORY_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("scenario_name", "env_overrides", "expected_source"),
+    [
+        ("missing-selection", {}, "default"),
+        ("empty-selection", {"DMTOOLS_SKILLS": ""}, "env"),
+        ("all-selection", {"DMTOOLS_SKILLS": "all"}, "env"),
+    ],
+)
+def test_dmc_926_missing_or_empty_skill_selection_installs_all_skills_by_default(
+    tmp_path: Path,
+    scenario_name: str,
+    env_overrides: dict[str, str],
+    expected_source: str,
+) -> None:
+    scenario_dir = tmp_path / scenario_name
+    scenario_dir.mkdir()
+    install_root = scenario_dir / "install-root"
+    bin_dir = install_root / "bin"
+    installer_env_path = bin_dir / "dmtools-installer.env"
+    jar_path = install_root / "dmtools.jar"
+    script_path = bin_dir / "dmtools"
+
+    result = run_installer_with_stubbed_runtime(
+        scenario_dir,
+        env_overrides=env_overrides,
+    )
+    stdout = strip_ansi(result.stdout)
+    stderr = strip_ansi(result.stderr)
+
+    assert result.returncode == 0, (
+        f"Installer run failed for {scenario_name}.\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert not stderr.strip(), f"Expected no stderr output for {scenario_name}, got:\n{stderr}"
+    assert f"Installing all skills (source: {expected_source})" in stdout, (
+        "Installer did not announce the default full-install selection for "
+        f"{scenario_name}.\nstdout:\n{stdout}"
+    )
+    assert f"Effective skills: {ALL_SKILLS} (source: {expected_source})" in stdout, (
+        "Installer did not show the canonical all-skills selection for "
+        f"{scenario_name}.\nstdout:\n{stdout}"
+    )
+    assert "Configured installer-managed skills at" in stdout, (
+        "Installer did not report the persisted skill configuration path.\n"
+        f"stdout:\n{stdout}"
+    )
+
+    assert install_root.is_dir(), f"Expected install root to exist: {install_root}"
+    assert bin_dir.is_dir(), f"Expected bin directory to exist: {bin_dir}"
+    assert jar_path.is_file(), f"Expected installer to create JAR artifact: {jar_path}"
+    assert script_path.is_file(), f"Expected installer to create CLI script: {script_path}"
+    assert installer_env_path.is_file(), (
+        "Expected installer to persist the selected skill set at "
+        f"{installer_env_path}"
+    )
+    assert os.stat(script_path).st_mode & stat.S_IXUSR, (
+        f"Expected installer-created CLI script to be executable: {script_path}"
+    )
+
+    installer_env = parse_installer_env(installer_env_path)
+    assert installer_env.get("DMTOOLS_SKILLS") == ALL_SKILLS, (
+        "Persisted DMTOOLS_SKILLS did not contain the canonical full install set.\n"
+        f"expected: {ALL_SKILLS}\nactual: {installer_env.get('DMTOOLS_SKILLS')}"
+    )
+    assert installer_env.get("DMTOOLS_INTEGRATIONS") == ALL_INTEGRATIONS, (
+        "Persisted DMTOOLS_INTEGRATIONS did not contain the canonical full install set.\n"
+        f"expected: {ALL_INTEGRATIONS}\nactual: {installer_env.get('DMTOOLS_INTEGRATIONS')}"
+    )

--- a/testing/tests/DMC-926/test_dmc_926.py
+++ b/testing/tests/DMC-926/test_dmc_926.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-import os
-import re
-import stat
-import subprocess
 import sys
 from pathlib import Path
 
@@ -14,170 +10,82 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-INSTALL_SCRIPT = REPOSITORY_ROOT / "install.sh"
-ALL_SKILLS = (
-    "dmtools,jira,confluence,github,gitlab,figma,teams,"
-    "sharepoint,ado,testrail,xray"
+from testing.components.services.installer_full_install_audit_service import (  # noqa: E402
+    InstallerFullInstallAuditService,
 )
-ALL_INTEGRATIONS = (
-    "ai,cli,file,kb,mermaid,jira,confluence,github,gitlab,figma,"
-    "teams,teams_auth,sharepoint,ado,testrail,jira_xray"
-)
-ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
-
-
-def strip_ansi(value: str) -> str:
-    return ANSI_ESCAPE_PATTERN.sub("", value)
-
-
-def parse_installer_env(path: Path) -> dict[str, str]:
-    values: dict[str, str] = {}
-    for raw_line in path.read_text(encoding="utf-8").splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        key, _, raw_value = line.partition("=")
-        values[key] = raw_value.strip().strip('"')
-    return values
-
-
-def run_installer_with_stubbed_runtime(
-    temp_dir: Path,
-    *,
-    args: tuple[str, ...] = (),
-    env_overrides: dict[str, str | None] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    install_dir = temp_dir / "install-root"
-    bin_dir = install_dir / "bin"
-    installer_env_path = bin_dir / "dmtools-installer.env"
-
-    env = os.environ.copy()
-    env["DMTOOLS_INSTALLER_TEST_MODE"] = "true"
-    env["DMTOOLS_INSTALL_DIR"] = str(install_dir)
-    env["DMTOOLS_BIN_DIR"] = str(bin_dir)
-    env["DMTOOLS_INSTALLER_ENV_PATH"] = str(installer_env_path)
-    env.pop("DMTOOLS_SKILLS", None)
-    if env_overrides:
-        for key, value in env_overrides.items():
-            if value is None:
-                env.pop(key, None)
-            else:
-                env[key] = value
-
-    script = f"""
-set -e
-source "{INSTALL_SCRIPT}"
-
-check_java() {{
-    info "check_java stub"
-}}
-
-get_latest_version() {{
-    printf '%s' 'v9.9.9'
-}}
-
-download_dmtools() {{
-    local version="$1"
-    progress "Downloading DMTools $version (stub)"
-    mkdir -p "$INSTALL_DIR" "$BIN_DIR"
-    printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
-    cat > "$SCRIPT_PATH" <<'EOF'
-#!/bin/bash
-echo "dmtools stub"
-EOF
-    chmod +x "$SCRIPT_PATH"
-}}
-
-update_shell_config() {{
-    info "update_shell_config stub"
-}}
-
-verify_installation() {{
-    [ -s "$JAR_PATH" ] || error "Expected installer to create $JAR_PATH"
-    [ -x "$SCRIPT_PATH" ] || error "Expected installer to create executable $SCRIPT_PATH"
-    info "verify_installation stub"
-}}
-
-print_instructions() {{
-    info "print_instructions stub"
-}}
-
-main "$@"
-"""
-
-    return subprocess.run(
-        ["bash", "-lc", script, "installer-test", *args],
-        cwd=REPOSITORY_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
 
 
 @pytest.mark.parametrize(
-    ("scenario_name", "env_overrides", "expected_source"),
+    ("scenario_name", "extra_env", "expected_source"),
     [
-        ("missing-selection", {}, "default"),
-        ("empty-selection", {"DMTOOLS_SKILLS": ""}, "env"),
-        ("all-selection", {"DMTOOLS_SKILLS": "all"}, "env"),
+        pytest.param("missing-selection", {}, "default", id="missing-selection"),
+        pytest.param("empty-selection", {"DMTOOLS_SKILLS": ""}, None, id="empty-selection"),
+        pytest.param("all-selection", {"DMTOOLS_SKILLS": "all"}, "env", id="all-selection"),
     ],
 )
 def test_dmc_926_missing_or_empty_skill_selection_installs_all_skills_by_default(
-    tmp_path: Path,
+    installer_full_install_audit_service: InstallerFullInstallAuditService,
     scenario_name: str,
-    env_overrides: dict[str, str],
-    expected_source: str,
+    extra_env: dict[str, str | None],
+    expected_source: str | None,
 ) -> None:
-    scenario_dir = tmp_path / scenario_name
-    scenario_dir.mkdir()
-    install_root = scenario_dir / "install-root"
-    bin_dir = install_root / "bin"
-    installer_env_path = bin_dir / "dmtools-installer.env"
-    jar_path = install_root / "dmtools.jar"
-    script_path = bin_dir / "dmtools"
+    observation = installer_full_install_audit_service.observe(extra_env=extra_env)
 
-    result = run_installer_with_stubbed_runtime(
-        scenario_dir,
-        env_overrides=env_overrides,
+    assert observation.execution.returncode == 0, (
+        f"Installer run failed for {scenario_name}.\n"
+        f"stdout:\n{observation.stdout}\n\nstderr:\n{observation.stderr}"
     )
-    stdout = strip_ansi(result.stdout)
-    stderr = strip_ansi(result.stderr)
-
-    assert result.returncode == 0, (
-        f"Installer run failed for {scenario_name}.\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+    assert not observation.stderr, (
+        f"Expected no stderr output for {scenario_name}, got:\n{observation.stderr}"
     )
-    assert not stderr.strip(), f"Expected no stderr output for {scenario_name}, got:\n{stderr}"
-    assert f"Installing all skills (source: {expected_source})" in stdout, (
-        "Installer did not announce the default full-install selection for "
-        f"{scenario_name}.\nstdout:\n{stdout}"
+    assert "Installing all skills" in observation.stdout, (
+        "Installer did not announce the full-install fallback for "
+        f"{scenario_name}.\nstdout:\n{observation.stdout}"
     )
-    assert f"Effective skills: {ALL_SKILLS} (source: {expected_source})" in stdout, (
+    assert (
+        f"Effective skills: {InstallerFullInstallAuditService.ALL_SKILLS}" in observation.stdout
+    ), (
         "Installer did not show the canonical all-skills selection for "
-        f"{scenario_name}.\nstdout:\n{stdout}"
+        f"{scenario_name}.\nstdout:\n{observation.stdout}"
     )
-    assert "Configured installer-managed skills at" in stdout, (
+    if expected_source is not None:
+        assert f"Installing all skills (source: {expected_source})" in observation.stdout, (
+            "Installer did not report the expected selection source for "
+            f"{scenario_name}.\nstdout:\n{observation.stdout}"
+        )
+        assert (
+            f"Effective skills: {InstallerFullInstallAuditService.ALL_SKILLS} "
+            f"(source: {expected_source})" in observation.stdout
+        ), (
+            "Installer did not report the expected source alongside the canonical all-skills "
+            f"selection for {scenario_name}.\nstdout:\n{observation.stdout}"
+        )
+    assert "Configured installer-managed skills at" in observation.stdout, (
         "Installer did not report the persisted skill configuration path.\n"
-        f"stdout:\n{stdout}"
+        f"stdout:\n{observation.stdout}"
     )
 
-    assert install_root.is_dir(), f"Expected install root to exist: {install_root}"
-    assert bin_dir.is_dir(), f"Expected bin directory to exist: {bin_dir}"
-    assert jar_path.is_file(), f"Expected installer to create JAR artifact: {jar_path}"
-    assert script_path.is_file(), f"Expected installer to create CLI script: {script_path}"
-    assert installer_env_path.is_file(), (
-        "Expected installer to persist the selected skill set at "
-        f"{installer_env_path}"
-    )
-    assert os.stat(script_path).st_mode & stat.S_IXUSR, (
-        f"Expected installer-created CLI script to be executable: {script_path}"
+    assert observation.install_root_exists, "Expected install root to exist after installation."
+    assert observation.bin_dir_exists, "Expected bin directory to exist after installation."
+    assert observation.jar_exists, "Expected installer to create a non-empty dmtools.jar."
+    assert observation.script_exists, "Expected installer to create the dmtools launcher script."
+    assert observation.script_is_executable, (
+        "Expected installer-created dmtools launcher script to be executable."
     )
 
-    installer_env = parse_installer_env(installer_env_path)
-    assert installer_env.get("DMTOOLS_SKILLS") == ALL_SKILLS, (
+    assert (
+        observation.installer_env.get("DMTOOLS_SKILLS")
+        == InstallerFullInstallAuditService.ALL_SKILLS
+    ), (
         "Persisted DMTOOLS_SKILLS did not contain the canonical full install set.\n"
-        f"expected: {ALL_SKILLS}\nactual: {installer_env.get('DMTOOLS_SKILLS')}"
+        f"expected: {InstallerFullInstallAuditService.ALL_SKILLS}\n"
+        f"actual: {observation.installer_env.get('DMTOOLS_SKILLS')}"
     )
-    assert installer_env.get("DMTOOLS_INTEGRATIONS") == ALL_INTEGRATIONS, (
+    assert (
+        observation.installer_env.get("DMTOOLS_INTEGRATIONS")
+        == InstallerFullInstallAuditService.ALL_INTEGRATIONS
+    ), (
         "Persisted DMTOOLS_INTEGRATIONS did not contain the canonical full install set.\n"
-        f"expected: {ALL_INTEGRATIONS}\nactual: {installer_env.get('DMTOOLS_INTEGRATIONS')}"
+        f"expected: {InstallerFullInstallAuditService.ALL_INTEGRATIONS}\n"
+        f"actual: {observation.installer_env.get('DMTOOLS_INTEGRATIONS')}"
     )


### PR DESCRIPTION
## Result

**Passed.** Added `testing/tests/DMC-926/test_dmc_926.py` to cover backward-compatible full-install behavior when skill selection is missing, empty, or explicitly set to `all`.

## What automation checked

- The installer logs a full-install selection with the correct source (`default` or `env`).
- The target install directory is created.
- `dmtools.jar` is created.
- `bin/dmtools` is created and executable.
- The canonical full skill and integration set is persisted in `bin/dmtools-installer.env`.

## Human-style verification

- Ran fresh installer flows with no `DMTOOLS_SKILLS` and with `DMTOOLS_SKILLS=all`.
- Observed `Installing all skills (source: default)` for the missing-selection flow.
- Observed `Installing all skills (source: env)` for the explicit-`all` flow.
- Observed the persisted installer-managed config in the target directory:
  - `DMTOOLS_SKILLS="dmtools,jira,confluence,github,gitlab,figma,teams,sharepoint,ado,testrail,xray"`
  - `DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira,confluence,github,gitlab,figma,teams,teams_auth,sharepoint,ado,testrail,jira_xray"`
- Observed `dmtools.jar` and executable `bin/dmtools` in both fresh install directories.

## Notes

- The observed behavior matched the expected backward-compatible default full install behavior.
- The live installer persists the selected skill set in `bin/dmtools-installer.env`; that persisted artifact was used for the verification.
