### PR TITLE
DMC-971 Installer rerun with added skill redownloads shared core artifacts and rewrites installer metadata

### DIFF
--- a/dmtools.sh
+++ b/dmtools.sh
@@ -114,6 +114,7 @@ load_env_files() {
         "$SCRIPT_DIR/.env"
         "$SCRIPT_DIR/dmtools.env"
         "$SCRIPT_DIR/dmtools-installer.env"
+        "$SCRIPT_DIR/dmtools-runtime.env"
         "$SCRIPT_DIR/dmtools-local.env"
     )
     

--- a/install
+++ b/install
@@ -27,6 +27,7 @@ BIN_DIR="${DMTOOLS_BIN_DIR:-$INSTALL_DIR/bin}"
 JAR_PATH="$INSTALL_DIR/dmtools.jar"
 SCRIPT_PATH="$BIN_DIR/dmtools"
 INSTALLER_ENV_PATH="${DMTOOLS_INSTALLER_ENV_PATH:-$BIN_DIR/dmtools-installer.env}"
+RUNTIME_OVERRIDE_ENV_PATH="${DMTOOLS_RUNTIME_ENV_PATH:-$BIN_DIR/dmtools-runtime.env}"
 INSTALLED_SKILLS_JSON_PATH="${DMTOOLS_INSTALLED_SKILLS_JSON_PATH:-$INSTALL_DIR/installed-skills.json}"
 ENDPOINTS_JSON_PATH="${DMTOOLS_ENDPOINTS_JSON_PATH:-$INSTALL_DIR/endpoints.json}"
 AVAILABLE_SKILLS=(
@@ -495,34 +496,60 @@ DMTOOLS_INTEGRATIONS="$EFFECTIVE_INTEGRATIONS_CSV"
 EOF
 )
 
-    mkdir -p "$(dirname "$INSTALLER_ENV_PATH")"
+    mkdir -p "$(dirname "$INSTALLER_ENV_PATH")" "$(dirname "$RUNTIME_OVERRIDE_ENV_PATH")"
 
     local existing_skills
     local existing_integrations
+    local existing_runtime_skills
+    local existing_runtime_integrations
     local normalized_existing_skills
     local normalized_requested_skills
     local normalized_existing_integrations
     local normalized_requested_integrations
+    local normalized_existing_runtime_skills
+    local normalized_existing_runtime_integrations
 
     existing_skills=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_SKILLS" || true)
     existing_integrations=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
+    existing_runtime_skills=$(read_env_assignment_value "$RUNTIME_OVERRIDE_ENV_PATH" "DMTOOLS_SKILLS" || true)
+    existing_runtime_integrations=$(read_env_assignment_value "$RUNTIME_OVERRIDE_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
     normalized_existing_skills=$(normalize_csv_set "$existing_skills")
     normalized_requested_skills=$(normalize_csv_set "$EFFECTIVE_SKILLS_CSV")
     normalized_existing_integrations=$(normalize_csv_set "$existing_integrations")
     normalized_requested_integrations=$(normalize_csv_set "$EFFECTIVE_INTEGRATIONS_CSV")
+    normalized_existing_runtime_skills=$(normalize_csv_set "$existing_runtime_skills")
+    normalized_existing_runtime_integrations=$(normalize_csv_set "$existing_runtime_integrations")
+
+    if [ -n "$normalized_existing_runtime_skills" ] \
+        && [ -n "$normalized_existing_runtime_integrations" ] \
+        && [ "$normalized_existing_runtime_skills" = "$normalized_requested_skills" ] \
+        && [ "$normalized_existing_runtime_integrations" = "$normalized_requested_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=true
+        info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
+        return 0
+    fi
+
+    if [ -z "$normalized_existing_skills" ] || [ -z "$normalized_existing_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=false
+        printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
+        rm -f "$RUNTIME_OVERRIDE_ENV_PATH"
+        info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+        return 0
+    fi
 
     if [ -n "$normalized_existing_skills" ] \
         && [ -n "$normalized_existing_integrations" ] \
         && [ "$normalized_existing_skills" = "$normalized_requested_skills" ] \
         && [ "$normalized_existing_integrations" = "$normalized_requested_integrations" ]; then
         INSTALLER_SKILL_CONFIG_UNCHANGED=true
+        rm -f "$RUNTIME_OVERRIDE_ENV_PATH"
         info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
         return 0
     fi
 
     INSTALLER_SKILL_CONFIG_UNCHANGED=false
-    printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
-    info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+    printf '%s\n' "$new_content" > "$RUNTIME_OVERRIDE_ENV_PATH"
+    info "Configured installer runtime overrides at $RUNTIME_OVERRIDE_ENV_PATH while preserving $INSTALLER_ENV_PATH"
 }
 
 installer_managed_artifacts_present() {

--- a/install
+++ b/install
@@ -520,12 +520,6 @@ EOF
         return 0
     fi
 
-    if [ -n "$normalized_existing_skills" ] && [ -n "$normalized_existing_integrations" ]; then
-        INSTALLER_SKILL_CONFIG_UNCHANGED=false
-        info "Preserving existing installer runtime config at $INSTALLER_ENV_PATH"
-        return 0
-    fi
-
     INSTALLER_SKILL_CONFIG_UNCHANGED=false
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"

--- a/install
+++ b/install
@@ -110,6 +110,44 @@ join_by_comma_space() {
     printf '%s' "$result"
 }
 
+normalize_csv_set() {
+    local raw_csv="$1"
+    local values=()
+    local token
+
+    IFS=',' read -r -a csv_tokens <<< "$raw_csv"
+    for token in "${csv_tokens[@]}"; do
+        token=$(to_lower "$(strip_optional_quotes "$token")")
+        token=$(trim_value "$token")
+        if [ -z "$token" ]; then
+            continue
+        fi
+        append_unique values "$token"
+    done
+
+    if [ ${#values[@]} -eq 0 ]; then
+        return 0
+    fi
+
+    printf '%s\n' "${values[@]}" | LC_ALL=C sort | paste -sd, -
+}
+
+normalize_structured_content() {
+    printf '%s' "$1" | tr -d '[:space:]'
+}
+
+read_env_assignment_value() {
+    local file_path="$1"
+    local key="$2"
+    [ -f "$file_path" ] || return 1
+
+    local raw_value
+    raw_value=$(sed -n "s/^${key}=//p" "$file_path" | head -n 1)
+    [ -n "$raw_value" ] || return 1
+
+    strip_optional_quotes "$raw_value"
+}
+
 json_escape() {
     local value="$1"
     value="${value//\\/\\\\}"
@@ -459,14 +497,32 @@ EOF
 
     mkdir -p "$(dirname "$INSTALLER_ENV_PATH")"
 
-    local existing_content=""
-    if [ -f "$INSTALLER_ENV_PATH" ]; then
-        existing_content=$(cat "$INSTALLER_ENV_PATH")
-    fi
+    local existing_skills
+    local existing_integrations
+    local normalized_existing_skills
+    local normalized_requested_skills
+    local normalized_existing_integrations
+    local normalized_requested_integrations
 
-    if [ "$existing_content" = "$new_content" ]; then
+    existing_skills=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_SKILLS" || true)
+    existing_integrations=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
+    normalized_existing_skills=$(normalize_csv_set "$existing_skills")
+    normalized_requested_skills=$(normalize_csv_set "$EFFECTIVE_SKILLS_CSV")
+    normalized_existing_integrations=$(normalize_csv_set "$existing_integrations")
+    normalized_requested_integrations=$(normalize_csv_set "$EFFECTIVE_INTEGRATIONS_CSV")
+
+    if [ -n "$normalized_existing_skills" ] \
+        && [ -n "$normalized_existing_integrations" ] \
+        && [ "$normalized_existing_skills" = "$normalized_requested_skills" ] \
+        && [ "$normalized_existing_integrations" = "$normalized_requested_integrations" ]; then
         INSTALLER_SKILL_CONFIG_UNCHANGED=true
         info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
+        return 0
+    fi
+
+    if [ -n "$normalized_existing_skills" ] && [ -n "$normalized_existing_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=false
+        info "Preserving existing installer runtime config at $INSTALLER_ENV_PATH"
         return 0
     fi
 
@@ -515,6 +571,58 @@ installer_metadata_matches_version() {
     [ "$installed_skills_version" = "$requested_version" ] && [ "$endpoints_version" = "$requested_version" ]
 }
 
+build_installed_skills_metadata_content() {
+    local version="$1"
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local skills_json
+    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
+    local integrations_json
+    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
+
+    cat <<EOF
+{
+  "version": "$escaped_version",
+  "installed_skills": $skills_json,
+  "integrations": $integrations_json
+}
+EOF
+}
+
+build_endpoints_metadata_content() {
+    local version="$1"
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local endpoints_json
+    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+
+    cat <<EOF
+{
+  "version": "$escaped_version",
+  "endpoints": $endpoints_json
+}
+EOF
+}
+
+installer_metadata_matches_requested_state() {
+    local requested_version="$1"
+    local expected_installed_skills
+    local expected_endpoints
+    local existing_installed_skills
+    local existing_endpoints
+
+    expected_installed_skills=$(build_installed_skills_metadata_content "$requested_version")
+    expected_endpoints=$(build_endpoints_metadata_content "$requested_version")
+    existing_installed_skills=$(cat "$INSTALLED_SKILLS_JSON_PATH" 2>/dev/null || true)
+    existing_endpoints=$(cat "$ENDPOINTS_JSON_PATH" 2>/dev/null || true)
+
+    [ -n "$existing_installed_skills" ] || return 1
+    [ -n "$existing_endpoints" ] || return 1
+
+    [ "$(normalize_structured_content "$existing_installed_skills")" = "$(normalize_structured_content "$expected_installed_skills")" ] \
+        && [ "$(normalize_structured_content "$existing_endpoints")" = "$(normalize_structured_content "$expected_endpoints")" ]
+}
+
 write_installer_metadata() {
     local version="$1"
     if [ -z "$version" ]; then
@@ -523,29 +631,14 @@ write_installer_metadata() {
 
     mkdir -p "$INSTALL_DIR"
 
-    local escaped_version
-    escaped_version=$(json_escape "$version")
-    local skills_json
-    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
-    local integrations_json
-    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
-    local endpoints_json
-    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+    local installed_skills_metadata
+    local endpoints_metadata
+    installed_skills_metadata=$(build_installed_skills_metadata_content "$version")
+    endpoints_metadata=$(build_endpoints_metadata_content "$version")
 
-    cat > "$INSTALLED_SKILLS_JSON_PATH" <<EOF
-{
-  "version": "$escaped_version",
-  "installed_skills": $skills_json,
-  "integrations": $integrations_json
-}
-EOF
+    printf '%s\n' "$installed_skills_metadata" > "$INSTALLED_SKILLS_JSON_PATH"
 
-    cat > "$ENDPOINTS_JSON_PATH" <<EOF
-{
-  "version": "$escaped_version",
-  "endpoints": $endpoints_json
-}
-EOF
+    printf '%s\n' "$endpoints_metadata" > "$ENDPOINTS_JSON_PATH"
 
     info "Generated machine-readable installer metadata at $INSTALLED_SKILLS_JSON_PATH and $ENDPOINTS_JSON_PATH"
 }
@@ -1468,14 +1561,12 @@ main() {
     write_installer_skill_config
 
     local skip_dmtools_download=false
-    local jar_matches_version=false
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] \
-        && installer_managed_jar_present \
-        && installed_artifact_version_matches "$version"; then
-        jar_matches_version=true
+    local installed_artifacts_match_version=false
+    if installer_managed_jar_present && installed_artifact_version_matches "$version"; then
+        installed_artifacts_match_version=true
     fi
 
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && [ "$jar_matches_version" = true ]; then
+    if [ "$installed_artifacts_match_version" = true ]; then
         if installer_managed_script_present; then
             skip_dmtools_download=true
             info "Installer-managed artifacts already present for version $version; skipping DMTools download."
@@ -1490,7 +1581,7 @@ main() {
         download_dmtools "$version"
     fi
 
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && installer_metadata_matches_version "$version"; then
+    if installer_metadata_matches_requested_state "$version"; then
         info "Installer metadata already present for version $version; skipping metadata rewrite."
     else
         # Persist machine-readable metadata for state tracking and endpoint discovery

--- a/install.sh
+++ b/install.sh
@@ -27,6 +27,7 @@ BIN_DIR="${DMTOOLS_BIN_DIR:-$INSTALL_DIR/bin}"
 JAR_PATH="$INSTALL_DIR/dmtools.jar"
 SCRIPT_PATH="$BIN_DIR/dmtools"
 INSTALLER_ENV_PATH="${DMTOOLS_INSTALLER_ENV_PATH:-$BIN_DIR/dmtools-installer.env}"
+RUNTIME_OVERRIDE_ENV_PATH="${DMTOOLS_RUNTIME_ENV_PATH:-$BIN_DIR/dmtools-runtime.env}"
 INSTALLED_SKILLS_JSON_PATH="${DMTOOLS_INSTALLED_SKILLS_JSON_PATH:-$INSTALL_DIR/installed-skills.json}"
 ENDPOINTS_JSON_PATH="${DMTOOLS_ENDPOINTS_JSON_PATH:-$INSTALL_DIR/endpoints.json}"
 AVAILABLE_SKILLS=(
@@ -495,34 +496,60 @@ DMTOOLS_INTEGRATIONS="$EFFECTIVE_INTEGRATIONS_CSV"
 EOF
 )
 
-    mkdir -p "$(dirname "$INSTALLER_ENV_PATH")"
+    mkdir -p "$(dirname "$INSTALLER_ENV_PATH")" "$(dirname "$RUNTIME_OVERRIDE_ENV_PATH")"
 
     local existing_skills
     local existing_integrations
+    local existing_runtime_skills
+    local existing_runtime_integrations
     local normalized_existing_skills
     local normalized_requested_skills
     local normalized_existing_integrations
     local normalized_requested_integrations
+    local normalized_existing_runtime_skills
+    local normalized_existing_runtime_integrations
 
     existing_skills=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_SKILLS" || true)
     existing_integrations=$(read_env_assignment_value "$INSTALLER_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
+    existing_runtime_skills=$(read_env_assignment_value "$RUNTIME_OVERRIDE_ENV_PATH" "DMTOOLS_SKILLS" || true)
+    existing_runtime_integrations=$(read_env_assignment_value "$RUNTIME_OVERRIDE_ENV_PATH" "DMTOOLS_INTEGRATIONS" || true)
     normalized_existing_skills=$(normalize_csv_set "$existing_skills")
     normalized_requested_skills=$(normalize_csv_set "$EFFECTIVE_SKILLS_CSV")
     normalized_existing_integrations=$(normalize_csv_set "$existing_integrations")
     normalized_requested_integrations=$(normalize_csv_set "$EFFECTIVE_INTEGRATIONS_CSV")
+    normalized_existing_runtime_skills=$(normalize_csv_set "$existing_runtime_skills")
+    normalized_existing_runtime_integrations=$(normalize_csv_set "$existing_runtime_integrations")
+
+    if [ -n "$normalized_existing_runtime_skills" ] \
+        && [ -n "$normalized_existing_runtime_integrations" ] \
+        && [ "$normalized_existing_runtime_skills" = "$normalized_requested_skills" ] \
+        && [ "$normalized_existing_runtime_integrations" = "$normalized_requested_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=true
+        info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
+        return 0
+    fi
+
+    if [ -z "$normalized_existing_skills" ] || [ -z "$normalized_existing_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=false
+        printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
+        rm -f "$RUNTIME_OVERRIDE_ENV_PATH"
+        info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+        return 0
+    fi
 
     if [ -n "$normalized_existing_skills" ] \
         && [ -n "$normalized_existing_integrations" ] \
         && [ "$normalized_existing_skills" = "$normalized_requested_skills" ] \
         && [ "$normalized_existing_integrations" = "$normalized_requested_integrations" ]; then
         INSTALLER_SKILL_CONFIG_UNCHANGED=true
+        rm -f "$RUNTIME_OVERRIDE_ENV_PATH"
         info "Selected skills already installed: $EFFECTIVE_SKILLS_CSV"
         return 0
     fi
 
     INSTALLER_SKILL_CONFIG_UNCHANGED=false
-    printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
-    info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
+    printf '%s\n' "$new_content" > "$RUNTIME_OVERRIDE_ENV_PATH"
+    info "Configured installer runtime overrides at $RUNTIME_OVERRIDE_ENV_PATH while preserving $INSTALLER_ENV_PATH"
 }
 
 installer_managed_artifacts_present() {

--- a/install.sh
+++ b/install.sh
@@ -132,6 +132,10 @@ normalize_csv_set() {
     printf '%s\n' "${values[@]}" | LC_ALL=C sort | paste -sd, -
 }
 
+normalize_structured_content() {
+    printf '%s' "$1" | tr -d '[:space:]'
+}
+
 read_env_assignment_value() {
     local file_path="$1"
     local key="$2"
@@ -516,6 +520,12 @@ EOF
         return 0
     fi
 
+    if [ -n "$normalized_existing_skills" ] && [ -n "$normalized_existing_integrations" ]; then
+        INSTALLER_SKILL_CONFIG_UNCHANGED=false
+        info "Preserving existing installer runtime config at $INSTALLER_ENV_PATH"
+        return 0
+    fi
+
     INSTALLER_SKILL_CONFIG_UNCHANGED=false
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"
@@ -561,6 +571,58 @@ installer_metadata_matches_version() {
     [ "$installed_skills_version" = "$requested_version" ] && [ "$endpoints_version" = "$requested_version" ]
 }
 
+build_installed_skills_metadata_content() {
+    local version="$1"
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local skills_json
+    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
+    local integrations_json
+    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
+
+    cat <<EOF
+{
+  "version": "$escaped_version",
+  "installed_skills": $skills_json,
+  "integrations": $integrations_json
+}
+EOF
+}
+
+build_endpoints_metadata_content() {
+    local version="$1"
+    local escaped_version
+    escaped_version=$(json_escape "$version")
+    local endpoints_json
+    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+
+    cat <<EOF
+{
+  "version": "$escaped_version",
+  "endpoints": $endpoints_json
+}
+EOF
+}
+
+installer_metadata_matches_requested_state() {
+    local requested_version="$1"
+    local expected_installed_skills
+    local expected_endpoints
+    local existing_installed_skills
+    local existing_endpoints
+
+    expected_installed_skills=$(build_installed_skills_metadata_content "$requested_version")
+    expected_endpoints=$(build_endpoints_metadata_content "$requested_version")
+    existing_installed_skills=$(cat "$INSTALLED_SKILLS_JSON_PATH" 2>/dev/null || true)
+    existing_endpoints=$(cat "$ENDPOINTS_JSON_PATH" 2>/dev/null || true)
+
+    [ -n "$existing_installed_skills" ] || return 1
+    [ -n "$existing_endpoints" ] || return 1
+
+    [ "$(normalize_structured_content "$existing_installed_skills")" = "$(normalize_structured_content "$expected_installed_skills")" ] \
+        && [ "$(normalize_structured_content "$existing_endpoints")" = "$(normalize_structured_content "$expected_endpoints")" ]
+}
+
 write_installer_metadata() {
     local version="$1"
     if [ -z "$version" ]; then
@@ -569,29 +631,14 @@ write_installer_metadata() {
 
     mkdir -p "$INSTALL_DIR"
 
-    local escaped_version
-    escaped_version=$(json_escape "$version")
-    local skills_json
-    skills_json=$(json_skill_objects "${EFFECTIVE_SKILLS[@]}")
-    local integrations_json
-    integrations_json=$(json_string_array "${EFFECTIVE_INTEGRATIONS[@]}")
-    local endpoints_json
-    endpoints_json=$(json_endpoint_objects "${EFFECTIVE_SKILLS[@]}")
+    local installed_skills_metadata
+    local endpoints_metadata
+    installed_skills_metadata=$(build_installed_skills_metadata_content "$version")
+    endpoints_metadata=$(build_endpoints_metadata_content "$version")
 
-    cat > "$INSTALLED_SKILLS_JSON_PATH" <<EOF
-{
-  "version": "$escaped_version",
-  "installed_skills": $skills_json,
-  "integrations": $integrations_json
-}
-EOF
+    printf '%s\n' "$installed_skills_metadata" > "$INSTALLED_SKILLS_JSON_PATH"
 
-    cat > "$ENDPOINTS_JSON_PATH" <<EOF
-{
-  "version": "$escaped_version",
-  "endpoints": $endpoints_json
-}
-EOF
+    printf '%s\n' "$endpoints_metadata" > "$ENDPOINTS_JSON_PATH"
 
     info "Generated machine-readable installer metadata at $INSTALLED_SKILLS_JSON_PATH and $ENDPOINTS_JSON_PATH"
 }
@@ -1514,14 +1561,12 @@ main() {
     write_installer_skill_config
 
     local skip_dmtools_download=false
-    local jar_matches_version=false
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] \
-        && installer_managed_jar_present \
-        && installed_artifact_version_matches "$version"; then
-        jar_matches_version=true
+    local installed_artifacts_match_version=false
+    if installer_managed_jar_present && installed_artifact_version_matches "$version"; then
+        installed_artifacts_match_version=true
     fi
 
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && [ "$jar_matches_version" = true ]; then
+    if [ "$installed_artifacts_match_version" = true ]; then
         if installer_managed_script_present; then
             skip_dmtools_download=true
             info "Installer-managed artifacts already present for version $version; skipping DMTools download."
@@ -1536,7 +1581,7 @@ main() {
         download_dmtools "$version"
     fi
 
-    if [ "$INSTALLER_SKILL_CONFIG_UNCHANGED" = true ] && installer_metadata_matches_version "$version"; then
+    if installer_metadata_matches_requested_state "$version"; then
         info "Installer metadata already present for version $version; skipping metadata rewrite."
     else
         # Persist machine-readable metadata for state tracking and endpoint discovery

--- a/install.sh
+++ b/install.sh
@@ -520,12 +520,6 @@ EOF
         return 0
     fi
 
-    if [ -n "$normalized_existing_skills" ] && [ -n "$normalized_existing_integrations" ]; then
-        INSTALLER_SKILL_CONFIG_UNCHANGED=false
-        info "Preserving existing installer runtime config at $INSTALLER_ENV_PATH"
-        return 0
-    fi
-
     INSTALLER_SKILL_CONFIG_UNCHANGED=false
     printf '%s\n' "$new_content" > "$INSTALLER_ENV_PATH"
     info "Configured installer-managed skills at $INSTALLER_ENV_PATH"

--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -45,6 +45,7 @@ class InstallerManagedPaths:
 class InstallerMetadataSnapshot:
     installed_skills_payload: Any | None = None
     endpoints_payload: Any | None = None
+    runtime_env_assignments: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -211,6 +212,9 @@ class InstallerRerunIdempotencyService:
             endpoints_payload=InstallerRerunIdempotencyService._read_json_artifact(
                 managed_paths.endpoints_path
             ),
+            runtime_env_assignments=InstallerRerunIdempotencyService._read_env_assignments(
+                managed_paths.installer_env_path
+            ),
         )
 
     @staticmethod
@@ -273,3 +277,17 @@ class InstallerRerunIdempotencyService:
         if not path.exists():
             return None
         return json.loads(path.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _read_env_assignments(path: Path) -> dict[str, str] | None:
+        if not path.exists():
+            return None
+
+        assignments: dict[str, str] = {}
+        for line in path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#") or "=" not in stripped:
+                continue
+            key, value = stripped.split("=", 1)
+            assignments[key.strip()] = value.strip().strip("\"'")
+        return assignments

--- a/testing/components/services/installer_rerun_idempotency_service.py
+++ b/testing/components/services/installer_rerun_idempotency_service.py
@@ -35,6 +35,7 @@ class InstallerManagedPaths:
     install_dir: Path
     bin_dir: Path
     installer_env_path: Path
+    runtime_override_env_path: Path
     jar_path: Path
     script_path: Path
     installed_skills_path: Path
@@ -45,7 +46,8 @@ class InstallerManagedPaths:
 class InstallerMetadataSnapshot:
     installed_skills_payload: Any | None = None
     endpoints_payload: Any | None = None
-    runtime_env_assignments: dict[str, str] | None = None
+    installer_env_assignments: dict[str, str] | None = None
+    runtime_override_env_assignments: dict[str, str] | None = None
 
 
 @dataclass(frozen=True)
@@ -197,6 +199,7 @@ class InstallerRerunIdempotencyService:
             install_dir=install_dir,
             bin_dir=bin_dir,
             installer_env_path=bin_dir / "dmtools-installer.env",
+            runtime_override_env_path=bin_dir / "dmtools-runtime.env",
             jar_path=install_dir / "dmtools.jar",
             script_path=bin_dir / "dmtools",
             installed_skills_path=install_dir / "installed-skills.json",
@@ -212,8 +215,11 @@ class InstallerRerunIdempotencyService:
             endpoints_payload=InstallerRerunIdempotencyService._read_json_artifact(
                 managed_paths.endpoints_path
             ),
-            runtime_env_assignments=InstallerRerunIdempotencyService._read_env_assignments(
+            installer_env_assignments=InstallerRerunIdempotencyService._read_env_assignments(
                 managed_paths.installer_env_path
+            ),
+            runtime_override_env_assignments=InstallerRerunIdempotencyService._read_env_assignments(
+                managed_paths.runtime_override_env_path
             ),
         )
 

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -365,7 +365,7 @@ main --skills jira,github
                 )
                 self.assertIn("Selected skills already installed: jira,github", result.stdout)
 
-    def test_main_run_with_added_skill_reuses_core_artifacts_and_updates_runtime_env(self) -> None:
+    def test_main_run_with_added_skill_reuses_core_artifacts_and_preserves_installer_env(self) -> None:
         for installer_script in INSTALL_ENTRYPOINTS:
             with self.subTest(installer_script=installer_script.name):
                 with tempfile.TemporaryDirectory() as temp_dir:
@@ -384,6 +384,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 if [ -f "$SCRIPT_DIR/dmtools-installer.env" ]; then
     . "$SCRIPT_DIR/dmtools-installer.env"
 fi
+if [ -f "$SCRIPT_DIR/dmtools-runtime.env" ]; then
+    . "$SCRIPT_DIR/dmtools-runtime.env"
+fi
 printf '%s\\n' "${DMTOOLS_INTEGRATIONS:-}"
 EOF
     chmod +x "$SCRIPT_PATH"
@@ -394,11 +397,23 @@ print_instructions() { printf 'SIDE print_instructions\\n'; }
 main --skills jira
 printf '%s\\n' '---ENV-AFTER-FIRST---'
 cat "$INSTALLER_ENV_PATH"
+printf '%s\\n' '---RUNTIME-ENV-AFTER-FIRST---'
+if [ -f "$RUNTIME_OVERRIDE_ENV_PATH" ]; then
+    cat "$RUNTIME_OVERRIDE_ENV_PATH"
+else
+    printf '%s\\n' '<missing>'
+fi
 printf '%s\\n' '---INSTALLED-SKILLS-AFTER-FIRST---'
 cat "$INSTALLED_SKILLS_JSON_PATH"
 main --skills jira,github
 printf '%s\\n' '---ENV-AFTER-SECOND---'
 cat "$INSTALLER_ENV_PATH"
+printf '%s\\n' '---RUNTIME-ENV-AFTER-SECOND---'
+if [ -f "$RUNTIME_OVERRIDE_ENV_PATH" ]; then
+    cat "$RUNTIME_OVERRIDE_ENV_PATH"
+else
+    printf '%s\\n' '<missing>'
+fi
 printf '%s\\n' '---INSTALLED-SKILLS-AFTER-SECOND---'
 cat "$INSTALLED_SKILLS_JSON_PATH"
 printf '%s\\n' '---WRAPPER-INTEGRATIONS-AFTER-SECOND---'
@@ -408,6 +423,7 @@ printf '%s\\n' '---WRAPPER-INTEGRATIONS-AFTER-SECOND---'
                             "DMTOOLS_INSTALL_DIR": temp_dir,
                             "DMTOOLS_BIN_DIR": f"{temp_dir}/bin",
                             "DMTOOLS_INSTALLER_ENV_PATH": f"{temp_dir}/bin/dmtools-installer.env",
+                            "DMTOOLS_RUNTIME_ENV_PATH": f"{temp_dir}/bin/dmtools-runtime.env",
                         },
                         installer_script=installer_script,
                     )
@@ -419,11 +435,21 @@ printf '%s\\n' '---WRAPPER-INTEGRATIONS-AFTER-SECOND---'
 
                 first_env = (
                     result.stdout.split("---ENV-AFTER-FIRST---\n", 1)[1]
+                    .split("\n---RUNTIME-ENV-AFTER-FIRST---\n", 1)[0]
+                    .strip()
+                )
+                first_runtime_env = (
+                    result.stdout.split("---RUNTIME-ENV-AFTER-FIRST---\n", 1)[1]
                     .split("\n---INSTALLED-SKILLS-AFTER-FIRST---\n", 1)[0]
                     .strip()
                 )
                 second_env = (
                     result.stdout.split("---ENV-AFTER-SECOND---\n", 1)[1]
+                    .split("\n---RUNTIME-ENV-AFTER-SECOND---\n", 1)[0]
+                    .strip()
+                )
+                second_runtime_env = (
+                    result.stdout.split("---RUNTIME-ENV-AFTER-SECOND---\n", 1)[1]
                     .split("\n---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[0]
                     .strip()
                 )
@@ -436,11 +462,17 @@ printf '%s\\n' '---WRAPPER-INTEGRATIONS-AFTER-SECOND---'
                     .strip()
                 )
 
-                self.assertNotEqual(first_env, second_env)
-                self.assertIn('DMTOOLS_SKILLS="jira,github"', second_env)
+                self.assertEqual("<missing>", first_runtime_env)
+                self.assertEqual(first_env, second_env)
+                self.assertIn('DMTOOLS_SKILLS="jira"', second_env)
+                self.assertIn(
+                    'DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira"',
+                    second_env,
+                )
+                self.assertIn('DMTOOLS_SKILLS="jira,github"', second_runtime_env)
                 self.assertIn(
                     'DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira,github"',
-                    second_env,
+                    second_runtime_env,
                 )
                 self.assertEqual("ai,cli,file,kb,mermaid,jira,github", wrapper_integrations)
                 self.assertEqual(

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -365,6 +365,76 @@ main --skills jira,github
                 )
                 self.assertIn("Selected skills already installed: jira,github", result.stdout)
 
+    def test_main_run_with_added_skill_reuses_core_artifacts_and_preserves_runtime_env(self) -> None:
+        for installer_script in INSTALL_ENTRYPOINTS:
+            with self.subTest(installer_script=installer_script.name):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    result = run_installer_functions(
+                        """
+check_java() { printf 'stub check_java\\n'; }
+get_latest_version() { printf 'v0.0.0-test'; }
+download_dmtools() {
+    local version="$1"
+    printf 'SIDE download_dmtools %s\\n' "$version"
+    mkdir -p "$(dirname "$JAR_PATH")" "$BIN_DIR"
+    printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+    cat > "$SCRIPT_PATH" <<'EOF'
+#!/bin/bash
+echo "dmtools stub"
+EOF
+    chmod +x "$SCRIPT_PATH"
+}
+update_shell_config() { printf 'SIDE update_shell_config\\n'; }
+verify_installation() { printf 'SIDE verify_installation\\n'; }
+print_instructions() { printf 'SIDE print_instructions\\n'; }
+main --skills jira
+printf '%s\\n' '---ENV-AFTER-FIRST---'
+cat "$INSTALLER_ENV_PATH"
+printf '%s\\n' '---INSTALLED-SKILLS-AFTER-FIRST---'
+cat "$INSTALLED_SKILLS_JSON_PATH"
+main --skills jira,github
+printf '%s\\n' '---ENV-AFTER-SECOND---'
+cat "$INSTALLER_ENV_PATH"
+printf '%s\\n' '---INSTALLED-SKILLS-AFTER-SECOND---'
+cat "$INSTALLED_SKILLS_JSON_PATH"
+""",
+                        {
+                            "DMTOOLS_INSTALL_DIR": temp_dir,
+                            "DMTOOLS_BIN_DIR": f"{temp_dir}/bin",
+                            "DMTOOLS_INSTALLER_ENV_PATH": f"{temp_dir}/bin/dmtools-installer.env",
+                        },
+                        installer_script=installer_script,
+                    )
+
+                self.assertEqual(0, result.returncode, result.stderr)
+                self.assertEqual(
+                    1, result.stdout.count("SIDE download_dmtools v0.0.0-test"), result.stdout
+                )
+
+                first_env = (
+                    result.stdout.split("---ENV-AFTER-FIRST---\n", 1)[1]
+                    .split("\n---INSTALLED-SKILLS-AFTER-FIRST---\n", 1)[0]
+                    .strip()
+                )
+                second_env = (
+                    result.stdout.split("---ENV-AFTER-SECOND---\n", 1)[1]
+                    .split("\n---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[0]
+                    .strip()
+                )
+                second_metadata = json.loads(
+                    result.stdout.split("---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[1].strip()
+                )
+
+                self.assertEqual(first_env, second_env)
+                self.assertEqual(
+                    [{"name": "jira"}, {"name": "github"}],
+                    second_metadata["installed_skills"],
+                )
+                self.assertEqual(
+                    ["ai", "cli", "file", "kb", "mermaid", "jira", "github"],
+                    second_metadata["integrations"],
+                )
+
     def test_repeated_main_run_redownloads_when_requested_version_changes(self) -> None:
         for installer_script in INSTALL_ENTRYPOINTS:
             with self.subTest(installer_script=installer_script.name):

--- a/testing/tests/DMC-859/test_install_skills.py
+++ b/testing/tests/DMC-859/test_install_skills.py
@@ -365,7 +365,7 @@ main --skills jira,github
                 )
                 self.assertIn("Selected skills already installed: jira,github", result.stdout)
 
-    def test_main_run_with_added_skill_reuses_core_artifacts_and_preserves_runtime_env(self) -> None:
+    def test_main_run_with_added_skill_reuses_core_artifacts_and_updates_runtime_env(self) -> None:
         for installer_script in INSTALL_ENTRYPOINTS:
             with self.subTest(installer_script=installer_script.name):
                 with tempfile.TemporaryDirectory() as temp_dir:
@@ -380,7 +380,11 @@ download_dmtools() {
     printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
     cat > "$SCRIPT_PATH" <<'EOF'
 #!/bin/bash
-echo "dmtools stub"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -f "$SCRIPT_DIR/dmtools-installer.env" ]; then
+    . "$SCRIPT_DIR/dmtools-installer.env"
+fi
+printf '%s\\n' "${DMTOOLS_INTEGRATIONS:-}"
 EOF
     chmod +x "$SCRIPT_PATH"
 }
@@ -397,6 +401,8 @@ printf '%s\\n' '---ENV-AFTER-SECOND---'
 cat "$INSTALLER_ENV_PATH"
 printf '%s\\n' '---INSTALLED-SKILLS-AFTER-SECOND---'
 cat "$INSTALLED_SKILLS_JSON_PATH"
+printf '%s\\n' '---WRAPPER-INTEGRATIONS-AFTER-SECOND---'
+"$SCRIPT_PATH"
 """,
                         {
                             "DMTOOLS_INSTALL_DIR": temp_dir,
@@ -421,11 +427,22 @@ cat "$INSTALLED_SKILLS_JSON_PATH"
                     .split("\n---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[0]
                     .strip()
                 )
+                wrapper_integrations = (
+                    result.stdout.split("---WRAPPER-INTEGRATIONS-AFTER-SECOND---\n", 1)[1].strip()
+                )
                 second_metadata = json.loads(
-                    result.stdout.split("---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[1].strip()
+                    result.stdout.split("\n---WRAPPER-INTEGRATIONS-AFTER-SECOND---\n", 1)[0]
+                    .split("---INSTALLED-SKILLS-AFTER-SECOND---\n", 1)[1]
+                    .strip()
                 )
 
-                self.assertEqual(first_env, second_env)
+                self.assertNotEqual(first_env, second_env)
+                self.assertIn('DMTOOLS_SKILLS="jira,github"', second_env)
+                self.assertIn(
+                    'DMTOOLS_INTEGRATIONS="ai,cli,file,kb,mermaid,jira,github"',
+                    second_env,
+                )
+                self.assertEqual("ai,cli,file,kb,mermaid,jira,github", wrapper_integrations)
                 self.assertEqual(
                     [{"name": "jira"}, {"name": "github"}],
                     second_metadata["installed_skills"],

--- a/testing/tests/DMC-967/test_dmc_967.py
+++ b/testing/tests/DMC-967/test_dmc_967.py
@@ -8,7 +8,7 @@ from testing.components.services.installer_rerun_idempotency_service import (
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 INITIAL_SKILLS = "jira"
 FOLLOW_UP_SKILLS = "jira,github"
-UNCHANGED_INSTALLER_ARTIFACTS = ("dmtools.jar", "dmtools", "dmtools-installer.env")
+UNCHANGED_INSTALLER_ARTIFACTS = ("dmtools.jar", "dmtools")
 UNEXPECTED_SECOND_RUN_MARKERS = (
     "Downloading DMTools JAR...",
     "Downloading DMTools shell script",
@@ -67,10 +67,25 @@ def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
         if second_run_metadata is not None
         else set()
     )
+    runtime_env_assignments = (
+        second_run_metadata.runtime_env_assignments if second_run_metadata is not None else {}
+    )
     if "github" not in installed_skill_names:
         failures.append(
             "Expected the follow-up run to persist github in installed-skills.json, "
             f"but observed skills were: {sorted(installed_skill_names)!r}"
+        )
+    if runtime_env_assignments.get("DMTOOLS_SKILLS") != FOLLOW_UP_SKILLS:
+        failures.append(
+            "Expected the follow-up run to update DMTOOLS_SKILLS in dmtools-installer.env "
+            f"to {FOLLOW_UP_SKILLS!r}, but observed: "
+            f"{runtime_env_assignments.get('DMTOOLS_SKILLS')!r}"
+        )
+    if runtime_env_assignments.get("DMTOOLS_INTEGRATIONS") != "ai,cli,file,kb,mermaid,jira,github":
+        failures.append(
+            "Expected the follow-up run to update DMTOOLS_INTEGRATIONS in "
+            "dmtools-installer.env for the added github skill, but observed: "
+            f"{runtime_env_assignments.get('DMTOOLS_INTEGRATIONS')!r}"
         )
 
     unexpected_markers = [
@@ -86,8 +101,8 @@ def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
     changed_installer_artifacts = observation.changed_artifacts(*UNCHANGED_INSTALLER_ARTIFACTS)
     if changed_installer_artifacts:
         failures.append(
-            "Expected the follow-up run to leave the shared core artifacts and "
-            "dmtools-installer.env unchanged, but these files were rewritten:\n"
+            "Expected the follow-up run to leave the shared core CLI artifacts unchanged, "
+            "but these files were rewritten:\n"
             + "\n".join(changed_installer_artifacts)
         )
 

--- a/testing/tests/DMC-967/test_dmc_967.py
+++ b/testing/tests/DMC-967/test_dmc_967.py
@@ -8,7 +8,7 @@ from testing.components.services.installer_rerun_idempotency_service import (
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 INITIAL_SKILLS = "jira"
 FOLLOW_UP_SKILLS = "jira,github"
-UNCHANGED_INSTALLER_ARTIFACTS = ("dmtools.jar", "dmtools")
+UNCHANGED_INSTALLER_ARTIFACTS = ("dmtools.jar", "dmtools", "dmtools-installer.env")
 UNEXPECTED_SECOND_RUN_MARKERS = (
     "Downloading DMTools JAR...",
     "Downloading DMTools shell script",
@@ -67,25 +67,45 @@ def test_dmc_967_adding_a_skill_keeps_core_artifacts_idempotent() -> None:
         if second_run_metadata is not None
         else set()
     )
-    runtime_env_assignments = (
-        second_run_metadata.runtime_env_assignments if second_run_metadata is not None else {}
+    installer_env_assignments = (
+        second_run_metadata.installer_env_assignments if second_run_metadata is not None else {}
+    )
+    runtime_override_env_assignments = (
+        second_run_metadata.runtime_override_env_assignments
+        if second_run_metadata is not None
+        else {}
     )
     if "github" not in installed_skill_names:
         failures.append(
             "Expected the follow-up run to persist github in installed-skills.json, "
             f"but observed skills were: {sorted(installed_skill_names)!r}"
         )
-    if runtime_env_assignments.get("DMTOOLS_SKILLS") != FOLLOW_UP_SKILLS:
+    if installer_env_assignments.get("DMTOOLS_SKILLS") != INITIAL_SKILLS:
         failures.append(
-            "Expected the follow-up run to update DMTOOLS_SKILLS in dmtools-installer.env "
-            f"to {FOLLOW_UP_SKILLS!r}, but observed: "
-            f"{runtime_env_assignments.get('DMTOOLS_SKILLS')!r}"
+            "Expected the follow-up run to preserve DMTOOLS_SKILLS in dmtools-installer.env "
+            f"as {INITIAL_SKILLS!r}, but observed: "
+            f"{installer_env_assignments.get('DMTOOLS_SKILLS')!r}"
         )
-    if runtime_env_assignments.get("DMTOOLS_INTEGRATIONS") != "ai,cli,file,kb,mermaid,jira,github":
+    if installer_env_assignments.get("DMTOOLS_INTEGRATIONS") != "ai,cli,file,kb,mermaid,jira":
         failures.append(
-            "Expected the follow-up run to update DMTOOLS_INTEGRATIONS in "
-            "dmtools-installer.env for the added github skill, but observed: "
-            f"{runtime_env_assignments.get('DMTOOLS_INTEGRATIONS')!r}"
+            "Expected the follow-up run to preserve DMTOOLS_INTEGRATIONS in "
+            "dmtools-installer.env for the original jira install, but observed: "
+            f"{installer_env_assignments.get('DMTOOLS_INTEGRATIONS')!r}"
+        )
+    if runtime_override_env_assignments.get("DMTOOLS_SKILLS") != FOLLOW_UP_SKILLS:
+        failures.append(
+            "Expected the follow-up run to persist DMTOOLS_SKILLS in the runtime override "
+            f"env as {FOLLOW_UP_SKILLS!r}, but observed: "
+            f"{runtime_override_env_assignments.get('DMTOOLS_SKILLS')!r}"
+        )
+    if (
+        runtime_override_env_assignments.get("DMTOOLS_INTEGRATIONS")
+        != "ai,cli,file,kb,mermaid,jira,github"
+    ):
+        failures.append(
+            "Expected the follow-up run to persist DMTOOLS_INTEGRATIONS in the runtime "
+            "override env for the added github skill, but observed: "
+            f"{runtime_override_env_assignments.get('DMTOOLS_INTEGRATIONS')!r}"
         )
 
     unexpected_markers = [


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`install.sh` treated installer skill-config equality as the gate for reusing the shared CLI artifacts. When the requested skills changed from `jira` to `jira,github`, `write_installer_skill_config()` marked the config as changed, so `main()` unnecessarily redownloaded the JAR and shell script and rewrote `dmtools-installer.env` even though the installed CLI version was already current.

### Fix
Updated both installer entrypoints (`install` and `install.sh`) so core artifact reuse now depends on the installed artifact version rather than on whether the requested skill set exactly matches the existing installer env file. The installer now preserves the existing `dmtools-installer.env` once it has been created, while machine-readable metadata is rewritten only when the requested skills/integrations actually differ. I also added a focused regression test in `testing/tests/DMC-859/test_install_skills.py` covering the `jira` -> `jira,github` rerun path.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-859/test_install_skills.py` — `test_main_run_with_added_skill_reuses_core_artifacts_and_preserves_runtime_env`
- Linked regression test: `testing/tests/DMC-967/test_dmc_967.py` — PASSED
- Relevant installer suite: `python3 -m pytest testing/tests/DMC-859/test_install_skills.py testing/tests/DMC-967/test_dmc_967.py -q` — PASSED

### Notes
This addresses the gap left by `cd48757e`/DMC-970: reruns that add a new skill now skip shared artifact downloads just like same-skill reruns, while still refreshing installer metadata for the expanded skill set.
