### PR TITLE
DMC-932 Installation README lacks release placeholders and mutable-latest guidance

### DIFF
--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -30,6 +30,8 @@ This script will:
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 ```
 
+The `latest` release alias is mutable. For reusable automation snippets, pinned release-tags are the authoritative reference, so prefer `${DMTOOLS_RELEASE_TAG}` and `${DMTOOLS_VERSION}` when documenting a repeatable install flow.
+
 If you need a tagged reinstall for rollback or migration validation, use the example in [Upgrading from legacy installs](#upgrading-from-legacy-installs).
 
 ## Install Only the Skills You Need
@@ -82,7 +84,9 @@ irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | i
 Use a tagged installer only when you need to validate or roll back to a previously deployed release during migration work:
 
 ```bash
-curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
+export DMTOOLS_VERSION=1.7.179
+export DMTOOLS_RELEASE_TAG=v${DMTOOLS_VERSION}
+curl -fsSL https://github.com/epam/dm.ai/releases/download/${DMTOOLS_RELEASE_TAG}/install.sh | bash -s -- ${DMTOOLS_RELEASE_TAG}
 ```
 
 ### Method 2: Local Development Installation


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present at the repository root, so the implementation followed the ticket inputs that were available under `input/DMC-932/`.
- The broader `python3 -m pytest testing/tests -q -r a` sweep still fails in unrelated pre-existing tickets: `DMC-893`, `DMC-896`, `DMC-897`, and `DMC-909`.

## Approach

Updated `dmtools-ai-docs/references/installation/README.md` so the reusable tagged reinstall flow now uses `DMTOOLS_VERSION` plus `DMTOOLS_RELEASE_TAG`, and added an explicit prose note that the `latest` release alias is mutable while pinned release-tags are the authoritative reference for repeatable automation.

## Files Modified

- `dmtools-ai-docs/references/installation/README.md` — added the mutable-`latest` guidance note and replaced the hard-coded tagged reinstall example with a placeholder-based pinned snippet.
- `outputs/rca.md` — captured the root cause and fix direction for the ticket.

## Test Coverage

- Reproduction/verification test: `python3 -m pytest testing/tests/DMC-917/test_dmc_917.py testing/tests/DMC-901/test_dmc_901.py testing/tests/DMC-899/test_dmc_899.py testing/tests/DMC-902/test_dmc_902.py testing/tests/DMC-906/test_dmc_906.py -q -r a` — **12 passed**
- Core regression suite: `./gradlew :dmtools-core:test` — **passed**
- Broader Python suite: `python3 -m pytest testing/tests -q -r a` — **failed in unrelated existing audits (`DMC-893`, `DMC-896`, `DMC-897`, `DMC-909`)**
