### PR TITLE
DMC-963 Test: Deselect all skills — all artifacts removed and metadata cleared

### DIFF
--- a/testing/components/services/skill_installer_service.py
+++ b/testing/components/services/skill_installer_service.py
@@ -7,7 +7,7 @@ import zipfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from testing.core.utils.repo_sandbox import CommandResult, RepoSandbox
 
@@ -54,6 +54,41 @@ class SkillSelectionAuditFailure:
     step: int
     summary: str
     details: str
+
+
+@dataclass(frozen=True)
+class SkillEndpointsMetadata:
+    command_entries: tuple[str, ...]
+    raw: str
+
+
+@dataclass(frozen=True)
+class SkillDeselectAllAuditResult:
+    installer_command_result: CommandResult
+    workspace_root: str
+    installer_path: str
+    skills_root: str
+    metadata_path: str
+    endpoints_path: str
+    seeded_skills: tuple[str, ...]
+    initial_skill_states: tuple[SkillDirectoryState, ...]
+    initial_metadata_exists: bool
+    initial_metadata_raw: str | None
+    initial_metadata: InstalledSkillsMetadata | None
+    initial_parse_error: str | None
+    initial_endpoints_exists: bool
+    initial_endpoints_raw: str | None
+    initial_endpoints: SkillEndpointsMetadata | None
+    initial_endpoints_parse_error: str | None
+    final_skill_states: tuple[SkillDirectoryState, ...]
+    final_metadata_exists: bool
+    final_metadata_raw: str | None
+    final_metadata: InstalledSkillsMetadata | None
+    final_parse_error: str | None
+    final_endpoints_exists: bool
+    final_endpoints_raw: str | None
+    final_endpoints: SkillEndpointsMetadata | None
+    final_endpoints_parse_error: str | None
 
 
 class Sandbox(Protocol):
@@ -114,7 +149,7 @@ class SkillInstallerService:
                     installer_path=installer_path,
                     fake_bin_dir=sandbox.workspace.parent / "fake-bin",
                     fake_release_dir=sandbox.workspace.parent / "fake-releases",
-                    selected_skill=retained_skill,
+                    selected_skills_csv=retained_skill,
                 )
             )
 
@@ -236,6 +271,179 @@ class SkillInstallerService:
 
         return failures
 
+    def run_deselect_all_skills(
+        self,
+        *,
+        seeded_skills: tuple[str, ...] = ("jira",),
+    ) -> SkillDeselectAllAuditResult:
+        sandbox = self._sandbox_factory(self.repository_root)
+        try:
+            installer_path = sandbox.workspace / self.INSTALLER_RELATIVE_PATH
+            skills_root = sandbox.workspace / self.SKILLS_ROOT_RELATIVE_PATH
+            metadata_path = skills_root / "installed-skills.json"
+            endpoints_path = skills_root / "endpoints.json"
+
+            self._prepare_fake_release_environment(sandbox, "dmtools")
+            self._seed_skill_selection_state(skills_root, seeded_skills)
+
+            (
+                initial_metadata_exists,
+                initial_metadata_raw,
+                initial_metadata,
+                initial_parse_error,
+            ) = self._read_metadata(metadata_path)
+            (
+                initial_endpoints_exists,
+                initial_endpoints_raw,
+                initial_endpoints,
+                initial_endpoints_parse_error,
+            ) = self._read_endpoints_metadata(endpoints_path)
+            initial_skill_states = self._skill_directory_states(skills_root)
+
+            installer_command_result = sandbox.run(
+                self._build_installer_command(
+                    installer_path=installer_path,
+                    fake_bin_dir=sandbox.workspace.parent / "fake-bin",
+                    fake_release_dir=sandbox.workspace.parent / "fake-releases",
+                    selected_skills_csv="",
+                )
+            )
+
+            (
+                final_metadata_exists,
+                final_metadata_raw,
+                final_metadata,
+                final_parse_error,
+            ) = self._read_metadata(metadata_path)
+            (
+                final_endpoints_exists,
+                final_endpoints_raw,
+                final_endpoints,
+                final_endpoints_parse_error,
+            ) = self._read_endpoints_metadata(endpoints_path)
+
+            return SkillDeselectAllAuditResult(
+                installer_command_result=installer_command_result,
+                workspace_root=sandbox.workspace.as_posix(),
+                installer_path=installer_path.as_posix(),
+                skills_root=skills_root.as_posix(),
+                metadata_path=metadata_path.as_posix(),
+                endpoints_path=endpoints_path.as_posix(),
+                seeded_skills=seeded_skills,
+                initial_skill_states=initial_skill_states,
+                initial_metadata_exists=initial_metadata_exists,
+                initial_metadata_raw=initial_metadata_raw,
+                initial_metadata=initial_metadata,
+                initial_parse_error=initial_parse_error,
+                initial_endpoints_exists=initial_endpoints_exists,
+                initial_endpoints_raw=initial_endpoints_raw,
+                initial_endpoints=initial_endpoints,
+                initial_endpoints_parse_error=initial_endpoints_parse_error,
+                final_skill_states=self._skill_directory_states(skills_root),
+                final_metadata_exists=final_metadata_exists,
+                final_metadata_raw=final_metadata_raw,
+                final_metadata=final_metadata,
+                final_parse_error=final_parse_error,
+                final_endpoints_exists=final_endpoints_exists,
+                final_endpoints_raw=final_endpoints_raw,
+                final_endpoints=final_endpoints,
+                final_endpoints_parse_error=final_endpoints_parse_error,
+            )
+        finally:
+            sandbox.cleanup()
+
+    def validate_deselect_all_skills(
+        self,
+        result: SkillDeselectAllAuditResult,
+    ) -> list[SkillSelectionAuditFailure]:
+        failures: list[SkillSelectionAuditFailure] = []
+
+        for state in result.initial_skill_states:
+            failures.extend(
+                self._validate_skill_directory(
+                    step=1,
+                    state=state,
+                    expected_exists=True,
+                    required_files=("SKILL.md",),
+                    expectation=(
+                        "The precondition must include installed skill artifacts before clearing the selection."
+                    ),
+                )
+            )
+        failures.extend(
+            self._validate_metadata(
+                step=1,
+                metadata_exists=result.initial_metadata_exists,
+                metadata=result.initial_metadata,
+                parse_error=result.initial_parse_error,
+                metadata_path=result.metadata_path,
+                expected_skills=result.seeded_skills,
+            )
+        )
+        failures.extend(
+            self._validate_endpoints_metadata(
+                step=1,
+                endpoints_exists=result.initial_endpoints_exists,
+                endpoints=result.initial_endpoints,
+                parse_error=result.initial_endpoints_parse_error,
+                endpoints_path=result.endpoints_path,
+                expected_commands=tuple(
+                    self.skill_command_name(skill) for skill in result.seeded_skills
+                ),
+            )
+        )
+
+        if result.installer_command_result.returncode != 0:
+            failures.append(
+                SkillSelectionAuditFailure(
+                    step=2,
+                    summary="Re-running the skill installer with an empty DMTOOLS_SKILLS value should succeed.",
+                    details=(
+                        f"Command exited with {result.installer_command_result.returncode}.\n"
+                        f"Command: {result.installer_command_result.command}"
+                    ),
+                )
+            )
+            return failures
+
+        if result.final_skill_states:
+            failures.append(
+                SkillSelectionAuditFailure(
+                    step=3,
+                    summary="All skill folders should be removed after deselecting every skill.",
+                    details=(
+                        "Observed remaining directories: "
+                        + ", ".join(
+                            f"{state.path} (files={', '.join(state.files) or '<empty>'})"
+                            for state in result.final_skill_states
+                        )
+                    ),
+                )
+            )
+
+        failures.extend(
+            self._validate_metadata(
+                step=4,
+                metadata_exists=result.final_metadata_exists,
+                metadata=result.final_metadata,
+                parse_error=result.final_parse_error,
+                metadata_path=result.metadata_path,
+                expected_skills=(),
+            )
+        )
+        failures.extend(
+            self._validate_endpoints_metadata(
+                step=5,
+                endpoints_exists=result.final_endpoints_exists,
+                endpoints=result.final_endpoints,
+                parse_error=result.final_endpoints_parse_error,
+                endpoints_path=result.endpoints_path,
+                expected_commands=(),
+            )
+        )
+
+        return failures
+
     def format_failures(
         self,
         result: SkillSelectionAuditResult,
@@ -324,6 +532,103 @@ class SkillInstallerService:
         )
         return "\n".join(lines)
 
+    def format_deselect_all_failures(
+        self,
+        result: SkillDeselectAllAuditResult,
+        failures: list[SkillSelectionAuditFailure],
+    ) -> str:
+        seeded_skills_display = ", ".join(result.seeded_skills)
+        lines = [
+            "Empty skill selection clearing verification failed.",
+            "",
+            "Steps to reproduce:",
+            (
+                "1. Start from a workspace where .claude/skills contains installed skill folders "
+                f"for {seeded_skills_display} plus installed-skills.json and endpoints.json."
+            ),
+            "2. Re-run dmtools-ai-docs/install.sh with DMTOOLS_SKILLS set to an empty string.",
+            "3. Verify that no dmtools skill folders remain and both metadata files are cleared.",
+            "",
+            "Observed state:",
+            f"- Installer: {result.installer_path}",
+            f"- Workspace: {result.workspace_root}",
+            f"- Skills root: {result.skills_root}",
+            f"- Installed-skills metadata: {result.metadata_path}",
+            f"- Endpoints metadata: {result.endpoints_path}",
+            (
+                "- Initial skill directories: "
+                + (
+                    ", ".join(
+                        f"{state.path} (files={', '.join(state.files) or '<empty>'})"
+                        for state in result.initial_skill_states
+                    )
+                    or "<none>"
+                )
+            ),
+            (
+                "- Final skill directories: "
+                + (
+                    ", ".join(
+                        f"{state.path} (files={', '.join(state.files) or '<empty>'})"
+                        for state in result.final_skill_states
+                    )
+                    or "<none>"
+                )
+            ),
+            (
+                f"- Initial installed-skills exists={result.initial_metadata_exists} "
+                f"parse_error={result.initial_parse_error or '<none>'}"
+            ),
+            (
+                f"- Final installed-skills exists={result.final_metadata_exists} "
+                f"parse_error={result.final_parse_error or '<none>'}"
+            ),
+            (
+                f"- Initial endpoints exists={result.initial_endpoints_exists} "
+                f"parse_error={result.initial_endpoints_parse_error or '<none>'}"
+            ),
+            (
+                f"- Final endpoints exists={result.final_endpoints_exists} "
+                f"parse_error={result.final_endpoints_parse_error or '<none>'}"
+            ),
+            "",
+            "Initial installed-skills.json:",
+            result.initial_metadata_raw.rstrip() if result.initial_metadata_raw is not None else "<missing>",
+            "",
+            "Final installed-skills.json:",
+            result.final_metadata_raw.rstrip() if result.final_metadata_raw is not None else "<missing>",
+            "",
+            "Initial endpoints.json:",
+            result.initial_endpoints_raw.rstrip() if result.initial_endpoints_raw is not None else "<missing>",
+            "",
+            "Final endpoints.json:",
+            result.final_endpoints_raw.rstrip() if result.final_endpoints_raw is not None else "<missing>",
+        ]
+
+        if failures:
+            lines.extend(
+                [
+                    "",
+                    "Failures:",
+                    *[
+                        f"- Step {failure.step}: {failure.summary} {failure.details}"
+                        for failure in failures
+                    ],
+                ]
+            )
+
+        lines.extend(
+            [
+                "",
+                "Installer stdout:",
+                result.installer_command_result.stdout.rstrip() or "<empty>",
+                "",
+                "Installer stderr:",
+                result.installer_command_result.stderr.rstrip() or "<empty>",
+            ]
+        )
+        return "\n".join(lines)
+
     @staticmethod
     def skill_install_name(skill: str) -> str:
         return "dmtools" if skill == "dmtools" else f"dmtools-{skill}"
@@ -346,17 +651,24 @@ class SkillInstallerService:
     def _prepare_fake_release_environment(
         self,
         sandbox: Sandbox,
-        retained_skill: str,
+        *skills: str,
     ) -> None:
         fake_release_dir = sandbox.workspace.parent / "fake-releases"
         fake_bin_dir = sandbox.workspace.parent / "fake-bin"
         fake_release_dir.mkdir(parents=True, exist_ok=True)
         fake_bin_dir.mkdir(parents=True, exist_ok=True)
 
-        self._write_skill_package(
-            fake_release_dir / self.skill_asset_name(retained_skill),
-            retained_skill,
-        )
+        prepared_skills: list[str] = []
+        for skill in skills:
+            normalized_skill = skill.strip().lower()
+            if normalized_skill and normalized_skill not in prepared_skills:
+                prepared_skills.append(normalized_skill)
+
+        for skill in prepared_skills:
+            self._write_skill_package(
+                fake_release_dir / self.skill_asset_name(skill),
+                skill,
+            )
         self._write_fake_curl(fake_bin_dir / "curl")
         self._write_fake_unzip(fake_bin_dir / "unzip")
 
@@ -367,18 +679,53 @@ class SkillInstallerService:
         retained_skill: str,
         removed_skill: str,
     ) -> None:
+        self._seed_skill_selection_state(
+            skills_root,
+            (retained_skill, removed_skill),
+        )
+
+    def _seed_skill_selection_state(
+        self,
+        skills_root: Path,
+        skills: tuple[str, ...],
+    ) -> None:
         skills_root.mkdir(parents=True, exist_ok=True)
-        self._seed_skill_directory(skills_root / self.skill_install_name(retained_skill), retained_skill)
-        self._seed_skill_directory(skills_root / self.skill_install_name(removed_skill), removed_skill)
+        for skill in skills:
+            self._seed_skill_directory(skills_root / self.skill_install_name(skill), skill)
+        self._write_installed_skills_metadata(skills_root, skills)
+        self._write_endpoints_metadata(skills_root, skills)
+
+    def _write_installed_skills_metadata(
+        self,
+        skills_root: Path,
+        skills: tuple[str, ...],
+    ) -> None:
         metadata = {
-            "installed_skills": [retained_skill, removed_skill],
-            "active_commands": [
-                self.skill_command_name(retained_skill),
-                self.skill_command_name(removed_skill),
-            ],
+            "installed_skills": list(skills),
+            "active_commands": [self.skill_command_name(skill) for skill in skills],
         }
         (skills_root / "installed-skills.json").write_text(
             json.dumps(metadata, indent=2),
+            encoding="utf-8",
+        )
+
+    def _write_endpoints_metadata(
+        self,
+        skills_root: Path,
+        skills: tuple[str, ...],
+    ) -> None:
+        payload = {
+            "version": "test-seed",
+            "endpoints": [
+                {
+                    "name": skill,
+                    "path": self.skill_command_name(skill),
+                }
+                for skill in skills
+            ],
+        }
+        (skills_root / "endpoints.json").write_text(
+            json.dumps(payload, indent=2),
             encoding="utf-8",
         )
 
@@ -509,6 +856,17 @@ class SkillInstallerService:
         return True, raw, metadata, parse_error
 
     @staticmethod
+    def _read_endpoints_metadata(
+        endpoints_path: Path,
+    ) -> tuple[bool, str | None, SkillEndpointsMetadata | None, str | None]:
+        if not endpoints_path.is_file():
+            return False, None, None, None
+
+        raw = endpoints_path.read_text(encoding="utf-8")
+        metadata, parse_error = SkillInstallerService._parse_endpoints_metadata(raw)
+        return True, raw, metadata, parse_error
+
+    @staticmethod
     def _parse_metadata(
         raw: str,
     ) -> tuple[InstalledSkillsMetadata | None, str | None]:
@@ -541,22 +899,67 @@ class SkillInstallerService:
         )
 
     @staticmethod
+    def _parse_endpoints_metadata(
+        raw: str,
+    ) -> tuple[SkillEndpointsMetadata | None, str | None]:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError as error:
+            return None, f"Invalid JSON: {error}"
+
+        command_entries = tuple(
+            dict.fromkeys(SkillInstallerService._collect_dmtools_entries(payload))
+        )
+        return (
+            SkillEndpointsMetadata(
+                command_entries=command_entries,
+                raw=raw,
+            ),
+            None,
+        )
+
+    @staticmethod
+    def _collect_dmtools_entries(payload: Any) -> tuple[str, ...]:
+        if isinstance(payload, str):
+            return (payload,) if payload.startswith("/dmtools") else ()
+        if isinstance(payload, list):
+            collected: list[str] = []
+            for item in payload:
+                collected.extend(SkillInstallerService._collect_dmtools_entries(item))
+            return tuple(collected)
+        if isinstance(payload, dict):
+            collected = []
+            for value in payload.values():
+                collected.extend(SkillInstallerService._collect_dmtools_entries(value))
+            return tuple(collected)
+        return ()
+
+    @staticmethod
     def _build_installer_command(
         *,
         installer_path: Path,
         fake_bin_dir: Path,
         fake_release_dir: Path,
-        selected_skill: str,
+        selected_skills_csv: str,
     ) -> str:
         return textwrap.dedent(
             f"""\
             set -e
             export PATH={shlex.quote(fake_bin_dir.as_posix())}:$PATH
             export SKILL_INSTALLER_FAKE_RELEASES={shlex.quote(fake_release_dir.as_posix())}
-            export DMTOOLS_SKILLS={shlex.quote(selected_skill)}
+            export DMTOOLS_SKILLS={shlex.quote(selected_skills_csv)}
             bash {shlex.quote(installer_path.as_posix())}
             """
         ).strip()
+
+    @staticmethod
+    def _skill_directory_states(skills_root: Path) -> tuple[SkillDirectoryState, ...]:
+        if not skills_root.is_dir():
+            return ()
+        return tuple(
+            SkillInstallerService._directory_state(path)
+            for path in sorted(child for child in skills_root.iterdir() if child.is_dir())
+        )
 
     def _validate_metadata(
         self,
@@ -613,6 +1016,54 @@ class SkillInstallerService:
                     details=(
                         f"Expected {expected_commands}, observed {metadata.active_commands} "
                         f"in {metadata_path}."
+                    ),
+                )
+            )
+
+        return failures
+
+    @staticmethod
+    def _validate_endpoints_metadata(
+        *,
+        step: int,
+        endpoints_exists: bool,
+        endpoints: SkillEndpointsMetadata | None,
+        parse_error: str | None,
+        endpoints_path: str,
+        expected_commands: tuple[str, ...],
+    ) -> list[SkillSelectionAuditFailure]:
+        failures: list[SkillSelectionAuditFailure] = []
+
+        if not endpoints_exists:
+            failures.append(
+                SkillSelectionAuditFailure(
+                    step=step,
+                    summary="endpoints.json must exist.",
+                    details=f"{endpoints_path} was not found.",
+                )
+            )
+            return failures
+
+        if parse_error is not None:
+            failures.append(
+                SkillSelectionAuditFailure(
+                    step=step,
+                    summary="endpoints.json must be valid JSON.",
+                    details=f"{endpoints_path} could not be parsed: {parse_error}",
+                )
+            )
+            return failures
+
+        assert endpoints is not None
+
+        if endpoints.command_entries != expected_commands:
+            failures.append(
+                SkillSelectionAuditFailure(
+                    step=step,
+                    summary="endpoints.json must match the selected command entries exactly.",
+                    details=(
+                        f"Expected {expected_commands}, observed {endpoints.command_entries} "
+                        f"in {endpoints_path}."
                     ),
                 )
             )

--- a/testing/tests/DMC-963/README.md
+++ b/testing/tests/DMC-963/README.md
@@ -1,0 +1,31 @@
+# DMC-963 automated test
+
+This test verifies the Claude skill installer flow in `dmtools-ai-docs/install.sh`
+when `DMTOOLS_SKILLS` is explicitly set to an empty string.
+
+It starts from the ticket precondition where `.claude/skills` already contains an
+installed skill plus `installed-skills.json` and `endpoints.json`, reruns the
+installer with an empty skill selection, and checks that:
+
+- no `dmtools*` skill folders remain under `.claude/skills`
+- `installed-skills.json` is present and contains no installed skills or commands
+- `endpoints.json` is present and contains no active `/dmtools*` command entries
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-963/test_dmc_963.py -q
+```
+
+## Environment
+
+No credentials are required. The test runs `dmtools-ai-docs/install.sh` in an
+isolated repository sandbox, seeds the `.claude/skills` precondition, and stubs
+release downloads with local zip assets so the ticket scenario executes against
+the checked-out installer implementation.

--- a/testing/tests/DMC-963/config.yaml
+++ b/testing/tests/DMC-963/config.yaml
@@ -1,0 +1,7 @@
+test_id: DMC-963
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+seeded_skills:
+  - jira

--- a/testing/tests/DMC-963/test_dmc_963.py
+++ b/testing/tests/DMC-963/test_dmc_963.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.skill_installer_service import SkillInstallerService  # noqa: E402
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+SEEDED_SKILLS = tuple(str(skill) for skill in CONFIG["seeded_skills"])
+
+
+def test_dmc_963_empty_skill_selection_removes_all_artifacts_and_clears_metadata() -> None:
+    service = SkillInstallerService(REPOSITORY_ROOT)
+
+    result = service.run_deselect_all_skills(seeded_skills=SEEDED_SKILLS)
+    failures = service.validate_deselect_all_skills(result)
+
+    assert not failures, service.format_deselect_all_failures(result, failures)


### PR DESCRIPTION
# DMC-963 test automation result: **FAILED**

## Scope

- Added `testing/tests/DMC-963/test_dmc_963.py`
- Added `testing/tests/DMC-963/config.yaml`
- Added `testing/tests/DMC-963/README.md`
- Extended `testing/components/services/skill_installer_service.py` to seed and verify the empty-selection installer scenario in an isolated sandbox

## What automation checked

1. Seeded `.claude/skills` with an existing installed skill (`dmtools-jira`) plus `installed-skills.json` and `endpoints.json`.
2. Re-ran `dmtools-ai-docs/install.sh` with `DMTOOLS_SKILLS=""`.
3. Verified that no `dmtools*` skill directories remained.
4. Verified that `installed-skills.json` contained no installed skills or active commands.
5. Verified that `endpoints.json` contained no active `/dmtools*` command entries.

## Real human-style verification

I checked the observable user-facing outcome as if a user re-ran the installer from the terminal:

- The installer printed `Effective skills: dmtools (source: default)`.
- The success message advertised `/dmtools` as available after the run.
- `.claude/skills/dmtools` existed after completion.
- `installed-skills.json` ended with `["dmtools"]` and `["/dmtools"]`.
- `endpoints.json` still contained stale `/dmtools-jira`.

That does **not** match the expected result for an empty skill selection.

## Failure details

| Step | Expected | Actual |
| --- | --- | --- |
| 1 | Jira precondition exists | Passed |
| 2 | Installer succeeds | Passed (`exit 0`) |
| 3 | No skill folders remain | Failed: `.claude/skills/dmtools` remained |
| 4 | `installed-skills.json` is empty | Failed: `installed_skills=["dmtools"]`, `active_commands=["/dmtools"]` |
| 5 | `endpoints.json` is cleared | Failed: stale `/dmtools-jira` remained |

## Exact assertion output

```text
_____________________ test_dmc_963_empty_skill_selection_removes_all_artifacts_and_clears_metadata _____________________

    def test_dmc_963_empty_skill_selection_removes_all_artifacts_and_clears_metadata() -> None:
        service = SkillInstallerService(REPOSITORY_ROOT)

        result = service.run_deselect_all_skills(seeded_skills=SEEDED_SKILLS)
        failures = service.validate_deselect_all_skills(result)

>       assert not failures, service.format_deselect_all_failures(result, failures)
E       AssertionError: Empty skill selection clearing verification failed.
E
E       Failures:
E       - Step 3: All skill folders should be removed after deselecting every skill. Observed remaining directories: /home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-2kp3mql2/workspace/.claude/skills/dmtools (files=SKILL.md, artifact.txt)
E       - Step 4: installed_skills must match the selected skills exactly. Expected (), observed ('dmtools',) in /home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-2kp3mql2/workspace/.claude/skills/installed-skills.json.
E       - Step 4: active_commands must match the selected skills exactly. Expected (), observed ('/dmtools',) in /home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-2kp3mql2/workspace/.claude/skills/installed-skills.json.
E       - Step 5: endpoints.json must match the selected command entries exactly. Expected (), observed ('/dmtools-jira',) in /home/runner/work/dm.ai/dm.ai/.repo-sandboxes/dmc-897-2kp3mql2/workspace/.claude/skills/endpoints.json.
```

## Environment

- OS: Linux 6.17.0-1010-azure x86_64
- Test runner: pytest 8.4.2
- Installer under test: `dmtools-ai-docs/install.sh`
- Repro command: `python3 -m pytest testing/tests/DMC-929/test_dmc_929.py testing/tests/DMC-963/test_dmc_963.py -q`
