### PR TITLE
DMC-903 Test: Verify cross-link between README and DMTools docs — installation sections are linked correctly

### DIFF
--- a/testing/tests/DMC-903/README.md
+++ b/testing/tests/DMC-903/README.md
@@ -17,3 +17,9 @@ python3 -m pytest testing/tests/DMC-903/test_dmc_903.py -q
 ## Environment
 
 No environment variables are required. The test reads markdown files directly from this repository checkout.
+
+## Expected passing output
+
+```text
+1 passed
+```


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-903 — Verify cross-link between README and DMTools docs — installation sections are linked correctly

## What was automated
- Validated that `README.md` `### Installation` links to `dmtools-ai-docs/references/installation/README.md` and `dmtools-ai-docs/references/installation/troubleshooting.md`
- Validated that both linked documents exist and each contains a backlink to `README.md#installation`

## Real user-style verification
- Checked the visible README installation content a user would follow and confirmed it shows links to the installation guide and troubleshooting guide
- Checked both detailed installation documents and confirmed each displays a visible `Back to README installation` link at the top of the page pointing to `../../../README.md#installation`
- Observed behavior matched the expected round-trip navigation between the README quick-start installation section and the detailed DMTools installation docs

## Result
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest testing/tests/DMC-903/test_dmc_903.py -q` passed with `1 passed in 0.03s`

## How to run
```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m pytest testing/tests/DMC-903/test_dmc_903.py -q
```
