### PR TITLE
DMC-907 Docs sync scripts fail to refresh MCP index and SKILL.md after teammate-configs edits

### DIFF
--- a/scripts/generate-mcp-docs.sh
+++ b/scripts/generate-mcp-docs.sh
@@ -45,15 +45,17 @@ public class GenerateMCPDocs {
         // Parse tool definitions
         Map<String, List<ToolDef>> toolsByIntegration = new LinkedHashMap<>();
         Pattern toolPattern = Pattern.compile(
-            "tools\\.put\\(\"([^\"]+)\",\\s*new MCPToolDefinition\\(\"([^\"]+)\",\\s*\"([^\"]+)\",\\s*\"([^\"]*)\",\\s*\"([^\"]*)\""
+            "tools\\.put\\(\"([^\"]+)\",\\s*new MCPToolDefinition\\(\"([^\"]+)\",\\s*\"([^\"]+)\",\\s*\"([^\"]+)\",\\s*\"([^\"]*)\""
         );
 
         Matcher matcher = toolPattern.matcher(content);
         while (matcher.find()) {
-            String name = matcher.group(1);
-            String description = matcher.group(2);
-            String integration = matcher.group(3);
-            String category = matcher.group(4);
+            String key = matcher.group(1);
+            String registryName = matcher.group(2);
+            String description = matcher.group(3);
+            String integration = matcher.group(4);
+            String category = matcher.group(5);
+            String name = key.isEmpty() ? registryName : key;
 
             ToolDef tool = new ToolDef(name, description, integration, category);
             toolsByIntegration.computeIfAbsent(integration, k -> new ArrayList<>()).add(tool);
@@ -68,7 +70,8 @@ public class GenerateMCPDocs {
                 integration = "misc";
             }
 
-            String filename = outputDir + "/" + integration + "-tools.md";
+            String fileSlug = sanitizeFilename(integration);
+            String filename = outputDir + "/" + fileSlug + "-tools.md";
             try (PrintWriter out = new PrintWriter(new FileWriter(filename))) {
                 out.println("# " + capitalizeFirst(integration) + " MCP Tools");
                 out.println();
@@ -115,9 +118,10 @@ public class GenerateMCPDocs {
                 String integration = entry.getKey();
                 if (integration.isEmpty()) integration = "misc";
                 int count = entry.getValue().size();
+                String fileSlug = sanitizeFilename(integration);
                 out.printf("- [%s](%s-tools.md) - %d tools%n",
                     capitalizeFirst(integration),
-                    integration,
+                    fileSlug,
                     count
                 );
             }
@@ -134,6 +138,17 @@ public class GenerateMCPDocs {
     private static String capitalizeFirst(String str) {
         if (str == null || str.isEmpty()) return str;
         return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+    }
+
+    private static String sanitizeFilename(String str) {
+        if (str == null || str.isEmpty()) return "misc";
+
+        String sanitized = str
+            .toLowerCase(Locale.ROOT)
+            .replaceAll("[^a-z0-9._-]+", "-")
+            .replaceAll("^-+|-+$", "");
+
+        return sanitized.isEmpty() ? "misc" : sanitized;
     }
 
     static class ToolDef {
@@ -157,7 +172,7 @@ javac /tmp/GenerateMCPDocs.java
 java -cp /tmp GenerateMCPDocs "$REGISTRY_FILE" "$OUTPUT_DIR"
 
 # Cleanup
-rm /tmp/GenerateMCPDocs.class /tmp/GenerateMCPDocs.java
+rm -f /tmp/GenerateMCPDocs*.class /tmp/GenerateMCPDocs.java
 
 echo "✅ MCP tools documentation generated in: $OUTPUT_DIR"
 echo "📄 Files created:"

--- a/scripts/update-skill-docs.sh
+++ b/scripts/update-skill-docs.sh
@@ -26,6 +26,127 @@ echo "📝 Generating MCP tools documentation..."
 cd "$PROJECT_ROOT"
 ./scripts/generate-mcp-tables.sh
 
+echo "🔗 Syncing agent references in SKILL.md..."
+python3 - "$PROJECT_ROOT" <<'PYTHON_SYNC'
+from pathlib import Path
+import re
+import sys
+
+
+def first_heading(markdown_lines: list[str]) -> tuple[int, str]:
+    for index, line in enumerate(markdown_lines):
+        if line.startswith("# "):
+            return index, line[2:].strip()
+    raise ValueError("No H1 heading found")
+
+
+def is_summary_candidate(text: str) -> bool:
+    if not text:
+        return False
+
+    disallowed_prefixes = (
+        "#",
+        ">",
+        "- ",
+        "* ",
+        "|",
+        "![",
+        "<",
+        "**→",
+        "**->",
+        "*See also",
+        "**See also",
+        "```",
+    )
+    return not text.startswith(disallowed_prefixes)
+
+
+def paragraph_after(lines: list[str], start_index: int) -> str | None:
+    in_code_block = False
+    paragraph: list[str] = []
+
+    for line in lines[start_index + 1 :]:
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            if paragraph:
+                break
+            continue
+        if in_code_block:
+            continue
+
+        if not stripped:
+            if paragraph:
+                candidate = " ".join(paragraph).strip()
+                return candidate if is_summary_candidate(candidate) else None
+            continue
+
+        if stripped.startswith("#"):
+            if paragraph:
+                candidate = " ".join(paragraph).strip()
+                return candidate if is_summary_candidate(candidate) else None
+            continue
+
+        paragraph.append(stripped)
+
+    if paragraph:
+        candidate = " ".join(paragraph).strip()
+        return candidate if is_summary_candidate(candidate) else None
+
+    return None
+
+
+def extract_title_and_summary(markdown_path: Path) -> tuple[str, str]:
+    lines = markdown_path.read_text(encoding="utf-8").splitlines()
+    heading_index, title = first_heading(lines)
+
+    summary = paragraph_after(lines, heading_index)
+    if summary:
+        return title, summary
+
+    overview_pattern = re.compile(r"^##+\s+(?:[^\w]*\s*)?(overview|summary)\b", re.IGNORECASE)
+    for index in range(heading_index + 1, len(lines)):
+        if overview_pattern.match(lines[index].strip()):
+            summary = paragraph_after(lines, index)
+            if summary:
+                return title, summary
+
+    for index in range(heading_index + 1, len(lines)):
+        summary = paragraph_after(lines, index)
+        if summary:
+            return title, summary
+
+    raise ValueError(f"No summary paragraph found in {markdown_path}")
+
+
+project_root = Path(sys.argv[1])
+skill_path = project_root / "dmtools-ai-docs" / "SKILL.md"
+skill_lines = skill_path.read_text(encoding="utf-8").splitlines()
+
+row_pattern = re.compile(
+    r"^\|(?P<category>[^|]*)\|\s*\[(?P<title>[^\]]+)\]\((?P<path>references/agents/[^)#]+\.md)\)\s*\|\s*(?P<description>.*?)\s*\|$"
+)
+
+updated_lines: list[str] = []
+for line in skill_lines:
+    match = row_pattern.match(line)
+    if not match:
+        updated_lines.append(line)
+        continue
+
+    source_path = project_root / "dmtools-ai-docs" / match.group("path")
+    if not source_path.exists():
+        updated_lines.append(line)
+        continue
+
+    title, summary = extract_title_and_summary(source_path)
+    category = match.group("category").strip()
+    updated_lines.append(f"| {category} | [{title}]({match.group('path')}) | {summary} |")
+
+skill_path.write_text("\n".join(updated_lines) + "\n", encoding="utf-8")
+PYTHON_SYNC
+
 echo ""
 echo "📊 Documentation Statistics:"
 echo ""
@@ -55,6 +176,6 @@ echo "   - references/mcp-tools/cli-tools.md"
 echo ""
 echo "💡 Next steps:"
 echo "   1. Review generated documentation"
-echo "   2. Update SKILL.md if tool counts changed"
+echo "   2. Review synced SKILL.md reference entries"
 echo "   3. Commit changes: git add dmtools-ai-docs/"
 echo "   4. Create release: ./release-skill.sh X.Y.Z"


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`scripts/generate-mcp-docs.sh` was parsing `MCPToolRegistry.java` with shifted regex groups, so it treated full tool descriptions as integration names. That made the generator try to write invalid filenames like `Generate Mermaid diagrams from content sources (Confluence or Jira)...-tools.md`, which crashed the script and left the MCP index stale. Separately, `scripts/update-skill-docs.sh` never refreshed the `dmtools-ai-docs/SKILL.md` agent reference rows from the source markdown files, so `teammate-configs.md` edits did not propagate into the skill index.

### Fix
- Updated `scripts/generate-mcp-docs.sh` to read the correct registry fields, use a safe filename slug for generated integration docs, and clean up all temporary compiled classes.
- Updated `scripts/update-skill-docs.sh` to sync `references/agents/*.md` rows in `dmtools-ai-docs/SKILL.md` from each source document's current H1 title and summary paragraph.

### Test Coverage
- Reproduction test: `testing/tests/DMC-897/test_dmc_897.py::test_dmc_897_skill_docs_stay_synchronized` — PASSED
- Core test suite: `./gradlew :dmtools-core:test --quiet` — PASSED

### Notes
- `instruction.md` was not present at the repository root, so implementation followed the ticket context files that were available under `input/DMC-907/`.
