### PR TITLE
DMC-966 Test: Re-run installer with permuted skill list — core artifacts remain unchanged

### DIFF
--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -23,13 +23,17 @@ class InstallerRunSnapshot:
 
 @dataclass(frozen=True)
 class InstallerRerunObservation:
-    skills_csv: str
+    initial_skills_csv: str
+    rerun_skills_csv: str
     first_run: InstallerRunSnapshot
     second_run: InstallerRunSnapshot
 
-    def changed_artifacts(self) -> list[str]:
+    def changed_artifacts(self, *relative_paths: str) -> list[str]:
+        expected_paths = set(relative_paths)
         changed: list[str] = []
         for relative_path, first_snapshot in self.first_run.artifacts.items():
+            if expected_paths and relative_path not in expected_paths:
+                continue
             second_snapshot = self.second_run.artifacts[relative_path]
             if (
                 first_snapshot.mtime_ns != second_snapshot.mtime_ns
@@ -51,32 +55,46 @@ class Sandbox(Protocol):
     def run(self, command: str, timeout: int = 1800) -> CommandResult: ...
 
 
+def reports_noop_status_for_selected_skills(output: str, skills_csv: str) -> bool:
+    expected_skills = tuple(skill.strip().lower() for skill in skills_csv.split(",") if skill.strip())
+    for line in output.splitlines():
+        normalized_line = line.lower()
+        if "already installed" not in normalized_line and "no-op" not in normalized_line:
+            continue
+        if all(skill in normalized_line for skill in expected_skills):
+            return True
+    return False
+
+
 class InstallerRerunIdempotencyService:
     def __init__(
         self,
         repository_root: Path,
         *,
-        skills_csv: str = "jira,github",
+        initial_skills_csv: str = "jira,github",
+        rerun_skills_csv: str | None = None,
         sandbox_factory: Callable[[Path], Sandbox] = RepoSandbox,
     ) -> None:
         self._repository_root = repository_root
-        self._skills_csv = skills_csv
+        self._initial_skills_csv = initial_skills_csv
+        self._rerun_skills_csv = rerun_skills_csv or initial_skills_csv
         self._sandbox_factory = sandbox_factory
 
     def exercise(self) -> InstallerRerunObservation:
         sandbox = self._sandbox_factory(self._repository_root)
         try:
-            first_run = self._run_installer(sandbox)
-            second_run = self._run_installer(sandbox)
+            first_run = self._run_installer(sandbox, self._initial_skills_csv)
+            second_run = self._run_installer(sandbox, self._rerun_skills_csv)
             return InstallerRerunObservation(
-                skills_csv=self._skills_csv,
+                initial_skills_csv=self._initial_skills_csv,
+                rerun_skills_csv=self._rerun_skills_csv,
                 first_run=first_run,
                 second_run=second_run,
             )
         finally:
             sandbox.cleanup()
 
-    def _run_installer(self, sandbox: Sandbox) -> InstallerRunSnapshot:
+    def _run_installer(self, sandbox: Sandbox, skills_csv: str) -> InstallerRunSnapshot:
         install_dir = sandbox.home / ".dmtools"
         bin_dir = install_dir / "bin"
         installer_env_path = bin_dir / "dmtools-installer.env"
@@ -88,7 +106,7 @@ class InstallerRerunIdempotencyService:
                 'export DMTOOLS_INSTALL_DIR="$HOME/.dmtools"',
                 'export DMTOOLS_BIN_DIR="$HOME/.dmtools/bin"',
                 'export DMTOOLS_INSTALLER_ENV_PATH="$HOME/.dmtools/bin/dmtools-installer.env"',
-                f'bash ./install.sh --skills "{self._skills_csv}"',
+                f'bash ./install.sh --skills "{skills_csv}"',
             ]
         )
 

--- a/testing/tests/DMC-966/README.md
+++ b/testing/tests/DMC-966/README.md
@@ -1,0 +1,32 @@
+# DMC-966 automated test
+
+This test validates that the installer treats a repeated selective install as a
+no-op even when the second run provides the same skills in a different order.
+It performs a real install of `jira,github` inside an isolated HOME directory,
+reruns `install.sh` with `--skills github,jira`, and verifies the user-visible
+logs plus the installed core artifact timestamps.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-966/test_dmc_966.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the live installer in a
+temporary sandboxed HOME directory and observes the generated files under that
+isolated installation target.
+
+## Expected passing output
+
+```text
+1 passed
+```
+

--- a/testing/tests/DMC-966/config.yaml
+++ b/testing/tests/DMC-966/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-966
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-966/test_dmc_966.py
+++ b/testing/tests/DMC-966/test_dmc_966.py
@@ -7,14 +7,22 @@ from testing.components.services.installer_rerun_idempotency_service import (
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
-EXPECTED_SKILLS = "jira,github"
+INITIAL_SKILLS = "jira,github"
+RERUN_SKILLS = "github,jira"
+CORE_ARTIFACTS = ("dmtools.jar", "dmtools")
 UNEXPECTED_SECOND_RUN_MARKERS = (
     "Downloading DMTools JAR...",
     "Downloading DMTools shell script",
     "dmtools.sh not found in release assets, downloading from repository...",
 )
-def test_dmc_928_rerunning_installer_for_the_same_skill_set_is_idempotent() -> None:
-    service = InstallerRerunIdempotencyService(REPOSITORY_ROOT, initial_skills_csv=EXPECTED_SKILLS)
+
+
+def test_dmc_966_rerunning_installer_with_permuted_skill_order_keeps_core_artifacts_unchanged() -> None:
+    service = InstallerRerunIdempotencyService(
+        REPOSITORY_ROOT,
+        initial_skills_csv=INITIAL_SKILLS,
+        rerun_skills_csv=RERUN_SKILLS,
+    )
 
     observation = service.exercise()
 
@@ -23,17 +31,18 @@ def test_dmc_928_rerunning_installer_for_the_same_skill_set_is_idempotent() -> N
         f"{observation.first_run.command.combined_output}"
     )
     assert observation.second_run.command.returncode == 0, (
-        "The repeated installer run failed unexpectedly.\n"
+        "The repeated installer run with a permuted skill list failed unexpectedly.\n"
         f"{observation.second_run.command.combined_output}"
     )
 
     second_run_output = observation.second_run.command.combined_output
     failures: list[str] = []
 
-    if not reports_noop_status_for_selected_skills(second_run_output, EXPECTED_SKILLS):
+    if not reports_noop_status_for_selected_skills(second_run_output, RERUN_SKILLS):
         failures.append(
             "Expected the rerun to report an already-installed or no-op status for the "
-            "selected skills, but no matching status line was found in the output."
+            "same selected skills even when they are provided in a different order, "
+            "but no matching status line was found in the output."
         )
 
     unexpected_markers = [
@@ -41,20 +50,22 @@ def test_dmc_928_rerunning_installer_for_the_same_skill_set_is_idempotent() -> N
     ]
     if unexpected_markers:
         failures.append(
-            "Expected the rerun to avoid download work, but the output still showed: "
+            "Expected the rerun with a permuted skill order to avoid download work, "
+            "but the output still showed: "
             + ", ".join(repr(marker) for marker in unexpected_markers)
         )
 
-    changed_artifacts = observation.changed_artifacts()
+    changed_artifacts = observation.changed_artifacts(*CORE_ARTIFACTS)
     if changed_artifacts:
         failures.append(
-            "Expected the rerun to leave installer-managed files unchanged, but these "
-            "artifacts were rewritten:\n" + "\n".join(changed_artifacts)
+            "Expected the rerun with the same skill set in a different order to leave "
+            "the core installer-managed artifacts unchanged, but these artifacts were rewritten:\n"
+            + "\n".join(changed_artifacts)
         )
 
     assert not failures, (
-        "Re-running install.sh with the same skill selection should be a no-op for the "
-        "target installation.\n"
+        "Re-running install.sh with the same skills in a different order should be a "
+        "no-op for the target installation.\n"
         + "\n\n".join(failures)
         + "\n\nSecond run output:\n"
         + second_run_output


### PR DESCRIPTION
## Test Automation Result

**Status:** ❌ FAILED  
**Test Case:** DMC-966 — Re-run installer with permuted skill list — core artifacts remain unchanged

## What was automated

- Added `testing/tests/DMC-966/test_dmc_966.py`, a pytest regression that performs a real install with `bash ./install.sh --skills jira,github` and reruns `bash ./install.sh --skills github,jira` in the same isolated Linux HOME.
- Checked the second-run user-visible output for an already-installed / no-op message and for the absence of `Downloading DMTools JAR...` and `Downloading DMTools shell script...`.
- Checked the observable artifact state a user depends on by comparing `dmtools.jar` and `dmtools` timestamps before and after the rerun.

## Result

- The rerun did **not** behave like a no-op for the same skills in a different order.
- The second-run output showed `Effective skills: github, jira (source: cli)`, then `Downloading DMTools JAR...` and `Downloading DMTools shell script...`, and it did not show any already-installed / no-op status line.
- The core artifacts were rewritten on the rerun:

  ```text
  dmtools.jar: first mtime_ns=1777766960872628249, second mtime_ns=1777766962769122165
  dmtools: first mtime_ns=1777766961033385090, second mtime_ns=1777766962899683918
  ```

- Human-style verification: re-running the installer directly from the shell reproduced the same user-visible behavior. The rerun printed the same download messages and advanced the artifact timestamps:

  ```text
  dmtools.jar: 1777766977 -> 1777766978
  dmtools: 1777766977 -> 1777766979
  ```

- Context: `testing/tests/DMC-928/test_dmc_928.py` still passed in the same session, so the regression appears specific to the permuted skill-order path.

## How to run

```bash
python3 -m pytest testing/tests/DMC-966/test_dmc_966.py -q
```

