### PR TITLE
DMC-958 Test: Run installer with --skills= syntax alias — comma-separated list is parsed correctly

### DIFF
--- a/testing/tests/DMC-958/README.md
+++ b/testing/tests/DMC-958/README.md
@@ -1,0 +1,19 @@
+# DMC-958 automated test
+
+This test verifies that the root `install.sh` installer accepts the `--skills=<name,name>` alias, exits successfully, and shows the expected user-visible `Effective skills` line.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-958/test_dmc_958.py -q
+```
+
+## Environment
+
+The test runs against the checked-out root `install.sh` script and enables `DMTOOLS_INSTALLER_TEST_MODE=true` through the shared installer script service so it can exercise the live installer flow without performing a real installation.

--- a/testing/tests/DMC-958/config.yaml
+++ b/testing/tests/DMC-958/config.yaml
@@ -10,6 +10,7 @@ expected_effective_skills:
   - github
 expected_skills_source: cli
 expected_banner_fragment: Installing DMTools CLI...
+expected_continuation_fragment: Configured installer-managed skills at
 forbidden_output_fragments:
   - Unknown installer option
   - invalid option

--- a/testing/tests/DMC-958/config.yaml
+++ b/testing/tests/DMC-958/config.yaml
@@ -1,0 +1,15 @@
+test_id: DMC-958
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+installer_args:
+  - --skills=jira,github
+expected_effective_skills:
+  - jira
+  - github
+expected_skills_source: cli
+expected_banner_fragment: Installing DMTools CLI...
+forbidden_output_fragments:
+  - Unknown installer option
+  - invalid option

--- a/testing/tests/DMC-958/test_dmc_958.py
+++ b/testing/tests/DMC-958/test_dmc_958.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_958_installer_accepts_skills_equals_alias() -> None:
+    installer_script: InstallerScript = create_installer_script(REPOSITORY_ROOT)
+
+    execution = installer_script.run_main(args=("--skills=jira,github",))
+    stdout = installer_script.normalized_stdout(execution)
+    stderr = installer_script.normalized_stderr(execution)
+    combined_output = installer_script.normalized_combined_output(execution)
+
+    assert execution.returncode == 0, (
+        "The installer should accept the equals-sign --skills alias without treating it "
+        "as an unsupported option.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert "Installing DMTools CLI..." in stdout, (
+        "The installer should show the normal user-visible startup banner when the "
+        "--skills=<name,name> alias is used.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Effective skills: jira, github (source: cli)" in stdout, (
+        "The user-visible effective skills line should list both skills parsed from "
+        "the equals-sign alias in the original order.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Unknown installer option" not in combined_output, (
+        "The installer must not reject --skills=<name,name> as an unknown option.\n"
+        f"output:\n{combined_output}"
+    )
+    assert "invalid option" not in combined_output.lower(), (
+        "The installer must not surface an invalid-option error for the equals-sign "
+        "--skills alias.\n"
+        f"output:\n{combined_output}"
+    )

--- a/testing/tests/DMC-958/test_dmc_958.py
+++ b/testing/tests/DMC-958/test_dmc_958.py
@@ -19,6 +19,7 @@ INSTALLER_ARGS = tuple(str(argument) for argument in CONFIG["installer_args"])
 EXPECTED_EFFECTIVE_SKILLS = tuple(str(skill) for skill in CONFIG["expected_effective_skills"])
 EXPECTED_SKILLS_SOURCE = str(CONFIG["expected_skills_source"])
 EXPECTED_BANNER_FRAGMENT = str(CONFIG["expected_banner_fragment"])
+EXPECTED_CONTINUATION_FRAGMENT = str(CONFIG["expected_continuation_fragment"])
 FORBIDDEN_OUTPUT_FRAGMENTS = tuple(str(fragment) for fragment in CONFIG["forbidden_output_fragments"])
 EXPECTED_EFFECTIVE_SKILLS_LINE = (
     f"Effective skills: {', '.join(EXPECTED_EFFECTIVE_SKILLS)} "
@@ -47,6 +48,12 @@ def test_dmc_958_installer_accepts_skills_equals_alias() -> None:
     assert EXPECTED_EFFECTIVE_SKILLS_LINE in stdout, (
         "The user-visible effective skills line should list both skills parsed from "
         "the equals-sign alias in the original order.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert EXPECTED_CONTINUATION_FRAGMENT in stdout, (
+        "The installer should continue into the real installation flow after "
+        "accepting --skills=<name,name>, which proves the alias was processed "
+        "instead of printing the banner and exiting early.\n"
         f"stdout:\n{stdout}"
     )
     normalized_output = combined_output.lower()

--- a/testing/tests/DMC-958/test_dmc_958.py
+++ b/testing/tests/DMC-958/test_dmc_958.py
@@ -1,16 +1,35 @@
-from pathlib import Path
+from __future__ import annotations
 
-from testing.components.factories.installer_script_factory import create_installer_script
-from testing.core.interfaces.installer_script import InstallerScript
+import sys
+from pathlib import Path
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_script_factory import create_installer_script  # noqa: E402
+from testing.core.interfaces.installer_script import InstallerScript  # noqa: E402
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+INSTALLER_ARGS = tuple(str(argument) for argument in CONFIG["installer_args"])
+EXPECTED_EFFECTIVE_SKILLS = tuple(str(skill) for skill in CONFIG["expected_effective_skills"])
+EXPECTED_SKILLS_SOURCE = str(CONFIG["expected_skills_source"])
+EXPECTED_BANNER_FRAGMENT = str(CONFIG["expected_banner_fragment"])
+FORBIDDEN_OUTPUT_FRAGMENTS = tuple(str(fragment) for fragment in CONFIG["forbidden_output_fragments"])
+EXPECTED_EFFECTIVE_SKILLS_LINE = (
+    f"Effective skills: {', '.join(EXPECTED_EFFECTIVE_SKILLS)} "
+    f"(source: {EXPECTED_SKILLS_SOURCE})"
+)
 
 
 def test_dmc_958_installer_accepts_skills_equals_alias() -> None:
     installer_script: InstallerScript = create_installer_script(REPOSITORY_ROOT)
 
-    execution = installer_script.run_main(args=("--skills=jira,github",))
+    execution = installer_script.run_main(args=INSTALLER_ARGS)
     stdout = installer_script.normalized_stdout(execution)
     stderr = installer_script.normalized_stderr(execution)
     combined_output = installer_script.normalized_combined_output(execution)
@@ -20,22 +39,22 @@ def test_dmc_958_installer_accepts_skills_equals_alias() -> None:
         "as an unsupported option.\n"
         f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
     )
-    assert "Installing DMTools CLI..." in stdout, (
+    assert EXPECTED_BANNER_FRAGMENT in stdout, (
         "The installer should show the normal user-visible startup banner when the "
         "--skills=<name,name> alias is used.\n"
         f"stdout:\n{stdout}"
     )
-    assert "Effective skills: jira, github (source: cli)" in stdout, (
+    assert EXPECTED_EFFECTIVE_SKILLS_LINE in stdout, (
         "The user-visible effective skills line should list both skills parsed from "
         "the equals-sign alias in the original order.\n"
         f"stdout:\n{stdout}"
     )
-    assert "Unknown installer option" not in combined_output, (
-        "The installer must not reject --skills=<name,name> as an unknown option.\n"
-        f"output:\n{combined_output}"
-    )
-    assert "invalid option" not in combined_output.lower(), (
-        "The installer must not surface an invalid-option error for the equals-sign "
-        "--skills alias.\n"
-        f"output:\n{combined_output}"
-    )
+    normalized_output = combined_output.lower()
+    for forbidden_fragment in FORBIDDEN_OUTPUT_FRAGMENTS:
+        candidate_output = normalized_output if forbidden_fragment.islower() else combined_output
+        assert forbidden_fragment not in candidate_output, (
+            "The installer must not reject --skills=<name,name> while parsing the "
+            "equals-sign alias.\n"
+            f"Forbidden fragment: {forbidden_fragment!r}\n"
+            f"output:\n{combined_output}"
+        )


### PR DESCRIPTION
# DMC-958 Test Result: PASSED

**Automation checked**
- Ran `python3 -m pytest testing/tests/DMC-958/test_dmc_958.py -q`
- Verified the root installer flow for `bash install.sh --skills=jira,github`
- Verified exit code `0`
- Verified the visible line `Effective skills: jira, github (source: cli)`
- Verified no unknown-option or invalid-option error was shown

**Human-style verification checked**
- Observed the installer banner `🚀 Installing DMTools CLI...`
- Observed the effective-skills feedback in the normal visible installer output
- Observed the installer continue through installation steps after parsing the alias, including installation directory creation and metadata generation

**Observed result**
```text
🚀 Installing DMTools CLI...
Effective skills: jira, github (source: cli)
Effective integrations: ai,cli,file,kb,mermaid,jira,github
...
Generated machine-readable installer metadata at /tmp/.../installed-skills.json and /tmp/.../endpoints.json
```

**Match against expected result**
- Yes. The installer parsed both skills from the `--skills=` alias, completed successfully, and showed the expected user-facing effective-skills line without rejecting the syntax.
