### PR TITLE
DMC-928 Test: Re-run installer for existing skill set — operation is idempotent

### DIFF
--- a/testing/tests/DMC-928/README.md
+++ b/testing/tests/DMC-928/README.md
@@ -18,3 +18,8 @@ python3 -m pytest testing/tests/DMC-928/test_dmc_928.py -q
 
 No external credentials are required. The test runs the real installer in a temporary isolated HOME directory and observes the generated files under that sandbox.
 
+## Expected passing output
+
+```text
+1 passed
+```


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-928 — Re-run installer for existing skill set — operation is idempotent

## What was automated
- Ran the real `install.sh --skills jira,github` flow twice in an isolated HOME via `testing/tests/DMC-928/test_dmc_928.py`.
- Verified the second run exits successfully, reports an already-installed / no-op style status for the selected skills, avoids download work, and leaves `dmtools.jar`, `dmtools`, and `dmtools-installer.env` unchanged.

## Result
- Automation passed: `python3 -m pytest testing/tests/DMC-928/test_dmc_928.py -q` returned `1 passed`.
- Human-style verification passed: running `HOME=/tmp/tmp.cssGAK0XEN/home SHELL=/bin/bash bash ./install.sh --skills jira,github` twice showed `Selected skills already installed: jira,github`, `Installer-managed artifacts already present for version v1.7.179; skipping DMTools download.`, and `Installer metadata already present for version v1.7.179; skipping metadata rewrite.`
- The observed artifact timestamps and sizes for `dmtools.jar`, `dmtools`, and `dmtools-installer.env` were identical before and after the second run, matching the expected user-visible no-op behavior.

## How to run
```bash
python3 -m pytest testing/tests/DMC-928/test_dmc_928.py -q
```
