### PR TITLE
DMC-945 Test: Run installer with --strict flag as the first argument — flag is parsed correctly

### DIFF
--- a/testing/tests/DMC-945/README.md
+++ b/testing/tests/DMC-945/README.md
@@ -1,0 +1,24 @@
+# DMC-945 automated test
+
+This regression test exercises the real installer argument parser for the
+`./install.sh --strict --skills='jira'` flow while stubbing download and system
+mutation steps. It verifies the user-visible CLI output, successful exit status,
+and the generated installer skill configuration.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-945/test_dmc_945.py -q
+```
+
+## Environment
+
+No credentials are required. The test runs the repository `install.sh` locally in
+`DMTOOLS_INSTALLER_TEST_MODE=true`, captures stdout/stderr, and inspects the
+installer-managed environment file that a user installation would generate.

--- a/testing/tests/DMC-945/config.yaml
+++ b/testing/tests/DMC-945/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-945
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-945/conftest.py
+++ b/testing/tests/DMC-945/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def installer_script() -> InstallerScript:
+    return create_installer_script(REPOSITORY_ROOT)

--- a/testing/tests/DMC-945/test_dmc_945.py
+++ b/testing/tests/DMC-945/test_dmc_945.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.core.interfaces.installer_script import InstallerScript  # noqa: E402
+
+
+def test_dmc_945_strict_flag_is_accepted_when_it_is_the_first_cli_argument(
+    installer_script: InstallerScript,
+) -> None:
+    execution = installer_script.run_main(
+        args=("--strict", "--skills=jira"),
+        post_script="""
+printf 'installer_env_path=%s\\n' "$INSTALLER_ENV_PATH"
+cat "$INSTALLER_ENV_PATH"
+""",
+    )
+    stdout = installer_script.normalized_stdout(execution)
+    stderr = installer_script.normalized_stderr(execution)
+
+    assert execution.returncode == 0, (
+        "The installer should accept --strict when it is the first CLI argument and "
+        "continue with the requested valid skill.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert "Installing DMTools CLI..." in stdout, (
+        "A user should see the standard installer banner before argument parsing completes.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Effective skills: jira (source: cli)" in stdout, (
+        "The installer should treat the following --skills option as the effective selection.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Effective integrations: ai,cli,file,kb,mermaid,jira" in stdout, (
+        "The installer should resolve integrations for the accepted jira skill.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert 'DMTOOLS_SKILLS="jira"' in stdout, (
+        "The generated installer environment should persist the selected jira skill.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert 'DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"' in stdout, (
+        "The generated installer environment should persist the resolved jira integrations.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Unknown installer option: --strict" not in stderr, (
+        "The strict flag must be parsed as a supported option, not rejected by the CLI parser.\n"
+        f"stderr:\n{stderr}"
+    )
+    assert "No valid skills selected" not in stderr, (
+        "A valid jira selection should not trigger strict-mode validation errors.\n"
+        f"stderr:\n{stderr}"
+    )


### PR DESCRIPTION
# DMC-945 test automation result: PASSED

## Automated coverage
- Added regression test: `testing/tests/DMC-945/test_dmc_945.py`
- Command executed:
  ```bash
  python3 -m pytest testing/tests/DMC-945/test_dmc_945.py -q
  ```
- Result: `1 passed in 0.21s`

## What automation verified
1. Executed the installer with `./install.sh --strict --skills='jira'` via the existing installer script test component.
2. Confirmed exit code `0`.
3. Confirmed stdout contained the expected user-facing lines:
   - `Installing DMTools CLI...`
   - `Effective skills: jira (source: cli)`
   - `Effective integrations: ai,cli,file,kb,mermaid,jira`
4. Confirmed the generated installer env output contained:
   ```text
   DMTOOLS_SKILLS="jira"
   DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"
   ```
5. Confirmed stderr did not contain `Unknown installer option: --strict` and did not contain `No valid skills selected`.

## Human-style verification
I checked the scenario from the user’s point of view by reviewing the visible CLI output and final result of the successful run. The installer accepted `--strict` when it was the first argument, continued with the valid `--skills=jira` selection, displayed the expected skill/integration resolution, and completed without any command-line parsing error. This matched the expected result.
