### PR TITLE
DMC-948 Test: Selective install completion — post-install dmtools command test passes

### DIFF
--- a/testing/components/services/installer_metadata_service.py
+++ b/testing/components/services/installer_metadata_service.py
@@ -57,16 +57,21 @@ class InstallerMetadataService:
         self.runner = runner
         self.installer_url = installer_url
 
-    def run_selective_install(self, skills: Sequence[str]) -> InstallerMetadataRun:
+    def run_selective_install(
+        self,
+        skills: Sequence[str],
+        *,
+        use_default_home_install_dir: bool = False,
+    ) -> InstallerMetadataRun:
         normalized_skills = tuple(skill.strip().lower() for skill in skills if skill.strip())
         if not normalized_skills:
             raise ValueError("At least one skill must be provided.")
 
         temp_root = Path(tempfile.mkdtemp(prefix="dmtools-installer-metadata-"))
-        install_dir = temp_root / "install"
-        bin_dir = install_dir / "bin"
         home_dir = temp_root / "home"
         installer_path = temp_root / "install_script"
+        install_dir = home_dir / ".dmtools" if use_default_home_install_dir else temp_root / "install"
+        bin_dir = install_dir / "bin"
 
         script = "\n".join(
             [
@@ -77,18 +82,21 @@ class InstallerMetadataService:
                 'bash "$INSTALLER_PATH"',
             ]
         )
+        execution_env = {
+            "HOME": str(home_dir),
+            "SHELL": "/bin/bash",
+            "INSTALLER_URL": self.installer_url,
+            "INSTALLER_PATH": str(installer_path),
+            "DMTOOLS_SKILLS": ",".join(normalized_skills),
+        }
+        if not use_default_home_install_dir:
+            execution_env["DMTOOLS_INSTALL_DIR"] = str(install_dir)
+            execution_env["DMTOOLS_BIN_DIR"] = str(bin_dir)
+
         execution = self.runner.run(
             ["bash", "-c", script],
             cwd=self.repository_root,
-            env={
-                "HOME": str(home_dir),
-                "SHELL": "/bin/bash",
-                "INSTALLER_URL": self.installer_url,
-                "INSTALLER_PATH": str(installer_path),
-                "DMTOOLS_INSTALL_DIR": str(install_dir),
-                "DMTOOLS_BIN_DIR": str(bin_dir),
-                "DMTOOLS_SKILLS": ",".join(normalized_skills),
-            },
+            env=execution_env,
         )
 
         return InstallerMetadataRun(

--- a/testing/tests/DMC-948/README.md
+++ b/testing/tests/DMC-948/README.md
@@ -1,0 +1,38 @@
+# DMC-948 automated test
+
+This test runs the live DMTools installer from the raw `main` branch in an isolated
+temporary home directory, performs a selective `jira,confluence` install in the
+default `~/.dmtools` location, and verifies that the installer's internal
+post-install `dmtools` command validation succeeds without surfacing metadata
+assertion warnings.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-948/test_dmc_948.py -q
+```
+
+## Environment
+
+The test requires outbound network access to:
+
+- `raw.githubusercontent.com` for the live installer script
+- `github.com` for the downloaded release assets
+
+It uses a temp directory for `HOME` so the installer writes to an isolated
+`~/.dmtools` tree without modifying the user environment.
+
+## Expected output when the test passes
+
+- `pytest` reports `1 passed`
+- The installer output includes `Installing DMTools CLI...`
+- The installer output includes `Effective skills: jira,confluence (source: env)`
+- The installer output includes `DMTools CLI installed successfully!`
+- The installer output does not include `Installation completed but dmtools command test failed`
+- The isolated `~/.dmtools` directory contains `installed-skills.json` and `endpoints.json`

--- a/testing/tests/DMC-948/config.yaml
+++ b/testing/tests/DMC-948/config.yaml
@@ -1,0 +1,9 @@
+test_id: DMC-948
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+installer_url: https://raw.githubusercontent.com/epam/dm.ai/main/install
+selected_skills:
+  - jira
+  - confluence

--- a/testing/tests/DMC-948/test_dmc_948.py
+++ b/testing/tests/DMC-948/test_dmc_948.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_metadata_service_factory import (  # noqa: E402
+    create_installer_metadata_service,
+)
+from testing.components.services.installer_metadata_service import (  # noqa: E402
+    InstallerMetadataService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+SELECTED_SKILLS = tuple(str(skill) for skill in CONFIG["selected_skills"])
+EXPECTED_ENDPOINTS = tuple(f"/dmtools/{skill}" for skill in SELECTED_SKILLS)
+FAILED_COMMAND_TEST_WARNING = "Installation completed but dmtools command test failed"
+SUCCESSFUL_COMMAND_TEST_MESSAGE = "DMTools CLI installed successfully!"
+MISSING_METADATA_ASSERTION = "AssertionError"
+
+
+def build_service() -> InstallerMetadataService:
+    return create_installer_metadata_service(
+        repository_root=REPOSITORY_ROOT,
+        installer_url=str(CONFIG["installer_url"]),
+    )
+
+
+def test_dmc_948_selective_install_completes_without_post_install_dmtools_warning() -> None:
+    service = build_service()
+    run = service.run_selective_install(
+        SELECTED_SKILLS,
+        use_default_home_install_dir=True,
+    )
+    combined_output = run.execution.combined_output
+
+    assert run.execution.returncode == 0, service.format_execution_failure(run)
+    assert "Installing DMTools CLI..." in run.execution.stdout, (
+        "The installer should show its normal startup banner to the user.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert "Effective skills: jira,confluence (source: env)" in run.execution.stdout, (
+        "The installer did not report the selected skills in its user-visible output.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert SUCCESSFUL_COMMAND_TEST_MESSAGE in run.execution.stdout, (
+        "The installer did not report a successful post-install dmtools command validation.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert FAILED_COMMAND_TEST_WARNING not in combined_output, (
+        "The post-install dmtools command validation still reported a user-visible failure.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert MISSING_METADATA_ASSERTION not in combined_output, (
+        "The installer surfaced an assertion failure during post-install validation.\n"
+        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+    )
+
+    assert run.installed_skills_path.exists(), service.format_missing_artifact(
+        run,
+        run.installed_skills_path,
+        "The selective install should finish with installed-skills.json available for the "
+        "post-install dmtools command test.",
+    )
+    assert run.endpoints_path.exists(), service.format_missing_artifact(
+        run,
+        run.endpoints_path,
+        "The selective install should finish with endpoints.json available for the "
+        "post-install dmtools command test.",
+    )
+
+    installed_skills_payload = service.read_json(run.installed_skills_path)
+    assert service.payload_contains_skills(
+        installed_skills_payload,
+        SELECTED_SKILLS,
+    ), service.format_unexpected_payload(
+        run.installed_skills_path,
+        installed_skills_payload,
+        "installed-skills.json does not expose the selected skill list after the "
+        "post-install validation completes.",
+    )
+    assert service.payload_contains_version(installed_skills_payload), (
+        service.format_unexpected_payload(
+            run.installed_skills_path,
+            installed_skills_payload,
+            "installed-skills.json does not expose installer or artifact version "
+            "information after the post-install validation completes.",
+        )
+    )
+
+    endpoints_payload = service.read_json(run.endpoints_path)
+    discovered_endpoint_paths = service.endpoint_paths(endpoints_payload)
+    missing_endpoints = [
+        endpoint for endpoint in EXPECTED_ENDPOINTS if endpoint not in discovered_endpoint_paths
+    ]
+    assert not missing_endpoints, service.format_unexpected_payload(
+        run.endpoints_path,
+        endpoints_payload,
+        "endpoints.json is missing one or more REST-friendly skill endpoints after the "
+        "post-install validation completes: " + ", ".join(missing_endpoints),
+    )

--- a/testing/tests/DMC-948/test_dmc_948.py
+++ b/testing/tests/DMC-948/test_dmc_948.py
@@ -20,6 +20,7 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
 SELECTED_SKILLS = tuple(str(skill) for skill in CONFIG["selected_skills"])
+SELECTED_SKILLS_DISPLAY = ", ".join(SELECTED_SKILLS)
 EXPECTED_ENDPOINTS = tuple(f"/dmtools/{skill}" for skill in SELECTED_SKILLS)
 FAILED_COMMAND_TEST_WARNING = "Installation completed but dmtools command test failed"
 SUCCESSFUL_COMMAND_TEST_MESSAGE = "DMTools CLI installed successfully!"
@@ -46,7 +47,7 @@ def test_dmc_948_selective_install_completes_without_post_install_dmtools_warnin
         "The installer should show its normal startup banner to the user.\n"
         f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
     )
-    assert "Effective skills: jira,confluence (source: env)" in run.execution.stdout, (
+    assert f"Effective skills: {SELECTED_SKILLS_DISPLAY} (source: env)" in run.execution.stdout, (
         "The installer did not report the selected skills in its user-visible output.\n"
         f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
     )


### PR DESCRIPTION
# DMC-948 test automation

**Status:** Passed  
**Automated test:** `python3 -m pytest testing/tests/DMC-948/test_dmc_948.py -q`  
**Result:** `1 passed in 1.44s`

## What automation verified

1. Ran the live installer from `https://raw.githubusercontent.com/epam/dm.ai/main/install` with `DMTOOLS_SKILLS=jira,confluence` in an isolated temp HOME-backed install directory.
2. Verified the console showed `Installing DMTools CLI...`, `Effective skills: jira,confluence (source: env)`, and `DMTools CLI installed successfully!`.
3. Verified the console did **not** show `Installation completed but dmtools command test failed` or `AssertionError`.
4. Verified `installed-skills.json` and `endpoints.json` were created and exposed the selected skills, version metadata, and endpoints `/dmtools/jira` and `/dmtools/confluence`.

## Human-style verification

1. Ran the installed launcher directly from the generated temp HOME: `/tmp/dmc948-default-ShuGyn/home/.dmtools/bin/dmtools list`.
2. Observed exit code `0`, JSON tool output on stdout, and no stderr.
3. Observed the installer artifacts at `/tmp/dmc948-default-ShuGyn/home/.dmtools`, including `dmtools.jar`, `installed-skills.json`, `endpoints.json`, and `bin/dmtools`.
4. The observed behavior matched the expected user outcome: selective install completed cleanly and the internal post-install `dmtools` command test passed.

## Files changed

- `testing/tests/DMC-948/config.yaml`
- `testing/tests/DMC-948/test_dmc_948.py`
- `testing/components/services/installer_metadata_service.py`
