### PR TITLE
DMC-939 Installer rerun with same skills still downloads and rewrites dmtools artifacts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ EFFECTIVE_INTEGRATIONS=()
 EFFECTIVE_SKILLS_CSV=""
 INVALID_SKILLS_CSV=""
 EFFECTIVE_INTEGRATIONS_CSV=""
+INSTALLER_SKILL_CONFIG_UNCHANGED=false
 
 # Helper functions
 error() {
@@ -297,12 +298,18 @@ EOF
     fi
 
     if [ "$existing_content" = "$new_content" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=true
         info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
         return 0
     fi
 
+    INSTALLER_SKILL_CONFIG_UNCHANGED=false
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+}
+
+installer_managed_artifacts_present() {
+    [ -s "$JAR_PATH" ] && [ -s "$SCRIPT_PATH" ]
 }
 
 # Detect platform
@@ -1210,8 +1217,12 @@ main() {
     # Persist installer-managed skill selection
     write_installer_skill_config
     
-    # Download DMTools
-    download_dmtools "$version"
+    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && installer_managed_artifacts_present; then
+        info "Installer-managed artifacts already present; skipping DMTools download."
+    else
+        # Download DMTools
+        download_dmtools "$version"
+    fi
     
     # Update shell configuration
     update_shell_config

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -186,6 +186,44 @@ cat "$INSTALLER_ENV_PATH"
         self.assertIn('DMTOOLS_SKILLS="jira"', result.stdout)
         self.assertIn('DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"', result.stdout)
 
+    def test_repeated_main_run_skips_download_when_configuration_and_artifacts_match(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = run_installer_functions(
+                """
+check_java() { printf 'stub check_java\\n'; }
+get_latest_version() { printf 'v0.0.0-test'; }
+download_dmtools() {
+    local version="$1"
+    printf 'SIDE download_dmtools %s\\n' "$version"
+    mkdir -p "$(dirname "$JAR_PATH")" "$BIN_DIR"
+    printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+    cat > "$SCRIPT_PATH" <<'EOF'
+#!/bin/bash
+echo "dmtools stub"
+EOF
+    chmod +x "$SCRIPT_PATH"
+}
+update_shell_config() { printf 'SIDE update_shell_config\\n'; }
+verify_installation() { printf 'SIDE verify_installation\\n'; }
+print_instructions() { printf 'SIDE print_instructions\\n'; }
+main --skills jira,github
+main --skills jira,github
+""",
+                {
+                    "DMTOOLS_INSTALL_DIR": temp_dir,
+                    "DMTOOLS_BIN_DIR": f"{temp_dir}/bin",
+                    "DMTOOLS_INSTALLER_ENV_PATH": f"{temp_dir}/bin/dmtools-installer.env",
+                },
+            )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(1, result.stdout.count("SIDE download_dmtools v0.0.0-test"), result.stdout)
+        self.assertIn("Selected skills already installed: jira,github", result.stdout)
+        self.assertIn(
+            "Installer-managed artifacts already present; skipping DMTools download.",
+            result.stdout,
+        )
+
     def test_runtime_backed_skills_add_expected_integrations(self) -> None:
         command_lines = []
         for skill in RUNTIME_SKILL_INTEGRATIONS:


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`install.sh` already detected the unchanged installer-managed skill selection and printed `Selected skills already installed: ...`, but that no-op signal was not used anywhere else. `main()` always continued into `download_dmtools`, which rewrote `dmtools.jar` and `bin/dmtools` on every rerun even when the selected skills and installer-managed config were unchanged.

### Fix
Updated `install.sh` to track whether `write_installer_skill_config` found an unchanged skill configuration, added an installer-managed artifact presence check, and skipped `download_dmtools` when both conditions are true. This keeps legitimate recovery behavior intact when the config changes or required artifacts are missing, while making same-skill reruns stop rewriting DMTools artifacts.

Added a focused regression test in `testing/tests/DMC-859/test_install_skills.py` that runs `main --skills jira,github` twice in the same temp install root and verifies the download step is only executed once.

### Test Coverage
- Reproduction test: `testing/tests/DMC-928/test_dmc_928.py::test_dmc_928_rerunning_installer_for_the_same_skill_set_is_idempotent` — PASSED
- Focused installer tests: `python3 -m pytest testing/tests/DMC-859/test_install_skills.py testing/tests/DMC-928/test_dmc_928.py -q` — PASSED
- Compile check: `./gradlew :dmtools-core:compileJava` — PASSED
- Full Python suite: `python3 -m pytest testing/tests -q` — 11 unrelated pre-existing failures:
  - `testing/tests/DMC-893/test_agent_names_and_status.py` (3 failures)
  - `testing/tests/DMC-896/test_dmc_896.py` (2 failures)
  - `testing/tests/DMC-897/test_dmc_897.py`
  - `testing/tests/DMC-915/test_dmc_915.py`
  - `testing/tests/DMC-925/test_dmc_925.py`
  - `testing/tests/DMC-927/test_dmc_927.py`
  - `testing/tests/DMC-930/test_dmc_930.py`
  - `testing/tests/DMC-933/test_dmc_933.py`

### Notes
- The repository root `instruction.md` referenced in the task prompt was not present, so implementation proceeded from the ticket inputs and current repository state.
