### PR TITLE
DMC-950 Test: Selective install with unrecognized skill name — metadata generated for valid skills only

### DIFF
--- a/testing/tests/DMC-950/README.md
+++ b/testing/tests/DMC-950/README.md
@@ -1,0 +1,36 @@
+# DMC-950 automated test
+
+This test runs the live DMTools installer from the raw `main` branch in an isolated
+temporary home directory, requests a selective install with one valid skill and one
+unknown skill, and verifies the installer preserves metadata for the valid skill
+without leaking the invalid one into generated artifacts.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-950/test_dmc_950.py -q
+```
+
+## Environment
+
+The test requires outbound network access to:
+
+- `raw.githubusercontent.com` for the live installer script
+- `github.com` for the downloaded release assets
+
+It uses a temp directory for `HOME`, `DMTOOLS_INSTALL_DIR`, and `DMTOOLS_BIN_DIR`
+so it does not modify the user environment.
+
+## Expected output when the test passes
+
+- `pytest` reports `1 passed`
+- The installer output warns about `non_existent_skill_xyz`
+- The installer output still reports `Effective skills: jira (source: env)`
+- `installed-skills.json` contains only `jira` plus version metadata
+- `endpoints.json` contains only `/dmtools/jira`

--- a/testing/tests/DMC-950/config.yaml
+++ b/testing/tests/DMC-950/config.yaml
@@ -1,0 +1,13 @@
+test_id: DMC-950
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+installer_url: https://raw.githubusercontent.com/epam/dm.ai/main/install
+requested_skills:
+  - jira
+  - non_existent_skill_xyz
+expected_valid_skills:
+  - jira
+expected_invalid_skills:
+  - non_existent_skill_xyz

--- a/testing/tests/DMC-950/test_dmc_950.py
+++ b/testing/tests/DMC-950/test_dmc_950.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_metadata_service_factory import (  # noqa: E402
+    create_installer_metadata_service,
+)
+from testing.components.services.installer_metadata_service import (  # noqa: E402
+    InstallerMetadataService,
+)
+from testing.components.services.installer_script_service import (  # noqa: E402
+    InstallerScriptService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+REQUESTED_SKILLS = tuple(str(skill) for skill in CONFIG["requested_skills"])
+EXPECTED_VALID_SKILLS = tuple(str(skill) for skill in CONFIG["expected_valid_skills"])
+EXPECTED_INVALID_SKILLS = tuple(str(skill) for skill in CONFIG["expected_invalid_skills"])
+EXPECTED_ENDPOINTS = tuple(f"/dmtools/{skill}" for skill in EXPECTED_VALID_SKILLS)
+UNEXPECTED_ENDPOINTS = tuple(f"/dmtools/{skill}" for skill in EXPECTED_INVALID_SKILLS)
+
+
+def build_service() -> InstallerMetadataService:
+    return create_installer_metadata_service(
+        repository_root=REPOSITORY_ROOT,
+        installer_url=str(CONFIG["installer_url"]),
+    )
+
+
+def test_dmc_950_selective_install_ignores_unknown_skills_without_corrupting_metadata() -> None:
+    service = build_service()
+    run = service.run_selective_install(REQUESTED_SKILLS)
+    visible_stdout = InstallerScriptService.strip_ansi(run.execution.stdout)
+
+    assert run.execution.returncode == 0, service.format_execution_failure(run)
+    assert "Warning: Skipping unknown skills: non_existent_skill_xyz" in visible_stdout, (
+        "A user should see which requested skill name was rejected while the install continues.\n"
+        f"stdout:\n{visible_stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert "Effective skills: jira (source: env)" in visible_stdout, (
+        "The installer should visibly confirm that only the valid skill remains selected.\n"
+        f"stdout:\n{visible_stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert run.installer_env_path.exists(), service.format_missing_artifact(
+        run,
+        run.installer_env_path,
+        "The selective install should persist its filtered runtime skill selection state.",
+    )
+    installer_env = run.installer_env_path.read_text(encoding="utf-8")
+    assert 'DMTOOLS_SKILLS="jira"' in installer_env, (
+        "The persisted installer-managed environment should keep only the valid requested skill.\n"
+        f"{installer_env}"
+    )
+    assert "non_existent_skill_xyz" not in installer_env, (
+        "Unknown skills must not leak into the installer-managed environment file.\n"
+        f"{installer_env}"
+    )
+    assert run.installed_skills_path.exists(), service.format_missing_artifact(
+        run,
+        run.installed_skills_path,
+        "The installer should create installed-skills.json for the surviving valid skill.",
+    )
+    assert run.endpoints_path.exists(), service.format_missing_artifact(
+        run,
+        run.endpoints_path,
+        "The installer should create endpoints.json for the surviving valid skill.",
+    )
+
+    installed_skills_payload = service.read_json(run.installed_skills_path)
+    declared_skills = service.declared_skills(installed_skills_payload)
+    assert declared_skills == {skill.lower() for skill in EXPECTED_VALID_SKILLS}, (
+        service.format_unexpected_payload(
+            run.installed_skills_path,
+            installed_skills_payload,
+            "installed-skills.json should contain only the valid requested skill.",
+        )
+    )
+    assert service.payload_contains_version(installed_skills_payload), (
+        service.format_unexpected_payload(
+            run.installed_skills_path,
+            installed_skills_payload,
+            "installed-skills.json should include version metadata for downstream consumers.",
+        )
+    )
+
+    endpoints_payload = service.read_json(run.endpoints_path)
+    discovered_endpoint_paths = service.endpoint_paths(endpoints_payload)
+    assert discovered_endpoint_paths == set(EXPECTED_ENDPOINTS), service.format_unexpected_payload(
+        run.endpoints_path,
+        endpoints_payload,
+        "endpoints.json should contain only the endpoint paths for the valid requested skills.",
+    )
+    for unexpected_endpoint in UNEXPECTED_ENDPOINTS:
+        assert unexpected_endpoint not in discovered_endpoint_paths, service.format_unexpected_payload(
+            run.endpoints_path,
+            endpoints_payload,
+            "endpoints.json must exclude endpoints for unknown requested skills.",
+        )


### PR DESCRIPTION
## DMC-950

**Status:** Passed

**Automated verification**
- Ran the live installer with `DMTOOLS_SKILLS=jira,non_existent_skill_xyz`.
- Confirmed the visible CLI output included `Warning: Skipping unknown skills: non_existent_skill_xyz`.
- Confirmed the installer continued with `Effective skills: jira (source: env)`.
- Confirmed `installed-skills.json` was generated with only `jira` and version `v1.7.179`.
- Confirmed `endpoints.json` was generated with only `/dmtools/jira`.

**Human-style verification**
- Reviewed the user-facing installer flow in the CLI output: startup banner, warning, effective skill summary, metadata generation message, and final completion message.
- Checked the persisted runtime config in `dmtools-installer.env` and observed `DMTOOLS_SKILLS="jira"` with no trace of `non_existent_skill_xyz`.

**Observed result**
- The installer filtered out the unrecognized skill and produced clean metadata for the valid skill only.
- The observed behavior matched the expected result.
