### PR TITLE
DMC-937 Per-skill documentation catalogue pages are missing from dmtools-ai-docs/per-skill-packages

### DIFF
--- a/dmtools-ai-docs/per-skill-packages/dmtools-ado.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-ado.md
@@ -1,0 +1,61 @@
+# dmtools-ado
+
+## Overview
+
+`dmtools-ado` is the focused DMtools package for Azure DevOps work-item and pull-request workflows, including planning, ticket updates, comments, reviewers, and code-review thread management.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.microsoft.ado`
+- Artifact alias: `com.github.istin:dmtools-ado`
+- Focused slash command: `/dmtools-ado`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills ado
+```
+
+```bash
+bash install.sh --skills ado
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-ado`
+- Core configuration keys: `ADO_BASE_PATH`, `ADO_PAT`, `ADO_PROJECT`
+- Common optional keys: `ADO_AREA_PATH`, `ADO_ITERATION_PATH`, `ADO_TEAM`
+
+## Minimal usage example
+
+```text
+/dmtools-ado get work item 12345, review its pull requests, and draft an update comment
+```
+
+```bash
+dmtools ado_get_work_item 12345
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Supports Azure DevOps organizations configured through the standard DMtools PAT flow
+
+## Security & Permissions
+
+- Keep PAT values in secret storage and prefer scoped tokens over all-access credentials
+- Review repository and work-item permissions before enabling write operations from automation
+- Do not commit exported work-item payloads or PR data with sensitive customer details
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Azure DevOps configuration guide](../references/configuration/integrations/ado.md)
+- [ADO MCP tools reference](../references/mcp-tools/ado-tools.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
@@ -1,0 +1,61 @@
+# dmtools-confluence
+
+## Overview
+
+`dmtools-confluence` is the focused DMtools package for Confluence content discovery and page-management workflows, including page lookup, search, hierarchy traversal, and update automation.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.atlassian.confluence`
+- Artifact alias: `com.github.istin:dmtools-confluence`
+- Focused slash command: `/dmtools-confluence`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills confluence
+```
+
+```bash
+bash install.sh --skills confluence
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-confluence`
+- Core configuration keys: `CONFLUENCE_BASE_PATH`, `CONFLUENCE_LOGIN_PASS_TOKEN`
+- Common optional keys: `CONFLUENCE_GRAPHQL_PATH`, `CONFLUENCE_DEFAULT_SPACE`
+
+## Minimal usage example
+
+```text
+/dmtools-confluence find the onboarding page in the TEAM space and summarize the latest updates
+```
+
+```bash
+dmtools confluence_content_by_title_and_space "Onboarding" "TEAM"
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Works with the DMtools configuration flow documented for Confluence-backed content access
+
+## Security & Permissions
+
+- Keep Confluence credentials in secret storage and out of source control
+- Use least-privilege API access for spaces and pages that the automation actually needs
+- Review generated page updates before writing into shared documentation spaces
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Confluence MCP tools reference](../references/mcp-tools/confluence-tools.md)
+- [Global configuration reference](../references/configuration/README.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-figma.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-figma.md
@@ -1,0 +1,61 @@
+# dmtools-figma
+
+## Overview
+
+`dmtools-figma` is the focused DMtools package for Figma design-analysis workflows, including file structure inspection, node exports, image extraction, icon discovery, and design-token access.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.figma`
+- Artifact alias: `com.github.istin:dmtools-figma`
+- Focused slash command: `/dmtools-figma`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills figma
+```
+
+```bash
+bash install.sh --skills figma
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-figma`
+- Core configuration keys: `FIGMA_TOKEN`, `FIGMA_BASE_PATH`
+- Common optional keys: `FIGMA_FILE_KEY`, node-specific `href` and `nodeId` parameters in CLI usage
+
+## Minimal usage example
+
+```text
+/dmtools-figma inspect a Figma screen, list top-level layers, and extract the exportable icons
+```
+
+```bash
+dmtools figma_get_layers "https://www.figma.com/file/abc123/Product?node-id=1%3A2"
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Uses the Figma API through the standard DMtools token-based configuration pattern
+
+## Security & Permissions
+
+- Keep Figma personal access tokens in secret storage only
+- Limit shared design links and downloaded artifacts to the teams that need them
+- Review whether design files contain confidential roadmap, brand, or customer information before exporting them
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Figma MCP tools reference](../references/mcp-tools/figma-tools.md)
+- [Global configuration reference](../references/configuration/README.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-github.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-github.md
@@ -1,0 +1,61 @@
+# dmtools-github
+
+## Overview
+
+`dmtools-github` is the focused DMtools package for GitHub pull-request review workflows, including PR inspection, comment management, labels, and review-thread follow-up.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.github`
+- Artifact alias: `com.github.istin:dmtools-github`
+- Focused slash command: `/dmtools-github`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills github
+```
+
+```bash
+bash install.sh --skills github
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-github`
+- Core configuration keys: `SOURCE_GITHUB_TOKEN`, `SOURCE_GITHUB_BASE_PATH`
+- Common optional keys: `SOURCE_GITHUB_WORKSPACE`, `SOURCE_GITHUB_REPOSITORY`, `SOURCE_GITHUB_BRANCH`
+
+## Minimal usage example
+
+```text
+/dmtools-github review pull request 42 in epam/dm.ai and summarize unresolved comments
+```
+
+```bash
+dmtools github_get_pr workspace=epam repository=dm.ai pullRequestId=42
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Supports GitHub.com and GitHub Enterprise via configurable base paths
+
+## Security & Permissions
+
+- Store PATs in secure environment variables or CI secret storage only
+- Grant the minimum GitHub scopes required for read-only review or comment-writing workflows
+- Avoid pasting private repository contents into public channels when using AI-assisted review
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [GitHub configuration guide](../references/configuration/integrations/github.md)
+- [GitHub MCP tools reference](../references/mcp-tools/github-tools.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-gitlab.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-gitlab.md
@@ -1,0 +1,61 @@
+# dmtools-gitlab
+
+## Overview
+
+`dmtools-gitlab` is the focused DMtools package for GitLab merge-request review workflows, including MR inspection, comments, review activities, and inline feedback.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.gitlab`
+- Artifact alias: `com.github.istin:dmtools-gitlab`
+- Focused slash command: `/dmtools-gitlab`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills gitlab
+```
+
+```bash
+bash install.sh --skills gitlab
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-gitlab`
+- Core configuration keys: `GITLAB_TOKEN`, `GITLAB_BASE_PATH`
+- Common optional keys: `GITLAB_WORKSPACE`, `GITLAB_REPOSITORY`, `GITLAB_BRANCH`
+
+## Minimal usage example
+
+```text
+/dmtools-gitlab inspect merge request 42 for mygroup/myrepo and list blocking review comments
+```
+
+```bash
+dmtools gitlab_get_mr workspace=mygroup repository=myrepo pullRequestId=42
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Supports GitLab SaaS and self-hosted GitLab instances through `GITLAB_BASE_PATH`
+
+## Security & Permissions
+
+- Keep GitLab tokens in secret storage and rotate them on your normal credential schedule
+- Use scoped tokens with the minimum repository access required for the workflow
+- Treat merge-request discussions and diffs as potentially sensitive engineering data
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [GitLab MCP tools reference](../references/mcp-tools/gitlab-tools.md)
+- [Global configuration reference](../references/configuration/README.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-jira.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-jira.md
@@ -1,0 +1,61 @@
+# dmtools-jira
+
+## Overview
+
+`dmtools-jira` is the focused DMtools package for Jira workflows, including ticket lookup, JQL search, comments, assignments, and Jira/Xray-driven delivery automation.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.atlassian.jira`
+- Artifact alias: `com.github.istin:dmtools-jira`
+- Focused slash command: `/dmtools-jira`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira
+```
+
+```bash
+bash install.sh --skills jira
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-jira`
+- Core configuration keys: `JIRA_BASE_PATH`, `JIRA_LOGIN_PASS_TOKEN`, `JIRA_AUTH_TYPE`
+- Optional test-management keys: `XRAY_BASE_PATH`, `XRAY_CLIENT_ID`, `XRAY_CLIENT_SECRET`
+
+## Minimal usage example
+
+```text
+/dmtools-jira help me search Jira issues assigned to me and prepare a test-case plan for PROJ-123
+```
+
+```bash
+dmtools jira_get_ticket PROJ-123
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Intended for repositories that use the DMtools installer and `dmtools.env` configuration model
+
+## Security & Permissions
+
+- Store Jira credentials only in `dmtools.env`, `dmtools-local.env`, or CI secret storage
+- Use the minimum Jira and Xray permissions needed for the project you automate
+- Do not commit base64 tokens, API keys, or exported ticket data containing sensitive information
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Jira configuration guide](../references/configuration/integrations/jira.md)
+- [Jira MCP tools reference](../references/mcp-tools/jira-tools.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-report.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-report.md
@@ -1,0 +1,61 @@
+# dmtools-report
+
+## Overview
+
+`dmtools-report` is the focused DMtools package for report-generation workflows, including configurable productivity reports, data-source aggregation, computed metrics, and HTML/JSON outputs.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.report`
+- Artifact alias: `com.github.istin:dmtools-report`
+- Focused slash command: `/dmtools-report`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills report
+```
+
+```bash
+bash install.sh --skills report
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-report`
+- Primary runtime entrypoint: `dmtools run dmtools-ai-docs/references/examples/report-generator-job.json`
+- Common dependent configuration keys: `JIRA_BASE_PATH`, `ADO_BASE_PATH`, `SOURCE_GITHUB_TOKEN`, `GITLAB_TOKEN`, `FIGMA_TOKEN`, and one configured AI provider such as `GEMINI_API_KEY` or `OPENAI_API_KEY`
+
+## Minimal usage example
+
+```text
+/dmtools-report generate a contribution report for the backend team using Jira and GitHub data from the last sprint
+```
+
+```bash
+dmtools run dmtools-ai-docs/references/examples/report-generator-job.json
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Supports the data sources documented in the DMtools reporting guides and example job configs
+
+## Security & Permissions
+
+- Reports inherit access from their underlying data sources, so secure every referenced tracker, VCS, or design-system credential
+- Review report outputs before sharing because HTML and JSON exports can expose internal metrics and identities
+- Keep generated files out of source control unless they are intentionally published artifacts
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Report generation guide](../references/reporting/report-generation.md)
+- [Job system reference](../references/jobs/README.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-teams.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-teams.md
@@ -1,0 +1,61 @@
+# dmtools-teams
+
+## Overview
+
+`dmtools-teams` is the focused DMtools package for Microsoft Teams communication workflows, including chat lookup, message retrieval, transcript discovery, file download, and sending messages.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.microsoft.teams`
+- Artifact alias: `com.github.istin:dmtools-teams`
+- Focused slash command: `/dmtools-teams`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills teams
+```
+
+```bash
+bash install.sh --skills teams
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-teams`
+- Core configuration keys: `TEAMS_TENANT_ID`, `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`
+- Common optional keys: `TEAMS_CHANNEL_ID` and Teams-specific chat or team identifiers passed to CLI commands
+
+## Minimal usage example
+
+```text
+/dmtools-teams summarize new messages from the Release Coordination chat since yesterday
+```
+
+```bash
+dmtools teams_messages_since "Release Coordination" "2026-05-01T00:00:00Z"
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Uses Microsoft Graph-backed Teams access through the standard DMtools authentication flow
+
+## Security & Permissions
+
+- Keep Microsoft application credentials and refresh tokens in secure secret storage
+- Grant the minimum Graph permissions required for chats, channels, files, or transcripts
+- Treat downloaded chats, recordings, and transcripts as sensitive collaboration data
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [Teams MCP tools reference](../references/mcp-tools/teams-tools.md)
+- [Global configuration reference](../references/configuration/README.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/dmtools-testrail.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-testrail.md
@@ -1,0 +1,61 @@
+# dmtools-testrail
+
+## Overview
+
+`dmtools-testrail` is the focused DMtools package for TestRail test-management workflows, including case lookup, requirement linking, label handling, and generated test-case creation.
+
+## Package / Artifact
+
+- Java package: `com.github.istin.dmtools.testrail`
+- Artifact alias: `com.github.istin:dmtools-testrail`
+- Focused slash command: `/dmtools-testrail`
+
+## Installer / CLI example
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills testrail
+```
+
+```bash
+bash install.sh --skills testrail
+```
+
+## Endpoints / Config keys
+
+- Slash command entrypoint: `/dmtools-testrail`
+- Core configuration keys: `TESTRAIL_BASE_PATH`, `TESTRAIL_USERNAME`, `TESTRAIL_API_KEY`
+- Common optional keys: `TESTRAIL_PROJECT`, `TESTRAIL_LOGGING_ENABLED`
+
+## Minimal usage example
+
+```text
+/dmtools-testrail create or link test cases for PROJ-123 in the Regression project
+```
+
+```bash
+dmtools testrail_get_cases_by_refs PROJ-123 "Regression"
+```
+
+## Compatibility / Supported versions
+
+- Compatible with Java 17+ and current DMtools focused skill releases
+- Uses the standard DMtools TestRail integration and job-based test-generation flows
+
+## Security & Permissions
+
+- Keep TestRail usernames and API keys in secure environment storage only
+- Scope project access so automation can reach only the suites and cases it needs
+- Enable request logging only when debugging, because logs can include sensitive metadata
+
+## Linkbacks
+
+- [Central installation guide](../references/installation/README.md)
+- [Per-skill package index](index.md)
+- [TestRail configuration guide](../references/configuration/integrations/testrail.md)
+- [TestRail MCP tools reference](../references/mcp-tools/testrail-tools.md)
+
+## Maintainer / Contact
+
+- Maintainer: DMtools Team
+- Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
+

--- a/dmtools-ai-docs/per-skill-packages/index.md
+++ b/dmtools-ai-docs/per-skill-packages/index.md
@@ -13,3 +13,15 @@ This page is the canonical catalogue for the approved focused DMtools skill pack
 | `dmtools-testrail` | `/dmtools-testrail` | `com.github.istin.dmtools.testrail` | `com.github.istin:dmtools-testrail` |
 | `dmtools-teams` | `/dmtools-teams` | `com.github.istin.dmtools.microsoft.teams` | `com.github.istin:dmtools-teams` |
 | `dmtools-report` | `/dmtools-report` | `com.github.istin.dmtools.report` | `com.github.istin:dmtools-report` |
+
+## Child pages
+
+- [dmtools-jira](dmtools-jira.md)
+- [dmtools-confluence](dmtools-confluence.md)
+- [dmtools-github](dmtools-github.md)
+- [dmtools-gitlab](dmtools-gitlab.md)
+- [dmtools-ado](dmtools-ado.md)
+- [dmtools-figma](dmtools-figma.md)
+- [dmtools-testrail](dmtools-testrail.md)
+- [dmtools-teams](dmtools-teams.md)
+- [dmtools-report](dmtools-report.md)

--- a/testing/tests/DMC-916/test_per_skill_page_audit_service.py
+++ b/testing/tests/DMC-916/test_per_skill_page_audit_service.py
@@ -10,6 +10,9 @@ from testing.components.services.per_skill_page_audit_service import (
 )
 
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
 def write_page_fixture(repository_root: Path, skill_name: str, package_name: str) -> Path:
     installation_guide = (
         repository_root / "dmtools-ai-docs" / "references" / "installation" / "README.md"
@@ -133,3 +136,14 @@ def test_child_pages_excludes_per_skill_index_aliases(tmp_path: Path) -> None:
     service = PerSkillPageAuditService(repository_root)
 
     assert service.child_pages() == [skill_page]
+
+
+def test_repository_exposes_child_pages_for_each_canonical_skill() -> None:
+    service = PerSkillPageAuditService(REPOSITORY_ROOT)
+
+    expected_pages = sorted(
+        REPOSITORY_ROOT / "dmtools-ai-docs" / "per-skill-packages" / f"{skill.skill_name}.md"
+        for skill in PerSkillCatalogService.EXPECTED_SKILLS
+    )
+
+    assert service.child_pages() == expected_pages


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`dmtools-ai-docs/per-skill-packages/` only contained `index.md`, so the repository had no actual per-skill child pages for the canonical focused packages. Because `PerSkillPageAuditService` excludes the index from `child_pages()`, the DMC-916 audit failed immediately with "none were found" before it could validate headings, identifiers, or linkbacks.

### Fix
Added the missing per-skill catalogue pages for all 9 canonical focused packages: Jira, Confluence, GitHub, GitLab, ADO, Figma, TestRail, Teams, and Report. Each page now follows the mandatory template, includes the exact Java package identifier and matching `/dmtools-...` slash command, and links back to both the installation guide and the per-skill index. The per-skill index was also updated to link to each child page, and a focused regression test was added to assert that the repository exposes child pages for every canonical skill.

### Test Coverage
- Reproduction test confirmed failing before the fix: `testing/tests/DMC-916/test_dmc_916.py::test_dmc_916_individual_skill_pages_follow_the_mandatory_template`
- Regression test added: `testing/tests/DMC-916/test_per_skill_page_audit_service.py::test_repository_exposes_child_pages_for_each_canonical_skill`
- Validation run: `python3 -m pytest testing/tests/DMC-914 testing/tests/DMC-916 -q` -> `11 passed`
- Core validation: `./gradlew --no-daemon :dmtools-core:compileJava :dmtools-core:test` -> `BUILD SUCCESSFUL`

### Notes
No prior implementation attempt was present in the ticket comments, so the fix directly addressed the missing-content root cause.
