### PR TITLE
DMC-949 Test: Selective install with write-protected installation directory — installer reports failure and non-zero exit code

### DIFF
--- a/testing/components/services/installer_metadata_service.py
+++ b/testing/components/services/installer_metadata_service.py
@@ -34,6 +34,7 @@ class InstallerMetadataRun:
 
 class InstallerMetadataService:
     DEFAULT_INSTALLER_URL = "https://raw.githubusercontent.com/epam/dm.ai/main/install"
+    _POST_METADATA_STEP_MARKER = "UNEXPECTED post_metadata_step"
     _SKILL_COLLECTION_KEYS = frozenset(
         {
             "skills",
@@ -93,6 +94,65 @@ class InstallerMetadataService:
 
         return InstallerMetadataRun(
             installer_url=self.installer_url,
+            temp_root=temp_root,
+            install_dir=install_dir,
+            bin_dir=bin_dir,
+            requested_skills=normalized_skills,
+            execution=execution,
+        )
+
+    @property
+    def post_metadata_step_marker(self) -> str:
+        return self._POST_METADATA_STEP_MARKER
+
+    def run_local_selective_install_with_write_protected_install_dir(
+        self,
+        skills: Sequence[str],
+    ) -> InstallerMetadataRun:
+        normalized_skills = tuple(skill.strip().lower() for skill in skills if skill.strip())
+        if not normalized_skills:
+            raise ValueError("At least one skill must be provided.")
+
+        temp_root = Path(tempfile.mkdtemp(prefix="dmtools-installer-metadata-readonly-"))
+        install_dir = temp_root / "install"
+        bin_dir = install_dir / "bin"
+        home_dir = temp_root / "home"
+
+        install_dir.mkdir(parents=True, exist_ok=True)
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        install_dir.chmod(0o555)
+        bin_dir.chmod(0o555)
+
+        script = "\n".join(
+            [
+                "set -e",
+                f'source "{self.repository_root / "install.sh"}"',
+                "check_java() { :; }",
+                "get_latest_version() { printf 'v0.0.0-test'; }",
+                "create_install_dir() { :; }",
+                "write_installer_skill_config() { :; }",
+                "download_dmtools() { :; }",
+                f'update_shell_config() {{ printf "{self._POST_METADATA_STEP_MARKER}\\n"; }}',
+                f'verify_installation() {{ printf "{self._POST_METADATA_STEP_MARKER}\\n"; }}',
+                f'print_instructions() {{ printf "{self._POST_METADATA_STEP_MARKER}\\n"; }}',
+                "main",
+            ]
+        )
+        execution = self.runner.run(
+            ["bash", "-lc", script],
+            cwd=self.repository_root,
+            env={
+                "HOME": str(home_dir),
+                "SHELL": "/bin/bash",
+                "DMTOOLS_INSTALLER_TEST_MODE": "true",
+                "DMTOOLS_INSTALL_DIR": str(install_dir),
+                "DMTOOLS_BIN_DIR": str(bin_dir),
+                "DMTOOLS_SKILLS": ",".join(normalized_skills),
+            },
+        )
+
+        return InstallerMetadataRun(
+            installer_url=str(self.repository_root / "install.sh"),
             temp_root=temp_root,
             install_dir=install_dir,
             bin_dir=bin_dir,

--- a/testing/tests/DMC-949/README.md
+++ b/testing/tests/DMC-949/README.md
@@ -1,0 +1,35 @@
+# DMC-949 automated test
+
+This test exercises the repository's live `install.sh` main flow for a selective
+`jira` install while the target installation directory is write-protected. It
+stubs the unrelated download and shell-update steps so the run deterministically
+reaches the real machine-readable metadata write and verifies that the installer
+fails with a non-zero exit code instead of reporting a false success.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-949/test_dmc_949.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs `install.sh` with
+`DMTOOLS_INSTALLER_TEST_MODE=true`, `DMTOOLS_SKILLS=jira`, and a temporary
+write-protected installation directory.
+
+## Expected output when the test passes
+
+- `pytest` reports `1 passed`
+- The installer output includes `Installing DMTools CLI...`
+- The installer output includes `Effective skills: jira (source: env)`
+- The installer exits with a non-zero status after reporting a permission error
+  for `installed-skills.json`
+- The installer does not print the metadata success message or continue into
+  later success-path steps

--- a/testing/tests/DMC-949/config.yaml
+++ b/testing/tests/DMC-949/config.yaml
@@ -1,0 +1,7 @@
+test_id: DMC-949
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+selected_skills:
+  - jira

--- a/testing/tests/DMC-949/test_dmc_949.py
+++ b/testing/tests/DMC-949/test_dmc_949.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_metadata_service_factory import (  # noqa: E402
+    create_installer_metadata_service,
+)
+from testing.components.services.installer_metadata_service import (  # noqa: E402
+    InstallerMetadataService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+SELECTED_SKILLS = tuple(str(skill) for skill in CONFIG["selected_skills"])
+
+
+def build_service() -> InstallerMetadataService:
+    return create_installer_metadata_service(REPOSITORY_ROOT)
+
+
+def test_dmc_949_selective_install_with_write_protected_directory_fails_without_false_success() -> None:
+    service = build_service()
+    run = service.run_local_selective_install_with_write_protected_install_dir(SELECTED_SKILLS)
+
+    assert run.execution.returncode != 0, (
+        "The installer must exit with a non-zero code when machine-readable metadata cannot "
+        "be written inside a write-protected installation directory.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert "Installing DMTools CLI..." in run.execution.stdout, (
+        "A user should still see the normal installer banner before the metadata write failure.\n"
+        f"stdout:\n{run.execution.stdout}"
+    )
+    assert "Effective skills: jira (source: env)" in run.execution.stdout, (
+        "The visible output should preserve the requested selective-skill announcement.\n"
+        f"stdout:\n{run.execution.stdout}"
+    )
+    assert "Latest version: v0.0.0-test" in run.execution.stdout, (
+        "The installer should reach the visible version-resolution step before the "
+        "metadata write fails.\n"
+        f"stdout:\n{run.execution.stdout}"
+    )
+    assert "installed-skills.json" in run.execution.stderr, (
+        "The error output must identify the metadata file that could not be written.\n"
+        f"stderr:\n{run.execution.stderr}"
+    )
+    assert "Permission denied" in run.execution.stderr, (
+        "The error output must make the filesystem permission problem explicit.\n"
+        f"stderr:\n{run.execution.stderr}"
+    )
+    assert not run.installed_skills_path.exists(), (
+        "The installer must not leave behind a partial installed-skills.json artifact after "
+        "the permission failure."
+    )
+    assert not run.endpoints_path.exists(), (
+        "The installer must not create endpoints.json when metadata generation aborts."
+    )
+    assert "Generated machine-readable installer metadata" not in run.execution.stdout, (
+        "The installer must not report metadata generation as successful after the "
+        "permission failure.\n"
+        f"stdout:\n{run.execution.stdout}"
+    )
+    assert service.post_metadata_step_marker not in run.execution.combined_output, (
+        "The installer should stop immediately at the metadata write failure instead of "
+        "continuing into later success-path steps.\n"
+        f"output:\n{run.execution.combined_output}"
+    )


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-949 — Selective install with write-protected installation directory reports failure and non-zero exit code

## What was automated
- Added `testing/tests/DMC-949/test_dmc_949.py` plus ticket config/README for the selective `jira` installer permission-failure scenario.
- Reused the shared installer metadata service to run the real installer `main` flow with downstream setup steps stubbed so the metadata write failure is isolated and deterministic.
- Asserted non-zero exit, visible permission error output for `installed-skills.json`, absence of `installed-skills.json` and `endpoints.json`, and no false-success continuation.

## Result
- Automation passed: `python3 -m pytest testing/tests/DMC-949/test_dmc_949.py -q` -> `1 passed in 0.08s`.
- Human-style verification passed: a direct CLI-style run displayed the installer banner, `Effective skills: jira (source: env)`, `Latest version: v0.0.0-test`, then `Permission denied` for `installed-skills.json` with exit code `1`.
- Observed behavior matched the expected result because the installer failed clearly and did not print the metadata success message or any later success-path output.

## How to run
```bash
python3 -m pytest testing/tests/DMC-949/test_dmc_949.py -q
```
