### PR TITLE
DMC-969 Installer treats reordered skill list as changed selection and redownloads core artifacts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,6 +110,40 @@ join_by_comma_space() {
     printf '%s' "$result"
 }
 
+normalize_csv_set() {
+    local raw_csv="$1"
+    local values=()
+    local token
+
+    IFS=',' read -r -a csv_tokens <<< "$raw_csv"
+    for token in "${csv_tokens[@]}"; do
+        token=$(to_lower "$(strip_optional_quotes "$token")")
+        token=$(trim_value "$token")
+        if [ -z "$token" ]; then
+            continue
+        fi
+        append_unique values "$token"
+    done
+
+    if [ ${#values[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    printf '%s\n' "${values[@]}" | LC_ALL=C sort | paste -sd, -
+}
+
+read_env_assignment_value() {
+    local file_path="$1"
+    local key="$2"
+    [ -f "$file_path" ] || return 1
+
+    local raw_value
+    raw_value=$(sed -n "s/^${key}=//p" "$file_path" | head -n 1)
+    [ -n "$raw_value" ] || return 1
+
+    strip_optional_quotes "$raw_value"
+}
+
 json_escape() {
     local value="$1"
     value="${value//\\/\\\\}"
@@ -459,12 +493,24 @@ EOF
 
     mkdir -p "$(dirname "$INSTALLER_ENV_PATH")"
 
-    local existing_content=""
-    if [ -f "$INSTALLER_ENV_PATH" ]; then
-        existing_content=$(cat "$INSTALLER_ENV_PATH")
-    fi
+    local existing_skills
+    local existing_integrations
+    local normalized_existing_skills
+    local normalized_requested_skills
+    local normalized_existing_integrations
+    local normalized_requested_integrations
 
-    if [ "$existing_content" = "$new_content" ]; then
+    existing_skills=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_SKILLS" || true)
+    existing_integrations=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
+    normalized_existing_skills=$(normalize_csv_set "$existing_skills")
+    normalized_requested_skills=$(normalize_csv_set "$EFFECTIVE_SKILLS_CSV")
+    normalized_existing_integrations=$(normalize_csv_set "$existing_integrations")
+    normalized_requested_integrations=$(normalize_csv_set "$EFFECTIVE_INTEGRATIONS_CSV")
+
+    if [ -n "$normalized_existing_skills" ] \
+        && [ -n "$normalized_existing_integrations" ] \
+        && [ "$normalized_existing_skills" = "$normalized_requested_skills" ] \
+        && [ "$normalized_existing_integrations" = "$normalized_requested_integrations" ]; then
         INSTALLER_SKILL_CONFIG_UNCHANGED=true
         info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
         return 0


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present at the repository root, so implementation followed the ticket context plus the repository guidance already available in-tree.
- The broader Python suite still has unrelated pre-existing failures (`DMC-911`, `DMC-918`, `DMC-933`, `DMC-940`, and others); they were not introduced by this installer change.

## Approach

The root cause was in `install.sh`'s idempotency gate: `write_installer_skill_config()` treated the persisted `DMTOOLS_SKILLS` / `DMTOOLS_INTEGRATIONS` env file as order-sensitive, so `jira,github` and `github,jira` were considered different selections. That set `INSTALLER_SKILL_CONFIG_UNCHANGED=false`, which in turn forced the installer to redownload `dmtools.jar` and `dmtools` instead of taking the no-op path.

I fixed this by normalizing both the existing env values and the current effective CSVs into order-independent sets before deciding whether the skill configuration changed. The installer still preserves the user-visible effective-skill display, but reruns with the same selected set now correctly report the skills as already installed and skip core-artifact downloads.

## Files Modified

- `install.sh` — added CSV normalization/env-reading helpers and changed `write_installer_skill_config()` to compare installer-managed skills and integrations order-independently.
- `outputs/rca.md` — recorded the confirmed RCA for the ticket.
- `outputs/response.md` — recorded the implementation summary and validation results.

## Test Coverage

- Reproduction/regression tests: `python3 -m pytest testing/tests/DMC-966/test_dmc_966.py testing/tests/DMC-928/test_dmc_928.py -q -r a` — passed.
- Core suite: `./gradlew :dmtools-core:test` — passed.
- Broader Python suite: `python3 -m pytest testing/tests -q -r a` — completed with 10 unrelated pre-existing failures; the installer regression tests remained passing.
