### PR TITLE
DMC-953 Test: Skill source precedence — CLI argument --skills overrides DMTOOLS_SKILLS variable

### DIFF
--- a/testing/components/services/installer_skill_selection_service.py
+++ b/testing/components/services/installer_skill_selection_service.py
@@ -41,6 +41,21 @@ class InstallerSkillSelectionService(InstallerSkillSelection):
             extra_env={"DMTOOLS_SKILLS": skills_csv},
         )
 
+    def resolve_with_env_and_cli(
+        self,
+        env_skills_csv: str,
+        cli_skills_csv: str,
+    ) -> InstallerSkillSelectionObservation:
+        return self._run(
+            command_label="env+cli",
+            raw_skills_input=f"env={env_skills_csv!r}; cli={cli_skills_csv!r}",
+            commands=(
+                f"parse_installer_args --skills={shlex.quote(cli_skills_csv)}",
+                "resolve_skill_selection",
+            ),
+            extra_env={"DMTOOLS_SKILLS": env_skills_csv},
+        )
+
     def resolve_with_cli(self, skills_csv: str) -> InstallerSkillSelectionObservation:
         return self._run(
             command_label="cli",

--- a/testing/core/interfaces/installer_skill_selection.py
+++ b/testing/core/interfaces/installer_skill_selection.py
@@ -14,6 +14,13 @@ class InstallerSkillSelection(Protocol):
     ) -> InstallerSkillSelectionObservation:
         raise NotImplementedError
 
+    def resolve_with_env_and_cli(
+        self,
+        env_skills_csv: str,
+        cli_skills_csv: str,
+    ) -> InstallerSkillSelectionObservation:
+        raise NotImplementedError
+
     def resolve_with_cli(
         self,
         skills_csv: str,

--- a/testing/tests/DMC-953/README.md
+++ b/testing/tests/DMC-953/README.md
@@ -1,0 +1,19 @@
+# DMC-953 automated test
+
+This test validates that the installer gives `--skills` precedence over `DMTOOLS_SKILLS` and reports the winning source in the user-visible `Effective skills` log line.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-953/test_dmc_953.py -q
+```
+
+## Environment
+
+The test runs against the checked-out `install.sh` script and enables `DMTOOLS_INSTALLER_TEST_MODE=true` through the shared installer skill-selection service so it can exercise the live argument parsing and precedence logic without performing a full installation.

--- a/testing/tests/DMC-953/config.yaml
+++ b/testing/tests/DMC-953/config.yaml
@@ -1,0 +1,15 @@
+test_id: DMC-953
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+env_skills:
+  - jira
+  - github
+cli_skills:
+  - confluence
+  - teams
+expected_effective_skills:
+  - confluence
+  - teams
+expected_skills_source: cli

--- a/testing/tests/DMC-953/test_dmc_953.py
+++ b/testing/tests/DMC-953/test_dmc_953.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_skill_selection_service_factory import (  # noqa: E402
+    create_installer_skill_selection_service,
+)
+from testing.core.interfaces.installer_skill_selection import InstallerSkillSelection  # noqa: E402
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+ENV_SKILLS = tuple(str(skill) for skill in CONFIG["env_skills"])
+CLI_SKILLS = tuple(str(skill) for skill in CONFIG["cli_skills"])
+EXPECTED_EFFECTIVE_SKILLS = tuple(str(skill) for skill in CONFIG["expected_effective_skills"])
+EXPECTED_SKILLS_SOURCE = str(CONFIG["expected_skills_source"])
+EXPECTED_EFFECTIVE_SKILLS_LINE = (
+    f"Effective skills: {', '.join(EXPECTED_EFFECTIVE_SKILLS)} "
+    f"(source: {EXPECTED_SKILLS_SOURCE})"
+)
+
+
+def build_service() -> InstallerSkillSelection:
+    return create_installer_skill_selection_service(REPOSITORY_ROOT)
+
+
+def test_dmc_953_cli_skills_override_dmtools_skills_env_var() -> None:
+    service = build_service()
+    observation = service.resolve_with_env_and_cli(
+        env_skills_csv=",".join(ENV_SKILLS),
+        cli_skills_csv=",".join(CLI_SKILLS),
+    )
+
+    assert observation.returncode == 0, service.format_execution_failure(observation)
+    assert observation.skills_source == EXPECTED_SKILLS_SOURCE, (
+        "When both DMTOOLS_SKILLS and --skills are provided, the installer must report "
+        "that the CLI argument won.\n"
+        f"Observed line: {observation.effective_skills_line!r}"
+    )
+    assert observation.effective_skills == EXPECTED_EFFECTIVE_SKILLS, (
+        "The installer must use only the CLI-provided skill list and ignore the "
+        "environment variable values.\n"
+        f"Observed line: {observation.effective_skills_line!r}\n"
+        f"Visible output:\n{observation.visible_output}"
+    )
+    assert observation.effective_skills_line == EXPECTED_EFFECTIVE_SKILLS_LINE, (
+        "The user-visible 'Effective skills' line should show the CLI skills in the "
+        "expected order with the CLI source label.\n"
+        f"Observed output:\n{observation.visible_output}"
+    )
+    for env_skill in ENV_SKILLS:
+        assert env_skill not in observation.effective_skills, (
+            "The final effective skill list must not retain any value that came only "
+            "from DMTOOLS_SKILLS after --skills overrides it.\n"
+            f"Observed line: {observation.effective_skills_line!r}"
+        )
+


### PR DESCRIPTION
# DMC-953 Test Automation Result: **FAILED**

## What was automated

- Added `testing/tests/DMC-953/test_dmc_953.py`
- Added `testing/tests/DMC-953/config.yaml`
- Added `testing/tests/DMC-953/README.md`
- Extended the shared installer skill-selection test service to run a combined `DMTOOLS_SKILLS` + `--skills` precedence scenario

## What automation checked

1. `DMTOOLS_SKILLS` was set to `jira,github`
2. The installer skill-selection flow was executed with `--skills=confluence,teams`
3. The resulting source label was `cli`
4. The effective skill list resolved to only `confluence, teams`
5. The user-visible `Effective skills` log line exactly matched `Effective skills: confluence, teams (source: cli)`

## What was checked as a real user / human-style scenario

I manually ran the live installer skill-selection flow and inspected the visible output a user would see:

```bash
DMTOOLS_INSTALLER_TEST_MODE=true DMTOOLS_SKILLS='jira,github' bash -lc 'source install.sh; parse_installer_args --skills=confluence,teams; resolve_skill_selection'
```

Observed output:

```text
Effective skills: confluence,teams (source: cli)
Effective integrations: ai,cli,file,kb,mermaid,confluence,teams,teams_auth
```

## Observed result

- CLI precedence worked: the selected skills came from `--skills`, not `DMTOOLS_SKILLS`
- The source label was correctly reported as `cli`
- The visible `Effective skills` line did **not** match the expected result because the comma-separated list was rendered without a space after the comma

**Expected**

```text
Effective skills: confluence, teams (source: cli)
```

**Actual**

```text
Effective skills: confluence,teams (source: cli)
```

## Test run result

```text
FAILED testing/tests/DMC-953/test_dmc_953.py::test_dmc_953_cli_skills_override_dmtools_skills_env_var
```

Detailed reproduction and the full assertion output are in `outputs/bug_description.md`.
