### PR TITLE
DMC-955 Installer 'Effective skills' output omits spaces between CLI-selected skills

### DIFF
--- a/install
+++ b/install
@@ -387,7 +387,7 @@ resolve_skill_selection() {
         info "Installing all skills (source: $SKILLS_SOURCE)"
     fi
     local effective_skills_display="$EFFECTIVE_SKILLS_CSV"
-    if [ "$SKILLS_SOURCE" = "env" ] && [ "$INSTALL_ALL_SKILLS" != true ]; then
+    if [ "$INSTALL_ALL_SKILLS" != true ]; then
         effective_skills_display=$(join_by_comma_space "${EFFECTIVE_SKILLS[@]}")
     fi
     info "Effective skills: $effective_skills_display (source: $SKILLS_SOURCE)"

--- a/install.sh
+++ b/install.sh
@@ -387,7 +387,7 @@ resolve_skill_selection() {
         info "Installing all skills (source: $SKILLS_SOURCE)"
     fi
     local effective_skills_display="$EFFECTIVE_SKILLS_CSV"
-    if [ "$SKILLS_SOURCE" = "env" ] && [ "$INSTALL_ALL_SKILLS" != true ]; then
+    if [ "$INSTALL_ALL_SKILLS" != true ]; then
         effective_skills_display=$(join_by_comma_space "${EFFECTIVE_SKILLS[@]}")
     fi
     info "Effective skills: $effective_skills_display (source: $SKILLS_SOURCE)"

--- a/testing/components/services/installer_cli_documentation_service.py
+++ b/testing/components/services/installer_cli_documentation_service.py
@@ -145,7 +145,7 @@ class InstallerCliDocumentationService:
         multi_skill_result = installer_script.run_main(args=("--skills=jira,github",))
         if not self._command_succeeded(
             multi_skill_result,
-            "Effective skills: jira,github (source: cli)",
+            "Effective skills: jira, github (source: cli)",
         ):
             findings.append(
                 "The installer runtime does not accept `--skills=<name,name>` as a "

--- a/testing/tests/DMC-915/test_dmc_915.py
+++ b/testing/tests/DMC-915/test_dmc_915.py
@@ -65,7 +65,7 @@ def _ticket_compliant_installer() -> FakeInstallerScript:
             ("--skills=jira,github",): _result(
                 "--skills=jira,github",
                 returncode=0,
-                stdout="Effective skills: jira,github (source: cli)\n",
+                stdout="Effective skills: jira, github (source: cli)\n",
             ),
             ("--all-skills",): _result(
                 "--all-skills",
@@ -111,7 +111,7 @@ def _runtime_without_ticket_flags() -> FakeInstallerScript:
             ("--skills=jira,github",): _result(
                 "--skills=jira,github",
                 returncode=0,
-                stdout="Effective skills: jira,github (source: cli)\n",
+                stdout="Effective skills: jira, github (source: cli)\n",
             ),
             ("--all-skills",): _result(
                 "--all-skills",

--- a/testing/tests/DMC-948/README.md
+++ b/testing/tests/DMC-948/README.md
@@ -32,7 +32,7 @@ It uses a temp directory for `HOME` so the installer writes to an isolated
 
 - `pytest` reports `1 passed`
 - The installer output includes `Installing DMTools CLI...`
-- The installer output includes `Effective skills: jira,confluence (source: env)`
+- The installer output includes `Effective skills: jira, confluence (source: env)`
 - The installer output includes `DMTools CLI installed successfully!`
 - The installer output does not include `Installation completed but dmtools command test failed`
 - The isolated `~/.dmtools` directory contains `installed-skills.json` and `endpoints.json`


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`resolve_skill_selection()` in `install.sh`/`install` formatted the visible `Effective skills` line with `join_by_comma_space` only for `DMTOOLS_SKILLS` input. The CLI `--skills` path reused the raw CSV string instead, so multi-skill selections were printed as `confluence,teams` instead of `confluence, teams`.

### Fix
Updated the installer to use the existing comma-space formatter for every non-`all` visible `Effective skills` line, regardless of whether the selection came from env or CLI. I also aligned the installer documentation/runtime audit expectations with the corrected CLI output format and fixed the related test README example.

### Test Coverage
- Reproduction test: `testing/tests/DMC-953/test_dmc_953.py` — `test_dmc_953_cli_skills_override_dmtools_skills_env_var`
- Adjacent regression test: `testing/tests/DMC-925/test_dmc_925.py`
- Full Python suite: **13 failures / 98 passed**. The remaining failures are pre-existing and unrelated to this formatting fix (`DMC-893`, `DMC-896`, `DMC-897`, `DMC-911`, `DMC-915`, `DMC-918`, `DMC-928`, `DMC-931`, `DMC-933`, `DMC-940`).

### Notes
The linked ticket scenario now reproduces the expected user-visible line: `Effective skills: confluence, teams (source: cli)`.
