### PR TITLE
DMC-973 Test: Generate MCP docs with missing target folder — scripts recreate folder and refresh index

### DIFF
--- a/testing/components/services/mcp_docs_recovery_service.py
+++ b/testing/components/services/mcp_docs_recovery_service.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
-from testing.components.services.skill_docs_sync_service import SkillDocsSyncService
+from testing.components.services.skill_docs_sync_support import SkillDocsSyncSupport
 from testing.core.utils.repo_sandbox import CommandResult, RepoSandbox
 
 
@@ -57,16 +57,17 @@ class McpDocsRecoveryService:
         self,
         repository_root: Path,
         sandbox_factory: Callable[[Path], Sandbox] = RepoSandbox,
+        sync_support: SkillDocsSyncSupport | None = None,
     ) -> None:
         self.repository_root = repository_root
         self._sandbox_factory = sandbox_factory
+        self._sync_support = sync_support or SkillDocsSyncSupport()
 
     def run(self, ticket_config: McpDocsRecoveryConfig) -> McpDocsRecoveryResult:
         sandbox = self._sandbox_factory(self.repository_root)
-        helper = SkillDocsSyncService(self.repository_root, sandbox_factory=lambda _: sandbox)
         try:
-            helper._apply_manual_edits(sandbox, ticket_config)
-            helper._mark_generated_index_as_stale(sandbox)
+            self._sync_support.apply_manual_edits(sandbox, ticket_config)
+            self._sync_support.mark_generated_index_as_stale(sandbox)
 
             bootstrap_docs = sandbox.run("./buildInstallLocal.sh")
             update_docs = sandbox.run(ticket_config.scripts[0])
@@ -76,11 +77,10 @@ class McpDocsRecoveryService:
 
             generate_docs = sandbox.run(ticket_config.scripts[1])
 
-            generated_index = self._read_text_if_present(sandbox, helper.GENERATED_INDEX_PATH)
+            generated_index = self._read_text_if_present(sandbox, self._sync_support.GENERATED_INDEX_PATH)
             changelog = self._read_text_if_present(sandbox, "dmtools-ai-docs/CHANGELOG.md")
             skill_markdown = self._read_text_if_present(sandbox, "dmtools-ai-docs/SKILL.md")
             skill_reference_row = self._find_skill_reference_row_or_empty(
-                helper,
                 skill_markdown,
                 ticket_config.audited_document.skill_reference_path,
             )
@@ -91,7 +91,7 @@ class McpDocsRecoveryService:
                 generate_docs=generate_docs,
                 docs_directory_recreated=docs_directory.is_dir(),
                 generated_index_refreshed=generated_index is not None
-                and helper._generated_index_was_refreshed(generated_index),
+                and self._sync_support.generated_index_was_refreshed(generated_index),
                 changelog_mentions_correction=changelog is not None
                 and ticket_config.audited_document.changelog_marker in changelog,
                 skill_reference_title_synced=ticket_config.audited_document.updated_title in skill_reference_row,
@@ -110,13 +110,12 @@ class McpDocsRecoveryService:
 
     @staticmethod
     def _find_skill_reference_row_or_empty(
-        helper: SkillDocsSyncService,
         skill_markdown: str | None,
         skill_reference_path: str,
     ) -> str:
         if skill_markdown is None:
             return ""
         try:
-            return helper._find_skill_reference_row(skill_markdown, skill_reference_path)
+            return SkillDocsSyncSupport.find_skill_reference_row(skill_markdown, skill_reference_path)
         except AssertionError:
             return ""

--- a/testing/components/services/mcp_docs_recovery_service.py
+++ b/testing/components/services/mcp_docs_recovery_service.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from testing.components.services.skill_docs_sync_service import SkillDocsSyncService
+from testing.core.utils.repo_sandbox import CommandResult, RepoSandbox
+
+
+@dataclass(frozen=True)
+class SkillDocumentAudit:
+    source_relative_path: str
+    skill_reference_path: str
+    updated_title: str
+    updated_summary: str
+    changelog_marker: str
+
+
+@dataclass(frozen=True)
+class McpDocsRecoveryConfig:
+    ticket_key: str
+    docs_directory: str
+    scripts: tuple[str, ...]
+    audited_document: SkillDocumentAudit
+
+
+@dataclass(frozen=True)
+class McpDocsRecoveryResult:
+    bootstrap_docs: CommandResult
+    update_docs: CommandResult
+    generate_docs: CommandResult
+    docs_directory_recreated: bool
+    generated_index_refreshed: bool
+    changelog_mentions_correction: bool
+    skill_reference_title_synced: bool
+    skill_reference_summary_synced: bool
+    skill_reference_row: str
+
+
+class Sandbox(Protocol):
+    workspace: Path
+
+    def cleanup(self) -> None: ...
+
+    def read_text(self, relative_path: str) -> str: ...
+
+    def write_text(self, relative_path: str, content: str) -> None: ...
+
+    def run(self, command: str, timeout: int = 1800) -> CommandResult: ...
+
+
+class McpDocsRecoveryService:
+    def __init__(
+        self,
+        repository_root: Path,
+        sandbox_factory: Callable[[Path], Sandbox] = RepoSandbox,
+    ) -> None:
+        self.repository_root = repository_root
+        self._sandbox_factory = sandbox_factory
+
+    def run(self, ticket_config: McpDocsRecoveryConfig) -> McpDocsRecoveryResult:
+        sandbox = self._sandbox_factory(self.repository_root)
+        helper = SkillDocsSyncService(self.repository_root, sandbox_factory=lambda _: sandbox)
+        try:
+            helper._apply_manual_edits(sandbox, ticket_config)
+            helper._mark_generated_index_as_stale(sandbox)
+
+            bootstrap_docs = sandbox.run("./buildInstallLocal.sh")
+            update_docs = sandbox.run(ticket_config.scripts[0])
+
+            docs_directory = sandbox.workspace / ticket_config.docs_directory
+            shutil.rmtree(docs_directory, ignore_errors=True)
+
+            generate_docs = sandbox.run(ticket_config.scripts[1])
+
+            generated_index = self._read_text_if_present(sandbox, helper.GENERATED_INDEX_PATH)
+            changelog = self._read_text_if_present(sandbox, "dmtools-ai-docs/CHANGELOG.md")
+            skill_markdown = self._read_text_if_present(sandbox, "dmtools-ai-docs/SKILL.md")
+            skill_reference_row = self._find_skill_reference_row_or_empty(
+                helper,
+                skill_markdown,
+                ticket_config.audited_document.skill_reference_path,
+            )
+
+            return McpDocsRecoveryResult(
+                bootstrap_docs=bootstrap_docs,
+                update_docs=update_docs,
+                generate_docs=generate_docs,
+                docs_directory_recreated=docs_directory.is_dir(),
+                generated_index_refreshed=generated_index is not None
+                and helper._generated_index_was_refreshed(generated_index),
+                changelog_mentions_correction=changelog is not None
+                and ticket_config.audited_document.changelog_marker in changelog,
+                skill_reference_title_synced=ticket_config.audited_document.updated_title in skill_reference_row,
+                skill_reference_summary_synced=ticket_config.audited_document.updated_summary
+                in skill_reference_row,
+                skill_reference_row=skill_reference_row,
+            )
+        finally:
+            sandbox.cleanup()
+
+    @staticmethod
+    def _read_text_if_present(sandbox: Sandbox, relative_path: str) -> str | None:
+        if not (sandbox.workspace / relative_path).exists():
+            return None
+        return sandbox.read_text(relative_path)
+
+    @staticmethod
+    def _find_skill_reference_row_or_empty(
+        helper: SkillDocsSyncService,
+        skill_markdown: str | None,
+        skill_reference_path: str,
+    ) -> str:
+        if skill_markdown is None:
+            return ""
+        try:
+            return helper._find_skill_reference_row(skill_markdown, skill_reference_path)
+        except AssertionError:
+            return ""

--- a/testing/components/services/skill_docs_sync_service.py
+++ b/testing/components/services/skill_docs_sync_service.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from testing.components.services.skill_docs_sync_support import SkillDocsSyncSupport
 from testing.core.interfaces.skill_docs_sync import AuditedDocumentConfig, Sandbox, TicketConfig
 from testing.core.utils.repo_sandbox import CommandResult, RepoSandbox
 
@@ -20,31 +21,28 @@ class SyncRunResult:
     skill_reference_row: str
 
 class SkillDocsSyncService:
-    GENERATED_INDEX_PATH = "dmtools-ai-docs/references/mcp-tools/README.md"
-    GENERATED_INDEX_STALE_MARKER = "DMC-897 stale MCP tools index marker"
-    GENERATED_INDEX_HEADER = "# DMtools MCP Tools Reference"
-    GENERATED_INDEX_FOOTER = "*Generated from MCPToolRegistry on:"
-
     def __init__(
         self,
         repository_root: Path,
         sandbox_factory: Callable[[Path], Sandbox] = RepoSandbox,
+        sync_support: SkillDocsSyncSupport | None = None,
     ) -> None:
         self.repository_root = repository_root
         self._sandbox_factory = sandbox_factory
+        self._sync_support = sync_support or SkillDocsSyncSupport()
 
     def run(self, ticket_config: TicketConfig) -> SyncRunResult:
         sandbox = self._sandbox_factory(self.repository_root)
         try:
-            self._apply_manual_edits(sandbox, ticket_config)
-            self._mark_generated_index_as_stale(sandbox)
+            self._sync_support.apply_manual_edits(sandbox, ticket_config)
+            self._sync_support.mark_generated_index_as_stale(sandbox)
             bootstrap_docs = sandbox.run("./buildInstallLocal.sh")
             update_docs = sandbox.run(ticket_config.scripts[0])
             generate_docs = sandbox.run(ticket_config.scripts[1])
 
-            generated_index = sandbox.read_text(self.GENERATED_INDEX_PATH)
+            generated_index = sandbox.read_text(self._sync_support.GENERATED_INDEX_PATH)
             changelog = sandbox.read_text("dmtools-ai-docs/CHANGELOG.md")
-            skill_reference_row = self._find_skill_reference_row(
+            skill_reference_row = self._sync_support.find_skill_reference_row(
                 sandbox.read_text("dmtools-ai-docs/SKILL.md"),
                 ticket_config.audited_document.skill_reference_path,
             )
@@ -53,7 +51,7 @@ class SkillDocsSyncService:
                 bootstrap_docs=bootstrap_docs,
                 update_docs=update_docs,
                 generate_docs=generate_docs,
-                generated_index_refreshed=self._generated_index_was_refreshed(generated_index),
+                generated_index_refreshed=self._sync_support.generated_index_was_refreshed(generated_index),
                 changelog_mentions_correction=ticket_config.audited_document.changelog_marker in changelog,
                 skill_reference_title_synced=ticket_config.audited_document.updated_title in skill_reference_row,
                 skill_reference_summary_synced=ticket_config.audited_document.updated_summary in skill_reference_row,
@@ -61,58 +59,3 @@ class SkillDocsSyncService:
             )
         finally:
             sandbox.cleanup()
-
-    def _apply_manual_edits(self, sandbox: Sandbox, ticket_config: TicketConfig) -> None:
-        audited_document = ticket_config.audited_document
-        source_path = audited_document.source_relative_path
-        source_text = sandbox.read_text(source_path)
-        original_heading = "# AI Teammate Configuration Guide"
-        replacement_heading = (
-            f"# {audited_document.updated_title}\n\n"
-            f"{audited_document.updated_summary}"
-        )
-
-        if original_heading not in source_text:
-            raise AssertionError(f"Expected heading '{original_heading}' was not found in {source_path}")
-
-        sandbox.write_text(source_path, source_text.replace(original_heading, replacement_heading, 1))
-
-        changelog_path = "dmtools-ai-docs/CHANGELOG.md"
-        changelog_text = sandbox.read_text(changelog_path)
-        documentation_section = "### Documentation\n\n"
-        changelog_entry = f"- {audited_document.changelog_marker}\n"
-
-        if documentation_section in changelog_text:
-            updated_changelog = changelog_text.replace(
-                documentation_section,
-                documentation_section + changelog_entry,
-                1,
-            )
-        else:
-            updated_changelog = changelog_entry + "\n" + changelog_text
-
-        sandbox.write_text(changelog_path, updated_changelog)
-
-    def _mark_generated_index_as_stale(self, sandbox: Sandbox) -> None:
-        sandbox.write_text(
-            self.GENERATED_INDEX_PATH,
-            (
-                f"{self.GENERATED_INDEX_HEADER}\n\n"
-                "This content was intentionally replaced before the docs scripts ran.\n\n"
-                f"{self.GENERATED_INDEX_STALE_MARKER}\n"
-            ),
-        )
-
-    def _generated_index_was_refreshed(self, generated_index: str) -> bool:
-        return (
-            self.GENERATED_INDEX_STALE_MARKER not in generated_index
-            and self.GENERATED_INDEX_HEADER in generated_index
-            and self.GENERATED_INDEX_FOOTER in generated_index
-        )
-
-    @staticmethod
-    def _find_skill_reference_row(skill_markdown: str, skill_reference_path: str) -> str:
-        for line in skill_markdown.splitlines():
-            if skill_reference_path in line:
-                return line
-        raise AssertionError(f"Could not find SKILL.md row for {skill_reference_path}")

--- a/testing/components/services/skill_docs_sync_support.py
+++ b/testing/components/services/skill_docs_sync_support.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from testing.core.interfaces.skill_docs_sync import Sandbox, TicketConfig
+
+
+class SkillDocsSyncSupport:
+    GENERATED_INDEX_PATH = "dmtools-ai-docs/references/mcp-tools/README.md"
+    GENERATED_INDEX_STALE_MARKER = "DMC-897 stale MCP tools index marker"
+    GENERATED_INDEX_HEADER = "# DMtools MCP Tools Reference"
+    GENERATED_INDEX_FOOTER = "*Generated from MCPToolRegistry on:"
+
+    def apply_manual_edits(self, sandbox: Sandbox, ticket_config: TicketConfig) -> None:
+        audited_document = ticket_config.audited_document
+        source_path = audited_document.source_relative_path
+        source_text = sandbox.read_text(source_path)
+        original_heading = "# AI Teammate Configuration Guide"
+        replacement_heading = (
+            f"# {audited_document.updated_title}\n\n"
+            f"{audited_document.updated_summary}"
+        )
+
+        if original_heading not in source_text:
+            raise AssertionError(f"Expected heading '{original_heading}' was not found in {source_path}")
+
+        sandbox.write_text(source_path, source_text.replace(original_heading, replacement_heading, 1))
+
+        changelog_path = "dmtools-ai-docs/CHANGELOG.md"
+        changelog_text = sandbox.read_text(changelog_path)
+        documentation_section = "### Documentation\n\n"
+        changelog_entry = f"- {audited_document.changelog_marker}\n"
+
+        if documentation_section in changelog_text:
+            updated_changelog = changelog_text.replace(
+                documentation_section,
+                documentation_section + changelog_entry,
+                1,
+            )
+        else:
+            updated_changelog = changelog_entry + "\n" + changelog_text
+
+        sandbox.write_text(changelog_path, updated_changelog)
+
+    def mark_generated_index_as_stale(self, sandbox: Sandbox) -> None:
+        sandbox.write_text(
+            self.GENERATED_INDEX_PATH,
+            (
+                f"{self.GENERATED_INDEX_HEADER}\n\n"
+                "This content was intentionally replaced before the docs scripts ran.\n\n"
+                f"{self.GENERATED_INDEX_STALE_MARKER}\n"
+            ),
+        )
+
+    def generated_index_was_refreshed(self, generated_index: str) -> bool:
+        return (
+            self.GENERATED_INDEX_STALE_MARKER not in generated_index
+            and self.GENERATED_INDEX_HEADER in generated_index
+            and self.GENERATED_INDEX_FOOTER in generated_index
+        )
+
+    @staticmethod
+    def find_skill_reference_row(skill_markdown: str, skill_reference_path: str) -> str:
+        for line in skill_markdown.splitlines():
+            if skill_reference_path in line:
+                return line
+        raise AssertionError(f"Could not find SKILL.md row for {skill_reference_path}")

--- a/testing/tests/DMC-973/README.md
+++ b/testing/tests/DMC-973/README.md
@@ -1,0 +1,29 @@
+# DMC-973
+
+Automates the regression where `scripts/generate-mcp-docs.sh` must recreate
+`dmtools-ai-docs/references/mcp-tools/` after the directory is deleted, while
+keeping the documentation sync outputs user-visible and current.
+
+## Install dependencies
+
+```bash
+python3 -m pip install --user -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-973/test_dmc_973.py -q
+```
+
+## Required environment
+
+- Linux or macOS shell with `bash`
+- Java available for Gradle builds triggered by the documentation scripts
+- Network access if Gradle needs to download dependencies on a fresh environment
+
+## Expected passing output
+
+```text
+2 passed
+```

--- a/testing/tests/DMC-973/config.yaml
+++ b/testing/tests/DMC-973/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-973
+type: repo
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-973/doc_recovery_config.py
+++ b/testing/tests/DMC-973/doc_recovery_config.py
@@ -1,0 +1,21 @@
+from testing.components.services.mcp_docs_recovery_service import (
+    McpDocsRecoveryConfig,
+    SkillDocumentAudit,
+)
+
+
+DMC_973_CONFIG = McpDocsRecoveryConfig(
+    ticket_key="DMC-973",
+    docs_directory="dmtools-ai-docs/references/mcp-tools",
+    scripts=(
+        "./scripts/update-skill-docs.sh",
+        "./scripts/generate-mcp-docs.sh",
+    ),
+    audited_document=SkillDocumentAudit(
+        source_relative_path="dmtools-ai-docs/references/agents/teammate-configs.md",
+        skill_reference_path="references/agents/teammate-configs.md",
+        updated_title="Audited Teammate Configurations",
+        updated_summary="Audited configuration reference for teammate workflow documentation corrections.",
+        changelog_marker="Documentation corrections: teammate configuration references were audited for the skill index.",
+    ),
+)

--- a/testing/tests/DMC-973/test_dmc_973.py
+++ b/testing/tests/DMC-973/test_dmc_973.py
@@ -1,0 +1,148 @@
+import sys
+from pathlib import Path
+from runpy import run_path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from testing.components.services.mcp_docs_recovery_service import McpDocsRecoveryService
+from testing.core.utils.repo_sandbox import CommandResult
+
+
+DMC_973_CONFIG = run_path(str(Path(__file__).with_name("doc_recovery_config.py")))["DMC_973_CONFIG"]
+
+
+def test_dmc_973_generate_mcp_docs_recreates_missing_target_directory() -> None:
+    service = McpDocsRecoveryService(REPO_ROOT)
+    result = service.run(DMC_973_CONFIG)
+
+    failures: list[str] = []
+
+    if result.bootstrap_docs.returncode != 0:
+        failures.append(
+            "buildInstallLocal.sh failed while preparing the isolated repository.\n"
+            f"{result.bootstrap_docs.combined_output}"
+        )
+    if result.update_docs.returncode != 0:
+        failures.append(
+            "scripts/update-skill-docs.sh failed before the missing-folder recovery step.\n"
+            f"{result.update_docs.combined_output}"
+        )
+    if result.generate_docs.returncode != 0:
+        failures.append(
+            "scripts/generate-mcp-docs.sh failed after dmtools-ai-docs/references/mcp-tools/ was removed.\n"
+            f"{result.generate_docs.combined_output}"
+        )
+    if not result.docs_directory_recreated:
+        failures.append(
+            "scripts/generate-mcp-docs.sh did not recreate dmtools-ai-docs/references/mcp-tools/."
+        )
+    if not result.generated_index_refreshed:
+        failures.append(
+            "The generated MCP tools index was not recreated with the expected header/footer markers."
+        )
+    if not result.changelog_mentions_correction:
+        failures.append(
+            "CHANGELOG.md no longer mentions the audited documentation correction after the docs flow ran."
+        )
+    if not result.skill_reference_title_synced:
+        failures.append(
+            "SKILL.md did not keep the teammate guide title at the latest synced value after regenerating MCP docs.\n"
+            f"Actual row: {result.skill_reference_row}"
+        )
+    if not result.skill_reference_summary_synced:
+        failures.append(
+            "SKILL.md did not keep the teammate guide summary at the latest synced value after regenerating MCP docs.\n"
+            f"Actual row: {result.skill_reference_row}"
+        )
+
+    assert not failures, "\n\n".join(failures)
+
+
+class FakeSandbox:
+    def __init__(self, root: Path) -> None:
+        self.workspace = root / "workspace"
+        self.workspace.mkdir(parents=True)
+        self.commands: list[str] = []
+        self.cleaned_up = False
+
+        self._write(
+            "dmtools-ai-docs/references/agents/teammate-configs.md",
+            "# AI Teammate Configuration Guide\n\nOriginal summary.\n",
+        )
+        self._write(
+            "dmtools-ai-docs/CHANGELOG.md",
+            "## 1.7.133\n\n### Documentation\n\n- Existing item\n",
+        )
+        self._write(
+            "dmtools-ai-docs/references/mcp-tools/README.md",
+            "# DMtools MCP Tools Reference\n\nplaceholder\n",
+        )
+        self._write(
+            "dmtools-ai-docs/SKILL.md",
+            (
+                "| **Agents** | [Teammate Configs](references/agents/teammate-configs.md) | "
+                "Legacy summary |\n"
+            ),
+        )
+
+    def cleanup(self) -> None:
+        self.cleaned_up = True
+
+    def read_text(self, relative_path: str) -> str:
+        return (self.workspace / relative_path).read_text(encoding="utf-8")
+
+    def write_text(self, relative_path: str, content: str) -> None:
+        self._write(relative_path, content)
+
+    def run(self, command: str, timeout: int = 1800) -> CommandResult:
+        del timeout
+        self.commands.append(command)
+
+        if command == "./scripts/update-skill-docs.sh":
+            self._write(
+                "dmtools-ai-docs/SKILL.md",
+                (
+                    "| **Agents** | [Audited Teammate Configurations]"
+                    "(references/agents/teammate-configs.md) | "
+                    "Audited configuration reference for teammate workflow documentation corrections. |\n"
+                ),
+            )
+        elif command == "./scripts/generate-mcp-docs.sh":
+            self._write(
+                "dmtools-ai-docs/references/mcp-tools/README.md",
+                "# DMtools MCP Tools Reference\n\n*Generated from MCPToolRegistry on: Sun May 03 00:00:00 UTC 2026*\n",
+            )
+
+        return CommandResult(
+            command=command,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+    def _write(self, relative_path: str, content: str) -> None:
+        path = self.workspace / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def test_dmc_973_service_supports_injected_sandbox_recovery(tmp_path: Path) -> None:
+    sandbox = FakeSandbox(tmp_path)
+    service = McpDocsRecoveryService(REPO_ROOT, sandbox_factory=lambda _: sandbox)
+
+    result = service.run(DMC_973_CONFIG)
+
+    assert sandbox.commands == [
+        "./buildInstallLocal.sh",
+        "./scripts/update-skill-docs.sh",
+        "./scripts/generate-mcp-docs.sh",
+    ]
+    assert result.docs_directory_recreated is True
+    assert result.generated_index_refreshed is True
+    assert result.changelog_mentions_correction is True
+    assert result.skill_reference_title_synced is True
+    assert result.skill_reference_summary_synced is True
+    assert sandbox.cleaned_up is True


### PR DESCRIPTION
# DMC-973 test automation result

**Status:** Passed

## What automation checked

1. In an isolated repository sandbox, applied a documentation change to `dmtools-ai-docs/references/agents/teammate-configs.md` and updated `dmtools-ai-docs/CHANGELOG.md` so the latest synced state was observable.
2. Ran `./buildInstallLocal.sh` and `./scripts/update-skill-docs.sh`.
3. Deleted `dmtools-ai-docs/references/mcp-tools/`.
4. Ran `./scripts/generate-mcp-docs.sh`.
5. Verified the missing directory was recreated, the generated MCP index was refreshed, and `SKILL.md` kept the synced teammate guide title and summary.

## Human-style verification

- Checked the user-visible documentation outputs, not only the script return codes.
- Observed the `SKILL.md` row after regeneration as:

```text
|  | [Audited Teammate Configurations](references/agents/teammate-configs.md) | Audited configuration reference for teammate workflow documentation corrections. |
```

- Observed behavior matched the expected result: the missing MCP docs folder was recreated and the user-facing documentation remained current after regeneration.

## Commands and results

- `PYTHONPATH=. python3 -m pytest testing/tests/DMC-973/test_dmc_973.py -q` → `2 passed`
- `PYTHONPATH=. python3 -m pytest testing/tests/DMC-897/test_dmc_897.py -q` → `3 passed`

## Environment

- OS: Linux
- Framework: pytest
- Execution style: live repository scripts executed inside an isolated repo sandbox
