### PR TITLE
DMC-943 Test: Per-skill page with incorrect technical identifiers — documentation validation identifies failure

### DIFF
--- a/testing/tests/DMC-943/README.md
+++ b/testing/tests/DMC-943/README.md
@@ -1,0 +1,25 @@
+# DMC-943 automated test
+
+This test validates that the per-skill documentation validation suite fails when the live `dmtools-confluence` page is corrupted with the wrong Java package identifier and slash-command endpoint.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-943/test_dmc_943.py -q
+```
+
+## Environment
+
+No environment variables are required. The test verifies the checked-out repository content, then reruns the existing `DMC-916` validation in an isolated repository copy so the working tree is not modified.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-943/config.yaml
+++ b/testing/tests/DMC-943/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-943
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-943/test_dmc_943.py
+++ b/testing/tests/DMC-943/test_dmc_943.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shlex
+import site
+from pathlib import Path
+
+from testing.components.services.per_skill_page_audit_service import (
+    PerSkillPageAuditService,
+)
+from testing.core.utils.repo_sandbox import RepoSandbox
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+CONFLUENCE_PAGE_RELATIVE_PATH = "dmtools-ai-docs/per-skill-packages/dmtools-confluence.md"
+EXPECTED_JAVA_PACKAGE = "com.github.istin.dmtools.atlassian.confluence"
+WRONG_JAVA_PACKAGE = "com.wrong.package"
+EXPECTED_SLASH_COMMAND = "/dmtools-confluence"
+WRONG_SLASH_COMMAND = "/dmtools-jira"
+VALIDATION_COMMAND = (
+    f"PYTHONPATH={shlex.quote(site.getusersitepackages())}${{PYTHONPATH:+:$PYTHONPATH}} "
+    "python3 -m pytest testing/tests/DMC-916/test_dmc_916.py -q"
+)
+
+
+def test_dmc_943_validation_reports_wrong_confluence_identifiers() -> None:
+    live_audit = PerSkillPageAuditService(REPOSITORY_ROOT)
+    live_page = (REPOSITORY_ROOT / CONFLUENCE_PAGE_RELATIVE_PATH).read_text(encoding="utf-8")
+
+    assert live_audit.audit() == []
+    assert "## Package / Artifact" in live_page
+    assert f"Java package: `{EXPECTED_JAVA_PACKAGE}`" in live_page, (
+        "The live Confluence page should visibly show the canonical Java package marker "
+        "to a documentation reader."
+    )
+    assert f"Focused slash command: `{EXPECTED_SLASH_COMMAND}`" in live_page, (
+        "The live Confluence page should visibly show the canonical focused slash command "
+        "to a documentation reader."
+    )
+    assert f"Slash command entrypoint: `{EXPECTED_SLASH_COMMAND}`" in live_page, (
+        "The live Confluence page should repeat the same slash-command identifier in the "
+        "Endpoints / Config keys section."
+    )
+
+    sandbox = RepoSandbox(REPOSITORY_ROOT)
+    try:
+        baseline_result = sandbox.run(VALIDATION_COMMAND)
+        assert baseline_result.returncode == 0, baseline_result.combined_output
+        assert "1 passed" in baseline_result.stdout, baseline_result.stdout
+
+        sandbox.write_text(
+            CONFLUENCE_PAGE_RELATIVE_PATH,
+            _corrupt_confluence_page(sandbox.read_text(CONFLUENCE_PAGE_RELATIVE_PATH)),
+        )
+
+        corrupted_page = sandbox.read_text(CONFLUENCE_PAGE_RELATIVE_PATH)
+        assert WRONG_JAVA_PACKAGE in corrupted_page
+        assert WRONG_SLASH_COMMAND in corrupted_page
+        assert EXPECTED_JAVA_PACKAGE not in corrupted_page
+        assert EXPECTED_SLASH_COMMAND not in corrupted_page
+
+        failure_result = sandbox.run(VALIDATION_COMMAND)
+        combined_output = failure_result.combined_output
+
+        assert failure_result.returncode != 0, (
+            "The documentation validation suite should fail after the Confluence page "
+            "technical identifiers are corrupted."
+        )
+        assert (
+            "AssertionError: Per-skill documentation pages do not satisfy the required template."
+            in combined_output
+        )
+        assert (
+            "dmtools-ai-docs/per-skill-packages/dmtools-confluence.md does not include "
+            f"expected Java package identifier {EXPECTED_JAVA_PACKAGE!r}."
+        ) in combined_output
+        assert (
+            "dmtools-ai-docs/per-skill-packages/dmtools-confluence.md does not include "
+            f"expected slash-command identifier {EXPECTED_SLASH_COMMAND!r}."
+        ) in combined_output
+    finally:
+        sandbox.cleanup()
+
+
+def _corrupt_confluence_page(page_markdown: str) -> str:
+    corrupted = _replace_all(page_markdown, EXPECTED_JAVA_PACKAGE, WRONG_JAVA_PACKAGE)
+    return _replace_all(corrupted, EXPECTED_SLASH_COMMAND, WRONG_SLASH_COMMAND)
+
+
+def _replace_all(text: str, expected: str, replacement: str) -> str:
+    if expected not in text:
+        raise AssertionError(f"Expected text not found: {expected!r}")
+
+    updated = text.replace(expected, replacement)
+    if expected in updated:
+        raise AssertionError(f"Expected replacement to remove all {expected!r} occurrences.")
+
+    return updated


### PR DESCRIPTION
# DMC-943 automated test: PASSED

## What automation checked

- Added `testing/tests/DMC-943/test_dmc_943.py`.
- Verified the live `dmtools-ai-docs/per-skill-packages/dmtools-confluence.md` page currently passes the shared per-skill audit.
- In an isolated repository copy, replaced the Confluence Java package identifier `com.github.istin.dmtools.atlassian.confluence` with `com.wrong.package`.
- In the same isolated copy, replaced every visible `/dmtools-confluence` marker with `/dmtools-jira`.
- Reran the existing validation suite from `testing/tests/DMC-916/test_dmc_916.py` and confirmed it failed with both expected findings:

```text
dmtools-ai-docs/per-skill-packages/dmtools-confluence.md does not include expected Java package identifier 'com.github.istin.dmtools.atlassian.confluence'.
dmtools-ai-docs/per-skill-packages/dmtools-confluence.md does not include expected slash-command identifier '/dmtools-confluence'.
```

## Real user / human-style verification

- Checked the live `dmtools-confluence` page as a documentation reader would.
- Confirmed the visible `Package / Artifact` and `Endpoints / Config keys` sections show:
  - `Java package: com.github.istin.dmtools.atlassian.confluence`
  - `Focused slash command: /dmtools-confluence`
  - `Slash command entrypoint: /dmtools-confluence`
- Observed that the live page matches the expected content, while the validation suite correctly detects the intentionally corrupted identifiers in the isolated negative-path scenario.

## Execution result

```text
python3 -m pytest testing/tests/DMC-943/test_dmc_943.py -q
.                                                                        [100%]
1 passed in 0.77s
```
