### PR TITLE
DMC-917 Test: Validate release URL placeholders — reusable snippets use pinned patterns and mutable notes

### DIFF
--- a/testing/tests/DMC-917/README.md
+++ b/testing/tests/DMC-917/README.md
@@ -17,3 +17,9 @@ python3 -m pytest testing/tests/DMC-917/test_dmc_917.py -q
 ## Environment
 
 No environment variables are required. The test reads `dmtools-ai-docs/references/installation/README.md` from this repository checkout.
+
+## Expected passing output
+
+```text
+4 passed
+```


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-917 — Validate release URL placeholders — reusable snippets use pinned patterns and mutable notes

## What was automated
- Reused `testing/tests/DMC-917/test_dmc_917.py` to audit `dmtools-ai-docs/references/installation/README.md`.
- Verified reusable snippets use `${DMTOOLS_RELEASE_TAG}` and `${DMTOOLS_VERSION}`.
- Verified the guide still includes at least one `latest` release alias example.
- Verified the guide includes explicit reader-facing guidance that `latest` is mutable and pinned release-tags are the authoritative reference.

## Human-style verification
- Reviewed the installation guide content directly.
- Confirmed the visible note under Method 1 says the `latest` alias is mutable and that pinned release-tags are the authoritative reference.
- Confirmed the tagged installer example uses `DMTOOLS_VERSION`, `DMTOOLS_RELEASE_TAG`, and `releases/download/${DMTOOLS_RELEASE_TAG}/install.sh`.
- Confirmed the manual JAR example still uses `dmtools-v${DMTOOLS_VERSION}-all.jar`.

## Result
- `python3 -m pytest testing/tests/DMC-917/test_dmc_917.py -q -r a` passed with `4 passed`.
- The current main-branch documentation matches the expected result for DMC-917.

## How to run
```bash
python3 -m pytest testing/tests/DMC-917/test_dmc_917.py -q -r a
```
