### PR TITLE
DMC-968 Test: Re-run installer with partially missing core artifacts — only missing files are restored

### DIFF
--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -22,10 +22,28 @@ class InstallerRunSnapshot:
 
 
 @dataclass(frozen=True)
+class InstallerArtifactState:
+    relative_path: str
+    exists: bool
+    mtime_ns: int | None = None
+    size: int | None = None
+
+
+@dataclass(frozen=True)
+class InstallerManagedPaths:
+    install_dir: Path
+    bin_dir: Path
+    installer_env_path: Path
+    jar_path: Path
+    script_path: Path
+
+
+@dataclass(frozen=True)
 class InstallerRerunObservation:
     skills_csv: str
     first_run: InstallerRunSnapshot
     second_run: InstallerRunSnapshot
+    inter_run_artifacts: dict[str, InstallerArtifactState] | None = None
 
     def changed_artifacts(self) -> list[str]:
         changed: list[str] = []
@@ -63,24 +81,34 @@ class InstallerRerunIdempotencyService:
         self._skills_csv = skills_csv
         self._sandbox_factory = sandbox_factory
 
-    def exercise(self) -> InstallerRerunObservation:
+    def exercise(
+        self,
+        before_second_run: Callable[[InstallerManagedPaths], None] | None = None,
+    ) -> InstallerRerunObservation:
         sandbox = self._sandbox_factory(self._repository_root)
         try:
-            first_run = self._run_installer(sandbox)
+            managed_paths = self._managed_paths(sandbox)
+            first_run = self._run_installer(sandbox, managed_paths)
+            inter_run_artifacts: dict[str, InstallerArtifactState] | None = None
+            if before_second_run is not None:
+                before_second_run(managed_paths)
+                inter_run_artifacts = self._capture_artifact_states(managed_paths)
             second_run = self._run_installer(sandbox)
             return InstallerRerunObservation(
                 skills_csv=self._skills_csv,
                 first_run=first_run,
                 second_run=second_run,
+                inter_run_artifacts=inter_run_artifacts,
             )
         finally:
             sandbox.cleanup()
 
-    def _run_installer(self, sandbox: Sandbox) -> InstallerRunSnapshot:
-        install_dir = sandbox.home / ".dmtools"
-        bin_dir = install_dir / "bin"
-        installer_env_path = bin_dir / "dmtools-installer.env"
-
+    def _run_installer(
+        self,
+        sandbox: Sandbox,
+        managed_paths: InstallerManagedPaths | None = None,
+    ) -> InstallerRunSnapshot:
+        paths = managed_paths or self._managed_paths(sandbox)
         command = "\n".join(
             [
                 "set -e",
@@ -95,13 +123,52 @@ class InstallerRerunIdempotencyService:
         result = sandbox.run(command, timeout=1800)
 
         artifacts = self._snapshot_artifacts(
-            install_dir=install_dir,
-            bin_dir=bin_dir,
-            installer_env_path=installer_env_path,
+            install_dir=paths.install_dir,
+            bin_dir=paths.bin_dir,
+            installer_env_path=paths.installer_env_path,
             command_result=result,
         )
 
         return InstallerRunSnapshot(command=result, artifacts=artifacts)
+
+    @staticmethod
+    def _managed_paths(sandbox: Sandbox) -> InstallerManagedPaths:
+        install_dir = sandbox.home / ".dmtools"
+        bin_dir = install_dir / "bin"
+        return InstallerManagedPaths(
+            install_dir=install_dir,
+            bin_dir=bin_dir,
+            installer_env_path=bin_dir / "dmtools-installer.env",
+            jar_path=install_dir / "dmtools.jar",
+            script_path=bin_dir / "dmtools",
+        )
+
+    @staticmethod
+    def _capture_artifact_states(
+        managed_paths: InstallerManagedPaths,
+    ) -> dict[str, InstallerArtifactState]:
+        artifact_paths = (
+            managed_paths.jar_path,
+            managed_paths.script_path,
+            managed_paths.installer_env_path,
+        )
+        states: dict[str, InstallerArtifactState] = {}
+        for artifact_path in artifact_paths:
+            if not artifact_path.exists():
+                states[artifact_path.name] = InstallerArtifactState(
+                    relative_path=artifact_path.name,
+                    exists=False,
+                )
+                continue
+
+            stat_result = artifact_path.stat()
+            states[artifact_path.name] = InstallerArtifactState(
+                relative_path=artifact_path.name,
+                exists=True,
+                mtime_ns=stat_result.st_mtime_ns,
+                size=stat_result.st_size,
+            )
+        return states
 
     @staticmethod
     def _snapshot_artifacts(

--- a/testing/tests/DMC-968/README.md
+++ b/testing/tests/DMC-968/README.md
@@ -1,0 +1,23 @@
+# DMC-968 automated test
+
+This test validates that re-running `install.sh --skills jira,github` after manually
+deleting only the installed `dmtools` launcher restores the missing shell script
+without redownloading the existing `dmtools.jar`.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-968/test_dmc_968.py -q
+```
+
+## Environment
+
+No external credentials are required. The test runs the real installer in an isolated
+temporary HOME directory, removes only the installed launcher between runs, and then
+verifies the user-visible rerun output plus the final installer-managed artifacts.

--- a/testing/tests/DMC-968/config.yaml
+++ b/testing/tests/DMC-968/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-968
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-968/test_dmc_968.py
+++ b/testing/tests/DMC-968/test_dmc_968.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+from testing.components.services.installer_rerun_idempotency_service import (
+    InstallerManagedPaths,
+    InstallerRerunIdempotencyService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_SKILLS = "jira,github"
+EXPECTED_RESTORED_SCRIPT_MARKER = "Downloading DMTools shell script"
+UNEXPECTED_JAR_DOWNLOAD_MARKERS = (
+    "Downloading DMTools JAR...",
+    "Downloading DMTools JAR",
+)
+
+
+def _delete_only_shell_script(paths: InstallerManagedPaths) -> None:
+    assert paths.jar_path.exists(), (
+        "The test precondition requires an existing dmtools.jar before deleting the "
+        f"shell script.\nMissing path: {paths.jar_path}"
+    )
+    assert paths.script_path.exists(), (
+        "The test precondition requires an existing dmtools shell script before the "
+        f"manual deletion step.\nMissing path: {paths.script_path}"
+    )
+
+    paths.script_path.unlink()
+
+    assert not paths.script_path.exists(), (
+        "The inter-run setup should remove only the dmtools shell script before the "
+        f"rerun.\nPath still exists: {paths.script_path}"
+    )
+    assert paths.jar_path.exists(), (
+        "Deleting the dmtools shell script must leave dmtools.jar intact.\n"
+        f"Missing path after deletion: {paths.jar_path}"
+    )
+
+
+def test_dmc_968_rerun_restores_only_missing_shell_script() -> None:
+    service = InstallerRerunIdempotencyService(REPOSITORY_ROOT, skills_csv=EXPECTED_SKILLS)
+
+    observation = service.exercise(before_second_run=_delete_only_shell_script)
+
+    assert observation.first_run.command.returncode == 0, (
+        "The initial installer run failed unexpectedly.\n"
+        f"{observation.first_run.command.combined_output}"
+    )
+    assert observation.second_run.command.returncode == 0, (
+        "The rerun after deleting the shell script failed unexpectedly.\n"
+        f"{observation.second_run.command.combined_output}"
+    )
+    assert observation.inter_run_artifacts is not None, (
+        "The test should capture installer-managed artifact states after the manual "
+        "deletion step and before the rerun."
+    )
+
+    inter_run_artifacts = observation.inter_run_artifacts
+    assert inter_run_artifacts["dmtools"].exists is False, (
+        "After the manual deletion step, the dmtools shell script should be missing "
+        "before the rerun starts."
+    )
+    assert inter_run_artifacts["dmtools.jar"].exists is True, (
+        "After deleting the shell script, the existing dmtools.jar should still be "
+        "present before the rerun starts."
+    )
+
+    second_run_output = observation.second_run.command.combined_output
+    failures: list[str] = []
+
+    if EXPECTED_RESTORED_SCRIPT_MARKER not in second_run_output:
+        failures.append(
+            "Expected the rerun to visibly restore the missing dmtools shell script, "
+            f"but the output did not contain {EXPECTED_RESTORED_SCRIPT_MARKER!r}."
+        )
+
+    unexpected_jar_downloads = [
+        marker for marker in UNEXPECTED_JAR_DOWNLOAD_MARKERS if marker in second_run_output
+    ]
+    if unexpected_jar_downloads:
+        failures.append(
+            "Expected the rerun to avoid redownloading the existing dmtools.jar when "
+            "only the shell script was missing, but the output still showed: "
+            + ", ".join(repr(marker) for marker in unexpected_jar_downloads)
+        )
+
+    first_jar_snapshot = observation.first_run.artifacts["dmtools.jar"]
+    second_jar_snapshot = observation.second_run.artifacts["dmtools.jar"]
+    if first_jar_snapshot.mtime_ns != second_jar_snapshot.mtime_ns:
+        failures.append(
+            "Expected the existing dmtools.jar timestamp to remain unchanged, but it "
+            "was rewritten.\n"
+            f"First snapshot: {first_jar_snapshot}\n"
+            f"Second snapshot: {second_jar_snapshot}"
+        )
+    if first_jar_snapshot.size != second_jar_snapshot.size:
+        failures.append(
+            "Expected the existing dmtools.jar contents to remain unchanged, but its "
+            "size changed.\n"
+            f"First snapshot: {first_jar_snapshot}\n"
+            f"Second snapshot: {second_jar_snapshot}"
+        )
+
+    second_script_snapshot = observation.second_run.artifacts["dmtools"]
+    if second_script_snapshot.size <= 0:
+        failures.append(
+            "Expected the rerun to recreate a non-empty dmtools shell script.\n"
+            f"Final snapshot: {second_script_snapshot}"
+        )
+
+    assert not failures, (
+        "Re-running install.sh after deleting only the dmtools shell script should "
+        "restore the missing script without rewriting dmtools.jar.\n"
+        + "\n\n".join(failures)
+        + "\n\nSecond run output:\n"
+        + second_run_output
+    )


### PR DESCRIPTION
# DMC-968 Test Automation Result

## Status

**FAILED**

## Automated coverage

Implemented a new pytest regression test at `testing/tests/DMC-968/test_dmc_968.py`.

Automation verifies that:

1. `install.sh --skills jira,github` succeeds in an isolated temp HOME.
2. Only `~/.dmtools/bin/dmtools` is manually deleted between runs.
3. The rerun succeeds and restores the missing shell script.
4. The rerun does **not** redownload `~/.dmtools/dmtools.jar`.
5. The existing JAR timestamp remains unchanged.

To support this scenario, the shared helper `testing/components/services/installer_rerun_idempotency_service.py` now supports an inter-run mutation hook and captures artifact state before the rerun.

## Human-style verification

I also reproduced the scenario manually from the command line, as a user would:

1. Ran `bash ./install.sh --skills jira,github`.
2. Deleted only `~/.dmtools/bin/dmtools`.
3. Re-ran `bash ./install.sh --skills jira,github`.
4. Observed the visible installer output and compared artifact timestamps.

### What was observed

- The rerun displayed `Selected skills already installed: jira,github`.
- The rerun still displayed `Downloading DMTools JAR...`.
- The rerun also displayed `Downloading DMTools shell script...`.
- `dmtools.jar` kept the same size (`90349872`) but its timestamp changed, so it was rewritten.

### Expected vs actual

| Check | Expected | Actual |
| --- | --- | --- |
| Missing launcher restoration | Recreate only `bin/dmtools` | `bin/dmtools` was recreated |
| Existing JAR handling | Do not redownload or rewrite `dmtools.jar` | `Downloading DMTools JAR...` appeared and the JAR timestamp changed |
| User-visible outcome | Partial repair/no redundant download | Partial repair happened, but with redundant JAR download |

## Failing assertion

```text
AssertionError: Re-running install.sh after deleting only the dmtools shell script should restore the missing script without rewriting dmtools.jar.
Expected the rerun to avoid redownloading the existing dmtools.jar when only the shell script was missing, but the output still showed: 'Downloading DMTools JAR...', 'Downloading DMTools JAR'

Expected the existing dmtools.jar timestamp to remain unchanged, but it was rewritten.
First snapshot: InstallerArtifactSnapshot(relative_path='dmtools.jar', mtime_ns=1777766982689379207, size=90349872)
Second snapshot: InstallerArtifactSnapshot(relative_path='dmtools.jar', mtime_ns=1777766984156384556, size=90349872)
```
