### PR TITLE
DMC-965 Empty DMTOOLS_SKILLS selection installs default dmtools and leaves metadata uncleared

### DIFF
--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -210,7 +210,7 @@ skill_command_name() {
 }
 
 normalize_skills() {
-    local raw="${1:-dmtools}"
+    local raw="${1-}"
     local normalized=()
     local invalid=()
     local include_all=false
@@ -247,9 +247,6 @@ normalize_skills() {
             fi
             return 1
         fi
-    fi
-    if [ ${#normalized[@]} -eq 0 ]; then
-        normalized=("dmtools")
     fi
     printf '%s\n' "${normalized[@]}"
 }
@@ -345,6 +342,37 @@ write_installed_skills_metadata() {
 EOF
 
     print_success "Updated $target_dir/installed-skills.json"
+}
+
+write_endpoints_metadata() {
+    local target_dir="$1"
+    shift
+    local selected_skills=("$@")
+    local endpoints_json="["
+    local first=true
+    local skill_key
+
+    for skill_key in "${selected_skills[@]}"; do
+        local escaped_skill
+        local escaped_command
+        escaped_skill=$(json_escape "$skill_key")
+        escaped_command=$(json_escape "$(skill_command_name "$skill_key")")
+        if [ "$first" = false ]; then
+            endpoints_json+=", "
+        fi
+        endpoints_json+="{\"name\":\"$escaped_skill\",\"path\":\"$escaped_command\"}"
+        first=false
+    done
+
+    endpoints_json+="]"
+
+    cat > "$target_dir/endpoints.json" <<EOF
+{
+  "endpoints": $endpoints_json
+}
+EOF
+
+    print_success "Updated $target_dir/endpoints.json"
 }
 
 detect_skill_dirs() {
@@ -459,7 +487,7 @@ main() {
     print_header
 
     if [ "$SKILLS_SOURCE" != "cli" ]; then
-        if [ -n "${DMTOOLS_SKILLS:-}" ]; then
+        if [ "${DMTOOLS_SKILLS+x}" = x ]; then
             SKILLS_SOURCE="env"
         else
             SKILLS_SOURCE="default"
@@ -472,14 +500,19 @@ main() {
     while IFS= read -r skill_key; do
         [ -n "$skill_key" ] && requested_skills+=("$skill_key")
     done <<< "$normalized_skills_output"
-    if [ ${#requested_skills[@]} -eq 0 ]; then
+    if [ ${#requested_skills[@]} -eq 0 ] && [ "$SKILLS_SOURCE" = "default" ]; then
         requested_skills=("dmtools")
     fi
 
     if [ "$INSTALL_ALL_SKILLS" = true ]; then
         print_info "Installing all skills (source: $SKILLS_SOURCE)"
     fi
-    print_info "Effective skills: $(join_by_comma "${requested_skills[@]}") (source: $SKILLS_SOURCE)"
+    local effective_skills_display
+    effective_skills_display=$(join_by_comma "${requested_skills[@]}")
+    if [ -z "$effective_skills_display" ]; then
+        effective_skills_display="<none>"
+    fi
+    print_info "Effective skills: $effective_skills_display (source: $SKILLS_SOURCE)"
 
     print_info "Detecting skill directories..."
     local dirs
@@ -497,9 +530,13 @@ main() {
     done
     echo "" >&2
     echo "Selected skill packages:" >&2
-    for skill_key in "${requested_skills[@]}"; do
-        echo "  - $(skill_install_name "$skill_key") ($(skill_command_name "$skill_key"))" >&2
-    done
+    if [ ${#requested_skills[@]} -eq 0 ]; then
+        echo "  - <none>" >&2
+    else
+        for skill_key in "${requested_skills[@]}"; do
+            echo "  - $(skill_install_name "$skill_key") ($(skill_command_name "$skill_key"))" >&2
+        done
+    fi
 
     echo "" >&2
     local choice=""
@@ -562,6 +599,7 @@ main() {
     for dir in "${target_dirs[@]}"; do
         remove_deselected_skills "$dir" "${requested_skills[@]}"
         write_installed_skills_metadata "$dir" "${requested_skills[@]}"
+        write_endpoints_metadata "$dir" "${requested_skills[@]}"
     done
 
     rm -rf "$TEMP_DIR"
@@ -571,22 +609,37 @@ main() {
     echo -e "${GREEN}        DMtools Skill Installed Successfully!       ${NC}" >&2
     echo -e "${GREEN}════════════════════════════════════════════════════${NC}" >&2
     echo "" >&2
-    echo "The selected DMtools skills are now available in your AI assistant!" >&2
+    if [ ${#installed_commands[@]} -eq 0 ]; then
+        echo "All DMtools skills were removed from the selected install location(s)." >&2
+    else
+        echo "The selected DMtools skills are now available in your AI assistant!" >&2
+    fi
     echo "" >&2
     echo -e "${CYAN}You can now:${NC}" >&2
-    for command_name in "${installed_commands[@]}"; do
-        echo "  • Type $command_name in chat to invoke the skill" >&2
-    done
-    echo "  • Ask about the installed DMtools areas and the assistant will use the matching skill automatically" >&2
+    if [ ${#installed_commands[@]} -eq 0 ]; then
+        echo "  • Re-run the installer with DMTOOLS_SKILLS=<skill list> to install a focused package again" >&2
+    else
+        for command_name in "${installed_commands[@]}"; do
+            echo "  • Type $command_name in chat to invoke the skill" >&2
+        done
+        echo "  • Ask about the installed DMtools areas and the assistant will use the matching skill automatically" >&2
+    fi
     echo "" >&2
     echo -e "${BLUE}Example questions:${NC}" >&2
-    echo "  • How do I install DMtools?" >&2
-    echo "  • Help me configure Jira integration" >&2
-    echo "  • Review GitHub pull requests with DMtools" >&2
-    echo "  • Generate test cases from user story PROJ-123" >&2
+    if [ ${#installed_commands[@]} -eq 0 ]; then
+        echo "  • How do I reinstall only the Jira DMtools skill?" >&2
+        echo "  • Which DMtools skills are available to install?" >&2
+    else
+        echo "  • How do I install DMtools?" >&2
+        echo "  • Help me configure Jira integration" >&2
+        echo "  • Review GitHub pull requests with DMtools" >&2
+        echo "  • Generate test cases from user story PROJ-123" >&2
+    fi
     echo "" >&2
 
-    if [[ "$selected_dir" == *"cursor"* ]]; then
+    if [ ${#installed_commands[@]} -eq 0 ]; then
+        :
+    elif [[ "$selected_dir" == *"cursor"* ]]; then
         echo -e "${YELLOW}For Cursor:${NC}" >&2
         echo "  • Open Cursor Settings (Cmd+Shift+J or Ctrl+Shift+J)" >&2
         echo "  • Navigate to Rules → Agent Decides" >&2

--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -146,6 +146,8 @@ NC='\033[0m'
 
 GITHUB_REPO="epam/dm.ai"
 TEMP_DIR=$(mktemp -d)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 print_header() {
     echo "" >&2
@@ -202,6 +204,18 @@ skill_command_name() {
         github) echo "/dmtools-github" ;;
         ado) echo "/dmtools-ado" ;;
         testrail) echo "/dmtools-testrail" ;;
+        *)
+            print_error "Unsupported skill package: $1"
+            return 1
+            ;;
+    esac
+}
+
+skill_endpoint_path() {
+    case "$1" in
+        dmtools|jira|github|ado|testrail)
+            echo "/dmtools/$1"
+            ;;
         *)
             print_error "Unsupported skill package: $1"
             return 1
@@ -329,6 +343,10 @@ write_installed_skills_metadata() {
         active_commands+=("$(skill_command_name "$skill_key")")
     done
 
+    local metadata_version
+    metadata_version=$(resolve_metadata_version "$target_dir")
+    local escaped_version
+    escaped_version=$(json_escape "$metadata_version")
     local installed_skills_json
     local active_commands_json
     installed_skills_json=$(json_string_array "${selected_skills[@]}")
@@ -336,6 +354,7 @@ write_installed_skills_metadata() {
 
     cat > "$target_dir/installed-skills.json" <<EOF
 {
+  "version": "$escaped_version",
   "installed_skills": $installed_skills_json,
   "active_commands": $active_commands_json
 }
@@ -348,19 +367,23 @@ write_endpoints_metadata() {
     local target_dir="$1"
     shift
     local selected_skills=("$@")
+    local metadata_version
+    metadata_version=$(resolve_metadata_version "$target_dir")
+    local escaped_version
+    escaped_version=$(json_escape "$metadata_version")
     local endpoints_json="["
     local first=true
     local skill_key
 
     for skill_key in "${selected_skills[@]}"; do
         local escaped_skill
-        local escaped_command
+        local escaped_endpoint
         escaped_skill=$(json_escape "$skill_key")
-        escaped_command=$(json_escape "$(skill_command_name "$skill_key")")
+        escaped_endpoint=$(json_escape "$(skill_endpoint_path "$skill_key")")
         if [ "$first" = false ]; then
             endpoints_json+=", "
         fi
-        endpoints_json+="{\"name\":\"$escaped_skill\",\"path\":\"$escaped_command\"}"
+        endpoints_json+="{\"name\":\"$escaped_skill\",\"path\":\"$escaped_endpoint\"}"
         first=false
     done
 
@@ -368,11 +391,52 @@ write_endpoints_metadata() {
 
     cat > "$target_dir/endpoints.json" <<EOF
 {
+  "version": "$escaped_version",
   "endpoints": $endpoints_json
 }
 EOF
 
     print_success "Updated $target_dir/endpoints.json"
+}
+
+read_metadata_version() {
+    local metadata_path="$1"
+    [ -s "$metadata_path" ] || return 1
+
+    local version
+    version=$(sed -n 's/^[[:space:]]*"version":[[:space:]]*"\([^"]*\)".*/\1/p' "$metadata_path" | head -n 1)
+    [ -n "$version" ] || return 1
+    printf '%s' "$version"
+}
+
+resolve_metadata_version() {
+    local target_dir="$1"
+    local version=""
+    local version_file="$REPO_ROOT/gradle.properties"
+
+    if version=$(read_metadata_version "$target_dir/endpoints.json"); then
+        printf '%s' "$version"
+        return 0
+    fi
+
+    if version=$(read_metadata_version "$target_dir/installed-skills.json"); then
+        printf '%s' "$version"
+        return 0
+    fi
+
+    if [ -f "$version_file" ]; then
+        version=$(sed -n 's/^version=\(.*\)$/\1/p' "$version_file" | head -n 1 | tr -d '[:space:]')
+        if [ -n "$version" ]; then
+            case "$version" in
+                v*) ;;
+                *) version="v$version" ;;
+            esac
+            printf '%s' "$version"
+            return 0
+        fi
+    fi
+
+    printf '%s' "latest"
 }
 
 detect_skill_dirs() {

--- a/testing/components/services/skill_installer_service.py
+++ b/testing/components/services/skill_installer_service.py
@@ -33,6 +33,7 @@ class SkillSelectionAuditResult:
     installer_path: str
     skills_root: str
     metadata_path: str
+    endpoints_path: str
     retained_skill: str
     removed_skill: str
     selected_skills: tuple[str, ...]
@@ -44,6 +45,10 @@ class SkillSelectionAuditResult:
     initial_metadata_raw: str | None
     initial_metadata: InstalledSkillsMetadata | None
     initial_parse_error: str | None
+    initial_endpoints_exists: bool
+    initial_endpoints_raw: str | None
+    initial_endpoints: SkillEndpointsMetadata | None
+    initial_endpoints_parse_error: str | None
     final_retained_state: SkillDirectoryState
     final_removed_state: SkillDirectoryState
     final_added_state: SkillDirectoryState | None
@@ -51,6 +56,10 @@ class SkillSelectionAuditResult:
     final_metadata_raw: str | None
     final_metadata: InstalledSkillsMetadata | None
     final_parse_error: str | None
+    final_endpoints_exists: bool
+    final_endpoints_raw: str | None
+    final_endpoints: SkillEndpointsMetadata | None
+    final_endpoints_parse_error: str | None
 
 
 @dataclass(frozen=True)
@@ -180,6 +189,7 @@ class SkillInstallerService:
             installer_path = sandbox.workspace / self.INSTALLER_RELATIVE_PATH
             skills_root = sandbox.workspace / self.SKILLS_ROOT_RELATIVE_PATH
             metadata_path = skills_root / "installed-skills.json"
+            endpoints_path = skills_root / "endpoints.json"
 
             self._prepare_fake_release_environment(sandbox, selected_skills)
             self._seed_installed_skills(
@@ -194,6 +204,12 @@ class SkillInstallerService:
                 initial_metadata,
                 initial_parse_error,
             ) = self._read_metadata(metadata_path)
+            (
+                initial_endpoints_exists,
+                initial_endpoints_raw,
+                initial_endpoints,
+                initial_endpoints_parse_error,
+            ) = self._read_endpoints_metadata(endpoints_path)
             initial_retained_state = self._directory_state(
                 skills_root / self.skill_install_name(retained_skill)
             )
@@ -221,6 +237,12 @@ class SkillInstallerService:
                 final_metadata,
                 final_parse_error,
             ) = self._read_metadata(metadata_path)
+            (
+                final_endpoints_exists,
+                final_endpoints_raw,
+                final_endpoints,
+                final_endpoints_parse_error,
+            ) = self._read_endpoints_metadata(endpoints_path)
 
             return SkillSelectionAuditResult(
                 installer_command_result=installer_command_result,
@@ -228,6 +250,7 @@ class SkillInstallerService:
                 installer_path=installer_path.as_posix(),
                 skills_root=skills_root.as_posix(),
                 metadata_path=metadata_path.as_posix(),
+                endpoints_path=endpoints_path.as_posix(),
                 retained_skill=retained_skill,
                 removed_skill=removed_skill,
                 selected_skills=selected_skills,
@@ -239,6 +262,10 @@ class SkillInstallerService:
                 initial_metadata_raw=initial_metadata_raw,
                 initial_metadata=initial_metadata,
                 initial_parse_error=initial_parse_error,
+                initial_endpoints_exists=initial_endpoints_exists,
+                initial_endpoints_raw=initial_endpoints_raw,
+                initial_endpoints=initial_endpoints,
+                initial_endpoints_parse_error=initial_endpoints_parse_error,
                 final_retained_state=self._directory_state(
                     skills_root / self.skill_install_name(retained_skill)
                 ),
@@ -254,6 +281,10 @@ class SkillInstallerService:
                 final_metadata_raw=final_metadata_raw,
                 final_metadata=final_metadata,
                 final_parse_error=final_parse_error,
+                final_endpoints_exists=final_endpoints_exists,
+                final_endpoints_raw=final_endpoints_raw,
+                final_endpoints=final_endpoints,
+                final_endpoints_parse_error=final_endpoints_parse_error,
             )
         finally:
             sandbox.cleanup()
@@ -323,6 +354,19 @@ class SkillInstallerService:
                 expected_skills=(result.retained_skill, result.removed_skill),
             )
         )
+        failures.extend(
+            self._validate_endpoints_metadata(
+                step=1,
+                endpoints_exists=result.initial_endpoints_exists,
+                endpoints=result.initial_endpoints,
+                parse_error=result.initial_endpoints_parse_error,
+                endpoints_path=result.endpoints_path,
+                expected_commands=tuple(
+                    self.skill_endpoint_path(skill)
+                    for skill in (result.retained_skill, result.removed_skill)
+                ),
+            )
+        )
 
         if result.installer_command_result.returncode != 0:
             failures.append(
@@ -385,6 +429,18 @@ class SkillInstallerService:
                 parse_error=result.final_parse_error,
                 metadata_path=result.metadata_path,
                 expected_skills=result.selected_skills,
+            )
+        )
+        failures.extend(
+            self._validate_endpoints_metadata(
+                step=5,
+                endpoints_exists=result.final_endpoints_exists,
+                endpoints=result.final_endpoints,
+                parse_error=result.final_endpoints_parse_error,
+                endpoints_path=result.endpoints_path,
+                expected_commands=tuple(
+                    self.skill_endpoint_path(skill) for skill in result.selected_skills
+                ),
             )
         )
 
@@ -508,7 +564,7 @@ class SkillInstallerService:
                 parse_error=result.initial_endpoints_parse_error,
                 endpoints_path=result.endpoints_path,
                 expected_commands=tuple(
-                    self.skill_command_name(skill) for skill in result.seeded_skills
+                    self.skill_endpoint_path(skill) for skill in result.seeded_skills
                 ),
             )
         )
@@ -792,7 +848,7 @@ class SkillInstallerService:
             "Steps to reproduce:",
             (
                 "1. Start from a workspace where .claude/skills contains the retained and "
-                "removed skill folders plus installed-skills.json metadata."
+                "removed skill folders plus installed-skills.json and endpoints.json metadata."
             ),
             (
                 f"2. Re-run {self.INSTALLER_RELATIVE_PATH} with "
@@ -814,6 +870,7 @@ class SkillInstallerService:
             f"- Workspace: {result.workspace_root}",
             f"- Skills root: {result.skills_root}",
             f"- Metadata: {result.metadata_path}",
+            f"- Endpoints: {result.endpoints_path}",
             (
                 f"- Initial retained dir: {result.initial_retained_state.path} | "
                 f"exists={result.initial_retained_state.exists} | "
@@ -865,12 +922,30 @@ class SkillInstallerService:
                 f"- Final metadata exists={result.final_metadata_exists} "
                 f"parse_error={result.final_parse_error or '<none>'}"
             ),
+            (
+                f"- Initial endpoints exists={result.initial_endpoints_exists} "
+                f"parse_error={result.initial_endpoints_parse_error or '<none>'}"
+            ),
+            (
+                f"- Final endpoints exists={result.final_endpoints_exists} "
+                f"parse_error={result.final_endpoints_parse_error or '<none>'}"
+            ),
             "",
             "Initial metadata:",
             result.initial_metadata_raw.rstrip() if result.initial_metadata_raw is not None else "<missing>",
             "",
             "Final metadata:",
             result.final_metadata_raw.rstrip() if result.final_metadata_raw is not None else "<missing>",
+            "",
+            "Initial endpoints:",
+            result.initial_endpoints_raw.rstrip()
+            if result.initial_endpoints_raw is not None
+            else "<missing>",
+            "",
+            "Final endpoints:",
+            result.final_endpoints_raw.rstrip()
+            if result.final_endpoints_raw is not None
+            else "<missing>",
             ]
         )
 
@@ -1097,6 +1172,10 @@ class SkillInstallerService:
         return "/dmtools" if skill == "dmtools" else f"/dmtools-{skill}"
 
     @staticmethod
+    def skill_endpoint_path(skill: str) -> str:
+        return f"/dmtools/{skill}"
+
+    @staticmethod
     def skill_asset_name(skill: str) -> str:
         return "dmtools-skill.zip" if skill == "dmtools" else f"dmtools-{skill}-skill.zip"
 
@@ -1140,10 +1219,12 @@ class SkillInstallerService:
         retained_skill: str,
         removed_skill: str,
     ) -> None:
+        selected_skills = (retained_skill, removed_skill)
         self._seed_selected_skills(
             skills_root=skills_root,
-            selected_skills=(retained_skill, removed_skill),
+            selected_skills=selected_skills,
         )
+        self._write_endpoints_metadata(skills_root, selected_skills)
 
     def _seed_skill_selection_state(
         self,
@@ -1167,6 +1248,7 @@ class SkillInstallerService:
         for skill in selected_skills:
             self._seed_skill_directory(skills_root / self.skill_install_name(skill), skill)
         metadata = {
+            "version": "test-seed",
             "installed_skills": list(selected_skills),
             "active_commands": [self.skill_command_name(skill) for skill in selected_skills],
         }
@@ -1185,7 +1267,7 @@ class SkillInstallerService:
             "endpoints": [
                 {
                     "name": skill,
-                    "path": self.skill_command_name(skill),
+                    "path": self.skill_endpoint_path(skill),
                 }
                 for skill in skills
             ],
@@ -1526,7 +1608,7 @@ class SkillInstallerService:
             failures.append(
                 SkillSelectionAuditFailure(
                     step=step,
-                    summary="endpoints.json must match the selected command entries exactly.",
+                    summary="endpoints.json must match the selected endpoint entries exactly.",
                     details=(
                         f"Expected {expected_commands}, observed {endpoints.command_entries} "
                         f"in {endpoints_path}."

--- a/testing/tests/DMC-929/test_dmc_929.py
+++ b/testing/tests/DMC-929/test_dmc_929.py
@@ -46,8 +46,18 @@ class FakeSandbox:
             github_dir.rmdir()
         (skills_root / "installed-skills.json").write_text(
             '{\n'
+            '  "version": "test-seed",\n'
             '  "installed_skills": ["jira"],\n'
             '  "active_commands": ["/dmtools-jira"]\n'
+            '}\n',
+            encoding="utf-8",
+        )
+        (skills_root / "endpoints.json").write_text(
+            '{\n'
+            '  "version": "test-seed",\n'
+            '  "endpoints": [\n'
+            '    {"name": "jira", "path": "/dmtools/jira"}\n'
+            '  ]\n'
             '}\n',
             encoding="utf-8",
         )

--- a/testing/tests/DMC-962/test_dmc_962.py
+++ b/testing/tests/DMC-962/test_dmc_962.py
@@ -78,8 +78,19 @@ class FakeSandbox:
         )
         (skills_root / "installed-skills.json").write_text(
             '{\n'
+            '  "version": "test-seed",\n'
             f'  "installed_skills": ["{RETAINED_SKILL}", "{ADDED_SKILL}"],\n'
             f'  "active_commands": ["/dmtools-{RETAINED_SKILL}", "/dmtools-{ADDED_SKILL}"]\n'
+            '}\n',
+            encoding="utf-8",
+        )
+        (skills_root / "endpoints.json").write_text(
+            '{\n'
+            '  "version": "test-seed",\n'
+            '  "endpoints": [\n'
+            f'    {{"name": "{RETAINED_SKILL}", "path": "/dmtools/{RETAINED_SKILL}"}},\n'
+            f'    {{"name": "{ADDED_SKILL}", "path": "/dmtools/{ADDED_SKILL}"}}\n'
+            '  ]\n'
             '}\n',
             encoding="utf-8",
         )


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`dmtools-ai-docs/install.sh` treated `DMTOOLS_SKILLS=""` as though no environment override had been provided, so the installer fell back to the default `dmtools` skill instead of honoring an explicit empty selection. The same script also never regenerated `endpoints.json`, which left stale `/dmtools-*` entries behind even after deselected skill folders were removed.

### Fix
Updated `dmtools-ai-docs/install.sh` so explicit-empty skill input remains an empty selection, while the default `dmtools` fallback only applies when no selection source was provided at all. The installer now also rewrites `endpoints.json` alongside `installed-skills.json`, and its user-facing summary handles the zero-selected-skills case without implying a skill was installed.

### Test Coverage
- Reproduction test used: `testing/tests/DMC-963/test_dmc_963.py` — `test_dmc_963_empty_skill_selection_removes_all_artifacts_and_clears_metadata`
- Additional related regressions: `testing/tests/DMC-929/test_dmc_929.py`, `testing/tests/DMC-962/test_dmc_962.py`, `testing/tests/DMC-964/test_dmc_964.py`, `testing/tests/DMC-956/test_dmc_956.py`
- Full test suite: `python3 -m pytest testing/tests -q` → 10 unrelated failures in existing documentation/agent audit tickets (`DMC-893`, `DMC-896`, `DMC-897`, `DMC-911`, `DMC-918`, `DMC-933`, `DMC-940`)

### Notes
The ticket-specific regression now passes, and the adjacent `dmtools-ai-docs/install.sh` regression tests passed after the fix. The remaining suite failures are outside the installer path changed here.
