### PR TITLE
DMC-938 Installer does not generate installed-skills.json and endpoints.json for selective installs

### DIFF
--- a/install
+++ b/install
@@ -23,6 +23,8 @@ BIN_DIR="${DMTOOLS_BIN_DIR:-$INSTALL_DIR/bin}"
 JAR_PATH="$INSTALL_DIR/dmtools.jar"
 SCRIPT_PATH="$BIN_DIR/dmtools"
 INSTALLER_ENV_PATH="${DMTOOLS_INSTALLER_ENV_PATH:-$BIN_DIR/dmtools-installer.env}"
+INSTALLED_SKILLS_JSON_PATH="${DMTOOLS_INSTALLED_SKILLS_JSON_PATH:-$INSTALL_DIR/installed-skills.json}"
+ENDPOINTS_JSON_PATH="${DMTOOLS_ENDPOINTS_JSON_PATH:-$INSTALL_DIR/endpoints.json}"
 AVAILABLE_SKILLS=(
     dmtools jira confluence github gitlab figma teams
     sharepoint ado testrail xray
@@ -86,6 +88,76 @@ to_lower() {
 join_by_comma() {
     local IFS=","
     printf '%s' "$*"
+}
+
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
+json_string_array() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="\"$escaped\""
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
+}
+
+json_skill_objects() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="{\"name\":\"$escaped\"}"
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
+}
+
+json_endpoint_objects() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="{\"name\":\"$escaped\",\"path\":\"/dmtools/$escaped\"}"
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
 }
 
 append_unique() {
@@ -303,6 +375,41 @@ EOF
 
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+}
+
+write_installer_metadata() {
+    local version="$1"
+    if [ -z "$version" ]; then
+        error "Installer version is required to write machine-readable metadata."
+    fi
+
+    mkdir -p "$INSTALL_DIR"
+
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local skills_json
+    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
+    local integrations_json
+    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
+    local endpoints_json
+    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+
+    cat > "$INSTALLED_SKILLS_JSON_PATH" <<EOF
+{
+  "version": "$escaped_version",
+  "installed_skills": $skills_json,
+  "integrations": $integrations_json
+}
+EOF
+
+    cat > "$ENDPOINTS_JSON_PATH" <<EOF
+{
+  "version": "$escaped_version",
+  "endpoints": $endpoints_json
+}
+EOF
+
+    info "Generated machine-readable installer metadata at $INSTALLED_SKILLS_JSON_PATH and $ENDPOINTS_JSON_PATH"
 }
 
 # Detect platform
@@ -1212,6 +1319,9 @@ main() {
     
     # Download DMTools
     download_dmtools "$version"
+
+    # Persist machine-readable metadata for state tracking and endpoint discovery
+    write_installer_metadata "$version"
     
     # Update shell configuration
     update_shell_config

--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,8 @@ BIN_DIR="${DMTOOLS_BIN_DIR:-$INSTALL_DIR/bin}"
 JAR_PATH="$INSTALL_DIR/dmtools.jar"
 SCRIPT_PATH="$BIN_DIR/dmtools"
 INSTALLER_ENV_PATH="${DMTOOLS_INSTALLER_ENV_PATH:-$BIN_DIR/dmtools-installer.env}"
+INSTALLED_SKILLS_JSON_PATH="${DMTOOLS_INSTALLED_SKILLS_JSON_PATH:-$INSTALL_DIR/installed-skills.json}"
+ENDPOINTS_JSON_PATH="${DMTOOLS_ENDPOINTS_JSON_PATH:-$INSTALL_DIR/endpoints.json}"
 AVAILABLE_SKILLS=(
     dmtools jira confluence github gitlab figma teams
     sharepoint ado testrail xray
@@ -86,6 +88,76 @@ to_lower() {
 join_by_comma() {
     local IFS=","
     printf '%s' "$*"
+}
+
+json_escape() {
+    local value="$1"
+    value="${value//\\/\\\\}"
+    value="${value//\"/\\\"}"
+    value="${value//$'\n'/\\n}"
+    value="${value//$'\r'/\\r}"
+    value="${value//$'\t'/\\t}"
+    printf '%s' "$value"
+}
+
+json_string_array() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="\"$escaped\""
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
+}
+
+json_skill_objects() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="{\"name\":\"$escaped\"}"
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
+}
+
+json_endpoint_objects() {
+    local values=("$@")
+    local json="["
+    local first=true
+    local value
+    local escaped
+
+    for value in "${values[@]}"; do
+        escaped=$(json_escape "$value")
+        if [ "$first" = false ]; then
+            json+=", "
+        fi
+        json+="{\"name\":\"$escaped\",\"path\":\"/dmtools/$escaped\"}"
+        first=false
+    done
+
+    json+="]"
+    printf '%s' "$json"
 }
 
 append_unique() {
@@ -303,6 +375,41 @@ EOF
 
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+}
+
+write_installer_metadata() {
+    local version="$1"
+    if [ -z "$version" ]; then
+        error "Installer version is required to write machine-readable metadata."
+    fi
+
+    mkdir -p "$INSTALL_DIR"
+
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local skills_json
+    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
+    local integrations_json
+    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
+    local endpoints_json
+    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+
+    cat > "$INSTALLED_SKILLS_JSON_PATH" <<EOF
+{
+  "version": "$escaped_version",
+  "installed_skills": $skills_json,
+  "integrations": $integrations_json
+}
+EOF
+
+    cat > "$ENDPOINTS_JSON_PATH" <<EOF
+{
+  "version": "$escaped_version",
+  "endpoints": $endpoints_json
+}
+EOF
+
+    info "Generated machine-readable installer metadata at $INSTALLED_SKILLS_JSON_PATH and $ENDPOINTS_JSON_PATH"
 }
 
 # Detect platform
@@ -1212,6 +1319,9 @@ main() {
     
     # Download DMTools
     download_dmtools "$version"
+
+    # Persist machine-readable metadata for state tracking and endpoint discovery
+    write_installer_metadata "$version"
     
     # Update shell configuration
     update_shell_config

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -1,3 +1,4 @@
+import json
 import os
 import subprocess
 import tempfile
@@ -185,6 +186,57 @@ cat "$INSTALLER_ENV_PATH"
         self.assertIn("Selected skills already installed: jira", result.stdout)
         self.assertIn('DMTOOLS_SKILLS="jira"', result.stdout)
         self.assertIn('DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"', result.stdout)
+
+    def test_main_writes_machine_readable_metadata_files_for_selected_skills(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            install_dir = Path(temp_dir)
+            installed_skills_path = install_dir / "installed-skills.json"
+            endpoints_path = install_dir / "endpoints.json"
+            result = run_installer_functions(
+                """
+check_java() { :; }
+download_dmtools() {
+    mkdir -p "$(dirname "$JAR_PATH")" "$(dirname "$SCRIPT_PATH")"
+    printf 'jar' > "$JAR_PATH"
+    printf '#!/bin/bash\nexit 0\n' > "$SCRIPT_PATH"
+    chmod +x "$SCRIPT_PATH"
+}
+update_shell_config() { :; }
+verify_installation() { :; }
+print_instructions() { :; }
+main --skills jira,confluence v1.2.3
+""",
+                {
+                    "DMTOOLS_INSTALL_DIR": str(install_dir),
+                    "DMTOOLS_BIN_DIR": str(install_dir / "bin"),
+                    "DMTOOLS_INSTALLER_ENV_PATH": str(install_dir / "bin" / "dmtools-installer.env"),
+                },
+            )
+
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertTrue(installed_skills_path.exists(), result.stdout)
+            self.assertTrue(endpoints_path.exists(), result.stdout)
+
+            installed_skills_payload = json.loads(installed_skills_path.read_text(encoding="utf-8"))
+            self.assertEqual("v1.2.3", installed_skills_payload["version"])
+            self.assertEqual(
+                [{"name": "jira"}, {"name": "confluence"}],
+                installed_skills_payload["installed_skills"],
+            )
+            self.assertEqual(
+                ["ai", "cli", "file", "kb", "mermaid", "jira", "confluence"],
+                installed_skills_payload["integrations"],
+            )
+
+            endpoints_payload = json.loads(endpoints_path.read_text(encoding="utf-8"))
+            self.assertEqual("v1.2.3", endpoints_payload["version"])
+            self.assertEqual(
+                [
+                    {"name": "jira", "path": "/dmtools/jira"},
+                    {"name": "confluence", "path": "/dmtools/confluence"},
+                ],
+                endpoints_payload["endpoints"],
+            )
 
     def test_runtime_backed_skills_add_expected_integrations(self) -> None:
         command_lines = []


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The installer only persisted the selected skill state in `bin/dmtools-installer.env`. Neither `install` nor `install.sh` had any step that generated the machine-readable `installed-skills.json` and `endpoints.json` files after resolving skills and version, so selective installs completed without the metadata that DMC-930 asserts.

### Fix
Added a targeted metadata-writing step to both installer entrypoints. After the version is resolved and the CLI assets are downloaded, the installer now writes:
- `installed-skills.json` with installer version, selected skills, and effective integrations
- `endpoints.json` with REST-friendly `/dmtools/{skill}` entries for the selected skills

Also added a regression test in `testing/tests/DMC-859/test_install_skills.py` that drives `main` through a local, stubbed install flow and asserts both metadata files are created with the expected payloads.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-859/test_install_skills.py` — `test_main_writes_machine_readable_metadata_files_for_selected_skills`
- Installer regression coverage: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-859/test_install_skills.py -q`
- Nearby installer checks: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-926/test_dmc_926.py -q`
- Linked-test helper assertions: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-930/test_dmc_930.py -q -k 'not selective_install_generates_machine_readable_metadata_files'`
- Core unit suite: `./gradlew :dmtools-core:test`

### Notes
The linked live test in `DMC-930` fetches `https://raw.githubusercontent.com/epam/dm.ai/main/install`, so local verification used the current repository `install` script via `file://...` to validate the exact metadata contract before deployment.
