### PR TITLE
DMC-952 dmtools.sh run codegenerator rejects compatibility shim as missing config file

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGeneratorCompatibilityJob.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGeneratorCompatibilityJob.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class CodeGeneratorCompatibilityJob extends AbstractJob<BaseJobParams, List<ResultItem>> {
 
@@ -19,18 +20,26 @@ public class CodeGeneratorCompatibilityJob extends AbstractJob<BaseJobParams, Li
     public static final String REMOVAL_VERSION = "v1.8.0";
 
     private final Logger logger;
+    private final Consumer<String> warningSink;
 
     public CodeGeneratorCompatibilityJob() {
-        this(LogManager.getLogger(CodeGeneratorCompatibilityJob.class));
+        this(LogManager.getLogger(CodeGeneratorCompatibilityJob.class), System.err::println);
     }
 
     CodeGeneratorCompatibilityJob(Logger logger) {
+        this(logger, System.err::println);
+    }
+
+    CodeGeneratorCompatibilityJob(Logger logger, Consumer<String> warningSink) {
         this.logger = logger;
+        this.warningSink = warningSink;
     }
 
     @Override
     public List<ResultItem> runJob(BaseJobParams params) {
-        logger.warn(getDeprecationMessage());
+        String deprecationMessage = getDeprecationMessage();
+        logger.warn(deprecationMessage);
+        warningSink.accept(deprecationMessage);
         return Collections.singletonList(new ResultItem(getName(), getCompatibilityResponse()));
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
@@ -90,6 +90,13 @@ public class JobRunner {
         }
     }
 
+    static boolean isKnownJobName(String jobName) {
+        if (jobName == null || jobName.trim().isEmpty()) {
+            return false;
+        }
+        return createJobInstance(jobName.trim()) != null;
+    }
+
     /**
      * Static job instances used only for job listing and name lookup.
      * These should NOT be used for execution to avoid race conditions.
@@ -272,6 +279,7 @@ public class JobRunner {
         System.out.println("Usage:");
         System.out.println("  dmtools list                           # List available MCP tools");
         System.out.println("  dmtools run <json-file>                # Execute job with JSON config file");
+        System.out.println("  dmtools run <job-name> [--key value]   # Execute a registered job without a config file");
         System.out.println("  dmtools run <json-file> <encoded>      # Execute job with file + encoded overrides");
         System.out.println("  dmtools <tool> [args...]              # Execute MCP tool with args");
         System.out.println("  dmtools <tool> --data '{\"json\"}'      # Execute with inline JSON");
@@ -285,6 +293,7 @@ public class JobRunner {
         System.out.println("Examples:");
         System.out.println("  dmtools list");
         System.out.println("  dmtools run job-config.json");
+        System.out.println("  dmtools run codegenerator --param1 test");
         System.out.println("  dmtools run job-config.json \"eyJvdmVycmlkZSI6InZhbHVlIn0=\"  # base64 encoded");
         System.out.println("  dmtools run job-config.json \"%7B%22override%22%3A%22value%22%7D\"  # URL encoded");
         System.out.println("  dmtools jira_get_ticket DMC-479 summary,description");

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/RunCommandProcessor.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/RunCommandProcessor.java
@@ -96,6 +96,11 @@ public class RunCommandProcessor {
         }
 
         try {
+            if (JobRunner.isKnownJobName(filePath) && !Files.exists(Paths.get(filePath))) {
+                logger.info("Detected known job name for run command: {}", filePath);
+                return buildDirectJobParams(filePath, encodedConfig, cliOverrides);
+            }
+
             // Load JSON from file
             String fileJson = loadJsonFromFile(filePath);
 
@@ -103,37 +108,7 @@ public class RunCommandProcessor {
             JSONObject resolvedConfig = parentConfigResolver.resolve(new JSONObject(fileJson), Paths.get(filePath));
             fileJson = resolvedConfig.toString();
 
-            // Process encoded configuration if provided
-            String finalConfigJson;
-            if (encodedConfig != null && !encodedConfig.trim().isEmpty()) {
-                String decodedJson = encodingDetector.autoDetectAndDecode(encodedConfig);
-                finalConfigJson = configurationMerger.mergeConfigurations(fileJson, decodedJson);
-                logger.info("Configuration merged successfully from file and encoded parameter");
-            } else {
-                finalConfigJson = fileJson;
-                logger.info("Using file configuration only");
-            }
-
-            // Apply --key value CLI overrides into the "params" block
-            if (!cliOverrides.isEmpty()) {
-                JSONObject root = new JSONObject(finalConfigJson);
-                JSONObject params = root.optJSONObject(JobParams.PARAMS);
-                if (params == null) {
-                    params = new JSONObject();
-                    root.put(JobParams.PARAMS, params);
-                }
-                for (Map.Entry<String, String> entry : cliOverrides.entrySet()) {
-                    params.put(entry.getKey(), entry.getValue());
-                }
-                finalConfigJson = root.toString();
-                logger.info("Applied {} CLI override(s) to params block: {}", cliOverrides.size(), cliOverrides.keySet());
-            }
-
-            // Create JobParams with final merged configuration
-            JobParams jobParams = new JobParams(finalConfigJson);
-            logger.info("JobParams created successfully for job: {}", jobParams.getName());
-
-            return jobParams;
+            return createJobParams(fileJson, encodedConfig, cliOverrides);
 
         } catch (Exception e) {
             logger.error("Failed to process run command: {}", e.getMessage());
@@ -200,5 +175,51 @@ public class RunCommandProcessor {
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to build JSRunner JobParams: " + e.getMessage(), e);
         }
+    }
+
+    private JobParams buildDirectJobParams(String jobName, String encodedConfig, Map<String, String> cliOverrides) {
+        JSONObject root = new JSONObject();
+        root.put("name", jobName);
+        root.put(JobParams.PARAMS, new JSONObject());
+        return createJobParams(root.toString(), encodedConfig, cliOverrides);
+    }
+
+    private JobParams createJobParams(String baseConfigJson, String encodedConfig, Map<String, String> cliOverrides) {
+        String finalConfigJson = mergeEncodedConfig(baseConfigJson, encodedConfig);
+        finalConfigJson = applyCliOverrides(finalConfigJson, cliOverrides);
+
+        JobParams jobParams = new JobParams(finalConfigJson);
+        logger.info("JobParams created successfully for job: {}", jobParams.getName());
+        return jobParams;
+    }
+
+    private String mergeEncodedConfig(String baseConfigJson, String encodedConfig) {
+        if (encodedConfig == null || encodedConfig.trim().isEmpty()) {
+            logger.info("Using file/job configuration only");
+            return baseConfigJson;
+        }
+
+        String decodedJson = encodingDetector.autoDetectAndDecode(encodedConfig);
+        String mergedJson = configurationMerger.mergeConfigurations(baseConfigJson, decodedJson);
+        logger.info("Configuration merged successfully from base configuration and encoded parameter");
+        return mergedJson;
+    }
+
+    private String applyCliOverrides(String configJson, Map<String, String> cliOverrides) {
+        if (cliOverrides.isEmpty()) {
+            return configJson;
+        }
+
+        JSONObject root = new JSONObject(configJson);
+        JSONObject params = root.optJSONObject(JobParams.PARAMS);
+        if (params == null) {
+            params = new JSONObject();
+            root.put(JobParams.PARAMS, params);
+        }
+        for (Map.Entry<String, String> entry : cliOverrides.entrySet()) {
+            params.put(entry.getKey(), entry.getValue());
+        }
+        logger.info("Applied {} CLI override(s) to params block: {}", cliOverrides.size(), cliOverrides.keySet());
+        return root.toString();
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -20,7 +21,8 @@ public class CodeGeneratorTest {
     @Test
     public void testRunJobReturnsCompatibilityResponseAndLogsDeprecationWarning() {
         Logger logger = mock(Logger.class);
-        CodeGeneratorCompatibilityJob codeGenerator = new CodeGeneratorCompatibilityJob(logger);
+        AtomicReference<String> visibleWarning = new AtomicReference<>();
+        CodeGeneratorCompatibilityJob codeGenerator = new CodeGeneratorCompatibilityJob(logger, visibleWarning::set);
 
         List<ResultItem> resultItems = codeGenerator.runJob(null);
 
@@ -30,6 +32,7 @@ public class CodeGeneratorTest {
         assertNull(codeGenerator.getAi());
         assertTrue(CodeGeneratorCompatibilityJob.getDeprecationMessage().contains("deprecated"));
         assertTrue(CodeGeneratorCompatibilityJob.getDeprecationMessage().contains(CodeGeneratorCompatibilityJob.REMOVAL_VERSION));
+        assertEquals(CodeGeneratorCompatibilityJob.getDeprecationMessage(), visibleWarning.get());
         verify(logger).warn(CodeGeneratorCompatibilityJob.getDeprecationMessage());
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/RunCommandProcessorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/RunCommandProcessorTest.java
@@ -361,6 +361,17 @@ class RunCommandProcessorTest {
     }
 
     @Test
+    void testProcessRunCommand_knownJobNameWithCliOverrides() {
+        String[] args = {"run", "codegenerator", "--param1", "test"};
+
+        JobParams result = runCommandProcessor.processRunCommand(args);
+
+        assertNotNull(result);
+        assertEquals("codegenerator", result.getName());
+        assertEquals("test", result.getParams().getString("param1"));
+    }
+
+    @Test
     void testProcessRunCommand_jsonFileUnaffected() throws IOException {
         String jsonContent = "{\"name\":\"expert\",\"params\":{\"question\":\"test\"}}";
         Path jsonFile = tempDir.resolve("job.json");

--- a/dmtools.sh
+++ b/dmtools.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # DMTools CLI Wrapper
 # Usage: ./dmtools.sh [command] [args...]
-# Supports: STDIN, heredoc, file input, and inline JSON
+# Supports: STDIN, heredoc, file input, inline JSON, and direct job-name execution for `run`
 
 set -e
 
@@ -299,21 +299,12 @@ case "$COMMAND" in
         exit 0
         ;;
     "run")
-        # Handle new run command with JSON file + optional encoded parameter
+        # Handle run command with JSON file, JS file, or direct job name + optional encoded parameter
         if [ ${#ARGS[@]} -lt 1 ]; then
-            error "Run command requires at least one argument: json-file-path"
+            error "Run command requires at least one argument: json-file-path or job-name"
         fi
         
         JSON_FILE="${ARGS[0]}"
-
-        # Validate file exists and is readable
-        if [ ! -f "$JSON_FILE" ]; then
-            error "Configuration file not found: $JSON_FILE"
-        fi
-        
-        if [ ! -r "$JSON_FILE" ]; then
-            error "Configuration file is not readable: $JSON_FILE"
-        fi
         
         # Extra args after ARGS[0] (file) — includes optional encoded param and --key value pairs (e.g. --ciRunUrl)
         EXTRA_RUN_ARGS=("${ARGS[@]:1}")


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`dmtools.sh run ...` treated the first `run` argument as a required config file path and rejected `codegenerator` before the core CLI could resolve it as a registered compatibility job. Once that dispatch path was restored, the linked test still exposed a second gap: the shim only logged its deprecation message, so the wrapper path did not show a user-visible warning containing `deprecated` and `1.8.0`.

### Fix
Updated `dmtools.sh` to stop pre-validating `run` targets as files, and updated `dmtools-core/src/main/java/com/github/istin/dmtools/job/RunCommandProcessor.java` to recognize known job names like `codegenerator` and build in-memory `JobParams` for them, including `--key value` CLI overrides. Added `JobRunner.isKnownJobName(...)` to reuse the existing registry, and updated `dmtools-core/src/main/java/com/github/istin/dmtools/dev/CodeGeneratorCompatibilityJob.java` to emit the deprecation warning to stderr as well as the logger so the wrapper output satisfies the linked test contract.

### Test Coverage
- Reproduction test added: `dmtools-core/src/test/java/com/github/istin/dmtools/job/RunCommandProcessorTest.java` — `testProcessRunCommand_knownJobNameWithCliOverrides`
- Updated unit coverage: `dmtools-core/src/test/java/com/github/istin/dmtools/dev/CodeGeneratorTest.java` — `testRunJobReturnsCompatibilityResponseAndLogsDeprecationWarning`
- Linked test: `testing/tests/DMC-908/deprecated-codegenerator-run-compatibility.test.js` — PASSED
- Full test suite: `./gradlew :dmtools-core:test` — PASSED

### Notes
The repository-level `instruction.md` referenced by the task was not present in this checkout, so implementation followed the ticket bundle plus the repository guidance already in the repo.
