### PR TITLE
DMC-980 Test: Verify intent-based navigation — links route to maintained documentation hubs

### DIFF
--- a/testing/components/services/readme_documentation_navigation_service.py
+++ b/testing/components/services/readme_documentation_navigation_service.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.components.services.documentation_cross_link_service import (
+    DocumentationCrossLinkService,
+)
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class NavigationLinkObservation:
+    section_heading: str
+    text: str
+    target: str
+    line_number: int
+    line_text: str
+
+    def display(self) -> str:
+        return (
+            f"{self.section_heading} line {self.line_number}: "
+            f"[{self.text}]({self.target}) in {self.line_text.strip()}"
+        )
+
+
+@dataclass(frozen=True)
+class NavigationSection:
+    heading: str
+    start_line: int
+    body: str
+
+
+class ReadmeDocumentationNavigationService:
+    PRIMARY_USAGE_HEADING = "## Primary usage paths"
+    DOCUMENTATION_MAP_HEADING = "## Documentation map"
+    QUICK_START_HEADING = "## Quick start"
+
+    INSTALLATION_TARGET = "dmtools-ai-docs/references/installation/README.md"
+    CONFIGURATION_TARGET = "dmtools-ai-docs/references/configuration/README.md"
+    INTEGRATIONS_TARGET = "dmtools-ai-docs/references/configuration/integrations/"
+    MCP_TOOLS_TARGET = "dmtools-ai-docs/references/mcp-tools/README.md"
+    AI_TEAMMATE_TARGET = "dmtools-ai-docs/references/workflows/github-actions-teammate.md"
+    SKILL_GUIDE_TARGET = "dmtools-ai-docs/SKILL.md"
+
+    ALLOWED_TARGET_PREFIXES = ("dmtools-ai-docs/", ".github/workflows/")
+
+    REQUIRED_TARGETS = (
+        INSTALLATION_TARGET,
+        CONFIGURATION_TARGET,
+        INTEGRATIONS_TARGET,
+        MCP_TOOLS_TARGET,
+        AI_TEAMMATE_TARGET,
+        SKILL_GUIDE_TARGET,
+    )
+
+    REQUIRED_LINE_FRAGMENTS = {
+        INSTALLATION_TARGET: ("Installation and upgrade",),
+        CONFIGURATION_TARGET: ("Configuration overview",),
+        INTEGRATIONS_TARGET: ("Integration setup guides",),
+        MCP_TOOLS_TARGET: ("MCP tools reference", "CLI + MCP tools"),
+        AI_TEAMMATE_TARGET: ("GitHub workflow guidance", "GitHub workflow automation"),
+        SKILL_GUIDE_TARGET: ("AI assistant skills", "AI skill packages"),
+    }
+
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.readme_path = repository_root / "README.md"
+        self.readme_text = self.readme_path.read_text(encoding="utf-8")
+        self.lines = self.readme_text.splitlines()
+        self.cross_link_service = DocumentationCrossLinkService(repository_root)
+
+    def validate(self) -> list[ValidationFailure]:
+        failures: list[ValidationFailure] = []
+
+        primary_usage = self._load_section(self.PRIMARY_USAGE_HEADING)
+        documentation_map = self._load_section(self.DOCUMENTATION_MAP_HEADING)
+        quick_start_line = self._heading_line(self.QUICK_START_HEADING)
+
+        missing_sections = [
+            heading
+            for heading, section in (
+                (self.PRIMARY_USAGE_HEADING, primary_usage),
+                (self.DOCUMENTATION_MAP_HEADING, documentation_map),
+            )
+            if section is None
+        ]
+        if missing_sections:
+            failures.append(
+                ValidationFailure(
+                    step=1,
+                    summary="README is missing the maintained documentation navigation section(s).",
+                    expected=(
+                        "README should expose both 'Primary usage paths' and 'Documentation map' "
+                        "before Quick start."
+                    ),
+                    actual="Missing headings: " + ", ".join(missing_sections),
+                )
+            )
+
+        out_of_order_sections = [
+            section.heading
+            for section in (primary_usage, documentation_map)
+            if section is not None
+            and quick_start_line is not None
+            and section.start_line > quick_start_line
+        ]
+        if out_of_order_sections:
+            failures.append(
+                ValidationFailure(
+                    step=1,
+                    summary="README navigation sections appear after Quick start instead of guiding discovery first.",
+                    expected="Navigation sections should appear before '## Quick start'.",
+                    actual=(
+                        f"'## Quick start' starts on line {quick_start_line}, but these sections "
+                        f"start later: {', '.join(out_of_order_sections)}"
+                    ),
+                )
+            )
+
+        observations = self.navigation_links()
+        observations_by_target = self._observations_by_target(observations)
+
+        missing_targets = [
+            target for target in self.REQUIRED_TARGETS if target not in observations_by_target
+        ]
+        if missing_targets:
+            failures.append(
+                ValidationFailure(
+                    step=2,
+                    summary="README navigation is missing one or more required maintained documentation links.",
+                    expected=(
+                        "Navigation should include Installation, Configuration, Integrations, "
+                        "MCP tools, AI teammate workflow, and AI skill package links."
+                    ),
+                    actual="Missing targets: " + ", ".join(missing_targets),
+                )
+            )
+
+        mislabeled_targets = []
+        for target, required_fragments in self.REQUIRED_LINE_FRAGMENTS.items():
+            matching_observations = observations_by_target.get(target, [])
+            if not matching_observations:
+                continue
+            if not any(
+                any(fragment in observation.line_text for fragment in required_fragments)
+                for observation in matching_observations
+            ):
+                observed_lines = "; ".join(
+                    observation.line_text.strip() for observation in matching_observations
+                )
+                mislabeled_targets.append(f"{target}: {observed_lines}")
+        if mislabeled_targets:
+            failures.append(
+                ValidationFailure(
+                    step=2,
+                    summary="README navigation links are present but not exposed with the expected user-facing labels.",
+                    expected=(
+                        "Each maintained link should appear on a navigation row whose visible text "
+                        "matches the requested topic."
+                    ),
+                    actual="; ".join(mislabeled_targets),
+                )
+            )
+
+        invalid_targets = []
+        for observation in observations:
+            if not observation.target.startswith(self.ALLOWED_TARGET_PREFIXES):
+                invalid_targets.append(
+                    f"{observation.display()} resolves outside maintained docs roots."
+                )
+                continue
+
+            resolved_path = (self.repository_root / observation.target).resolve()
+            if not resolved_path.exists():
+                invalid_targets.append(
+                    f"{observation.display()} resolves to missing path "
+                    f"{resolved_path.relative_to(self.repository_root)}."
+                )
+        if invalid_targets:
+            failures.append(
+                ValidationFailure(
+                    step=3,
+                    summary="README navigation contains invalid or non-maintained link targets.",
+                    expected=(
+                        "Every navigation link should stay inside dmtools-ai-docs/ or "
+                        ".github/workflows/ and resolve to an existing repository path."
+                    ),
+                    actual=" | ".join(invalid_targets),
+                )
+            )
+
+        workflow_observations = [
+            observation
+            for observation in observations
+            if "workflow" in observation.line_text.lower()
+            or "teammate" in observation.target.lower()
+        ]
+        if self.AI_TEAMMATE_TARGET not in observations_by_target:
+            actual_targets = (
+                ", ".join(observation.target for observation in workflow_observations) or "none"
+            )
+            failures.append(
+                ValidationFailure(
+                    step=4,
+                    summary="README does not point the AI teammate workflow navigation entry to the maintained teammate guide.",
+                    expected=self.AI_TEAMMATE_TARGET,
+                    actual=f"Workflow-related targets found: {actual_targets}",
+                )
+            )
+
+        return failures
+
+    def navigation_links(self) -> list[NavigationLinkObservation]:
+        observations: list[NavigationLinkObservation] = []
+        for heading in (self.PRIMARY_USAGE_HEADING, self.DOCUMENTATION_MAP_HEADING):
+            section = self._load_section(heading)
+            if section is None:
+                continue
+
+            for link in self.cross_link_service.parse_markdown_links(
+                section.body,
+                start_line=section.start_line,
+            ):
+                observations.append(
+                    NavigationLinkObservation(
+                        section_heading=heading,
+                        text=link.text,
+                        target=link.target,
+                        line_number=link.line_number,
+                        line_text=self.lines[link.line_number - 1],
+                    )
+                )
+        return observations
+
+    @staticmethod
+    def format_failures(failures: list[ValidationFailure]) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def observation_for_target(self, target: str) -> NavigationLinkObservation:
+        observations = self._observations_by_target(self.navigation_links()).get(target, [])
+        if not observations:
+            raise AssertionError(f"Navigation link target {target!r} was not found in README.md.")
+        return observations[0]
+
+    def _load_section(self, heading: str) -> NavigationSection | None:
+        try:
+            start_line, body = self.cross_link_service.section_content(self.readme_path, heading)
+        except ValueError:
+            return None
+        return NavigationSection(heading=heading, start_line=start_line, body=body)
+
+    def _heading_line(self, heading: str) -> int | None:
+        for line_number, line in enumerate(self.lines, start=1):
+            if line.strip() == heading:
+                return line_number
+        return None
+
+    @staticmethod
+    def _observations_by_target(
+        observations: list[NavigationLinkObservation],
+    ) -> dict[str, list[NavigationLinkObservation]]:
+        by_target: dict[str, list[NavigationLinkObservation]] = {}
+        for observation in observations:
+            by_target.setdefault(observation.target, []).append(observation)
+        return by_target

--- a/testing/components/services/readme_documentation_navigation_service.py
+++ b/testing/components/services/readme_documentation_navigation_service.py
@@ -50,6 +50,7 @@ class ReadmeDocumentationNavigationService:
     DOCUMENTATION_MAP_HEADING = "## Documentation map"
     QUICK_START_HEADING = "## Quick start"
 
+    JOBS_REFERENCE_TARGET = "dmtools-ai-docs/references/jobs/README.md"
     INSTALLATION_TARGET = "dmtools-ai-docs/references/installation/README.md"
     CONFIGURATION_TARGET = "dmtools-ai-docs/references/configuration/README.md"
     INTEGRATIONS_TARGET = "dmtools-ai-docs/references/configuration/integrations/"
@@ -60,6 +61,7 @@ class ReadmeDocumentationNavigationService:
     ALLOWED_TARGET_PREFIXES = ("dmtools-ai-docs/", ".github/workflows/")
 
     REQUIRED_TARGETS = (
+        JOBS_REFERENCE_TARGET,
         INSTALLATION_TARGET,
         CONFIGURATION_TARGET,
         INTEGRATIONS_TARGET,
@@ -69,6 +71,11 @@ class ReadmeDocumentationNavigationService:
     )
 
     REQUIRED_LINE_FRAGMENTS = {
+        JOBS_REFERENCE_TARGET: (
+            "Jobs reference",
+            "Jobs + agents",
+            "Jobs and workflow orchestration",
+        ),
         INSTALLATION_TARGET: ("Installation and upgrade",),
         CONFIGURATION_TARGET: ("Configuration overview",),
         INTEGRATIONS_TARGET: ("Integration setup guides",),
@@ -144,8 +151,9 @@ class ReadmeDocumentationNavigationService:
                     step=2,
                     summary="README navigation is missing one or more required maintained documentation links.",
                     expected=(
-                        "Navigation should include Installation, Configuration, Integrations, "
-                        "MCP tools, AI teammate workflow, and AI skill package links."
+                        "Navigation should include Jobs/agents workflows, Installation, "
+                        "Configuration, Integrations, MCP tools, AI teammate workflow, "
+                        "and AI skill package links."
                     ),
                     actual="Missing targets: " + ", ".join(missing_targets),
                 )

--- a/testing/tests/DMC-980/README.md
+++ b/testing/tests/DMC-980/README.md
@@ -1,6 +1,6 @@
 # DMC-980 automated test
 
-This test validates that the README navigation surfaces point users to maintained repository documentation hubs for installation, configuration, integrations, MCP tools, teammate workflows, and AI skill packages.
+This test validates that the README navigation surfaces point users to maintained repository documentation hubs for jobs/agents workflows, installation, configuration, integrations, MCP tools, teammate workflows, and AI skill packages.
 
 ## Install dependencies
 
@@ -21,5 +21,5 @@ No environment variables are required. The test reads `README.md` and repository
 ## Expected passing output
 
 ```text
-3 passed
+4 passed
 ```

--- a/testing/tests/DMC-980/README.md
+++ b/testing/tests/DMC-980/README.md
@@ -1,0 +1,25 @@
+# DMC-980 automated test
+
+This test validates that the README navigation surfaces point users to maintained repository documentation hubs for installation, configuration, integrations, MCP tools, teammate workflows, and AI skill packages.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-980/test_dmc_980.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads `README.md` and repository documentation paths from this checkout.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-980/config.yaml
+++ b/testing/tests/DMC-980/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-980
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-980/test_dmc_980.py
+++ b/testing/tests/DMC-980/test_dmc_980.py
@@ -18,6 +18,7 @@ def test_dmc_980_readme_navigation_points_to_maintained_documentation_hubs() -> 
 
     assert not failures, service.format_failures(failures)
 
+    jobs_observation = service.observation_for_target(service.JOBS_REFERENCE_TARGET)
     installation_observation = service.observation_for_target(service.INSTALLATION_TARGET)
     configuration_observation = service.observation_for_target(service.CONFIGURATION_TARGET)
     integrations_observation = service.observation_for_target(service.INTEGRATIONS_TARGET)
@@ -25,6 +26,7 @@ def test_dmc_980_readme_navigation_points_to_maintained_documentation_hubs() -> 
     workflow_observation = service.observation_for_target(service.AI_TEAMMATE_TARGET)
     skill_observation = service.observation_for_target(service.SKILL_GUIDE_TARGET)
 
+    assert "Jobs + agents" in jobs_observation.line_text
     assert "Installation and upgrade" in installation_observation.line_text
     assert "Configuration overview" in configuration_observation.line_text
     assert "Integration setup guides" in integrations_observation.line_text
@@ -46,6 +48,7 @@ def test_dmc_980_service_accepts_current_navigation_pattern_in_synthetic_readme(
         | Usage path | What you do with it | Start here |
         |---|---|---|
         | CLI + MCP tools | Execute direct tool calls and integration operations from the terminal | [MCP tools reference](dmtools-ai-docs/references/mcp-tools/README.md) |
+        | Jobs + agents | Run orchestrated workflows such as Teammate, reporting, and test generation | [Jobs reference](dmtools-ai-docs/references/jobs/README.md) |
         | GitHub workflow automation | Run DMTools in CI/CD for ticket processing and teammate flows | [GitHub Actions teammate workflow](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
         | AI assistant skills | Install project-level DMTools skills for agent-driven usage | [Skill guide](dmtools-ai-docs/SKILL.md) |
 
@@ -53,6 +56,7 @@ def test_dmc_980_service_accepts_current_navigation_pattern_in_synthetic_readme(
 
         | Topic | Link |
         |---|---|
+        | Jobs and workflow orchestration | [references/jobs/README.md](dmtools-ai-docs/references/jobs/README.md) |
         | Installation and upgrade | [references/installation/README.md](dmtools-ai-docs/references/installation/README.md) |
         | Configuration overview | [references/configuration/README.md](dmtools-ai-docs/references/configuration/README.md) |
         | Integration setup guides | [references/configuration/integrations/](dmtools-ai-docs/references/configuration/integrations/) |
@@ -118,6 +122,46 @@ def test_dmc_980_service_rejects_external_or_wrong_workflow_navigation_targets(
     assert ".github/workflows/teammate.yml" in failures[2].actual
 
 
+def test_dmc_980_service_rejects_missing_jobs_workflow_navigation_hub(
+    tmp_path: Path,
+) -> None:
+    _write_readme(
+        tmp_path,
+        """
+        # DMTools
+
+        ## Primary usage paths
+
+        | Usage path | What you do with it | Start here |
+        |---|---|---|
+        | CLI + MCP tools | Execute direct tool calls and integration operations from the terminal | [MCP tools reference](dmtools-ai-docs/references/mcp-tools/README.md) |
+        | GitHub workflow automation | Run DMTools in CI/CD for ticket processing and teammate flows | [GitHub Actions teammate workflow](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
+        | AI assistant skills | Install project-level DMTools skills for agent-driven usage | [Skill guide](dmtools-ai-docs/SKILL.md) |
+
+        ## Documentation map
+
+        | Topic | Link |
+        |---|---|
+        | Installation and upgrade | [references/installation/README.md](dmtools-ai-docs/references/installation/README.md) |
+        | Configuration overview | [references/configuration/README.md](dmtools-ai-docs/references/configuration/README.md) |
+        | Integration setup guides | [references/configuration/integrations/](dmtools-ai-docs/references/configuration/integrations/) |
+
+        ## Quick start
+        """
+    )
+    _create_required_doc_targets(tmp_path)
+
+    service = ReadmeDocumentationNavigationService(tmp_path)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [2]
+    assert failures[0].summary == (
+        "README navigation is missing one or more required maintained documentation links."
+    )
+    assert service.JOBS_REFERENCE_TARGET in failures[0].actual
+
+
 def _write_readme(root: Path, content: str) -> None:
     (root / "README.md").write_text(
         textwrap.dedent(content).strip() + "\n",
@@ -127,6 +171,7 @@ def _write_readme(root: Path, content: str) -> None:
 
 def _create_required_doc_targets(root: Path) -> None:
     for relative_path in (
+        "dmtools-ai-docs/references/jobs/README.md",
         "dmtools-ai-docs/references/installation/README.md",
         "dmtools-ai-docs/references/configuration/README.md",
         "dmtools-ai-docs/references/workflows/github-actions-teammate.md",
@@ -139,4 +184,3 @@ def _create_required_doc_targets(root: Path) -> None:
 
     integrations_dir = root / "dmtools-ai-docs/references/configuration/integrations"
     integrations_dir.mkdir(parents=True, exist_ok=True)
-

--- a/testing/tests/DMC-980/test_dmc_980.py
+++ b/testing/tests/DMC-980/test_dmc_980.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from testing.components.services.readme_documentation_navigation_service import (
+    ReadmeDocumentationNavigationService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_980_readme_navigation_points_to_maintained_documentation_hubs() -> None:
+    service = ReadmeDocumentationNavigationService(REPOSITORY_ROOT)
+
+    failures = service.validate()
+
+    assert not failures, service.format_failures(failures)
+
+    installation_observation = service.observation_for_target(service.INSTALLATION_TARGET)
+    configuration_observation = service.observation_for_target(service.CONFIGURATION_TARGET)
+    integrations_observation = service.observation_for_target(service.INTEGRATIONS_TARGET)
+    mcp_observation = service.observation_for_target(service.MCP_TOOLS_TARGET)
+    workflow_observation = service.observation_for_target(service.AI_TEAMMATE_TARGET)
+    skill_observation = service.observation_for_target(service.SKILL_GUIDE_TARGET)
+
+    assert "Installation and upgrade" in installation_observation.line_text
+    assert "Configuration overview" in configuration_observation.line_text
+    assert "Integration setup guides" in integrations_observation.line_text
+    assert "MCP tools reference" in mcp_observation.line_text
+    assert workflow_observation.text == "GitHub Actions teammate workflow"
+    assert "AI assistant skills" in skill_observation.line_text
+
+
+def test_dmc_980_service_accepts_current_navigation_pattern_in_synthetic_readme(
+    tmp_path: Path,
+) -> None:
+    _write_readme(
+        tmp_path,
+        """
+        # DMTools
+
+        ## Primary usage paths
+
+        | Usage path | What you do with it | Start here |
+        |---|---|---|
+        | CLI + MCP tools | Execute direct tool calls and integration operations from the terminal | [MCP tools reference](dmtools-ai-docs/references/mcp-tools/README.md) |
+        | GitHub workflow automation | Run DMTools in CI/CD for ticket processing and teammate flows | [GitHub Actions teammate workflow](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
+        | AI assistant skills | Install project-level DMTools skills for agent-driven usage | [Skill guide](dmtools-ai-docs/SKILL.md) |
+
+        ## Documentation map
+
+        | Topic | Link |
+        |---|---|
+        | Installation and upgrade | [references/installation/README.md](dmtools-ai-docs/references/installation/README.md) |
+        | Configuration overview | [references/configuration/README.md](dmtools-ai-docs/references/configuration/README.md) |
+        | Integration setup guides | [references/configuration/integrations/](dmtools-ai-docs/references/configuration/integrations/) |
+
+        ## Quick start
+        """
+    )
+    _create_required_doc_targets(tmp_path)
+
+    service = ReadmeDocumentationNavigationService(tmp_path)
+
+    assert service.validate() == []
+
+
+def test_dmc_980_service_rejects_external_or_wrong_workflow_navigation_targets(
+    tmp_path: Path,
+) -> None:
+    _write_readme(
+        tmp_path,
+        """
+        # DMTools
+
+        ## Primary usage paths
+
+        | Usage path | What you do with it | Start here |
+        |---|---|---|
+        | CLI + MCP tools | Execute direct tool calls and integration operations from the terminal | [MCP tools reference](dmtools-ai-docs/references/mcp-tools/README.md) |
+        | GitHub workflow automation | Run DMTools in CI/CD for ticket processing and teammate flows | [Workflow file](.github/workflows/teammate.yml) |
+        | AI assistant skills | Install project-level DMTools skills for agent-driven usage | [Skill guide](https://docs.example.com/skills) |
+
+        ## Documentation map
+
+        | Topic | Link |
+        |---|---|
+        | Installation and upgrade | [references/installation/README.md](dmtools-ai-docs/references/installation/README.md) |
+        | Configuration overview | [references/configuration/README.md](dmtools-ai-docs/references/configuration/README.md) |
+        | Integration setup guides | [references/configuration/integrations/](dmtools-ai-docs/references/configuration/integrations/) |
+
+        ## Quick start
+        """
+    )
+    _create_required_doc_targets(tmp_path)
+    workflow_file = tmp_path / ".github/workflows/teammate.yml"
+    workflow_file.parent.mkdir(parents=True, exist_ok=True)
+    workflow_file.write_text("name: teammate\n", encoding="utf-8")
+
+    service = ReadmeDocumentationNavigationService(tmp_path)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [2, 3, 4]
+    assert failures[0].summary == (
+        "README navigation is missing one or more required maintained documentation links."
+    )
+    assert service.AI_TEAMMATE_TARGET in failures[0].actual
+    assert failures[1].summary == (
+        "README navigation contains invalid or non-maintained link targets."
+    )
+    assert "https://docs.example.com/skills" in failures[1].actual
+    assert failures[2].summary == (
+        "README does not point the AI teammate workflow navigation entry to the maintained teammate guide."
+    )
+    assert ".github/workflows/teammate.yml" in failures[2].actual
+
+
+def _write_readme(root: Path, content: str) -> None:
+    (root / "README.md").write_text(
+        textwrap.dedent(content).strip() + "\n",
+        encoding="utf-8",
+    )
+
+
+def _create_required_doc_targets(root: Path) -> None:
+    for relative_path in (
+        "dmtools-ai-docs/references/installation/README.md",
+        "dmtools-ai-docs/references/configuration/README.md",
+        "dmtools-ai-docs/references/workflows/github-actions-teammate.md",
+        "dmtools-ai-docs/references/mcp-tools/README.md",
+        "dmtools-ai-docs/SKILL.md",
+    ):
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("# Placeholder\n", encoding="utf-8")
+
+    integrations_dir = root / "dmtools-ai-docs/references/configuration/integrations"
+    integrations_dir.mkdir(parents=True, exist_ok=True)
+


### PR DESCRIPTION
# DMC-980 automated test result: PASSED

## What changed

- Added a pytest repository-audit test in `testing/tests/DMC-980/test_dmc_980.py`.
- Added reusable validation in `testing/components/services/readme_documentation_navigation_service.py`.

## Automated verification

- Ran `python3 -m pytest testing/tests/DMC-980/test_dmc_980.py -q`
- Observed `3 passed in 0.04s`
- Verified README exposes `## Primary usage paths` and `## Documentation map` before `## Quick start`
- Verified maintained links for installation, configuration, integrations, MCP tools, AI teammate workflow, and AI skill packages
- Verified every checked navigation target resolves to an existing path under `dmtools-ai-docs/`
- Verified the AI teammate workflow navigation target is exactly `dmtools-ai-docs/references/workflows/github-actions-teammate.md`

## Real human-style verification

- Checked the visible README navigation rows and labels a user would read:
  - line 30: `CLI + MCP tools` -> `MCP tools reference`
  - line 32: `GitHub workflow automation` -> `GitHub Actions teammate workflow`
  - line 33: `AI assistant skills` -> `Skill guide`
  - lines 41-43: `Installation and upgrade`, `Configuration overview`, and `Integration setup guides`
- Observed that all verified entries land on maintained in-repository documentation and no external or deprecated target appears in the checked navigation surfaces

## Result

The observed behavior matched the expected result.
