### PR TITLE
DMC-930 Test: Generate installer metadata — machine-readable state files created

### DIFF
--- a/testing/components/services/installer_metadata_service.py
+++ b/testing/components/services/installer_metadata_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -34,6 +35,10 @@ class InstallerMetadataRun:
 
 class InstallerMetadataService:
     DEFAULT_INSTALLER_URL = "https://raw.githubusercontent.com/epam/dm.ai/main/install"
+    _ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+    _EFFECTIVE_SKILLS_PATTERN = re.compile(
+        r"(?m)^Effective skills:\s*(?P<skills>.+?)\s+\(source:\s*(?P<source>[^)]+)\)$"
+    )
     _SKILL_COLLECTION_KEYS = frozenset(
         {
             "skills",
@@ -106,6 +111,29 @@ class InstallerMetadataService:
     def payload_contains_skills(self, payload: Any, expected_skills: Sequence[str]) -> bool:
         observed_skills = self.declared_skills(payload)
         return set(skill.lower() for skill in expected_skills).issubset(observed_skills)
+
+    def normalized_stdout(self, execution: ProcessExecutionResult) -> str:
+        return self._strip_ansi(execution.stdout)
+
+    def output_reports_selected_skills(
+        self,
+        execution: ProcessExecutionResult,
+        expected_skills: Sequence[str],
+        expected_source: str,
+    ) -> bool:
+        match = self._EFFECTIVE_SKILLS_PATTERN.search(self.normalized_stdout(execution))
+        if not match:
+            return False
+
+        observed_skills = tuple(
+            skill.strip().lower()
+            for skill in match.group("skills").split(",")
+            if skill.strip()
+        )
+        observed_source = match.group("source").strip().lower()
+        return observed_skills == tuple(skill.lower() for skill in expected_skills) and (
+            observed_source == expected_source.lower()
+        )
 
     def declared_skills(self, payload: Any) -> set[str]:
         if not isinstance(payload, dict):
@@ -223,6 +251,10 @@ class InstallerMetadataService:
 
     def _normalize_key(self, value: str) -> str:
         return value.replace("-", "_").lower()
+
+    @classmethod
+    def _strip_ansi(cls, text: str) -> str:
+        return cls._ANSI_ESCAPE_PATTERN.sub("", text)
 
     def _walk_key_values(self, payload: Any) -> Iterable[tuple[str, Any]]:
         if isinstance(payload, dict):

--- a/testing/tests/DMC-930/README.md
+++ b/testing/tests/DMC-930/README.md
@@ -30,7 +30,7 @@ so it does not modify the user environment.
 ## Expected output when the test passes
 
 - `pytest` reports `3 passed`
-- The installer output includes `Effective skills: jira,confluence (source: env)`
+- The installer output includes `Effective skills: jira, confluence (source: env)`
 - The install directory contains `installed-skills.json` and `endpoints.json`
 - `installed-skills.json` exposes the selected skills plus version metadata
 - `endpoints.json` includes `/dmtools/jira` and `/dmtools/confluence`

--- a/testing/tests/DMC-930/test_dmc_930.py
+++ b/testing/tests/DMC-930/test_dmc_930.py
@@ -35,11 +35,16 @@ def build_service() -> InstallerMetadataService:
 def test_dmc_930_selective_install_generates_machine_readable_metadata_files() -> None:
     service = build_service()
     run = service.run_selective_install(SELECTED_SKILLS)
+    visible_output = service.normalized_stdout(run.execution)
 
     assert run.execution.returncode == 0, service.format_execution_failure(run)
-    assert "Effective skills: jira,confluence (source: env)" in run.execution.stdout, (
+    assert service.output_reports_selected_skills(run.execution, SELECTED_SKILLS, "env"), (
         "The installer did not report the selected skills in its user-visible output.\n"
-        f"stdout:\n{run.execution.stdout}\n\nstderr:\n{run.execution.stderr}"
+        f"stdout:\n{visible_output}\n\nstderr:\n{run.execution.stderr}"
+    )
+    assert "DMTools CLI installation completed!" in visible_output, (
+        "The installer did not show the user-facing completion message after the selective "
+        f"install.\nstdout:\n{visible_output}\n\nstderr:\n{run.execution.stderr}"
     )
     assert run.installer_env_path.exists(), service.format_missing_artifact(
         run,
@@ -119,3 +124,19 @@ def test_dmc_930_payload_contains_skills_ignores_unrelated_nested_name_and_id_fi
     }
 
     assert not service.payload_contains_skills(payload, SELECTED_SKILLS)
+
+
+def test_dmc_930_output_reports_selected_skills_ignores_ansi_and_spacing() -> None:
+    service = InstallerMetadataService(REPOSITORY_ROOT, runner=_UnusedRunner())
+    execution = ProcessExecutionResult(
+        args=("bash",),
+        cwd=REPOSITORY_ROOT,
+        returncode=0,
+        stdout=(
+            "\x1b[0;32m🚀 Installing DMTools CLI...\x1b[0m\n"
+            "\x1b[0;32mEffective skills: jira, confluence (source: env)\x1b[0m\n"
+        ),
+        stderr="",
+    )
+
+    assert service.output_reports_selected_skills(execution, SELECTED_SKILLS, "env")


### PR DESCRIPTION
## DMC-930 automated test result

**Status:** PASSED

**What automation checked**

- Ran the live installer from `https://raw.githubusercontent.com/epam/dm.ai/main/install` with `DMTOOLS_SKILLS=jira,confluence` in an isolated temp installation directory.
- Verified the installer exited successfully and showed the user-visible selected-skill line `Effective skills: jira, confluence (source: env)`.
- Verified `installed-skills.json` and `endpoints.json` were created.
- Verified `installed-skills.json` contained the selected skills and version metadata.
- Verified `endpoints.json` contained `/dmtools/jira` and `/dmtools/confluence`.

**What was checked as a real user / human-style scenario**

- Reviewed the actual visible installer output, not just file existence.
- Confirmed the installer showed the selected skills, the metadata-generation message, and the success banner `DMTools CLI installation completed!`.
- Inspected the generated JSON payloads in the install directory the same way a user or downstream tooling would consume them.

**Observed**

- Installer output included `Effective skills: jira, confluence (source: env)`.
- Installer output included `Generated machine-readable installer metadata ... installed-skills.json and ... endpoints.json`.
- `installed-skills.json` contained version `v1.7.179` and installed skills `jira` and `confluence`.
- `endpoints.json` contained `/dmtools/jira` and `/dmtools/confluence`.
- Installer also showed `Warning: Installation completed but dmtools command test failed. You may need to restart your shell.`, but the required metadata files were still generated correctly.

**Expected result**

Both files exist. `installed-skills.json` contains the skill list and version info. `endpoints.json` contains entries for `/dmtools/jira` and `/dmtools/confluence`.

**Match with expected result:** Yes

**Test execution**

```text
python3 -m pytest testing/tests/DMC-930/test_dmc_930.py -q -r a
4 passed in 2.26s
```
