### PR TITLE
DMC-927 Test: Handle invalid skills in normal and strict mode — skip with warning or fail run

### DIFF
--- a/testing/tests/DMC-927/README.md
+++ b/testing/tests/DMC-927/README.md
@@ -20,3 +20,11 @@ python3 -m pytest testing/tests/DMC-927/test_dmc_927.py -q
 No credentials are required. The test executes the repository `install.sh` locally, isolates
 installer output in a temporary directory, and stubs Java/download verification steps so the
 assertions stay focused on user-visible invalid-skill behavior.
+
+## Expected output
+
+When the test passes, pytest reports:
+
+```text
+2 passed
+```

--- a/testing/tests/DMC-927/test_dmc_927.py
+++ b/testing/tests/DMC-927/test_dmc_927.py
@@ -41,3 +41,4 @@ def test_dmc_927_strict_mode_rejects_invalid_skills_with_invalid_skill_error(
     assert execution.returncode != 0, "Strict installer mode must fail for invalid skills."
     assert "No valid skills selected. Unknown skills: invalid." in execution.stderr
     assert "Allowed skills:" in execution.stderr
+    assert "Unknown installer option: --strict" not in execution.stderr


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-927 — Handle invalid skills in normal and strict mode — skip with warning or fail run

## What was automated
- Executed the real `install.sh` main flow with Java/download/shell-update steps stubbed so the assertions stayed focused on installer argument parsing, skill selection, visible logs, and persisted installer skill config.
- Verified normal mode with `DMTOOLS_SKILLS='jira,unknown_skill'`.
- Verified strict mode with `--skills=invalid --strict`.
- Performed terminal-style human verification of the exact stdout/stderr and exit codes a user would see in both runs.

## Result
- Normal mode passed: exit code `0`, warning `Warning: Skipping unknown skills: unknown_skill`, effective skill `jira`, and persisted installer config values `DMTOOLS_SKILLS="jira"` / `DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"`.
- Strict mode passed: exit code `1`, error `Error: No valid skills selected. Unknown skills: invalid. Allowed skills: dmtools,jira,confluence,github,gitlab,figma,teams,sharepoint,ado,testrail,xray`, and the previous regression message `Unknown installer option: --strict` was not shown.
- Human-style observation matched the expected result: a user sees a warning and successful continuation in normal mode, and a clear invalid-skill error in strict mode.

## How to run
```bash
python3 -m pytest testing/tests/DMC-927/test_dmc_927.py -q
```
