### PR TITLE
DMC-954 Test: Installer log formatting for single skill — list contains no trailing or leading separators

### DIFF
--- a/testing/tests/DMC-954/README.md
+++ b/testing/tests/DMC-954/README.md
@@ -1,0 +1,30 @@
+# DMC-954 automated test
+
+This test exercises the repository `install.sh` main flow with `DMTOOLS_SKILLS=' jira '`
+and verifies that the user-visible `Effective skills` log line is normalized to a single
+skill with no leading or trailing separators.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-954/test_dmc_954.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the repository `install.sh` locally,
+isolates installation side effects in a temporary directory, and stubs download and shell
+mutation steps so the assertions stay focused on the real user-visible installer output.
+
+## Expected output when the test passes
+
+- `pytest` reports `1 passed`
+- The installer output includes `Installing DMTools CLI...`
+- The installer output includes exactly `Effective skills: jira (source: env)`
+- The installer output does not include `Effective skills: jira,` or `Effective skills: ,jira`

--- a/testing/tests/DMC-954/config.yaml
+++ b/testing/tests/DMC-954/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-954
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-954/conftest.py
+++ b/testing/tests/DMC-954/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def installer_script() -> InstallerScript:
+    return create_installer_script(REPOSITORY_ROOT)

--- a/testing/tests/DMC-954/test_dmc_954.py
+++ b/testing/tests/DMC-954/test_dmc_954.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+def test_dmc_954_single_env_skill_renders_without_extra_separators(
+    installer_script: InstallerScript,
+) -> None:
+    execution = installer_script.run_main(extra_env={"DMTOOLS_SKILLS": " jira "})
+    stdout = installer_script.normalized_stdout(execution)
+    stderr = installer_script.normalized_stderr(execution)
+
+    assert execution.returncode == 0, (
+        "The installer should succeed when DMTOOLS_SKILLS contains a single valid skill with "
+        "leading and trailing whitespace.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert "Installing DMTools CLI..." in stdout, (
+        "A user should still see the standard installer banner during the run.\n"
+        f"stdout:\n{stdout}"
+    )
+
+    effective_skill_lines = [
+        line for line in stdout.splitlines() if line.startswith("Effective skills:")
+    ]
+    assert effective_skill_lines == ["Effective skills: jira (source: env)"], (
+        "The installer should show exactly one normalized single-skill line with no leading "
+        "or trailing separators.\n"
+        f"Observed lines: {effective_skill_lines!r}\n\nstdout:\n{stdout}"
+    )
+    assert "Effective skills: jira," not in stdout, (
+        "The visible installer output must not append a trailing comma to a single skill.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Effective skills: ,jira" not in stdout, (
+        "The visible installer output must not prepend a leading comma to a single skill.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Warning: Skipping unknown skills:" not in stdout, (
+        "A valid single-skill selection should not trigger unknown-skill warnings.\n"
+        f"stdout:\n{stdout}"
+    )


### PR DESCRIPTION
# DMC-954 automated test result

**Status:** PASSED

## Automated coverage

- Executed `python3 -m pytest testing/tests/DMC-954/test_dmc_954.py testing/tests/DMC-925/test_dmc_925.py testing/tests/DMC-927/test_dmc_927.py -q`
- Result: `4 passed in 0.91s`
- Added coverage in `testing/tests/DMC-954/test_dmc_954.py`
- Verified the installer succeeds when `DMTOOLS_SKILLS=' jira '`
- Verified the visible installer banner appears
- Verified the only visible effective-skills line is exactly `Effective skills: jira (source: env)`
- Verified malformed single-skill variants such as `Effective skills: jira,` and `Effective skills: ,jira` do not appear
- Verified no unknown-skill warning is shown

## Real user-style verification

I ran the installer main flow with `DMTOOLS_SKILLS=' jira '` and observed this user-facing output:

```text
Installing DMTools CLI...
Effective skills: jira (source: env)
Effective integrations: ai,cli,file,kb,mermaid,jira
Latest version: v0.0.0-test
```

The observed behavior matched the expected result: the skill was normalized to `jira`, no leading or trailing comma was displayed, and the installer continued successfully.

## Linked bug check

- Related bug `DMC-941` regression was not reproduced.
