### PR TITLE
DMC-981 Test: Validate consistent product identity — orchestrator terminology used across core docs

### DIFF
--- a/testing/components/services/product_identity_audit_service.py
+++ b/testing/components/services/product_identity_audit_service.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ProductIdentityAudit:
+    label: str
+    path: Path
+    location: str
+    line_number: int
+    text: str
+    issues: tuple[str, ...]
+
+
+class ProductIdentityAuditService:
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.root_readme_path = repository_root / "README.md"
+        self.docs_readme_path = repository_root / "dmtools-ai-docs/README.md"
+        self.skill_path = repository_root / "dmtools-ai-docs/SKILL.md"
+
+    def audit(self) -> list[ProductIdentityAudit]:
+        return [
+            self._audit_lead_paragraph(
+                self.root_readme_path,
+                label="root README lead paragraph",
+            ),
+            self._audit_lead_paragraph(
+                self.docs_readme_path,
+                label="documentation hub lead paragraph",
+            ),
+            self._audit_lead_paragraph(
+                self.skill_path,
+                label="skill guide lead paragraph",
+            ),
+        ]
+
+    @staticmethod
+    def format_findings(audits: list[ProductIdentityAudit]) -> str:
+        lines = [
+            "DMC-981 expects README.md, dmtools-ai-docs/README.md, and dmtools-ai-docs/SKILL.md "
+            "to describe DMTools consistently as an orchestrator with enterprise dark-factory "
+            "positioning and without conflicting toolkit wording."
+        ]
+        for audit in audits:
+            if not audit.issues:
+                continue
+            issue_list = ", ".join(audit.issues)
+            lines.append(
+                f"- {audit.label} ({audit.path.as_posix()}:L{audit.line_number}, {audit.location}): "
+                f"{issue_list}"
+            )
+            lines.append(f"  Observed text: {audit.text}")
+        return "\n".join(lines)
+
+    def _audit_lead_paragraph(self, path: Path, label: str) -> ProductIdentityAudit:
+        line_number, text = self._extract_lead_paragraph(path)
+        normalized = self._normalize(text)
+
+        issues = []
+        if re.search(r"\borchestrator\b", normalized) is None:
+            issues.append("missing orchestrator wording")
+        if not self._mentions_enterprise_dark_factory(normalized):
+            issues.append("missing enterprise dark-factory positioning")
+        if re.search(r"\btoolkit\b", normalized) is not None:
+            issues.append("contains conflicting toolkit wording")
+
+        return ProductIdentityAudit(
+            label=label,
+            path=path,
+            location="first paragraph after the H1 heading",
+            line_number=line_number,
+            text=text,
+            issues=tuple(issues),
+        )
+
+    @staticmethod
+    def _extract_lead_paragraph(path: Path) -> tuple[int, str]:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        content_start_index = ProductIdentityAuditService._content_start_index(lines)
+
+        heading_index = next(
+            (
+                index
+                for index in range(content_start_index, len(lines))
+                if lines[index].strip().startswith("# ")
+            ),
+            None,
+        )
+        if heading_index is None:
+            raise AssertionError(f"Could not find an H1 heading in {path.as_posix()}")
+
+        paragraph_start_index = next(
+            (
+                index
+                for index in range(heading_index + 1, len(lines))
+                if lines[index].strip() and not lines[index].strip().startswith("#")
+            ),
+            None,
+        )
+        if paragraph_start_index is None:
+            raise AssertionError(
+                f"Could not find a lead paragraph after the H1 heading in {path.as_posix()}"
+            )
+
+        paragraph_lines: list[str] = []
+        for index in range(paragraph_start_index, len(lines)):
+            stripped_line = lines[index].strip()
+            if not stripped_line or stripped_line.startswith("#") or stripped_line.startswith("```"):
+                break
+            paragraph_lines.append(stripped_line)
+
+        if not paragraph_lines:
+            raise AssertionError(
+                f"Could not read a lead paragraph after the H1 heading in {path.as_posix()}"
+            )
+
+        return paragraph_start_index + 1, " ".join(paragraph_lines)
+
+    @staticmethod
+    def _content_start_index(lines: list[str]) -> int:
+        if not lines or lines[0].strip() != "---":
+            return 0
+
+        closing_index = next(
+            (index for index in range(1, len(lines)) if lines[index].strip() == "---"),
+            None,
+        )
+        if closing_index is None:
+            raise AssertionError("Encountered an unterminated YAML frontmatter block.")
+        return closing_index + 1
+
+    @staticmethod
+    def _mentions_enterprise_dark_factory(normalized: str) -> bool:
+        return (
+            re.search(r"\benterprise\b", normalized) is not None
+            and re.search(r"\bdark(?:-|\s)?fact(?:ory|ories)\b", normalized) is not None
+        )
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return re.sub(r"\s+", " ", text).strip().lower()

--- a/testing/tests/DMC-981/README.md
+++ b/testing/tests/DMC-981/README.md
@@ -1,0 +1,27 @@
+# DMC-981 automated test
+
+This test validates that the repository front door and the core DMTools documentation
+entry points use the same product identity language.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-981/test_dmc_981.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads the checked-out repository
+documentation directly.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-981/config.yaml
+++ b/testing/tests/DMC-981/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-981
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-981/test_dmc_981.py
+++ b/testing/tests/DMC-981/test_dmc_981.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from testing.components.services.product_identity_audit_service import (
+    ProductIdentityAuditService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_981_core_docs_use_consistent_orchestrator_identity() -> None:
+    service = ProductIdentityAuditService(REPOSITORY_ROOT)
+
+    audits = service.audit()
+
+    assert {audit.label for audit in audits} == {
+        "root README lead paragraph",
+        "documentation hub lead paragraph",
+        "skill guide lead paragraph",
+    }
+
+    failing_audits = [audit for audit in audits if audit.issues]
+    assert not failing_audits, service.format_findings(failing_audits)
+
+
+def test_dmc_981_accepts_frontmatter_docs_when_lead_identity_is_consistent(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    (repository_root / "dmtools-ai-docs").mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "Enterprise dark-factory orchestrator for automating delivery workflows.\n",
+        encoding="utf-8",
+    )
+    (repository_root / "dmtools-ai-docs/README.md").write_text(
+        "---\n"
+        "name: dmtools\n"
+        "description: Example metadata that should not affect the visible lead paragraph.\n"
+        "---\n\n"
+        "# DMtools Development Assistant\n\n"
+        "DMTools is an enterprise dark-factory orchestrator for reusable AI-assisted delivery workflows.\n",
+        encoding="utf-8",
+    )
+    (repository_root / "dmtools-ai-docs/SKILL.md").write_text(
+        "# DMtools Agent Skill\n\n"
+        "DMTools is an enterprise dark-factory orchestrator for project-level agent workflows.\n",
+        encoding="utf-8",
+    )
+
+    service = ProductIdentityAuditService(repository_root)
+
+    audits = service.audit()
+
+    assert [audit.issues for audit in audits] == [(), (), ()]
+
+
+def test_dmc_981_reports_conflicting_toolkit_identity_language(tmp_path: Path) -> None:
+    repository_root = tmp_path / "repo"
+    (repository_root / "dmtools-ai-docs").mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "Enterprise dark-factory orchestrator for automating delivery workflows.\n",
+        encoding="utf-8",
+    )
+    (repository_root / "dmtools-ai-docs/README.md").write_text(
+        "# DMtools Development Assistant\n\n"
+        "Comprehensive knowledge base for DMtools - an AI-powered development toolkit.\n",
+        encoding="utf-8",
+    )
+    (repository_root / "dmtools-ai-docs/SKILL.md").write_text(
+        "# DMtools Agent Skill\n\n"
+        "Universal AI assistant skill for DMtools.\n",
+        encoding="utf-8",
+    )
+
+    service = ProductIdentityAuditService(repository_root)
+
+    failing_audits = [audit for audit in service.audit() if audit.issues]
+
+    assert [audit.label for audit in failing_audits] == [
+        "documentation hub lead paragraph",
+        "skill guide lead paragraph",
+    ]
+    assert failing_audits[0].issues == (
+        "missing orchestrator wording",
+        "missing enterprise dark-factory positioning",
+        "contains conflicting toolkit wording",
+    )
+    assert failing_audits[1].issues == (
+        "missing orchestrator wording",
+        "missing enterprise dark-factory positioning",
+    )


### PR DESCRIPTION
# DMC-981 automated test result: **FAILED**

## Automation

- Added a documentation audit in `testing/components/services/product_identity_audit_service.py` and `testing/tests/DMC-981/test_dmc_981.py`.
- Ran `PYTHONPATH=. python3 -m pytest testing/tests/DMC-981/test_dmc_981.py -q`.
- Result: **1 failed, 2 passed**.

## Real user / human-style verification

I checked the first visible product-description paragraph in the three entry points a user would read:

- `README.md:L3` — `Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.`
- `dmtools-ai-docs/README.md:L3` — `Universal AI assistant skill for DMtools - works with Cursor, Claude, Codex, and any [Agent Skills](https://agentskills.io) compatible system.`
- `dmtools-ai-docs/SKILL.md:L17` — `Comprehensive knowledge base for DMtools - an AI-powered development toolkit that integrates with multiple platforms and provides 96+ MCP tools for automation.`

This did **not** match the expected result. The repository front door uses the requested **orchestrator** / **enterprise dark-factory** identity, while the documentation hub and skill entry points switch to **skill** and **toolkit** terminology.

## Step outcome

1. **Passed:** compared the product descriptions in `README.md`, `dmtools-ai-docs/README.md`, and `dmtools-ai-docs/SKILL.md`.
2. **Failed:** `dmtools-ai-docs/README.md` and `dmtools-ai-docs/SKILL.md` do not describe DMTools as an orchestrator and do not align on enterprise dark-factory positioning.
3. **Failed:** `dmtools-ai-docs/SKILL.md` still uses `development toolkit`, creating the identity confusion called out in the ticket.

## Exact pytest failure

```text
F..                                                                      [100%]
=================================== FAILURES ===================================
_________ test_dmc_981_core_docs_use_consistent_orchestrator_identity __________

    def test_dmc_981_core_docs_use_consistent_orchestrator_identity() -> None:
        service = ProductIdentityAuditService(REPOSITORY_ROOT)

        audits = service.audit()

        assert {audit.label for audit in audits} == {
            "root README lead paragraph",
            "documentation hub lead paragraph",
            "skill guide lead paragraph",
        }

        failing_audits = [audit for audit in audits if audit.issues]
>       assert not failing_audits, service.format_findings(failing_audits)
E       AssertionError: DMC-981 expects README.md, dmtools-ai-docs/README.md, and dmtools-ai-docs/SKILL.md to describe DMTools consistently as an orchestrator with enterprise dark-factory positioning and without conflicting toolkit wording.
E         - documentation hub lead paragraph (/home/runner/work/dm.ai/dm.ai/dmtools-ai-docs/README.md:L3, first paragraph after the H1 heading): missing orchestrator wording, missing enterprise dark-factory positioning
E           Observed text: Universal AI assistant skill for DMtools - works with Cursor, Claude, Codex, and any [Agent Skills](https://agentskills.io) compatible system.
E         - skill guide lead paragraph (/home/runner/work/dm.ai/dm.ai/dmtools-ai-docs/SKILL.md:L17, first paragraph after the H1 heading): missing orchestrator wording, missing enterprise dark-factory positioning, contains conflicting toolkit wording
E           Observed text: Comprehensive knowledge base for DMtools - an AI-powered development toolkit that integrates with multiple platforms and provides 96+ MCP tools for automation.
E       assert not [ProductIdentityAudit(label='documentation hub lead paragraph', path=PosixPath('/home/runner/work/dm.ai/dm.ai/dmtools-...missing orchestrator wording', 'missing enterprise dark-factory positioning', 'contains conflicting toolkit wording'))]

testing/tests/DMC-981/test_dmc_981.py:23: AssertionError
=========================== short test summary info ============================
FAILED testing/tests/DMC-981/test_dmc_981.py::test_dmc_981_core_docs_use_consistent_orchestrator_identity - AssertionError: DMC-981 expects README.md, dmtools-ai-docs/README.md, and dmtools-ai-docs/SKILL.md to describe DMTools consistently as an orchestrator with enterprise dark-factory positioning and without conflicting toolkit wording.
  - documentation hub lead paragraph (/home/runner/work/dm.ai/dm.ai/dmtools-ai-docs/README.md:L3, first paragraph after the H1 heading): missing orchestrator wording, missing enterprise dark-factory positioning
    Observed text: Universal AI assistant skill for DMtools - works with Cursor, Claude, Codex, and any [Agent Skills](https://agentskills.io) compatible system.
  - skill guide lead paragraph (/home/runner/work/dm.ai/dm.ai/dmtools-ai-docs/SKILL.md:L17, first paragraph after the H1 heading): missing orchestrator wording, missing enterprise dark-factory positioning, contains conflicting toolkit wording
    Observed text: Comprehensive knowledge base for DMtools - an AI-powered development toolkit that integrates with multiple platforms and provides 96+ MCP tools for automation.
assert not [ProductIdentityAudit(label='documentation hub lead paragraph', path=PosixPath('/home/runner/work/dm.ai/dm.ai/dmtools-...missing orchestrator wording', 'missing enterprise dark-factory positioning', 'contains conflicting toolkit wording'))]
1 failed, 2 passed in 0.04s
```

## Environment

- Repository: `epam/dm.ai`
- Working directory: `/home/runner/work/dm.ai/dm.ai`
- OS: `Linux 6.17.0-1010-azure x86_64 GNU/Linux`
- Python: `Python 3.12.3`
