### PR TITLE
DMC-982 Core docs use inconsistent product identity wording instead of orchestrator positioning

### DIFF
--- a/dmtools-ai-docs/README.md
+++ b/dmtools-ai-docs/README.md
@@ -1,6 +1,6 @@
 # DMtools Agent Skill
 
-Universal AI assistant skill for DMtools - works with Cursor, Claude, Codex, and any [Agent Skills](https://agentskills.io) compatible system.
+DMTools is an enterprise dark-factory orchestrator for project-level AI assistant workflows in Cursor, Claude, Codex, and other [Agent Skills](https://agentskills.io) compatible systems.
 
 ## 🚀 Quick Install
 

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dmtools
-description: Comprehensive documentation and assistance for DMtools - AI-powered development toolkit with 96+ MCP tools for Jira, Azure DevOps, Figma, Confluence, Teams, and test automation. Use when working with DMtools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows, or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator jobs.
+description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 96+ MCP tools for Jira, Azure DevOps, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows, or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator jobs.
 license: Apache-2.0
 compatibility:
   - Java 17+
@@ -14,7 +14,7 @@ metadata:
 
 # DMtools Development Assistant
 
-Comprehensive knowledge base for DMtools - an AI-powered development toolkit that integrates with multiple platforms and provides 96+ MCP tools for automation.
+DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 96+ MCP tools for reusable delivery automation.
 
 ## 🔧 FIRST-TIME SETUP (DO THIS PROACTIVELY)
 


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`dmtools-ai-docs/README.md` and `dmtools-ai-docs/SKILL.md` still used older lead-paragraph copy that described DMTools as a "skill" or "development toolkit" instead of using the orchestrator-based identity already established in the root `README.md`. The linked DMC-981 pytest audit failed on current `main` because those paragraphs were missing both the `orchestrator` wording and the `enterprise dark-factory` positioning.

### Fix
Updated the first product-description paragraph in `dmtools-ai-docs/README.md` and `dmtools-ai-docs/SKILL.md` so both now describe DMTools as an enterprise dark-factory orchestrator. Also updated the `dmtools-ai-docs/SKILL.md` frontmatter description to remove the stale `toolkit` wording from metadata-exposed surfaces while leaving the rest of the documentation intact.

### Test Coverage
- Reproduction test used: `testing/tests/DMC-981/test_dmc_981.py` — `test_dmc_981_core_docs_use_consistent_orchestrator_identity`
- Full linked test file: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-981/test_dmc_981.py -q` — PASSED (`3 passed`)

### Notes
The task payload referenced a repo-root `instruction.md`, but that file is not present in this checkout. The fix was completed against the provided `input/DMC-982/` ticket context.
