### PR TITLE
DMC-940 Test: Per-skill catalogue directory or files are missing — validation identifies missing documentation components

### DIFF
--- a/testing/components/services/per_skill_page_audit_service.py
+++ b/testing/components/services/per_skill_page_audit_service.py
@@ -67,6 +67,15 @@ class PerSkillPageAuditService:
             )
             return findings
 
+        missing_page_names = sorted(self.expected_page_names() - {path.name for path in child_pages})
+        if missing_page_names:
+            findings.append(
+                "Expected mandatory skill pages under "
+                f"{self.relative_path(self.per_skill_root)} are missing: "
+                + ", ".join(missing_page_names)
+                + "."
+            )
+
         for page_path in child_pages:
             findings.extend(self.audit_page(page_path))
 
@@ -78,6 +87,9 @@ class PerSkillPageAuditService:
             for path in self.per_skill_root.glob("*.md")
             if path.name.lower() not in self.PER_SKILL_INDEX_ALIASES
         )
+
+    def expected_page_names(self) -> set[str]:
+        return {f"{skill_name}.md" for skill_name in self.skill_expectations}
 
     def audit_page(self, page_path: Path) -> list[str]:
         findings: list[str] = []

--- a/testing/tests/DMC-916/test_per_skill_page_audit_service.py
+++ b/testing/tests/DMC-916/test_per_skill_page_audit_service.py
@@ -147,3 +147,22 @@ def test_repository_exposes_child_pages_for_each_canonical_skill() -> None:
     )
 
     assert service.child_pages() == expected_pages
+
+
+def test_audit_reports_missing_expected_skill_page(tmp_path: Path) -> None:
+    repository_root = tmp_path / "repo"
+    per_skill_root = repository_root / "dmtools-ai-docs" / "per-skill-packages"
+    per_skill_root.mkdir(parents=True)
+    (per_skill_root / "index.md").write_text("# Canonical index\n", encoding="utf-8")
+
+    for expectation in PerSkillCatalogService.EXPECTED_SKILLS:
+        if expectation.skill_name == "dmtools-github":
+            continue
+        write_page_fixture(repository_root, expectation.skill_name, expectation.java_package)
+
+    service = PerSkillPageAuditService(repository_root)
+
+    assert service.audit() == [
+        "Expected mandatory skill pages under dmtools-ai-docs/per-skill-packages are missing: "
+        "dmtools-github.md."
+    ]

--- a/testing/tests/DMC-940/README.md
+++ b/testing/tests/DMC-940/README.md
@@ -1,0 +1,25 @@
+# DMC-940 automated test
+
+This test verifies that the per-skill documentation validation suite fails with clear, user-visible messages when the entire `dmtools-ai-docs/per-skill-packages/` directory is missing or when a single mandatory child page such as `dmtools-github.md` is missing.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-940/test_dmc_940.py -q
+```
+
+## Environment
+
+No environment variables are required. The test copies the current repository into temporary sandboxes, mutates the documentation files there, and runs the existing DMC-916 pytest validation as a user would from the command line.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-940/config.yaml
+++ b/testing/tests/DMC-940/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-940
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-940/test_dmc_940.py
+++ b/testing/tests/DMC-940/test_dmc_940.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import shlex
+import shutil
+import site
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.core.utils.repo_sandbox import RepoSandbox  # noqa: E402
+
+
+VALIDATION_COMMAND = (
+    f"PYTHONPATH={shlex.quote(site.getusersitepackages())}${{PYTHONPATH:+:$PYTHONPATH}} "
+    "python3 -m pytest testing/tests/DMC-916/test_dmc_916.py -q"
+)
+DIRECTORY_MISSING_MESSAGE = (
+    "Expected per-skill catalogue directory dmtools-ai-docs/per-skill-packages to exist, but it is missing."
+)
+MISSING_PAGE_MESSAGE = (
+    "Expected mandatory skill pages under dmtools-ai-docs/per-skill-packages are missing: "
+    "dmtools-github.md."
+)
+
+
+def test_dmc_940_baseline_validation_suite_passes() -> None:
+    result = _run_validation_suite()
+
+    assert result.returncode == 0, result.combined_output
+    assert "1 passed" in result.stdout
+
+
+def test_dmc_940_missing_catalog_directory_fails_with_clear_message() -> None:
+    result = _run_validation_suite(
+        lambda sandbox: shutil.rmtree(sandbox.path("dmtools-ai-docs/per-skill-packages"))
+    )
+
+    assert result.returncode != 0, "Validation suite should fail when the catalogue directory is missing."
+    assert DIRECTORY_MISSING_MESSAGE in result.combined_output
+    assert "FAILED testing/tests/DMC-916/test_dmc_916.py::" in result.stdout
+
+
+def test_dmc_940_missing_mandatory_skill_page_fails_with_clear_message() -> None:
+    result = _run_validation_suite(
+        lambda sandbox: sandbox.path("dmtools-ai-docs/per-skill-packages/dmtools-github.md").unlink()
+    )
+
+    assert result.returncode != 0, "Validation suite should fail when a mandatory skill page is missing."
+    assert MISSING_PAGE_MESSAGE in result.combined_output
+    assert "dmtools-github.md" in result.combined_output
+    assert "FAILED testing/tests/DMC-916/test_dmc_916.py::" in result.stdout
+
+
+def _run_validation_suite(mutator=None):
+    sandbox = RepoSandbox(REPOSITORY_ROOT)
+    try:
+        if mutator is not None:
+            mutator(sandbox)
+        return sandbox.run(VALIDATION_COMMAND)
+    finally:
+        sandbox.cleanup()


### PR DESCRIPTION
# DMC-940 Automation Result

**Status:** PASSED

## What automation checked
1. Ran the live per-skill validation on the current repository state and confirmed it passes before any mutation.
2. In a sandbox copy, deleted `dmtools-ai-docs/per-skill-packages/` and reran `python3 -m pytest testing/tests/DMC-916/test_dmc_916.py -q`.
3. Confirmed the validation failed with:

   ```text
   Expected per-skill catalogue directory dmtools-ai-docs/per-skill-packages to exist, but it is missing.
   ```

4. In a fresh sandbox copy, deleted `dmtools-ai-docs/per-skill-packages/dmtools-github.md` and reran the same validation command.
5. Confirmed the validation failed with:

   ```text
   Expected mandatory skill pages under dmtools-ai-docs/per-skill-packages are missing: dmtools-github.md.
   ```

## Human-style verification
A user running the validation suite from the terminal would see pytest identify the exact missing documentation component in each scenario:

- missing directory -> the output names the missing catalogue directory;
- missing mandatory file -> the output names the missing `dmtools-github.md` page.

This matched the expected result.

## Observed result
- Added Pytest automation under `testing/tests/DMC-940/`.
- Strengthened `testing/components/services/per_skill_page_audit_service.py` so missing mandatory per-skill child pages are reported explicitly.
- Added a regression unit check in `testing/tests/DMC-916/test_per_skill_page_audit_service.py`.
- Final run:

  ```text
  python3 -m pytest testing/tests/DMC-916/test_dmc_916.py testing/tests/DMC-916/test_per_skill_page_audit_service.py testing/tests/DMC-940/test_dmc_940.py -q
  ............                                                                                                     [100%]
  12 passed in 1.58s
  ```
