### PR TITLE
DMC-915 Test: Validate installer CLI syntax documentation — selection flags and error behavior described

### DIFF
--- a/testing/components/services/installer_cli_documentation_service.py
+++ b/testing/components/services/installer_cli_documentation_service.py
@@ -38,12 +38,14 @@ class InstallerCliDocumentationService:
         self,
         repository_root: Path,
         installer_script: InstallerScript | None = None,
+        install_script_relative_path: str | Path = "dmtools-ai-docs/install.sh",
     ) -> None:
         self.repository_root = repository_root
         self.installation_readme_path = (
             repository_root / "dmtools-ai-docs/references/installation/README.md"
         )
-        self.install_script_path = repository_root / "install.sh"
+        self.install_script_relative_path = Path(install_script_relative_path)
+        self.install_script_path = repository_root / self.install_script_relative_path
         self.installer_script = installer_script
 
     def audit_installation_readme(self) -> list[str]:
@@ -59,6 +61,7 @@ class InstallerCliDocumentationService:
             "selection flags and invalid-skill behavior, and for the installer to "
             "actually support the documented contract.",
             f"Checked file: {self.installation_readme_path.relative_to(self.repository_root)}",
+            f"Checked installer: {self.install_script_relative_path.as_posix()}",
             "",
             "Missing or incomplete expectations:",
             *[f"- {finding}" for finding in findings],
@@ -145,7 +148,7 @@ class InstallerCliDocumentationService:
         multi_skill_result = installer_script.run_main(args=("--skills=jira,github",))
         if not self._command_succeeded(
             multi_skill_result,
-            "Effective skills: jira, github (source: cli)",
+            "Effective skills: jira,github (source: cli)",
         ):
             findings.append(
                 "The installer runtime does not accept `--skills=<name,name>` as a "
@@ -203,28 +206,32 @@ class InstallerCliDocumentationService:
     def _format_runtime_observations(self) -> list[str]:
         installer_script = self._installer_script()
         if installer_script is None:
-            return [f"  install.sh missing at {self.install_script_path}"]
+            return [
+                f"  {self.install_script_relative_path.as_posix()} missing at "
+                f"{self.install_script_path}"
+            ]
 
+        install_command = f"bash {self.install_script_relative_path.as_posix()}"
         observations = [
-            ("bash install.sh --skill jira", installer_script.run_main(args=("--skill", "jira"))),
+            (f"{install_command} --skill jira", installer_script.run_main(args=("--skill", "jira"))),
             (
-                "bash install.sh --skills=jira,github",
+                f"{install_command} --skills=jira,github",
                 installer_script.run_main(args=("--skills=jira,github",)),
             ),
             (
-                "bash install.sh --all-skills",
+                f"{install_command} --all-skills",
                 installer_script.run_main(args=("--all-skills",)),
             ),
             (
-                "bash install.sh --skills=jira,unknown",
+                f"{install_command} --skills=jira,unknown",
                 installer_script.run_main(args=("--skills=jira,unknown",)),
             ),
             (
-                "bash install.sh --skills=jira,unknown --skip-unknown",
+                f"{install_command} --skills=jira,unknown --skip-unknown",
                 installer_script.run_main(args=("--skills=jira,unknown", "--skip-unknown")),
             ),
             (
-                "bash install.sh --skill unknown",
+                f"{install_command} --skill unknown",
                 installer_script.run_main(args=("--skill", "unknown")),
             ),
         ]
@@ -238,7 +245,10 @@ class InstallerCliDocumentationService:
             return self.installer_script
         if not self.install_script_path.exists():
             return None
-        self.installer_script = create_installer_script(self.repository_root)
+        self.installer_script = create_installer_script(
+            self.repository_root,
+            self.install_script_relative_path,
+        )
         return self.installer_script
 
     def _observed_section(self) -> str | None:

--- a/testing/tests/DMC-915/README.md
+++ b/testing/tests/DMC-915/README.md
@@ -2,7 +2,7 @@
 
 This test validates both sides of the DMC-915 contract:
 1. `dmtools-ai-docs/references/installation/README.md` documents `--skill <name>` as the primary form, `--skills=<name,name>` as an alias, `--all-skills`, `--skip-unknown`, and explicit invalid-skill behavior.
-2. `install.sh` actually supports the same commands and failure/warning behavior so the documentation cannot pass while describing unsupported syntax.
+2. `dmtools-ai-docs/install.sh` actually supports the same commands and failure/warning behavior so the documentation cannot pass while describing unsupported syntax.
 
 ## Install dependencies
 

--- a/testing/tests/DMC-915/test_dmc_915.py
+++ b/testing/tests/DMC-915/test_dmc_915.py
@@ -65,7 +65,7 @@ def _ticket_compliant_installer() -> FakeInstallerScript:
             ("--skills=jira,github",): _result(
                 "--skills=jira,github",
                 returncode=0,
-                stdout="Effective skills: jira, github (source: cli)\n",
+                stdout="Effective skills: jira,github (source: cli)\n",
             ),
             ("--all-skills",): _result(
                 "--all-skills",
@@ -111,7 +111,7 @@ def _runtime_without_ticket_flags() -> FakeInstallerScript:
             ("--skills=jira,github",): _result(
                 "--skills=jira,github",
                 returncode=0,
-                stdout="Effective skills: jira, github (source: cli)\n",
+                stdout="Effective skills: jira,github (source: cli)\n",
             ),
             ("--all-skills",): _result(
                 "--all-skills",
@@ -314,7 +314,7 @@ def test_dmc_915_format_findings_handles_missing_section(tmp_path: Path) -> None
     assert "Observed 'Install Only the Skills You Need' section:" in formatted
     assert "  (section missing)" in formatted
     assert "Observed installer behavior:" in formatted
-    assert "bash install.sh --skill jira -> exit 0;" in formatted
+    assert "bash dmtools-ai-docs/install.sh --skill jira -> exit 0;" in formatted
 
 
 def test_dmc_915_keeps_code_block_comments_inside_extracted_section(


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-915 — Validate installer CLI syntax documentation — selection flags and error behavior described

### Automated verification
- Ran `python3 -m pytest testing/tests/DMC-915/test_dmc_915.py -q` → `6 passed`.
- Updated the DMC-915 automation to validate the documented runtime against `dmtools-ai-docs/install.sh`, which is the installer referenced by the ticket documentation and linked bug.
- The automated assertions verify:
  - the visible `Install Only the Skills You Need` section in `dmtools-ai-docs/references/installation/README.md`;
  - documentation for `--skill <name>`, `--skills=<name,name>`, `--all-skills`, and `--skip-unknown`;
  - the invalid-skill contract: mixed valid+invalid input fails without `--skip-unknown` and becomes a warning-backed success with `--skip-unknown`;
  - regression coverage for missing sections and fenced code blocks.

### Human-style verification
- Read the installer guide section as a user would and confirmed the examples and explanatory text are present in the expected section, not just elsewhere in the file.
- Ran `bash dmtools-ai-docs/install.sh --help` and confirmed the user-facing help lists:
  - `--skill <name>`
  - `--skills=<csv>`
  - `--all-skills`
  - `--skip-unknown`
- Ran the ticket flows directly:

```bash
bash dmtools-ai-docs/install.sh --skill jira
bash dmtools-ai-docs/install.sh --skills=jira,github
bash dmtools-ai-docs/install.sh --all-skills
bash dmtools-ai-docs/install.sh --skills=jira,unknown
bash dmtools-ai-docs/install.sh --skills=jira,unknown --skip-unknown
```

- Observed behavior:
  - `--skills=jira,unknown` shows `Unknown skills: unknown. Use --skip-unknown to continue.`
  - `--skills=jira,unknown --skip-unknown` shows `Warning: Skipping unknown skills: unknown` and continues into the install flow.
  - `--skill jira`, `--skills=jira,github`, and `--all-skills` are accepted and advance into the install flow instead of failing with unknown-option errors.
- In this checkout, the direct install commands later stop on release-asset/download/extraction limitations, but that happens after flag parsing and selection handling; the DMC-915 contract being tested here is the documented syntax and invalid-skill behavior, and that behavior matched the expected result.

### Files updated
- `testing/components/services/installer_cli_documentation_service.py`
- `testing/tests/DMC-915/test_dmc_915.py`
- `testing/tests/DMC-915/README.md`
