### PR TITLE
DMC-970 Installer rerun rewrites dmtools.jar when only dmtools shell script is missing

### DIFF
--- a/install
+++ b/install
@@ -476,7 +476,15 @@ EOF
 }
 
 installer_managed_artifacts_present() {
-    [ -s "$JAR_PATH" ] && [ -s "$SCRIPT_PATH" ]
+    installer_managed_jar_present && installer_managed_script_present
+}
+
+installer_managed_jar_present() {
+    [ -s "$JAR_PATH" ]
+}
+
+installer_managed_script_present() {
+    [ -s "$SCRIPT_PATH" ] && [ -x "$SCRIPT_PATH" ]
 }
 
 read_installer_metadata_version() {
@@ -1238,15 +1246,19 @@ download_script_from_repo() {
     return 1
 }
 
-# Download DMTools JAR and script
-download_dmtools() {
+# Download DMTools JAR
+download_dmtools_jar() {
     local version="$1"
     local jar_url="https://github.com/${REPO}/releases/download/${version}/dmtools-${version}-all.jar"
-    local script_url="https://github.com/${REPO}/releases/download/${version}/dmtools.sh"
-    
-    # Download JAR
+
     download_file "$jar_url" "$JAR_PATH" "DMTools JAR"
-    
+}
+
+# Download DMTools shell script
+download_dmtools_shell_script() {
+    local version="$1"
+    local script_url="https://github.com/${REPO}/releases/download/${version}/dmtools.sh"
+
     # Download shell script - try multiple methods
     # Method 1: Try redirect-based URL (standard GitHub release URL)
     if download_file "$script_url" "$SCRIPT_PATH" "DMTools shell script" "true"; then
@@ -1289,6 +1301,14 @@ Please try again later or download manually from:
   https://raw.githubusercontent.com/${REPO}/main/dmtools.sh
   
 And place it at: $SCRIPT_PATH"
+}
+
+# Download DMTools JAR and script
+download_dmtools() {
+    local version="$1"
+
+    download_dmtools_jar "$version"
+    download_dmtools_shell_script "$version"
 }
 
 # Update shell configuration
@@ -1448,11 +1468,22 @@ main() {
     write_installer_skill_config
 
     local skip_dmtools_download=false
+    local jar_matches_version=false
     if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] \
-        && installer_managed_artifacts_present \
+        && installer_managed_jar_present \
         && installed_artifact_version_matches "$version"; then
-        skip_dmtools_download=true
-        info "Installer-managed artifacts already present for version $version; skipping DMTools download."
+        jar_matches_version=true
+    fi
+
+    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && [ "$jar_matches_version" = true ]; then
+        if installer_managed_script_present; then
+            skip_dmtools_download=true
+            info "Installer-managed artifacts already present for version $version; skipping DMTools download."
+        else
+            skip_dmtools_download=true
+            info "Installer-managed DMTools JAR already present for version $version; skipping JAR download."
+            download_dmtools_shell_script "$version"
+        fi
     fi
 
     if [ "$skip_dmtools_download" != true ]; then

--- a/install.sh
+++ b/install.sh
@@ -522,7 +522,15 @@ EOF
 }
 
 installer_managed_artifacts_present() {
-    [ -s "$JAR_PATH" ] && [ -s "$SCRIPT_PATH" ]
+    installer_managed_jar_present && installer_managed_script_present
+}
+
+installer_managed_jar_present() {
+    [ -s "$JAR_PATH" ]
+}
+
+installer_managed_script_present() {
+    [ -s "$SCRIPT_PATH" ] && [ -x "$SCRIPT_PATH" ]
 }
 
 read_installer_metadata_version() {
@@ -1284,15 +1292,19 @@ download_script_from_repo() {
     return 1
 }
 
-# Download DMTools JAR and script
-download_dmtools() {
+# Download DMTools JAR
+download_dmtools_jar() {
     local version="$1"
     local jar_url="https://github.com/${REPO}/releases/download/${version}/dmtools-${version}-all.jar"
-    local script_url="https://github.com/${REPO}/releases/download/${version}/dmtools.sh"
-    
-    # Download JAR
+
     download_file "$jar_url" "$JAR_PATH" "DMTools JAR"
-    
+}
+
+# Download DMTools shell script
+download_dmtools_shell_script() {
+    local version="$1"
+    local script_url="https://github.com/${REPO}/releases/download/${version}/dmtools.sh"
+
     # Download shell script - try multiple methods
     # Method 1: Try redirect-based URL (standard GitHub release URL)
     if download_file "$script_url" "$SCRIPT_PATH" "DMTools shell script" "true"; then
@@ -1335,6 +1347,14 @@ Please try again later or download manually from:
   https://raw.githubusercontent.com/${REPO}/main/dmtools.sh
   
 And place it at: $SCRIPT_PATH"
+}
+
+# Download DMTools JAR and script
+download_dmtools() {
+    local version="$1"
+
+    download_dmtools_jar "$version"
+    download_dmtools_shell_script "$version"
 }
 
 # Update shell configuration
@@ -1494,11 +1514,22 @@ main() {
     write_installer_skill_config
 
     local skip_dmtools_download=false
+    local jar_matches_version=false
     if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] \
-        && installer_managed_artifacts_present \
+        && installer_managed_jar_present \
         && installed_artifact_version_matches "$version"; then
-        skip_dmtools_download=true
-        info "Installer-managed artifacts already present for version $version; skipping DMTools download."
+        jar_matches_version=true
+    fi
+
+    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && [ "$jar_matches_version" = true ]; then
+        if installer_managed_script_present; then
+            skip_dmtools_download=true
+            info "Installer-managed artifacts already present for version $version; skipping DMTools download."
+        else
+            skip_dmtools_download=true
+            info "Installer-managed DMTools JAR already present for version $version; skipping JAR download."
+            download_dmtools_shell_script "$version"
+        fi
     fi
 
     if [ "$skip_dmtools_download" != true ]; then

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -309,6 +309,62 @@ main --skills jira,github
                     result.stdout,
                 )
 
+    def test_repeated_main_run_restores_only_missing_shell_script(self) -> None:
+        for installer_script in INSTALL_ENTRYPOINTS:
+            with self.subTest(installer_script=installer_script.name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    result = run_installer_functions(
+                        """
+check_java() { printf 'stub check_java\\n'; }
+get_latest_version() { printf 'v0.0.0-test'; }
+download_file() {
+    local url="$1"
+    local output="$2"
+    local desc="$3"
+    printf 'SIDE download_file %s\\n' "$desc"
+    mkdir -p "$(dirname "$output")" "$BIN_DIR"
+    case "$desc" in
+        "DMTools JAR")
+            printf 'stub jar for %s\\n' "$url" > "$output"
+            ;;
+        *)
+            cat > "$output" <<'EOF'
+#!/bin/bash
+echo "dmtools stub"
+EOF
+            ;;
+    esac
+    return 0
+}
+download_script_from_repo() { printf 'SIDE download_script_from_repo\\n'; return 1; }
+update_shell_config() { printf 'SIDE update_shell_config\\n'; }
+verify_installation() { printf 'SIDE verify_installation\\n'; }
+print_instructions() { printf 'SIDE print_instructions\\n'; }
+main --skills jira,github
+rm -f "$SCRIPT_PATH"
+main --skills jira,github
+""",
+                        {
+                            "DMTOOLS_INSTALL_DIR": temp_dir,
+                            "DMTOOLS_BIN_DIR": f"{temp_dir}/bin",
+                            "DMTOOLS_INSTALLER_ENV_PATH": f"{temp_dir}/bin/dmtools-installer.env",
+                        },
+                        installer_script=installer_script,
+                    )
+
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertEqual(
+                    1,
+                    result.stdout.count("SIDE download_file DMTools JAR"),
+                    result.stdout,
+                )
+                self.assertEqual(
+                    2,
+                    result.stdout.count("SIDE download_file DMTools shell script"),
+                    result.stdout,
+                )
+                self.assertIn("Selected skills already installed: jira,github", result.stdout)
+
     def test_repeated_main_run_redownloads_when_requested_version_changes(self) -> None:
         for installer_script in INSTALL_ENTRYPOINTS:
             with self.subTest(installer_script=installer_script.name):


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The installer treated `dmtools.jar` and the `dmtools` launcher as a single all-or-nothing artifact set. On rerun, if the selected skills were unchanged but the launcher alone was missing, the `installer_managed_artifacts_present()` check failed and `main()` fell back to `download_dmtools`, which rewrote the existing JAR.

### Fix
I split the installer download path in both `install.sh` and `install` into separate JAR and shell-script helpers, then updated the rerun logic to detect a matching existing JAR independently from the launcher. When the selected skills are unchanged and the installed JAR version already matches, the installer now restores only the missing shell script and skips the JAR download.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-859/test_install_skills.py` — `test_repeated_main_run_restores_only_missing_shell_script`
- Linked regression test: `testing/tests/DMC-968/test_dmc_968.py` — PASSED
- Broader installer suite: `testing/tests/DMC-859/test_install_skills.py`, `testing/tests/DMC-928/test_dmc_928.py`, `testing/tests/DMC-966/test_dmc_966.py`, `testing/tests/DMC-968/test_dmc_968.py` — PASSED

### Notes
The missing `instruction.md` referenced in the task was not present at the repository root, so implementation followed the repository-local bug instructions and the ticket inputs under `input/DMC-970/`.
