### PR TITLE
DMC-908 Test: Invoke deprecated 'codegenerator' job — shim returns success with deprecation warning

### DIFF
--- a/testing/tests/DMC-908/deprecated-codegenerator-run-compatibility.test.js
+++ b/testing/tests/DMC-908/deprecated-codegenerator-run-compatibility.test.js
@@ -23,7 +23,7 @@ function formatResultDetails(label, result) {
 }
 
 function verifyUserFacingRuntimeCommand(service, failures) {
-  const result = service.runDmtools(['run', 'codegenerator', '--param1', 'test']);
+  const result = service.runDmtools(['run', 'codegenerator', '--param1=test']);
   const visibleOutput = service.combinedOutput(result);
 
   expectEqual(


### PR DESCRIPTION
# DMC-908: PASSED

## What changed
- Reused the existing DMC-908 CLI automation.
- Updated the wrapper invocation to use the exact ticket syntax: `./dmtools.sh run codegenerator --param1=test`.

## Automation coverage
- Runs `node testing/tests/DMC-908/deprecated-codegenerator-run-compatibility.test.js`.
- Executes the ticket command with the exact `--param1=test` argument form.
- Verifies exit code `0`.
- Verifies visible console output includes:
  - `deprecated`
  - removal version `1.8.0`
  - the compatibility shim success response
  - `No action was taken and no code artifacts were produced.`
- Verifies the wrapper does not treat `codegenerator` as a missing config file.
- Verifies the underlying `codegenerator` compatibility shim still returns the exact no-op result through direct `JobRunner` execution using a fat JAR built from the current checkout.

## Real user-style verification
I ran the same user-facing command and checked the visible console output a user would see. Because this shared runner has a stale `~/.dmtools/dmtools.jar`, I used an isolated temporary `HOME` so the command exercised the checkout-built main artifact under test instead of unrelated local state.

Observed output:

```text
Info: Executing job with file: codegenerator
CodeGenerator is deprecated and now runs as a compatibility shim. No code will be generated. Migrate to supported workflows before v1.8.0.
[
  {
    "key": "CodeGenerator",
    "result": "CodeGenerator compatibility shim executed successfully. No action was taken and no code artifacts were produced."
  }
]
```

Observed result:
- The deprecation warning was visible.
- The removal version `1.8.0` was visible.
- The compatibility shim no-op success response was visible.
- Exit code was `0`.

This matched the expected result.

## Environment
- Repository root: `/home/runner/work/dm.ai/dm.ai`
- Script: `./dmtools.sh`
- OS: `Linux 6.17.0-1010-azure #10~24.04.1-Ubuntu SMP Fri Mar 6 22:00:57 UTC 2026 x86_64 GNU/Linux`
- Node.js: `v20.20.2`
- Java: `openjdk version "17.0.18" 2026-01-20`
