### PR TITLE
Update ai-teammate to DMTools 1.7.180

### DIFF
--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -111,9 +111,9 @@ jobs:
           fi
           echo "Using Copilot model: ${COPILOT_MODEL}"
 
-      - name: Install DMTools CLI v1.7.179
+      - name: Install DMTools CLI v1.7.180
         run: |
-          curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v1.7.179/install.sh | bash -s v1.7.179
+          curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v1.7.180/install.sh | bash -s v1.7.180
 
       - name: Add DMTools to PATH
         run: echo "$HOME/.dmtools/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary
- update ai-teammate workflow to install DMTools CLI v1.7.180

## Validation
- verified v1.7.180 release exists and includes install.sh and dmtools-v1.7.180-all.jar
- checked workflow diff only changes the install version