### PR TITLE
Harden commons-io cleanup paths

### DIFF
--- a/dmtools-core/build.gradle
+++ b/dmtools-core/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     //api 'org.jboss.logging:jboss-logging:3.6.1.Final'
 
     // Apache Commons
-    //api 'commons-io:commons-io:2.18.0'
+    api 'commons-io:commons-io:2.18.0'
     //api 'commons-codec:commons-codec:1.17.1'
     api 'org.freemarker:freemarker:2.3.34'
     //api 'org.apache.commons:commons-collections4:4.4'
@@ -147,6 +147,7 @@ dependencies {
         force "org.jboss.logging:jboss-logging:3.6.1.Final"
         force "org.apache.poi:poi:${versions.poi}"
         force "org.apache.poi:poi-ooxml:${versions.poi}"
+        force "commons-io:commons-io:2.18.0"
 
         // Handle transitive dependencies
         eachDependency { DependencyResolveDetails details ->
@@ -173,6 +174,9 @@ dependencies {
                 if (details.requested.name in ['poi', 'poi-ooxml', 'poi-ooxml-lite']) {
                     details.useVersion versions.poi
                 }
+            }
+            if (details.requested.group == 'commons-io' && details.requested.name == 'commons-io') {
+                details.useVersion '2.18.0'
             }
         }
     }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -16,6 +16,7 @@ import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.common.tracker.model.Status;
 import com.github.istin.dmtools.common.utils.CacheManager;
 import com.github.istin.dmtools.common.utils.DateUtils;
+import com.github.istin.dmtools.common.utils.IOUtils;
 import com.github.istin.dmtools.common.utils.StringUtils;
 import com.github.istin.dmtools.context.UriToObject;
 import com.github.istin.dmtools.mcp.MCPParam;
@@ -198,7 +199,7 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
         }
         if (isClearCache) {
             cache.mkdirs();
-            FileUtils.deleteDirectory(cache);
+            IOUtils.deleteRecursively(cache);
         }
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/IOUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/IOUtils.java
@@ -7,7 +7,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -62,10 +66,35 @@ public class IOUtils {
             return;
         }
         for (File file : files) {
-            if (file != null && file.exists()) {
-                if (!file.delete()) {
-                    logger.error("Failed to delete temporary file: " + file.getAbsolutePath());
-                }
+            deleteFileIfExists(file);
+        }
+    }
+
+    public static void deleteFileIfExists(File file) {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(file.toPath());
+        } catch (IOException e) {
+            logger.error("Failed to delete file: {}", file.getAbsolutePath(), e);
+        }
+    }
+
+    public static void deleteRecursively(File file) throws IOException {
+        if (file == null) {
+            return;
+        }
+        deleteRecursively(file.toPath());
+    }
+
+    public static void deleteRecursively(Path path) throws IOException {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(path)) {
+            for (Path current : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(current);
             }
         }
     }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/expert/Expert.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/expert/Expert.java
@@ -41,6 +41,7 @@ import com.github.istin.dmtools.search.AbstractSearchOrchestrator;
 import com.github.istin.dmtools.search.CodebaseSearchOrchestrator;
 import com.github.istin.dmtools.search.ConfluenceSearchOrchestrator;
 import com.github.istin.dmtools.search.TrackerSearchOrchestrator;
+import com.github.istin.dmtools.common.utils.IOUtils;
 import lombok.Getter;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
@@ -396,7 +397,7 @@ public class Expert extends AbstractJob<ExpertParams, List<ResultItem>> {
                 tempFileResult
         );
         // Clean up temp file
-        FileUtils.deleteQuietly(tempFileResult);
+        IOUtils.deleteFileIfExists(tempFileResult);
     }
 
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
@@ -5,6 +5,7 @@ package com.github.istin.dmtools.networking;
 
 import com.github.istin.dmtools.common.networking.GenericRequest;
 import com.github.istin.dmtools.common.networking.RestClient;
+import com.github.istin.dmtools.common.utils.IOUtils;
 import okhttp3.*;
 import org.apache.commons.codec.digest.DigestUtils;
 import java.util.Arrays;
@@ -128,7 +129,7 @@ public abstract class AbstractRestClient implements RestClient {
         logger.info("cache folder: {}", cache.getAbsolutePath());
         if (isClearCache) {
             cache.mkdirs();
-            FileUtils.deleteDirectory(cache);
+            IOUtils.deleteRecursively(cache);
         }
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/report/ReportUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/report/ReportUtils.java
@@ -3,6 +3,7 @@
 
 package com.github.istin.dmtools.report;
 
+import com.github.istin.dmtools.common.utils.IOUtils;
 import freemarker.cache.ClassTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
@@ -38,7 +39,7 @@ public class ReportUtils {
             File file = new File("reports/" + reportName + ".html");
             if (writer == null) {
                 if (file.exists()) {
-                    FileUtils.forceDelete(file);
+                    IOUtils.deleteFileIfExists(file);
                 }
                 FileOutputStream fileOutputStream = FileUtils.openOutputStream(file);
                 writer = new OutputStreamWriter(fileOutputStream);

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -9,8 +9,8 @@ import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
+import com.github.istin.dmtools.common.utils.IOUtils;
 import com.github.istin.dmtools.common.utils.PropertyReader;
-import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -407,7 +407,7 @@ public class CliExecutionHelper {
         }
         
         try {
-            FileUtils.deleteDirectory(inputFolderPath.toFile());
+            IOUtils.deleteRecursively(inputFolderPath);
             logger.info("Cleaned up input folder: {}", inputFolderPath.toAbsolutePath());
         } catch (IOException e) {
             logger.warn("Failed to cleanup input folder {}: {}", 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -29,6 +29,7 @@ import com.github.istin.dmtools.prompt.IPromptTemplateReader;
 import com.github.istin.dmtools.search.CodebaseSearchOrchestrator;
 import com.github.istin.dmtools.search.ConfluenceSearchOrchestrator;
 import com.github.istin.dmtools.search.TrackerSearchOrchestrator;
+import com.github.istin.dmtools.common.utils.IOUtils;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import dagger.Component;
@@ -689,7 +690,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                 tempFileResult
         );
         // Clean up temp file
-        FileUtils.deleteQuietly(tempFileResult);
+        IOUtils.deleteFileIfExists(tempFileResult);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add an explicit forced commons-io 2.18.0 dependency instead of relying on transitive POI resolution
- add JDK-based IOUtils deletion helpers
- replace production FileUtils deleteDirectory/forceDelete/deleteQuietly usages with JDK deletion paths

## Why
DMC-907 bug_development completed the coding agent and wrote outputs/response.md, but the job failed during Teammate cleanup with NoClassDefFoundError: org/apache/commons/io/file/StandardDeleteOption. Even though the current release jar contains that class, deletion paths should not be able to fail the job due to commons-io runtime/classpath mismatch.

## Validation
- ./gradlew :dmtools-core:test --tests com.github.istin.dmtools.teammate.CliExecutionHelperTest --no-daemon --quiet
- ./gradlew :dmtools-core:dependencyInsight --dependency commons-io --configuration runtimeClasspath --no-daemon --quiet
- rg confirms no production FileUtils deleteDirectory/forceDelete/deleteQuietly/cleanDirectory usages remain