### PR TITLE
DMC-957 Test: Run installer with --all-skills flag — flag is accepted and all skills are installed

### DIFF
--- a/testing/tests/DMC-957/README.md
+++ b/testing/tests/DMC-957/README.md
@@ -1,0 +1,23 @@
+# DMC-957 automated test
+
+This test exercises the repository `install.sh` runtime with `--all-skills` and verifies
+that the live installer accepts the flag, surfaces the all-skills banner, and reports the
+full canonical skill list in the user-visible terminal output.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-957/test_dmc_957.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the repository `install.sh` locally in
+installer test mode, stubs external download/shell-mutation operations, and inspects the
+visible CLI output plus the generated installer skill config.

--- a/testing/tests/DMC-957/config.yaml
+++ b/testing/tests/DMC-957/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-957
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-957/conftest.py
+++ b/testing/tests/DMC-957/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from testing.components.factories.installer_script_factory import create_installer_script
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture
+def installer_script() -> InstallerScript:
+    return create_installer_script(REPOSITORY_ROOT)

--- a/testing/tests/DMC-957/test_dmc_957.py
+++ b/testing/tests/DMC-957/test_dmc_957.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from testing.core.interfaces.installer_script import InstallerScript
+
+
+_PROBE_PREFIX = "__DMC_957__:"
+_INSTALLER_ENV_LINE_KEY = "installer_env_line"
+
+
+def _probe_script() -> str:
+    return f"""
+if [ -f "$INSTALLER_ENV_PATH" ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+        printf '{_PROBE_PREFIX}{_INSTALLER_ENV_LINE_KEY}=%s\\n' "$line"
+    done < "$INSTALLER_ENV_PATH"
+fi
+""".strip()
+
+
+def _parse_probe_output(stdout: str) -> tuple[str, dict[str, str]]:
+    visible_lines: list[str] = []
+    installer_env: dict[str, str] = {}
+
+    for line in stdout.splitlines():
+        if not line.startswith(_PROBE_PREFIX):
+            visible_lines.append(line)
+            continue
+
+        key, _, value = line[len(_PROBE_PREFIX) :].partition("=")
+        if key != _INSTALLER_ENV_LINE_KEY:
+            continue
+
+        env_key, _, env_value = value.partition("=")
+        if env_key:
+            installer_env[env_key] = env_value.strip().strip('"')
+
+    return "\n".join(visible_lines).strip(), installer_env
+
+
+def test_dmc_957_all_skills_flag_installs_all_canonical_skills(
+    installer_script: InstallerScript,
+) -> None:
+    execution = installer_script.run_main(
+        args=("--all-skills",),
+        post_script=_probe_script(),
+    )
+    stdout, installer_env = _parse_probe_output(
+        installer_script.normalized_stdout(execution)
+    )
+    stderr = installer_script.normalized_stderr(execution)
+    expected_skills_csv = installer_script.available_skills_csv
+    expected_effective_skills_line = (
+        f"Effective skills: {expected_skills_csv} (source: cli)"
+    )
+    effective_skill_lines = [
+        line for line in stdout.splitlines() if line.startswith("Effective skills:")
+    ]
+
+    assert execution.returncode == 0, (
+        "The installer should accept --all-skills and complete successfully.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+    assert not stderr, (
+        "A successful --all-skills run should not emit user-visible stderr output.\n"
+        f"stderr:\n{stderr}"
+    )
+    assert "Installing DMTools CLI..." in stdout, (
+        "A user should see the standard installer banner before the all-skills selection "
+        "is processed.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Installing all skills (source: cli)" in stdout, (
+        "The installer should visibly confirm that the --all-skills toggle was accepted.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert effective_skill_lines == [expected_effective_skills_line], (
+        "The user-visible 'Effective skills' output should contain exactly one line with "
+        "the full canonical skill list in installer order.\n"
+        f"Observed lines: {effective_skill_lines!r}\n\nstdout:\n{stdout}"
+    )
+    assert "Warning:" not in stdout, (
+        "A valid all-skills selection should not surface warning banners.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Error:" not in stdout, (
+        "A passing all-skills flow should not surface error banners in the visible output.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert "Configured installer-managed skills at" in stdout, (
+        "A successful all-skills run should report where the generated installer skill "
+        "configuration was written.\n"
+        f"stdout:\n{stdout}"
+    )
+    assert installer_env.get("DMTOOLS_SKILLS") == expected_skills_csv, (
+        "The generated installer configuration should persist the full canonical skill list "
+        "after an --all-skills run.\n"
+        f"installer_env: {installer_env}"
+    )


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-957 — Run installer with `--all-skills` flag — flag is accepted and all skills are installed

## What was automated
- Ran the live repository `install.sh` flow with `--all-skills` through the shared installer harness in test mode.
- Verified the visible CLI output includes `Installing DMTools CLI...`, `Installing all skills (source: cli)`, and exactly one `Effective skills: dmtools,jira,confluence,github,gitlab,figma,teams,sharepoint,ado,testrail,xray (source: cli)` line.
- Verified the generated installer-managed env file persisted the same canonical `DMTOOLS_SKILLS` CSV after the run.

## Result
- The command finished with exit code `0` and no stderr output.
- Human-style verification of the terminal output matched the expected user experience: the all-skills banner and full canonical skill list were shown in the correct visible CLI state.
- Observed behavior matched the expected result.

## How to run
```bash
python3 -m pytest testing/tests/DMC-957/test_dmc_957.py -q
```
