### PR TITLE
DMC-941 Installer env skill list log omits spaces after commas in effective skills output

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -90,6 +90,18 @@ join_by_comma() {
     printf '%s' "$*"
 }
 
+join_by_comma_space() {
+    local result=""
+    local item
+    for item in "$@"; do
+        if [ -n "$result" ]; then
+            result="$result, "
+        fi
+        result="$result$item"
+    done
+    printf '%s' "$result"
+}
+
 append_unique() {
     local array_name="$1"
     local candidate="$2"
@@ -302,7 +314,9 @@ resolve_skill_selection() {
     if [ "$INSTALL_ALL_SKILLS" = true ]; then
         info "Installing all skills (source: $SKILLS_SOURCE)"
     fi
-    info "Effective skills: $EFFECTIVE_SKILLS_CSV (source: $SKILLS_SOURCE)"
+    local effective_skills_display
+    effective_skills_display=$(join_by_comma_space "${EFFECTIVE_SKILLS[@]}")
+    info "Effective skills: $effective_skills_display (source: $SKILLS_SOURCE)"
     info "Effective integrations: $EFFECTIVE_INTEGRATIONS_CSV"
 }
 

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -163,6 +163,20 @@ printf 'integrations=%s\\n' "$EFFECTIVE_INTEGRATIONS_CSV"
         self.assertIn("source=env", result.stdout)
         self.assertIn("integrations=ai,cli,file,kb,mermaid,jira,github", result.stdout)
 
+    def test_env_selection_logs_effective_skills_with_comma_space_formatting(self) -> None:
+        result = run_installer_functions(
+            """
+parse_installer_args
+resolve_skill_selection
+""",
+            {"DMTOOLS_SKILLS": " Jira, github, JIRA, , confluence "},
+        )
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn(
+            "Effective skills: jira, github, confluence (source: env)", result.stdout
+        )
+
     def test_unknown_skills_warn_and_known_skills_continue(self) -> None:
         result = run_installer_functions(
             """


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`install.sh` correctly normalized and deduplicated `DMTOOLS_SKILLS`, but it reused the compact config CSV (`jira,github,confluence`) for the visible `Effective skills` log line. That made the env-path installer output fail the exact formatting required by the linked test.

### Fix
Updated `install.sh` so `resolve_skill_selection()` still keeps `EFFECTIVE_SKILLS_CSV` as the compact comma-separated config value, but now formats the user-facing `Effective skills` line with a display-only `, ` join. Added a regression test in `testing/tests/DMC-859/test_install_skills.py` for the exact env-driven output line.

### Test Coverage
- Reproduction test: `testing/tests/DMC-925/test_dmc_925.py::test_dmc_925_installer_normalizes_and_deduplicates_skills_from_env_and_cli` — PASSED after fix
- Regression test: `testing/tests/DMC-859/test_install_skills.py::TestInstallerSkillSelection::test_env_selection_logs_effective_skills_with_comma_space_formatting` — PASSED
- Installer regression suite: `python3 -m pytest testing/tests/DMC-859/test_install_skills.py -q` — PASSED
- Core unit tests: `./gradlew :dmtools-core:test` — PASSED
- Full Python suite: `python3 -m pytest testing/tests -q` — FAILED in unrelated pre-existing documentation/agent sync tests (`DMC-893`, `DMC-896`, `DMC-897`)

### Notes
The fix is intentionally limited to installer display formatting. Stored skill CSV values and integration resolution behavior are unchanged.
