### PR TITLE
DMC-975 Reposition README around DMTools as an enterprise dark-factory orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # DMTools
-Delivery Management Tools
+
+Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.
 
 > Quick install
 >
@@ -11,98 +12,69 @@ Delivery Management Tools
 
 [![Latest Release](https://img.shields.io/github/v/release/epam/dm.ai?label=latest%20version)](https://github.com/epam/dm.ai/releases/latest) [![codecov](https://codecov.io/gh/epam/dm.ai/branch/main/graph/badge.svg)](https://codecov.io/gh/epam/dm.ai) [![](https://jitpack.io/v/epam/dm.ai.svg)](https://jitpack.io/#epam/dm.ai)
 
-> 🚀 **Latest DMTools release: [v1.7.179](https://github.com/epam/dm.ai/releases/tag/v1.7.179)** — installer assets are published under `https://github.com/epam/dm.ai/releases/latest/download/`.
+> DMTools is the current orchestration layer for enterprise dark factories. It is designed for self-hosted and enterprise environments where teams need repeatable AI-assisted workflows instead of one-off scripts or server-first demos.
 
----
+## What DMTools is for
 
-## 📚 Documentation
+DMTools helps platform, delivery, QA, and engineering teams orchestrate end-to-end work such as:
 
-**Complete documentation is available in [dmtools-ai-docs/](dmtools-ai-docs/):**
+- running MCP tools against Jira, Azure DevOps, GitHub, Confluence, Figma, Teams, SharePoint, and AI providers
+- executing reusable jobs and agents for analysis, test generation, reporting, and teammate workflows
+- wiring GitHub Actions and other CI/CD pipelines into delivery automation
+- packaging focused AI assistant skills for project-level usage in Cursor, Claude, and Codex
 
-### Quick Links
-- 🚀 **[Getting Started](dmtools-ai-docs/references/installation/README.md)** - Install, configure, and run your first commands
-  - [Installation Guide](dmtools-ai-docs/references/installation/README.md)
-  - [Configuration Guide](dmtools-ai-docs/references/configuration/README.md)
-  - [Examples](dmtools-ai-docs/references/examples/)
+## Primary usage paths
 
-- 💻 **[CLI Usage](dmtools-ai-docs/references/mcp-tools/README.md)** - Command-line interface guide
-  - [MCP Tools Reference](dmtools-ai-docs/references/mcp-tools/README.md) - 67+ built-in tools
+| Usage path | What you do with it | Start here |
+|---|---|---|
+| CLI + MCP tools | Execute direct tool calls and integration operations from the terminal | [MCP tools reference](dmtools-ai-docs/references/mcp-tools/README.md) |
+| Jobs + agents | Run orchestrated workflows such as Teammate, reporting, and test generation | [Jobs reference](dmtools-ai-docs/references/jobs/README.md) |
+| GitHub workflow automation | Run DMTools in CI/CD for ticket processing and teammate flows | [GitHub Actions teammate workflow](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
+| AI assistant skills | Install project-level DMTools skills for agent-driven usage | [Skill guide](dmtools-ai-docs/SKILL.md) |
 
-- ⚙️ **[Jobs (JobRunner)](dmtools-ai-docs/references/jobs/README.md)** - 20+ automation jobs
-  - [Job Reference](dmtools-ai-docs/references/jobs/README.md)
-  - [Workflows](dmtools-ai-docs/references/workflows/)
-  - [Reporting](dmtools-ai-docs/references/reporting/)
+## Documentation map
 
-- 🤖 **[AI Teammate Workflows](dmtools-ai-docs/references/workflows/github-actions-teammate.md)** - GitHub Actions automation
-  - [GitHub Actions Teammate](dmtools-ai-docs/references/workflows/github-actions-teammate.md)
-  - [Examples](dmtools-ai-docs/references/examples/)
-  - [Agent Skill Guide](dmtools-ai-docs/SKILL.md)
+All maintained documentation lives under [dmtools-ai-docs/](dmtools-ai-docs/).
 
-- 🔌 **[Integrations](dmtools-ai-docs/references/configuration/integrations/)** - Connect to Jira, Confluence, Figma, GitHub, etc.
+| Topic | Link |
+|---|---|
+| Installation and upgrade | [references/installation/README.md](dmtools-ai-docs/references/installation/README.md) |
+| Configuration overview | [references/configuration/README.md](dmtools-ai-docs/references/configuration/README.md) |
+| Integration setup guides | [references/configuration/integrations/](dmtools-ai-docs/references/configuration/integrations/) |
+| MCP tools reference | [references/mcp-tools/README.md](dmtools-ai-docs/references/mcp-tools/README.md) |
+| Jobs and workflow orchestration | [references/jobs/README.md](dmtools-ai-docs/references/jobs/README.md) |
+| GitHub workflow guidance | [references/workflows/github-actions-teammate.md](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
+| Examples | [references/examples/](dmtools-ai-docs/references/examples/) |
+| Documentation index | [dmtools-ai-docs/README.md](dmtools-ai-docs/README.md) |
 
-- 📖 **[Complete Documentation Index](dmtools-ai-docs/README.md)**
-
----
-
-## Table of Contents
-
-- [Installation](#installation)
-
----
-
-## Quick Start
+## Quick start
 
 ### Installation
 
-**Latest Version:** [![Latest Release](https://img.shields.io/github/v/release/epam/dm.ai?label=)](https://github.com/epam/dm.ai/releases/latest) — browse the [latest releases page](https://github.com/epam/dm.ai/releases/latest) for all installer assets.
+**Latest Version:** [![Latest Release](https://img.shields.io/github/v/release/epam/dm.ai?label=)](https://github.com/epam/dm.ai/releases/latest) — browse the [latest releases page](https://github.com/epam/dm.ai/releases/latest) for installer assets.
 
 **macOS / Linux / Git Bash:**
+
 ```bash
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
 ```
 
 **Windows PowerShell:**
+
 ```powershell
 irm https://github.com/epam/dm.ai/releases/latest/download/install.ps1 | iex
 ```
 
 **Verify installation:**
+
 ```bash
 dmtools --version
 dmtools list
 ```
 
-See the [installation guide](dmtools-ai-docs/references/installation/README.md) and [troubleshooting guide](dmtools-ai-docs/references/installation/troubleshooting.md) for details.
-
-### Upgrading from legacy installs
-
-1. Back up `~/.dmtools` before changing anything so you can restore the current wrapper, JAR, and local state if the migration goes wrong.
-2. Re-run the installer from `https://github.com/epam/dm.ai/releases/latest/download/install.sh` (or `install.bat` / `install.ps1` on Windows) to replace any `IstiN/dmtools` or raw GitHub bootstrap paths with the EPAM release asset path.
-3. Preserve or merge your existing `dmtools.env`, `dmtools-local.env`, and any other local configuration instead of overwriting them during the reinstall.
-4. If `which dmtools` or `Get-Command dmtools` resolves outside `~/.dmtools/bin`, remove stale aliases, wrapper scripts, and outdated PATH entries from your shell profile or CI bootstrap steps.
-5. Verify the migrated install with `dmtools --version` and `dmtools list`, and refresh CI cache keys that still reference legacy install URLs.
-6. If the migration fails, roll back by restoring the backup copy of `~/.dmtools` and re-enabling the previous wrapper or PATH entry.
-
-   Tagged reinstall example for rollback or migration validation:
-
-   **macOS / Linux / Git Bash:**
-   ```bash
-   curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
-   ```
-
-   **Windows:**
-   ```cmd
-   set DMTOOLS_VERSION=v1.7.179 && curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
-   ```
-
-### Deprecated compatibility shims
-
-- `CodeGenerator` is deprecated and kept only as a compatibility shim for one release. Invocations now log a warning and return a no-op response; migrate affected automation before `v1.8.0`.
-
-### Configuration
+### Minimal configuration
 
 ```bash
-# Create configuration file
 cat > dmtools.env << EOF
 JIRA_BASE_PATH=https://your-company.atlassian.net
 JIRA_EMAIL=your-email@company.com
@@ -110,249 +82,51 @@ JIRA_API_TOKEN=your-jira-api-token
 GEMINI_API_KEY=your-gemini-api-key
 EOF
 
-# Secure the file
 chmod 600 dmtools.env
 ```
 
-### Your First Command
+For provider-specific and integration-specific setup, use the maintained docs instead of copying old snippets from the repository root:
+
+- [Configuration overview](dmtools-ai-docs/references/configuration/README.md)
+- [Integration setup guides](dmtools-ai-docs/references/configuration/integrations/)
+
+### First commands
 
 ```bash
-# Get a Jira ticket
-dmtools jira_get_ticket YOUR-123
-
-# Search tickets
-dmtools jira_search_by_jql "project = PROJ AND status = Open" "summary,status"
-
-# List all available tools
 dmtools list
+dmtools jira_get_ticket YOUR-123
+dmtools run agents/story_development.json
 ```
 
-See the [examples reference](dmtools-ai-docs/references/examples/) for more usage patterns.
+## Upgrading from legacy installs
 
----
+Keep the latest-release installer flow introduced in DMC-858 when refreshing existing environments.
 
-## Simple Run (Legacy)
-1. Download the release from: [DMTools Releases](https://github.com/epam/dm.ai/releases)
-2. Set environment variables.
-3. Run the command:
-   ```bash
-   java -cp dmtools.jar com.github.istin.dmtools.job.UrlEncodedJobTrigger "$JOB_PARAMS"
-   ```
-   `JOB_PARAMS` is a Base64-encoded payload accepted by `UrlEncodedJobTrigger`.
+1. Back up `~/.dmtools` before changing anything so you can restore the current wrapper, JAR, and local state if migration fails.
+2. Re-run the installer from `https://github.com/epam/dm.ai/releases/latest/download/install.sh` (or `install.bat` / `install.ps1` on Windows) to replace any legacy bootstrap URLs.
+3. Preserve or merge your existing `dmtools.env`, `dmtools-local.env`, and local configuration instead of overwriting them.
+4. Remove stale aliases, wrapper scripts, and PATH entries that resolve outside `~/.dmtools/bin`.
+5. Verify the migrated install with `dmtools --version` and `dmtools list`.
 
----
+Tagged reinstall example for rollback or migration validation:
 
-## Build JAR
-To build the JAR file, run:
+**macOS / Linux / Git Bash:**
+
 ```bash
-gradle shadowJar
+curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.sh | bash -s -- v1.7.179
 ```
 
----
+**Windows:**
 
-## 🔐 OAuth2 Authentication Setup
-
-DMTools includes a **web application with OAuth2 authentication** supporting Google, Microsoft, and GitHub login.
-
-### Quick Setup
-For complete OAuth2 setup instructions including:
-- ✅ **Google, Microsoft, GitHub** OAuth provider configuration  
-- ✅ **Production deployment** on Google Cloud Run
-- ✅ **GitHub Actions** with secrets management
-- ✅ **Security configuration** and troubleshooting
-
-📖 **OAuth2 deployment notes are maintained with the server configuration in this repository.**
-
-### Live Application
-- **Production**: https://ai-native.cloud
-- **API Documentation**: https://ai-native.cloud/swagger-ui/index.html
-
----
-
-## Configuration
-
-### Jira Configuration
-```properties
-JIRA_BASE_PATH=https://jira.company.com
-JIRA_LOGIN_PASS_TOKEN=base64(email:token)
-JIRA_AUTH_TYPE=Bearer
-JIRA_WAIT_BEFORE_PERFORM=true
-JIRA_LOGGING_ENABLED=true
-JIRA_CLEAR_CACHE=true
-JIRA_EXTRA_FIELDS_PROJECT=customfield_10001,customfield_10002
-JIRA_EXTRA_FIELDS=summary,description,status
+```cmd
+set DMTOOLS_VERSION=v1.7.179 && curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.179/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
 ```
 
-#### How to Get Jira Token:
-1. Go to **Jira > Profile Settings > Security**.
-2. Under "API Token", click **Create and manage API tokens**.
-3. Click **Create API token** and give it a name (e.g., `dm_tools`).
-4. Copy the generated token.
-5. Convert `email:token` to base64 format.
-6. Add the following to your configuration:
-   ```properties
-   JIRA_LOGIN_PASS_TOKEN=base64(email:token)
-   JIRA_AUTH_TYPE=Bearer
-   ```
+## Build from source
 
----
-
-### Rally Configuration
-```properties
-RALLY_TOKEN=your_rally_token
-RALLY_PATH=https://rally1.rallydev.com
+```bash
+./gradlew :dmtools-core:shadowJar
+./buildInstallLocal.sh
 ```
 
-#### How to Get Rally Token:
-1. Log in to Rally.
-2. Navigate to **User Profile > API Keys**.
-3. Generate a new API key.
-4. Copy the token and add it to the configuration.
-
----
-
-### Bitbucket Configuration
-```properties
-BITBUCKET_TOKEN=Bearer your_token
-BITBUCKET_API_VERSION=V2
-BITBUCKET_WORKSPACE=your-workspace
-BITBUCKET_REPOSITORY=your-repo
-BITBUCKET_BRANCH=main
-BITBUCKET_BASE_PATH=https://api.bitbucket.org
-```
-
-#### How to Get Bitbucket Token:
-1. Go to **Bitbucket Settings > App passwords**.
-2. Click **Create app password**.
-3. Select the required permissions (e.g., read/write access).
-4. Copy the generated token.
-5. Add the following to your configuration:
-   ```properties
-   BITBUCKET_TOKEN=Bearer [token]
-   ```
-
----
-
-### GitHub Configuration
-```properties
-SOURCE_GITHUB_TOKEN=your_github_token
-SOURCE_GITHUB_WORKSPACE=your-org
-SOURCE_GITHUB_REPOSITORY=your-repo
-SOURCE_GITHUB_BRANCH=main
-SOURCE_GITHUB_BASE_PATH=https://api.github.com
-```
-
-#### How to Get GitHub Token:
-1. Go to **GitHub Settings > Developer settings > Personal access tokens**.
-2. Generate a new token (classic).
-3. Select the required scopes (e.g., repo access).
-4. Copy the generated token.
-5. Add the following to your configuration:
-   ```properties
-   SOURCE_GITHUB_TOKEN=[token]
-   ```
-
----
-
-### GitLab Configuration
-```properties
-GITLAB_TOKEN=your_gitlab_token
-GITLAB_WORKSPACE=your-workspace
-GITLAB_REPOSITORY=your-repo
-GITLAB_BRANCH=main
-GITLAB_BASE_PATH=https://gitlab.com/api/v4
-```
-
-#### How to Get GitLab Token:
-1. Go to **GitLab > User Settings > Access Tokens**.
-2. Create a new personal access token.
-3. Select the required scopes (e.g., API access).
-4. Copy the generated token and add it to the configuration.
-
----
-
-### Confluence Configuration
-```properties
-CONFLUENCE_BASE_PATH=https://confluence.company.com
-CONFLUENCE_LOGIN_PASS_TOKEN=base64(email:token)
-CONFLUENCE_GRAPHQL_PATH=/graphql
-CONFLUENCE_DEFAULT_SPACE=TEAM
-```
-
-#### How to Get Confluence Token:
-1. Go to **Confluence > Profile > Settings > Password**.
-2. Create an API token.
-3. Convert `email:token` to base64 format.
-4. Add the following to your configuration:
-   ```properties
-   CONFLUENCE_LOGIN_PASS_TOKEN=base64(email:token)
-   ```
-
----
-
-### AI Configuration
-```properties
-DIAL_BATH_PATH=https://api.dial.com/v1
-DIAL_API_KEY=your_dial_key
-DIAL_MODEL=gpt-4
-```
-
-#### How to Get DIAL Token:
-1. Go to the [DIAL Platform](https://platform.openai.com).
-2. Request your API key.
-3. Create a new secret key.
-4. Copy the key and add it to the configuration:
-   ```properties
-   DIAL_API_KEY=[token]
-   ```
-
----
-
-### AI Models Configuration
-```properties
-CODE_AI_MODEL=gpt-4
-TEST_AI_MODEL=gpt-4
-```
-
-****---
-
-### Figma Configuration
-```properties
-FIGMA_BASE_PATH=https://api.figma.com/v1
-FIGMA_TOKEN=your_figma_token
-```
-
-#### How to Get Figma Token:
-1. Log in to Figma.
-2. Go to **Account Settings > Personal Access Tokens**.
-3. Generate a new token.
-4. Copy the token and add it to the configuration.
-
----
-
-### Firebase Configuration
-```properties
-FIREBASE_PROJECT_ID=your-project-id
-FIREBASE_SERVICE_ACCOUNT_JSON_AUTH={"type":"service_account",...}
-```
-
-#### How to Get Firebase Credentials:
-1. Go to the [Firebase Console](https://console.firebase.google.com).
-2. Navigate to **Project Settings > Service Accounts**.
-3. Generate a new private key.
-4. Download the JSON file and use it in the configuration.
-
----
-
-## Notes
-- Replace all placeholder values (e.g., `your_token`, `your-org`) with actual values.
-- **Never commit sensitive tokens to version control.** Use environment variables or secure vaults instead.
-
-### Prompt Preparation Config
-```properties
-# Prompt Chunk Configurations
-PROMPT_CHUNK_TOKEN_LIMIT=4000
-PROMPT_CHUNK_MAX_SINGLE_FILE_SIZE_MB=4
-PROMPT_CHUNK_MAX_TOTAL_FILES_SIZE_MB=4
-PROMPT_CHUNK_MAX_FILES=10
-```
+See the [installation guide](dmtools-ai-docs/references/installation/README.md) for local development installation details.


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present at the repository root, so implementation followed the ticket inputs available under `input/DMC-975/`.
- This ticket was documentation-only. No production code paths changed, so no new unit tests were added.
- No CI/CD or repository configuration was changed.

## Approach

- Rewrote the top-level `README.md` around DMTools as an enterprise dark-factory orchestrator for self-hosted and enterprise environments.
- Replaced the old repository entry narrative with current primary usage paths: CLI/MCP tools, jobs/agents, GitHub workflow automation, and AI assistant skills.
- Removed obsolete server-first messaging and legacy public surface references, including the OAuth2/live-application section and the large root-level configuration dump.
- Kept the latest-release installation and upgrade guidance intact so the DMC-858 installer-path cleanup remains preserved.
- Pointed README navigation only to maintained documentation in `dmtools-ai-docs/` and current GitHub workflow guidance.

## Files Modified

- `README.md` — repositioned the repository entry experience, refreshed documentation/navigation structure, preserved current install flow, and removed outdated web-app/server messaging.
- `outputs/response.md` — technical PR summary for automated PR description generation.

## Test Coverage

- No new unit tests were necessary because the change is limited to repository documentation.
- Verification run:
  - `./gradlew :dmtools-core:compileJava :dmtools-core:test`
