### PR TITLE
DMC-953 Test: Skill source precedence — CLI argument --skills overrides DMTOOLS_SKILLS variable

### DIFF
--- a/testing/tests/DMC-953/README.md
+++ b/testing/tests/DMC-953/README.md
@@ -16,4 +16,11 @@ python3 -m pytest testing/tests/DMC-953/test_dmc_953.py -q
 
 ## Environment
 
-The test runs against the checked-out `install.sh` script and enables `DMTOOLS_INSTALLER_TEST_MODE=true` through the shared installer skill-selection service so it can exercise the live argument parsing and precedence logic without performing a full installation.
+No additional secrets are required. The test runs against the checked-out `install.sh` script and enables `DMTOOLS_INSTALLER_TEST_MODE=true` through the shared installer skill-selection service so it can exercise the live argument parsing and precedence logic without performing a full installation.
+
+## Expected passing output
+
+```text
+.                                                                        [100%]
+1 passed
+```


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-953 — Skill source precedence — CLI argument `--skills` overrides `DMTOOLS_SKILLS` variable

## What was automated

- Reused the existing pytest regression in `testing/tests/DMC-953/test_dmc_953.py`.
- Verified the installer flow with `DMTOOLS_SKILLS=jira,github` and `--skills=confluence,teams`.
- Confirmed the installer reports `cli` as the winning source and keeps only the CLI-selected skills.

## Result

- Automation passed: exit code was `0`, the effective skills were `confluence, teams`, and the exact visible line was `Effective skills: confluence, teams (source: cli)`.
- Human-style verification passed: running the installer flow directly produced:

```text
Effective skills: confluence, teams (source: cli)
Effective integrations: ai,cli,file,kb,mermaid,confluence,teams,teams_auth
```

- The observed user-facing output matched the expected result.

## How to run

```bash
python3 -m pytest testing/tests/DMC-953/test_dmc_953.py -q
```
