### PR TITLE
DMC-956 Test: Run installer with --skill flag — flag is accepted and processed

### DIFF
--- a/testing/tests/DMC-956/README.md
+++ b/testing/tests/DMC-956/README.md
@@ -1,0 +1,30 @@
+# DMC-956 automated test
+
+This test validates that the skill installer accepts `--skill jira`, reports the
+selected skill in the user-visible output, and continues into the installation
+flow without surfacing an unknown-option error.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-956/test_dmc_956.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the checked-out
+`dmtools-ai-docs/install.sh` entry point with the live argument parsing logic and
+stubs downstream installation side effects so it can safely verify the deployed
+CLI contract.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-956/config.yaml
+++ b/testing/tests/DMC-956/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-956
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-956/test_dmc_956.py
+++ b/testing/tests/DMC-956/test_dmc_956.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_956_skill_flag_is_accepted_and_processed_for_single_skill_install() -> None:
+    installer_script: InstallerScript = create_installer_script(
+        REPOSITORY_ROOT,
+        "dmtools-ai-docs/install.sh",
+    )
+
+    execution = installer_script.run_main(args=("--skill", "jira"))
+    combined_output = installer_script.normalized_combined_output(execution)
+
+    assert execution.returncode == 0, (
+        "Expected `bash install.sh --skill jira` to succeed for the skill installer.\n"
+        f"Observed output:\n{combined_output}"
+    )
+    assert "Effective skills: jira (source: cli)" in combined_output, (
+        "The installer should tell the user that `jira` became the effective skill "
+        "selection from the CLI.\n"
+        f"Observed output:\n{combined_output}"
+    )
+    assert "Unknown installer option" not in combined_output, (
+        "The user-visible logs must not report `--skill` as an unknown option.\n"
+        f"Observed output:\n{combined_output}"
+    )
+    assert installer_script.side_effect_marker in combined_output, (
+        "The installer should continue into the installation flow after accepting "
+        "`--skill jira`, which proves the flag was processed rather than ignored.\n"
+        f"Observed output:\n{combined_output}"
+    )


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-956 — Run installer with --skill flag — flag is accepted and processed

## What was automated
- Added `testing/tests/DMC-956/test_dmc_956.py` plus ticket metadata files under `testing/tests/DMC-956/`.
- Reused the shared installer component to execute the live `dmtools-ai-docs/install.sh` flow with `--skill jira`.
- Verified exit code `0`, the visible `Effective skills: jira (source: cli)` log, absence of unknown-option errors, and continued installation flow.

## Result
- Automation passed: `python3 -m pytest testing/tests/DMC-956/test_dmc_956.py -q` reported `1 passed`.
- Human-style verification passed: the installer banner, `Effective skills: jira (source: cli)`, `Selected skill packages: dmtools-jira`, and the success summary were all shown to the user in the expected order.

## How to run
```bash
python3 -m pytest testing/tests/DMC-956/test_dmc_956.py -q
```
