### PR TITLE
DMC-967 Test: Re-run installer with additional skill selection — core artifacts are not redownloaded

### DIFF
--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from testing.core.utils.repo_sandbox import CommandResult, RepoSandbox
 
@@ -36,6 +37,14 @@ class InstallerManagedPaths:
     installer_env_path: Path
     jar_path: Path
     script_path: Path
+    installed_skills_path: Path
+    endpoints_path: Path
+
+
+@dataclass(frozen=True)
+class InstallerMetadataSnapshot:
+    installed_skills_payload: Any | None = None
+    endpoints_payload: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -45,6 +54,7 @@ class InstallerRerunObservation:
     first_run: InstallerRunSnapshot
     second_run: InstallerRunSnapshot
     inter_run_artifacts: dict[str, InstallerArtifactState] | None = None
+    second_run_metadata: InstallerMetadataSnapshot | None = None
 
     def changed_artifacts(self, *relative_paths: str) -> list[str]:
         selected_paths = relative_paths
@@ -137,12 +147,14 @@ class InstallerRerunIdempotencyService:
                 self._rerun_skills_csv,
                 managed_paths,
             )
+            second_run_metadata = self._snapshot_metadata(managed_paths)
             return InstallerRerunObservation(
                 initial_skills_csv=self._initial_skills_csv,
                 rerun_skills_csv=self._rerun_skills_csv,
                 first_run=first_run,
                 second_run=second_run,
                 inter_run_artifacts=inter_run_artifacts,
+                second_run_metadata=second_run_metadata,
             )
         finally:
             sandbox.cleanup()
@@ -186,6 +198,19 @@ class InstallerRerunIdempotencyService:
             installer_env_path=bin_dir / "dmtools-installer.env",
             jar_path=install_dir / "dmtools.jar",
             script_path=bin_dir / "dmtools",
+            installed_skills_path=install_dir / "installed-skills.json",
+            endpoints_path=install_dir / "endpoints.json",
+        )
+
+    @staticmethod
+    def _snapshot_metadata(managed_paths: InstallerManagedPaths) -> InstallerMetadataSnapshot:
+        return InstallerMetadataSnapshot(
+            installed_skills_payload=InstallerRerunIdempotencyService._read_json_artifact(
+                managed_paths.installed_skills_path
+            ),
+            endpoints_payload=InstallerRerunIdempotencyService._read_json_artifact(
+                managed_paths.endpoints_path
+            ),
         )
 
     @staticmethod
@@ -242,3 +267,9 @@ class InstallerRerunIdempotencyService:
                 size=stat_result.st_size,
             )
         return snapshots
+
+    @staticmethod
+    def _read_json_artifact(path: Path) -> Any:
+        if not path.exists():
+            return None
+        return json.loads(path.read_text(encoding="utf-8"))

--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -23,13 +23,19 @@ class InstallerRunSnapshot:
 
 @dataclass(frozen=True)
 class InstallerRerunObservation:
-    skills_csv: str
+    initial_skills_csv: str
+    follow_up_skills_csv: str
     first_run: InstallerRunSnapshot
     second_run: InstallerRunSnapshot
 
-    def changed_artifacts(self) -> list[str]:
+    def changed_artifacts(
+        self,
+        artifact_names: tuple[str, ...] | None = None,
+    ) -> list[str]:
         changed: list[str] = []
-        for relative_path, first_snapshot in self.first_run.artifacts.items():
+        selected_artifact_names = artifact_names or tuple(self.first_run.artifacts)
+        for relative_path in selected_artifact_names:
+            first_snapshot = self.first_run.artifacts[relative_path]
             second_snapshot = self.second_run.artifacts[relative_path]
             if (
                 first_snapshot.mtime_ns != second_snapshot.mtime_ns
@@ -56,27 +62,36 @@ class InstallerRerunIdempotencyService:
         self,
         repository_root: Path,
         *,
-        skills_csv: str = "jira,github",
+        skills_csv: str | None = None,
+        initial_skills_csv: str = "jira,github",
+        follow_up_skills_csv: str | None = None,
         sandbox_factory: Callable[[Path], Sandbox] = RepoSandbox,
     ) -> None:
         self._repository_root = repository_root
-        self._skills_csv = skills_csv
+        selected_initial_skills = skills_csv or initial_skills_csv
+        self._initial_skills_csv = selected_initial_skills
+        self._follow_up_skills_csv = follow_up_skills_csv or selected_initial_skills
         self._sandbox_factory = sandbox_factory
 
     def exercise(self) -> InstallerRerunObservation:
         sandbox = self._sandbox_factory(self._repository_root)
         try:
-            first_run = self._run_installer(sandbox)
-            second_run = self._run_installer(sandbox)
+            first_run = self._run_installer(sandbox, self._initial_skills_csv)
+            second_run = self._run_installer(sandbox, self._follow_up_skills_csv)
             return InstallerRerunObservation(
-                skills_csv=self._skills_csv,
+                initial_skills_csv=self._initial_skills_csv,
+                follow_up_skills_csv=self._follow_up_skills_csv,
                 first_run=first_run,
                 second_run=second_run,
             )
         finally:
             sandbox.cleanup()
 
-    def _run_installer(self, sandbox: Sandbox) -> InstallerRunSnapshot:
+    def _run_installer(
+        self,
+        sandbox: Sandbox,
+        skills_csv: str,
+    ) -> InstallerRunSnapshot:
         install_dir = sandbox.home / ".dmtools"
         bin_dir = install_dir / "bin"
         installer_env_path = bin_dir / "dmtools-installer.env"
@@ -88,7 +103,7 @@ class InstallerRerunIdempotencyService:
                 'export DMTOOLS_INSTALL_DIR="$HOME/.dmtools"',
                 'export DMTOOLS_BIN_DIR="$HOME/.dmtools/bin"',
                 'export DMTOOLS_INSTALLER_ENV_PATH="$HOME/.dmtools/bin/dmtools-installer.env"',
-                f'bash ./install.sh --skills "{self._skills_csv}"',
+                f'bash ./install.sh --skills "{skills_csv}"',
             ]
         )
 

--- a/testing/tests/DMC-967/README.md
+++ b/testing/tests/DMC-967/README.md
@@ -1,0 +1,31 @@
+# DMC-967 automated test
+
+This regression test validates the live installer flow for an existing `jira`
+installation upgraded to `jira,github`. It checks the user-visible second-run
+output and the installed artifact timestamps to ensure the new skill can be
+added without redownloading or rewriting the shared core CLI artifacts.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-967/test_dmc_967.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the repository `install.sh`
+in an isolated temporary HOME directory, starting with `jira` installed and then
+re-running the live installer with `jira,github`.
+
+## Expected passing output
+
+```text
+1 passed
+```
+

--- a/testing/tests/DMC-967/config.yaml
+++ b/testing/tests/DMC-967/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-967
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-967/test_dmc_967.py
+++ b/testing/tests/DMC-967/test_dmc_967.py
@@ -16,6 +16,24 @@ UNEXPECTED_SECOND_RUN_MARKERS = (
 )
 
 
+def extract_installed_skill_names(payload: object) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+
+    observed_skills: set[str] = set()
+    for item in payload.get("installed_skills", ()):
+        if isinstance(item, str) and item.strip():
+            observed_skills.add(item.strip().lower())
+            continue
+        if not isinstance(item, dict):
+            continue
+        for key in ("skill", "slug", "name", "id"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                observed_skills.add(value.strip().lower())
+    return observed_skills
+
+
 def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
     service = InstallerRerunIdempotencyService(
         REPOSITORY_ROOT,
@@ -41,6 +59,18 @@ def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
         failures.append(
             "Expected the follow-up installer run to report the requested jira,github "
             "selection in its visible output."
+        )
+
+    second_run_metadata = observation.second_run_metadata
+    installed_skill_names = (
+        extract_installed_skill_names(second_run_metadata.installed_skills_payload)
+        if second_run_metadata is not None
+        else set()
+    )
+    if "github" not in installed_skill_names:
+        failures.append(
+            "Expected the follow-up run to persist github in installed-skills.json, "
+            f"but observed skills were: {sorted(installed_skill_names)!r}"
         )
 
     unexpected_markers = [

--- a/testing/tests/DMC-967/test_dmc_967.py
+++ b/testing/tests/DMC-967/test_dmc_967.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from testing.components.services.installer_rerun_idempotency_service import (
+    InstallerRerunIdempotencyService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+INITIAL_SKILLS = "jira"
+FOLLOW_UP_SKILLS = "jira,github"
+CORE_ARTIFACTS = ("dmtools.jar", "dmtools")
+UNEXPECTED_SECOND_RUN_MARKERS = (
+    "Downloading DMTools JAR...",
+    "Downloading DMTools shell script",
+    "dmtools.sh not found in release assets, downloading from repository...",
+)
+
+
+def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
+    service = InstallerRerunIdempotencyService(
+        REPOSITORY_ROOT,
+        initial_skills_csv=INITIAL_SKILLS,
+        follow_up_skills_csv=FOLLOW_UP_SKILLS,
+    )
+
+    observation = service.exercise()
+
+    assert observation.first_run.command.returncode == 0, (
+        "The initial installer run failed unexpectedly.\n"
+        f"{observation.first_run.command.combined_output}"
+    )
+    assert observation.second_run.command.returncode == 0, (
+        "The follow-up installer run failed unexpectedly.\n"
+        f"{observation.second_run.command.combined_output}"
+    )
+
+    second_run_output = observation.second_run.command.combined_output
+    failures: list[str] = []
+
+    if "Effective skills: jira, github" not in second_run_output:
+        failures.append(
+            "Expected the follow-up installer run to report the requested jira,github "
+            "selection in its visible output."
+        )
+
+    unexpected_markers = [
+        marker for marker in UNEXPECTED_SECOND_RUN_MARKERS if marker in second_run_output
+    ]
+    if unexpected_markers:
+        failures.append(
+            "Expected the follow-up run to avoid redownloading shared core artifacts, "
+            "but the output still showed: "
+            + ", ".join(repr(marker) for marker in unexpected_markers)
+        )
+
+    changed_core_artifacts = observation.changed_artifacts(CORE_ARTIFACTS)
+    if changed_core_artifacts:
+        failures.append(
+            "Expected the follow-up run to leave the shared core artifacts unchanged, "
+            "but these files were rewritten:\n" + "\n".join(changed_core_artifacts)
+        )
+
+    assert not failures, (
+        "Re-running install.sh with an added skill should preserve the already-installed "
+        "core CLI artifacts while extending the selected skill set.\n"
+        + "\n\n".join(failures)
+        + "\n\nSecond run output:\n"
+        + second_run_output
+    )


### PR DESCRIPTION
## Test Automation Result

**Status:** ❌ FAILED  
**Test Case:** DMC-967 — Re-run installer with additional skill selection — core artifacts are not redownloaded

## What was automated

- Added `testing/tests/DMC-967/test_dmc_967.py` plus the ticket `README.md` and `config.yaml`.
- Reused the shared installer sandbox service to exercise the live `install.sh` flow from `jira` to `jira,github`.
- Checked both automation-level assertions and the user-visible CLI output / installed file state after the rerun.

## Result

- The precondition install with `jira` succeeded.
- The follow-up `jira,github` run also succeeded and showed `Effective skills: jira, github`.
- Human-style verification of the CLI output failed because the rerun still displayed `Downloading DMTools JAR...` and `Downloading DMTools shell script`.
- Artifact verification failed because the shared core files were rewritten:

```text
dmtools.jar: first mtime_ns=1777766976841913960, second mtime_ns=1777766978442913283, first size=90349872, second size=90349872
dmtools: first mtime_ns=1777766976946913915, second mtime_ns=1777766978583487885, first size=16490, second size=16490
```

- The installer did update the visible skill configuration to `jira,github`, but it still redownloaded the shared core artifacts, so the expected result was not met.

## How to run

```bash
python3 -m pytest testing/tests/DMC-967/test_dmc_967.py -q
```

## Failure details

```text
AssertionError: Re-running install.sh with an added skill should preserve the already-installed core CLI artifacts while extending the selected skill set.
Expected the follow-up run to avoid redownloading shared core artifacts, but the output still showed: 'Downloading DMTools JAR...', 'Downloading DMTools shell script'

Expected the follow-up run to leave the shared core artifacts unchanged, but these files were rewritten:
dmtools.jar: first mtime_ns=1777766976841913960, second mtime_ns=1777766978442913283, first size=90349872, second size=90349872
dmtools: first mtime_ns=1777766976946913915, second mtime_ns=1777766978583487885, first size=16490, second size=16490
```

