### PR TITLE
DMC-962 Test: Mixed selective reinstall — artifacts and metadata correctly synced for additions and removals

### DIFF
--- a/testing/components/services/skill_installer_service.py
+++ b/testing/components/services/skill_installer_service.py
@@ -35,14 +35,18 @@ class SkillSelectionAuditResult:
     metadata_path: str
     retained_skill: str
     removed_skill: str
+    selected_skills: tuple[str, ...]
+    added_skill: str | None
     initial_retained_state: SkillDirectoryState
     initial_removed_state: SkillDirectoryState
+    initial_added_state: SkillDirectoryState | None
     initial_metadata_exists: bool
     initial_metadata_raw: str | None
     initial_metadata: InstalledSkillsMetadata | None
     initial_parse_error: str | None
     final_retained_state: SkillDirectoryState
     final_removed_state: SkillDirectoryState
+    final_added_state: SkillDirectoryState | None
     final_metadata_exists: bool
     final_metadata_raw: str | None
     final_metadata: InstalledSkillsMetadata | None
@@ -83,13 +87,42 @@ class SkillInstallerService:
         retained_skill: str = "jira",
         removed_skill: str = "github",
     ) -> SkillSelectionAuditResult:
+        return self._run_skill_transition(
+            retained_skill=retained_skill,
+            removed_skill=removed_skill,
+            selected_skills=(retained_skill,),
+            added_skill=None,
+        )
+
+    def run_selective_skill_transition(
+        self,
+        *,
+        retained_skill: str = "jira",
+        removed_skill: str = "github",
+        added_skill: str = "confluence",
+    ) -> SkillSelectionAuditResult:
+        return self._run_skill_transition(
+            retained_skill=retained_skill,
+            removed_skill=removed_skill,
+            selected_skills=(retained_skill, added_skill),
+            added_skill=added_skill,
+        )
+
+    def _run_skill_transition(
+        self,
+        *,
+        retained_skill: str,
+        removed_skill: str,
+        selected_skills: tuple[str, ...],
+        added_skill: str | None,
+    ) -> SkillSelectionAuditResult:
         sandbox = self._sandbox_factory(self.repository_root)
         try:
             installer_path = sandbox.workspace / self.INSTALLER_RELATIVE_PATH
             skills_root = sandbox.workspace / self.SKILLS_ROOT_RELATIVE_PATH
             metadata_path = skills_root / "installed-skills.json"
 
-            self._prepare_fake_release_environment(sandbox, retained_skill)
+            self._prepare_fake_release_environment(sandbox, selected_skills)
             self._seed_installed_skills(
                 skills_root=skills_root,
                 retained_skill=retained_skill,
@@ -108,13 +141,18 @@ class SkillInstallerService:
             initial_removed_state = self._directory_state(
                 skills_root / self.skill_install_name(removed_skill)
             )
+            initial_added_state = (
+                self._directory_state(skills_root / self.skill_install_name(added_skill))
+                if added_skill is not None
+                else None
+            )
 
             installer_command_result = sandbox.run(
                 self._build_installer_command(
                     installer_path=installer_path,
                     fake_bin_dir=sandbox.workspace.parent / "fake-bin",
                     fake_release_dir=sandbox.workspace.parent / "fake-releases",
-                    selected_skill=retained_skill,
+                    selected_skills=selected_skills,
                 )
             )
 
@@ -133,8 +171,11 @@ class SkillInstallerService:
                 metadata_path=metadata_path.as_posix(),
                 retained_skill=retained_skill,
                 removed_skill=removed_skill,
+                selected_skills=selected_skills,
+                added_skill=added_skill,
                 initial_retained_state=initial_retained_state,
                 initial_removed_state=initial_removed_state,
+                initial_added_state=initial_added_state,
                 initial_metadata_exists=initial_metadata_exists,
                 initial_metadata_raw=initial_metadata_raw,
                 initial_metadata=initial_metadata,
@@ -144,6 +185,11 @@ class SkillInstallerService:
                 ),
                 final_removed_state=self._directory_state(
                     skills_root / self.skill_install_name(removed_skill)
+                ),
+                final_added_state=(
+                    self._directory_state(skills_root / self.skill_install_name(added_skill))
+                    if added_skill is not None
+                    else None
                 ),
                 final_metadata_exists=final_metadata_exists,
                 final_metadata_raw=final_metadata_raw,
@@ -157,6 +203,18 @@ class SkillInstallerService:
         self,
         result: SkillSelectionAuditResult,
     ) -> list[SkillSelectionAuditFailure]:
+        return self._validate_skill_transition(result)
+
+    def validate_selective_transition(
+        self,
+        result: SkillSelectionAuditResult,
+    ) -> list[SkillSelectionAuditFailure]:
+        return self._validate_skill_transition(result)
+
+    def _validate_skill_transition(
+        self,
+        result: SkillSelectionAuditResult,
+    ) -> list[SkillSelectionAuditFailure]:
         failures: list[SkillSelectionAuditFailure] = []
 
         failures.extend(
@@ -166,7 +224,8 @@ class SkillInstallerService:
                 expected_exists=True,
                 required_files=("SKILL.md",),
                 expectation=(
-                    "The precondition must include the retained Jira skill artifacts before the rerun."
+                    f"The precondition must include the retained {result.retained_skill!r} "
+                    "skill artifacts before the rerun."
                 ),
             )
         )
@@ -177,10 +236,24 @@ class SkillInstallerService:
                 expected_exists=True,
                 required_files=("SKILL.md",),
                 expectation=(
-                    "The precondition must include the removable GitHub skill artifacts before the rerun."
+                    f"The precondition must include the removable {result.removed_skill!r} "
+                    "skill artifacts before the rerun."
                 ),
             )
         )
+        if result.added_skill is not None and result.initial_added_state is not None:
+            failures.extend(
+                self._validate_skill_directory(
+                    step=1,
+                    state=result.initial_added_state,
+                    expected_exists=False,
+                    required_files=(),
+                    expectation=(
+                        f"The precondition must not already include the new "
+                        f"{result.added_skill!r} skill artifacts before the rerun."
+                    ),
+                )
+            )
         failures.extend(
             self._validate_metadata(
                 step=1,
@@ -196,7 +269,10 @@ class SkillInstallerService:
             failures.append(
                 SkillSelectionAuditFailure(
                     step=2,
-                    summary="Re-running the skill installer with only Jira selected should succeed.",
+                    summary=(
+                        "Re-running the skill installer with the requested selective skill set "
+                        "should succeed."
+                    ),
                     details=(
                         f"Command exited with {result.installer_command_result.returncode}.\n"
                         f"Command: {result.installer_command_result.command}"
@@ -211,26 +287,45 @@ class SkillInstallerService:
                 state=result.final_retained_state,
                 expected_exists=True,
                 required_files=("SKILL.md",),
-                expectation="The Jira skill artifacts should remain installed after the rerun.",
+                expectation=(
+                    f"The retained {result.retained_skill!r} skill artifacts should remain "
+                    "installed after the rerun."
+                ),
             )
         )
         failures.extend(
             self._validate_skill_directory(
-                step=4,
+                step=3,
                 state=result.final_removed_state,
                 expected_exists=False,
                 required_files=(),
-                expectation="The GitHub skill artifacts should be removed after the rerun.",
+                expectation=(
+                    f"The removed {result.removed_skill!r} skill artifacts should be deleted "
+                    "after the rerun."
+                ),
             )
         )
+        if result.added_skill is not None and result.final_added_state is not None:
+            failures.extend(
+                self._validate_skill_directory(
+                    step=3,
+                    state=result.final_added_state,
+                    expected_exists=True,
+                    required_files=("SKILL.md",),
+                    expectation=(
+                        f"The newly selected {result.added_skill!r} skill artifacts should be "
+                        "installed during the rerun."
+                    ),
+                )
+            )
         failures.extend(
             self._validate_metadata(
-                step=5,
+                step=4,
                 metadata_exists=result.final_metadata_exists,
                 metadata=result.final_metadata,
                 parse_error=result.final_parse_error,
                 metadata_path=result.metadata_path,
-                expected_skills=(result.retained_skill,),
+                expected_skills=result.selected_skills,
             )
         )
 
@@ -242,21 +337,26 @@ class SkillInstallerService:
         failures: list[SkillSelectionAuditFailure],
     ) -> str:
         lines = [
-            "Selective skill uninstall verification failed.",
+            "Selective skill transition verification failed.",
             "",
             "Steps to reproduce:",
             (
-                "1. Start from a workspace where .claude/skills contains both Jira and GitHub "
-                "skill folders plus installed-skills.json metadata."
+                "1. Start from a workspace where .claude/skills contains the retained and "
+                "removed skill folders plus installed-skills.json metadata."
             ),
             (
                 f"2. Re-run {self.INSTALLER_RELATIVE_PATH} with "
-                f"DMTOOLS_SKILLS={result.retained_skill!r}."
+                f"DMTOOLS_SKILLS={','.join(result.selected_skills)!r}."
             ),
             (
                 f"3. Verify {self.skill_install_name(result.retained_skill)!r} remains, "
-                f"{self.skill_install_name(result.removed_skill)!r} is removed, and "
-                "installed-skills.json lists only Jira."
+                f"{self.skill_install_name(result.removed_skill)!r} is removed"
+                + (
+                    f", {self.skill_install_name(result.added_skill)!r} is installed,"
+                    if result.added_skill is not None
+                    else ","
+                )
+                + " and installed-skills.json matches the selected skills exactly."
             ),
             "",
             "Observed state:",
@@ -274,6 +374,17 @@ class SkillInstallerService:
                 f"exists={result.initial_removed_state.exists} | "
                 f"files={', '.join(result.initial_removed_state.files) or '<empty>'}"
             ),
+        ]
+        if result.initial_added_state is not None:
+            lines.append(
+                (
+                    f"- Initial added dir: {result.initial_added_state.path} | "
+                    f"exists={result.initial_added_state.exists} | "
+                    f"files={', '.join(result.initial_added_state.files) or '<empty>'}"
+                )
+            )
+        lines.extend(
+            [
             (
                 f"- Final retained dir: {result.final_retained_state.path} | "
                 f"exists={result.final_retained_state.exists} | "
@@ -284,6 +395,18 @@ class SkillInstallerService:
                 f"exists={result.final_removed_state.exists} | "
                 f"files={', '.join(result.final_removed_state.files) or '<empty>'}"
             ),
+            ]
+        )
+        if result.final_added_state is not None:
+            lines.append(
+                (
+                    f"- Final added dir: {result.final_added_state.path} | "
+                    f"exists={result.final_added_state.exists} | "
+                    f"files={', '.join(result.final_added_state.files) or '<empty>'}"
+                )
+            )
+        lines.extend(
+            [
             (
                 f"- Initial metadata exists={result.initial_metadata_exists} "
                 f"parse_error={result.initial_parse_error or '<none>'}"
@@ -298,7 +421,8 @@ class SkillInstallerService:
             "",
             "Final metadata:",
             result.final_metadata_raw.rstrip() if result.final_metadata_raw is not None else "<missing>",
-        ]
+            ]
+        )
 
         if failures:
             lines.extend(
@@ -346,17 +470,18 @@ class SkillInstallerService:
     def _prepare_fake_release_environment(
         self,
         sandbox: Sandbox,
-        retained_skill: str,
+        selected_skills: tuple[str, ...],
     ) -> None:
         fake_release_dir = sandbox.workspace.parent / "fake-releases"
         fake_bin_dir = sandbox.workspace.parent / "fake-bin"
         fake_release_dir.mkdir(parents=True, exist_ok=True)
         fake_bin_dir.mkdir(parents=True, exist_ok=True)
 
-        self._write_skill_package(
-            fake_release_dir / self.skill_asset_name(retained_skill),
-            retained_skill,
-        )
+        for skill in selected_skills:
+            self._write_skill_package(
+                fake_release_dir / self.skill_asset_name(skill),
+                skill,
+            )
         self._write_fake_curl(fake_bin_dir / "curl")
         self._write_fake_unzip(fake_bin_dir / "unzip")
 
@@ -546,14 +671,15 @@ class SkillInstallerService:
         installer_path: Path,
         fake_bin_dir: Path,
         fake_release_dir: Path,
-        selected_skill: str,
+        selected_skills: tuple[str, ...],
     ) -> str:
+        selected_skills_csv = ",".join(selected_skills)
         return textwrap.dedent(
             f"""\
             set -e
             export PATH={shlex.quote(fake_bin_dir.as_posix())}:$PATH
             export SKILL_INSTALLER_FAKE_RELEASES={shlex.quote(fake_release_dir.as_posix())}
-            export DMTOOLS_SKILLS={shlex.quote(selected_skill)}
+            export DMTOOLS_SKILLS={shlex.quote(selected_skills_csv)}
             bash {shlex.quote(installer_path.as_posix())}
             """
         ).strip()

--- a/testing/tests/DMC-962/README.md
+++ b/testing/tests/DMC-962/README.md
@@ -1,0 +1,29 @@
+# DMC-962 automated test
+
+This test verifies the real Claude skill installer flow in `dmtools-ai-docs/install.sh`
+for a mixed selective reinstall. It starts from the ticket precondition where
+`.claude/skills` already contains `dmtools-jira` and `dmtools-github` plus
+`installed-skills.json`, then reruns the installer with `DMTOOLS_SKILLS='jira,confluence'`
+and checks the user-visible output plus the resulting artifacts and metadata.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-962/test_dmc_962.py -q
+```
+
+## Environment
+
+No credentials are required. The test runs `dmtools-ai-docs/install.sh` in an isolated
+repository sandbox, stubs the release downloads with local zip assets, and verifies:
+
+- `dmtools-jira` remains installed
+- `dmtools-github` is removed
+- `dmtools-confluence` is added
+- `.claude/skills/installed-skills.json` lists only Jira and Confluence

--- a/testing/tests/DMC-962/config.yaml
+++ b/testing/tests/DMC-962/config.yaml
@@ -1,0 +1,8 @@
+test_id: DMC-962
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+retained_skill: jira
+removed_skill: github
+added_skill: confluence

--- a/testing/tests/DMC-962/test_dmc_962.py
+++ b/testing/tests/DMC-962/test_dmc_962.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.skill_installer_service import SkillInstallerService  # noqa: E402
+from testing.core.utils.repo_sandbox import CommandResult  # noqa: E402
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+ANSI_ESCAPE_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+RETAINED_SKILL = str(CONFIG["retained_skill"])
+REMOVED_SKILL = str(CONFIG["removed_skill"])
+ADDED_SKILL = str(CONFIG["added_skill"])
+EXPECTED_SELECTED_SKILLS = (RETAINED_SKILL, ADDED_SKILL)
+
+
+def test_dmc_962_mixed_selective_reinstall_syncs_artifacts_and_metadata() -> None:
+    service = SkillInstallerService(REPOSITORY_ROOT)
+
+    result = service.run_selective_skill_transition(
+        retained_skill=RETAINED_SKILL,
+        removed_skill=REMOVED_SKILL,
+        added_skill=ADDED_SKILL,
+    )
+    failures = service.validate_selective_transition(result)
+    normalized_stdout = _normalize_output(result.installer_command_result.stdout)
+
+    assert result.installer_command_result.returncode == 0, service.format_failures(
+        result,
+        failures,
+    )
+    assert (
+        f"Effective skills: {RETAINED_SKILL}, {ADDED_SKILL} (source: env)" in normalized_stdout
+    ), (
+        "The installer should tell the user exactly which mixed selective skill set "
+        "it will apply before changing artifacts and metadata.\n"
+        f"stdout:\n{normalized_stdout}\n\nstderr:\n{result.installer_command_result.stderr}"
+    )
+    assert not failures, service.format_failures(result, failures)
+
+
+class FakeSandbox:
+    def __init__(self, sandbox_root: Path) -> None:
+        self.workspace = sandbox_root / "workspace"
+        self.home = sandbox_root / "home"
+        self.workspace.mkdir(parents=True, exist_ok=True)
+        self.home.mkdir(parents=True, exist_ok=True)
+        self.commands: list[tuple[str, int]] = []
+        self.cleaned_up = False
+
+    def cleanup(self) -> None:
+        self.cleaned_up = True
+
+    def run(self, command: str, timeout: int = 1800) -> CommandResult:
+        self.commands.append((command, timeout))
+        skills_root = self.workspace / ".claude" / "skills"
+        github_dir = skills_root / "dmtools-github"
+        if github_dir.exists():
+            for child in github_dir.iterdir():
+                child.unlink()
+            github_dir.rmdir()
+        confluence_dir = skills_root / "dmtools-confluence"
+        confluence_dir.mkdir(parents=True, exist_ok=True)
+        (confluence_dir / "SKILL.md").write_text("# confluence\n", encoding="utf-8")
+        (confluence_dir / "artifact.txt").write_text(
+            "confluence artifact\n",
+            encoding="utf-8",
+        )
+        (skills_root / "installed-skills.json").write_text(
+            '{\n'
+            '  "installed_skills": ["jira", "confluence"],\n'
+            '  "active_commands": ["/dmtools-jira", "/dmtools-confluence"]\n'
+            '}\n',
+            encoding="utf-8",
+        )
+        return CommandResult(
+            command=command,
+            returncode=0,
+            stdout="Effective skills: jira, confluence (source: env)\n",
+            stderr="",
+        )
+
+
+def test_dmc_962_service_uses_injected_sandbox_and_tracks_added_skill_metadata(
+    tmp_path: Path,
+) -> None:
+    sandbox = FakeSandbox(tmp_path)
+    service = SkillInstallerService(
+        REPOSITORY_ROOT,
+        sandbox_factory=lambda _: sandbox,
+    )
+
+    result = service.run_selective_skill_transition(
+        retained_skill=RETAINED_SKILL,
+        removed_skill=REMOVED_SKILL,
+        added_skill=ADDED_SKILL,
+    )
+    failures = service.validate_selective_transition(result)
+
+    assert len(sandbox.commands) == 1
+    assert "dmtools-ai-docs/install.sh" in sandbox.commands[0][0]
+    assert "DMTOOLS_SKILLS=jira,confluence" in sandbox.commands[0][0]
+    assert "--skills jira,confluence" not in sandbox.commands[0][0]
+    assert sandbox.cleaned_up is True
+    assert result.initial_metadata is not None
+    assert result.initial_metadata.installed_skills == ("jira", "github")
+    assert result.initial_metadata.active_commands == ("/dmtools-jira", "/dmtools-github")
+    assert result.initial_added_state is not None
+    assert result.initial_added_state.exists is False
+    assert result.final_metadata is not None
+    assert result.final_metadata.installed_skills == ("jira", "confluence")
+    assert result.final_metadata.active_commands == (
+        "/dmtools-jira",
+        "/dmtools-confluence",
+    )
+    assert result.final_removed_state.exists is False
+    assert result.final_added_state is not None
+    assert result.final_added_state.exists is True
+    assert not failures, service.format_failures(result, failures)
+
+
+def _normalize_output(output: str) -> str:
+    return ANSI_ESCAPE_PATTERN.sub("", output)


### PR DESCRIPTION
# DMC-962 automation result

**Status:** Failed  
**Pytest command:** `python3 -m pytest testing/tests/DMC-962/test_dmc_962.py -q`  
**Result:** `1 passed, 1 failed`

## What automation checked

1. Seeded the ticket precondition with `dmtools-jira` and `dmtools-github` already installed plus `installed-skills.json`.
2. Re-ran `dmtools-ai-docs/install.sh` with `DMTOOLS_SKILLS=jira,confluence`.
3. Checked the user-visible installer output from the terminal.
4. Checked the final filesystem state under `.claude/skills`.
5. Checked `installed-skills.json` after the rerun.

## Real human-style verification

I verified the exact terminal behavior a user would observe. The installer banner rendered, then the flow stopped with:

```text
Unknown skills: confluence. Use --skip-unknown to continue.
```

So the observable behavior did **not** match the expected mixed selective reinstall outcome.

## Step results

1. Set `DMTOOLS_SKILLS=jira,confluence` — passed.
2. Trigger installer — **failed**. Exit code was `1`, and the installer rejected `confluence` as an unknown skill.
3. Verify filesystem sync — failed because the installer stopped early. `dmtools-jira` still existed, `dmtools-github` still existed, and `dmtools-confluence` was never created.
4. Verify metadata sync — failed because `installed-skills.json` remained unchanged with `installed_skills=["jira","github"]` and `active_commands=["/dmtools-jira","/dmtools-github"]`.

## Actual vs expected

**Expected:** keep `jira`, remove `github`, add `confluence`, and update metadata so only Jira and Confluence remain.

**Actual:** the installer rejected `confluence`, exited before syncing artifacts, kept GitHub installed, and left metadata unchanged.

## Environment

- OS: `Linux 6.17.0-1010-azure x86_64`
- Repository root: `/home/runner/work/dm.ai/dm.ai`
- Installer under test: `/home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-ua1rkzq9/workspace/dmtools-ai-docs/install.sh`
- Skills root during run: `/home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-ua1rkzq9/workspace/.claude/skills`
