### PR TITLE
DMC-916 Test: Verify individual skill page structure — child pages follow mandatory template

### DIFF
--- a/testing/components/services/per_skill_page_audit_service.py
+++ b/testing/components/services/per_skill_page_audit_service.py
@@ -67,6 +67,19 @@ class PerSkillPageAuditService:
             )
             return findings
 
+        expected_child_page_paths = {
+            skill_name: self.per_skill_root / f"{skill_name}.md"
+            for skill_name in self.skill_expectations
+        }
+        actual_skill_names = {self.canonical_skill_name(page_path) for page_path in child_pages}
+        missing_skill_names = sorted(expected_child_page_paths.keys() - actual_skill_names)
+        for skill_name in missing_skill_names:
+            findings.append(
+                "Expected canonical skill child page "
+                f"{self.relative_path(expected_child_page_paths[skill_name])} to exist, "
+                f"but it is missing."
+            )
+
         for page_path in child_pages:
             findings.extend(self.audit_page(page_path))
 

--- a/testing/tests/DMC-916/test_per_skill_page_audit_service.py
+++ b/testing/tests/DMC-916/test_per_skill_page_audit_service.py
@@ -74,6 +74,21 @@ def write_page_fixture(repository_root: Path, skill_name: str, package_name: str
     return page_path
 
 
+def write_all_page_fixtures(
+    repository_root: Path,
+    excluded_skills: set[str] | None = None,
+) -> None:
+    excluded_skills = excluded_skills or set()
+    for expectation in PerSkillCatalogService.EXPECTED_SKILLS:
+        if expectation.skill_name in excluded_skills:
+            continue
+        write_page_fixture(
+            repository_root,
+            expectation.skill_name,
+            expectation.java_package,
+        )
+
+
 @pytest.mark.parametrize(
     ("skill_name", "package_name"),
     [
@@ -147,3 +162,15 @@ def test_repository_exposes_child_pages_for_each_canonical_skill() -> None:
     )
 
     assert service.child_pages() == expected_pages
+
+
+def test_audit_reports_missing_expected_child_page(tmp_path: Path) -> None:
+    repository_root = tmp_path / "repo"
+    write_all_page_fixtures(repository_root, excluded_skills={"dmtools-github"})
+
+    service = PerSkillPageAuditService(repository_root)
+
+    assert service.audit() == [
+        "Expected canonical skill child page "
+        "dmtools-ai-docs/per-skill-packages/dmtools-github.md to exist, but it is missing."
+    ]


### PR DESCRIPTION
## Summary

DMC-916 automation now validates the full per-skill child-page contract and passes against the live repository state.

## What changed

- Reused the existing DMC-916 pytest-based documentation audit under `testing/tests/DMC-916/`.
- Tightened `testing/components/services/per_skill_page_audit_service.py` so the main ticket audit fails if any canonical child page from the shared per-skill catalogue mapping is missing.
- Added focused coverage in `testing/tests/DMC-916/test_per_skill_page_audit_service.py` for the missing-child-page case.

## Automated verification

- Ran `python3 -m pytest testing/tests/DMC-916/test_dmc_916.py -q`
- Ticket result: `1 passed in 0.02s`
- Also ran `python3 -m pytest testing/tests/DMC-914 testing/tests/DMC-916 -q`
- Regression result: `12 passed in 0.06s`
- Automation verified:
  - the per-skill index exists at `dmtools-ai-docs/per-skill-packages/index.md`;
  - every canonical child page exists under `dmtools-ai-docs/per-skill-packages/`;
  - each child page contains the required sections;
  - each child page contains the expected Java package identifier and matching `/dmtools-...` slash command;
  - each child page links back to the installation guide and per-skill index.

## Human-style verification

- Opened `dmtools-ai-docs/per-skill-packages/index.md` and representative user-facing child pages `dmtools-github.md`, `dmtools-jira.md`, and `dmtools-ado.md`.
- Observed the required headings are visible in the page content, the package/slash-command text is present in the correct sections, and the `Linkbacks` section points to the installation guide and catalogue index.
- Observed behavior matched the expected result.
