### PR TITLE
DMC-959 Test: Install with mixed valid and invalid skills — installer exits non-zero and identifies invalid names

### DIFF
--- a/testing/tests/DMC-959/README.md
+++ b/testing/tests/DMC-959/README.md
@@ -1,0 +1,28 @@
+# DMC-959 automated test
+
+This test runs the repository's live `install.sh` entrypoint with a mixed
+`--skills=jira,unknown_skill_abc` CLI selection and verifies the user-visible
+failure behavior required by the ticket:
+
+1. the installer exits non-zero by default;
+2. the console output explicitly identifies `unknown_skill_abc` as invalid;
+3. the installer stops before any downstream installation side effects can start.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-959/test_dmc_959.py -q
+```
+
+## Environment
+
+No external credentials are required. The test exercises the checked-out
+`install.sh` script in `DMTOOLS_INSTALLER_TEST_MODE=true` and stubs the
+downstream installation steps so it can validate the live CLI parsing and
+error-reporting behavior without performing a real install.

--- a/testing/tests/DMC-959/config.yaml
+++ b/testing/tests/DMC-959/config.yaml
@@ -1,0 +1,7 @@
+test_id: DMC-959
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+valid_skill: jira
+invalid_skill: unknown_skill_abc

--- a/testing/tests/DMC-959/test_dmc_959.py
+++ b/testing/tests/DMC-959/test_dmc_959.py
@@ -11,6 +11,11 @@ CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
 VALID_SKILL = str(CONFIG["valid_skill"])
 INVALID_SKILL = str(CONFIG["invalid_skill"])
 EXPECTED_INVALID_FRAGMENT = f"Unknown skills: {INVALID_SKILL}"
+DOWNSTREAM_INSTALL_SIGNALS = (
+    "Creating installation directory...",
+    "Configured installer-managed skills at",
+    "stubbed download_dmtools",
+)
 
 
 def test_dmc_959_mixed_valid_and_invalid_cli_skills_fail_with_invalid_names_listed() -> None:
@@ -42,9 +47,14 @@ def test_dmc_959_mixed_valid_and_invalid_cli_skills_fail_with_invalid_names_list
         "The failure message should tell the user how to opt into warning-only behavior.\n"
         f"output:\n{combined_output}"
     )
-    assert installer_script.side_effect_marker not in combined_output, (
-        "The installer should stop before any stubbed install side effects run so a "
-        "failed mixed-skill request cannot continue into a partial installation.\n"
+    unexpected_downstream_signals = [
+        signal for signal in DOWNSTREAM_INSTALL_SIGNALS if signal in combined_output
+    ]
+    assert not unexpected_downstream_signals, (
+        "The installer should stop at skill validation before any repository installer "
+        "signals for directory creation, persisted skill state, or download stubs appear, "
+        "so a failed mixed-skill request cannot continue into a partial installation.\n"
+        f"unexpected signals: {unexpected_downstream_signals}\n\n"
         f"output:\n{combined_output}"
     )
     assert "Effective skills:" not in stdout, (

--- a/testing/tests/DMC-959/test_dmc_959.py
+++ b/testing/tests/DMC-959/test_dmc_959.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+from testing.core.utils.ticket_config_loader import load_ticket_config
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+VALID_SKILL = str(CONFIG["valid_skill"])
+INVALID_SKILL = str(CONFIG["invalid_skill"])
+EXPECTED_INVALID_FRAGMENT = f"Unknown skills: {INVALID_SKILL}"
+
+
+def test_dmc_959_mixed_valid_and_invalid_cli_skills_fail_with_invalid_names_listed() -> None:
+    installer_script: InstallerScript = create_installer_script(REPOSITORY_ROOT)
+
+    execution = installer_script.run_main(args=(f"--skills={VALID_SKILL},{INVALID_SKILL}",))
+    stdout = installer_script.normalized_stdout(execution)
+    stderr = installer_script.normalized_stderr(execution)
+    combined_output = installer_script.normalized_combined_output(execution)
+
+    assert execution.returncode != 0, (
+        "The installer must exit non-zero when a CLI skill list mixes a valid skill "
+        "with an unknown skill and --skip-unknown is not provided.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert "Installing DMTools CLI..." in stdout, (
+        "A user should still see the installer start banner before validation fails.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert EXPECTED_INVALID_FRAGMENT in combined_output, (
+        "The user-visible output must explicitly identify the invalid skill name.\n"
+        f"output:\n{combined_output}"
+    )
+    assert INVALID_SKILL in combined_output, (
+        "The exact invalid skill requested by the user should appear in the failure output.\n"
+        f"output:\n{combined_output}"
+    )
+    assert "--skip-unknown" in combined_output, (
+        "The failure message should tell the user how to opt into warning-only behavior.\n"
+        f"output:\n{combined_output}"
+    )
+    assert installer_script.side_effect_marker not in combined_output, (
+        "The installer should stop before any stubbed install side effects run so a "
+        "failed mixed-skill request cannot continue into a partial installation.\n"
+        f"output:\n{combined_output}"
+    )
+    assert "Effective skills:" not in stdout, (
+        "The installer must not report a successful effective skill selection after "
+        "rejecting the mixed CLI request.\n"
+        f"stdout:\n{stdout}"
+    )


### PR DESCRIPTION
# DMC-959 Automation Result: PASSED

## Automated coverage
- Executed `python3 -m pytest testing/tests/DMC-959/test_dmc_959.py -q`
- Result: **1 passed, 0 failed**
- Verified that `bash install.sh --skills=jira,unknown_skill_abc` exits non-zero by default.
- Verified that the live installer output explicitly identifies `unknown_skill_abc` as invalid and tells the user to use `--skip-unknown` for warning-only behavior.
- Verified that no successful `Effective skills:` line is shown after the rejection and that the run stops before installer side effects continue.

## Real user-style verification
- Re-ran the mixed-skill command against the live `install.sh` flow through the shared installer harness.
- Observed console output:

```text
🚀 Installing DMTools CLI...
Error: Unknown skills: unknown_skill_abc. Use --skip-unknown to continue.
```

- Observed exit status: `1`
- From a user perspective, the installer starts, clearly identifies the invalid skill, and does not present a successful or partial installation state.

## Conclusion
The observed behavior matches the expected result for DMC-959.
