### PR TITLE
DMC-978 Test: Verify README product positioning — DMTools framed as dark-factory orchestrator

### DIFF
--- a/testing/components/services/readme_product_positioning_service.py
+++ b/testing/components/services/readme_product_positioning_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.components.services.documentation_cross_link_service import (
+    DocumentationCrossLinkService,
+)
+
+
+MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+MULTISPACE_PATTERN = re.compile(r"\s+")
+
+
+@dataclass(frozen=True)
+class MarkdownTableRow:
+    cells: tuple[str, ...]
+    line_number: int
+
+
+class ReadmeProductPositioningService:
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.readme_path = repository_root / "README.md"
+        self._cross_link_service = DocumentationCrossLinkService(repository_root)
+        self._lines = self.readme_path.read_text(encoding="utf-8").splitlines()
+
+    def heading_line_number(self, heading: str) -> int:
+        for index, line in enumerate(self._lines, start=1):
+            if line.strip() == heading:
+                return index
+        raise ValueError(f"Heading {heading!r} not found in {self.readme_path}")
+
+    def hero_markdown(self) -> str:
+        collected: list[str] = []
+        for line in self._lines:
+            if line.startswith("## "):
+                break
+            collected.append(line)
+        return "\n".join(collected).strip()
+
+    def hero_visible_text(self) -> str:
+        return self.visible_text(self.hero_markdown())
+
+    def section_visible_text(self, heading: str) -> str:
+        _, section = self._cross_link_service.section_content(self.readme_path, heading)
+        return self.visible_text(section)
+
+    def markdown_table_rows(self, heading: str) -> list[MarkdownTableRow]:
+        section_start_line, section = self._cross_link_service.section_content(
+            self.readme_path,
+            heading,
+        )
+        rows: list[MarkdownTableRow] = []
+        for offset, line in enumerate(section.splitlines(), start=section_start_line):
+            stripped = line.strip()
+            if not stripped.startswith("|"):
+                continue
+
+            cells = tuple(cell.strip() for cell in stripped.strip("|").split("|"))
+            if not cells or all(set(cell) <= {"-"} for cell in cells):
+                continue
+            rows.append(MarkdownTableRow(cells=cells, line_number=offset))
+        return rows
+
+    @staticmethod
+    def visible_text(markdown: str) -> str:
+        text = MARKDOWN_LINK_PATTERN.sub(r"\1", markdown)
+        cleaned_lines: list[str] = []
+        in_code_block = False
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("```"):
+                in_code_block = not in_code_block
+                continue
+            if in_code_block or not stripped:
+                continue
+
+            stripped = re.sub(r"^#+\s*", "", stripped)
+            stripped = re.sub(r"^>\s?", "", stripped)
+            stripped = stripped.replace("|", " ")
+            cleaned_lines.append(stripped)
+
+        return MULTISPACE_PATTERN.sub(" ", " ".join(cleaned_lines)).strip()
+
+    @staticmethod
+    def normalized_text(text: str) -> str:
+        return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+    def opening_stops_before(self, heading: str) -> bool:
+        documentation_map_line = self.heading_line_number("## Documentation map")
+        return self.heading_line_number(heading) < documentation_map_line

--- a/testing/tests/DMC-978/README.md
+++ b/testing/tests/DMC-978/README.md
@@ -1,0 +1,29 @@
+# DMC-978 automated test
+
+This test validates the root `README.md` opening as a user-facing product contract.
+It verifies that the hero and opening sections present DMTools as an enterprise
+dark-factory orchestrator, keep the CLI install path visible, explain who the
+product is for, and surface the primary usage paths for MCP tooling and jobs.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-978/test_dmc_978.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads `README.md` directly from
+this repository checkout and validates the visible opening content.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-978/README.md
+++ b/testing/tests/DMC-978/README.md
@@ -20,7 +20,7 @@ python3 -m pytest testing/tests/DMC-978/test_dmc_978.py -q
 ## Environment
 
 No environment variables are required. The test reads `README.md` directly from
-this repository checkout and validates the visible opening content.
+this repository checkout, and the ticket metadata is defined in `config.yaml`.
 
 ## Expected passing output
 

--- a/testing/tests/DMC-978/config.yaml
+++ b/testing/tests/DMC-978/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-978
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-978/test_dmc_978.py
+++ b/testing/tests/DMC-978/test_dmc_978.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+from testing.components.services.readme_product_positioning_service import (
+    ReadmeProductPositioningService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_INSTALL_COMMAND = (
+    "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash"
+)
+EXPECTED_AUDIENCES = ("platform", "delivery", "qa", "engineering")
+
+
+def test_dmc_978_readme_opening_positions_dmtools_as_dark_factory_orchestrator() -> None:
+    service = ReadmeProductPositioningService(REPOSITORY_ROOT)
+
+    hero_markdown = service.hero_markdown()
+    hero_text = service.hero_visible_text()
+    hero_normalized = service.normalized_text(hero_text)
+
+    assert hero_markdown.startswith("# DMTools"), (
+        "README.md must open with the DMTools product heading so the first screen is "
+        "clearly branded for readers landing on the repository."
+    )
+    assert EXPECTED_INSTALL_COMMAND in hero_markdown, (
+        "The README hero should keep the primary CLI install command visible so the "
+        "opening remains CLI-first for new users."
+    )
+    assert "dark factory orchestrator" in hero_normalized, (
+        "The README hero must frame DMTools as an orchestrator for enterprise dark "
+        "factories using visible user-facing language.\n"
+        f"Observed hero text: {hero_text}"
+    )
+    assert "self hosted and enterprise environments" in hero_normalized, (
+        "The opening must explicitly state that DMTools is intended for self-hosted "
+        "and enterprise environments.\n"
+        f"Observed hero text: {hero_text}"
+    )
+
+    what_is_for_text = service.section_visible_text("## What DMTools is for")
+    what_is_for_normalized = service.normalized_text(what_is_for_text)
+
+    missing_audiences = [
+        audience for audience in EXPECTED_AUDIENCES if audience not in what_is_for_normalized
+    ]
+    assert not missing_audiences, (
+        "The opening README section must explain who DMTools is for, including platform, "
+        "delivery, QA, and engineering teams. "
+        f"Missing audience terms: {', '.join(missing_audiences)}.\n"
+        f"Observed section text: {what_is_for_text}"
+    )
+    assert "mcp tools" in what_is_for_normalized, (
+        "The opening README section must describe the MCP connector/tooling path.\n"
+        f"Observed section text: {what_is_for_text}"
+    )
+
+    usage_rows = {
+        row.cells[0]: row for row in service.markdown_table_rows("## Primary usage paths") if row.cells
+    }
+    assert "CLI + MCP tools" in usage_rows, (
+        "README.md must list 'CLI + MCP tools' as a primary usage path so the product "
+        "is presented as CLI-first."
+    )
+    assert "Jobs + agents" in usage_rows, (
+        "README.md must list 'Jobs + agents' as a primary usage path for orchestrated workflows."
+    )
+
+    cli_row_text = " ".join(usage_rows["CLI + MCP tools"].cells)
+    jobs_row_text = " ".join(usage_rows["Jobs + agents"].cells)
+
+    assert "terminal" in service.normalized_text(cli_row_text), (
+        "The CLI + MCP tools usage path should explicitly tell users that this path is "
+        "run from the terminal.\n"
+        f"Observed row: {cli_row_text}"
+    )
+    assert "teammate" in service.normalized_text(jobs_row_text), (
+        "The jobs workflow row must call out teammate workflows in user-facing text.\n"
+        f"Observed row: {jobs_row_text}"
+    )
+
+    assert service.opening_stops_before("## What DMTools is for"), (
+        "The 'What DMTools is for' section should appear in the README opening before "
+        "the broader documentation map."
+    )
+    assert service.opening_stops_before("## Primary usage paths"), (
+        "The 'Primary usage paths' section should appear in the README opening before "
+        "the broader documentation map."
+    )


### PR DESCRIPTION
# DMC-978 test automation: PASSED

## What was checked by automation

- Ran `python3 -m pytest testing/tests/DMC-978/test_dmc_978.py -q`.
- Verified the root `README.md` opens with the DMTools heading and keeps the primary CLI install command visible in the hero.
- Verified the opening positions DMTools as a dark-factory orchestrator and explicitly mentions self-hosted and enterprise environments.
- Verified `## What DMTools is for` names the intended audience and includes the MCP tooling path.
- Verified `## Primary usage paths` includes `CLI + MCP tools` and `Jobs + agents`, with the jobs row calling out Teammate workflows.

## Human-style verification

- Opened the root `README.md` as a user landing on the repository.
- Observed the title, the product-positioning sentence, the quick-install block, and the self-hosted/enterprise explanation in the opening content.
- Continued through the opening sections and confirmed the audience guidance and usage-path table appear before the broader documentation map.
- The wording and placement matched the expected result from the ticket.

## Observed result

```text
1 passed in 0.03s
```
