### PR TITLE
DMC-977 Add GitHub repository discoverability metadata and maintainer playbook

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,40 @@
 ---
-name: Bug report
-about: Create a report to help us improve
-title: ''
+name: DMTools bug report
+about: Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation
+title: '[Bug]: '
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**What broke**
+Describe the problem and the affected DMTools workflow or surface.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+1. 
+2. 
+3. 
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+What should have happened instead?
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Affected surface**
+- CLI command or wrapper
+- MCP tool or integration
+- Job or agent configuration
+- GitHub Actions or CI workflow
+- Documentation or discoverability surface
+- Other:
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser: [e.g. chrome, safari]
- - Version: [e.g. 22]
+**Environment**
+- DMTools version (`dmtools --version` or release tag):
+- Java version:
+- Operating system / shell:
+- Integration(s) or provider(s) involved:
+- Workflow run / log link (if applicable):
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone 6]
- - OS: [e.g. iOS8.1]
- - Browser: [e.g. stock browser, safari]
- - Version: [e.g. 22]
+**Relevant output**
+Paste sanitized logs, stack traces, command output, or screenshots if they help.
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,29 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
-title: ''
+name: DMTools feature request
+about: Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces
+title: '[Feature]: '
 labels: ''
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**What workflow are you trying to improve?**
+Describe the delivery, automation, or AI-assisted workflow that needs to improve.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**What outcome do you want?**
+Describe the result you want from DMTools.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe the proposed solution**
+Explain the CLI, MCP tool, job, integration, docs, or GitHub-facing change you would like to see.
+
+**Which DMTools surfaces are involved?**
+- CLI or wrapper
+- MCP tools or integrations
+- Jobs or agents
+- GitHub Actions or CI workflows
+- AI assistant skills or docs
+- Repository discoverability or GitHub metadata
+- Other:
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Add any other context, examples, linked workflows, or screenshots here.

--- a/.github/workflows/release-ai-skill.yml
+++ b/.github/workflows/release-ai-skill.yml
@@ -106,7 +106,7 @@ jobs:
           cat > dist/release-notes.md << 'EOF'
           # DMtools Agent Skill v$VERSION
 
-          Universal AI assistant skill for DMtools - works with Cursor, Claude, Codex, and any Agent Skills compatible system.
+          DMTools agent skill for enterprise dark-factory orchestration across MCP tools, AI agents, and delivery workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems.
 
           ## 📦 Installation
 
@@ -218,7 +218,7 @@ jobs:
             "name": "@dm.ai/agent-skill",
             "version": "$VERSION",
             "description": "DMTools agent skill for enterprise dark-factory orchestration with MCP tools, AI agents, and generative-ai-friendly delivery workflows",
-            "keywords": ["dmtools", "dark-factory", "delivery-automation", "workflow-orchestration", "mcp", "ai-agents", "generative-ai", "self-hosted", "cursor", "claude", "codex"],
+            "keywords": ["dmtools", "dark-factory", "delivery-automation", "workflow-orchestration", "mcp", "ai-agents", "generative-ai", "self-hosted", "cursor", "claude", "codex", "jira", "azure-devops", "github"],
             "author": "DMtools Team",
             "license": "Apache-2.0",
             "repository": {

--- a/.github/workflows/release-ai-skill.yml
+++ b/.github/workflows/release-ai-skill.yml
@@ -217,8 +217,8 @@ jobs:
           {
             "name": "@dm.ai/agent-skill",
             "version": "$VERSION",
-            "description": "Agent Skill for DMtools - AI-powered development toolkit (Cursor, Claude, Codex compatible)",
-            "keywords": ["dmtools", "agent-skills", "cursor", "claude", "ai", "jira", "azure-devops"],
+            "description": "DMTools agent skill for enterprise dark-factory orchestration with MCP tools, AI agents, and generative-ai-friendly delivery workflows",
+            "keywords": ["dmtools", "dark-factory", "delivery-automation", "workflow-orchestration", "mcp", "ai-agents", "generative-ai", "self-hosted", "cursor", "claude", "codex"],
             "author": "DMtools Team",
             "license": "Apache-2.0",
             "repository": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,7 +378,7 @@ jobs:
           cat > release_notes.md << EOF
           # 🚀 DMTools Release v${VERSION}
 
-          This release includes the **DMTools CLI** and **Agent Skill** for AI assistants.
+          This release includes the **DMTools CLI** and **Agent Skill** for enterprise dark-factory orchestration across MCP tools, AI agents, and delivery workflows.
 
           ## 📦 What's Included
 
@@ -389,8 +389,8 @@ jobs:
           - **Wrapper script** (\`dmtools.sh\`)
 
           ### 🤖 DMTools Agent Skill
-          - **Universal AI assistant skill** for Cursor, Claude, Codex, and other Agent Skills compatible systems
-          - **Complete DMtools documentation** (67+ MCP tools, JavaScript agent development, configuration guides)
+          - **AI assistant skill** for MCP, AI-agent, and generative-ai-friendly DMTools workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems
+          - **Complete DMtools documentation** (67+ MCP tools, JavaScript agent development, and configuration guides)
           - **Cross-platform support** (works with all major AI coding assistants)
           
           ## 🎯 Quick Start

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,7 +389,7 @@ jobs:
           - **Wrapper script** (\`dmtools.sh\`)
 
           ### 🤖 DMTools Agent Skill
-          - **AI assistant skill** for MCP, AI-agent, and generative-ai-friendly DMTools workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems
+          - **AI assistant skill** for MCP, AI agents, and generative-ai-friendly DMTools workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems
           - **Complete DMtools documentation** (67+ MCP tools, JavaScript agent development, and configuration guides)
           - **Cross-platform support** (works with all major AI coding assistants)
           

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ cp dmtools.env.example dmtools.env
 4. Verify all tests pass: `./gradlew :dmtools-core:test`
 5. Open a pull request with a clear description of what you changed and why.
 
+## Maintainer discoverability checklist
+
+For repository positioning, GitHub About metadata, release-facing keyword alignment, and the split between repo-backed updates and manual GitHub settings, use the canonical playbook in `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md`.
+
 ## Adding a New MCP Tool
 
 See the step-by-step guide in `CLAUDE.md` under **"Adding a New MCP Tool"** and the full tool reference in `docs/README-MCP.md`.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All maintained documentation lives under [dmtools-ai-docs/](dmtools-ai-docs/).
 | MCP tools reference | [references/mcp-tools/README.md](dmtools-ai-docs/references/mcp-tools/README.md) |
 | Jobs and workflow orchestration | [references/jobs/README.md](dmtools-ai-docs/references/jobs/README.md) |
 | GitHub workflow guidance | [references/workflows/github-actions-teammate.md](dmtools-ai-docs/references/workflows/github-actions-teammate.md) |
+| GitHub repository discoverability | [references/workflows/github-repository-discoverability-playbook.md](dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md) |
 | Examples | [references/examples/](dmtools-ai-docs/references/examples/) |
 | Documentation index | [dmtools-ai-docs/README.md](dmtools-ai-docs/README.md) |
 

--- a/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
+++ b/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
@@ -1,0 +1,56 @@
+# GitHub Repository Discoverability Playbook
+
+Use this page as the maintainer source of truth for repository discoverability updates. The canonical metadata values are versioned in `dmtools-core/src/main/resources/github-repository-discoverability.json` and covered by `GitHubRepositoryDiscoverabilityTest`.
+
+## Canonical repository metadata
+
+| Surface | Canonical value |
+|---|---|
+| Short description | `Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.` |
+| About text | `DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.` |
+| GitHub topics | `dark-factory`, `delivery-automation`, `workflow-orchestration`, `platform-engineering`, `self-hosted`, `enterprise-ai`, `mcp`, `ai-agents`, `generative-ai`, `workflow-automation` |
+| Supporting release/package keywords | `dmtools`, `dark-factory`, `delivery-automation`, `workflow-orchestration`, `mcp`, `ai-agents`, `generative-ai`, `self-hosted`, then vendor or connector terms such as `cursor`, `claude`, `codex`, `jira`, `azure-devops`, `github` |
+
+### Topic strategy
+
+- Keep the GitHub topic list anchored on orchestration and enterprise positioning first.
+- Use only a small number of AI discovery terms in canonical topics: `mcp`, `ai-agents`, and `generative-ai`.
+- Do not spend canonical topic slots on vendor-specific names. Use those only in supporting release or package copy when they add search value.
+
+## Manual GitHub settings
+
+These settings are not stored in the repository and must be applied in the GitHub UI:
+
+1. **About description and topics**: update the repository About panel in GitHub using the canonical values above.
+2. **Homepage**: keep the repo homepage pointed at the canonical project entry point you want users and GitHub searchers to land on, usually the repository README or a future product site if one becomes authoritative.
+3. **Social preview**: upload a dark hero card with the DMTools wordmark and one short value line only.
+
+### Social preview asset guidance
+
+- Use a dark, high-contrast base with light text.
+- Keep the text to the product name plus one short positioning line only.
+- Preferred value line: `Enterprise dark-factory orchestrator`.
+- Use at most one restrained accent colour.
+- Any text rendered into the image must meet WCAG AA contrast guidance.
+- Do not use screenshots, integration collages, or feature-list text in the image.
+
+## Repo-backed files that must stay aligned
+
+These files are versioned and should move together when positioning changes:
+
+- `README.md` for the primary public entry point and documentation map.
+- `CONTRIBUTING.md` for the maintainer-facing link to this playbook.
+- `.github/ISSUE_TEMPLATE/*` for GitHub entry-surface language.
+- `.github/workflows/release.yml` and `.github/workflows/release-ai-skill.yml` for release and package-facing keyword copy.
+- `dmtools-core/src/main/resources/github-repository-discoverability.json` for canonical metadata values.
+
+## Maintainer checklist
+
+Run this checklist before a release or any positioning refresh:
+
+1. Update `github-repository-discoverability.json` if the approved product positioning changes.
+2. Keep README and contributor links pointing to this playbook.
+3. Confirm issue templates still describe DMTools surfaces accurately.
+4. Sync release-note or package copy so orchestration-first language stays ahead of vendor-specific keywords.
+5. Apply any required About, topics, homepage, and social-preview changes in the GitHub UI.
+6. If new vendor or connector keywords are needed, add them only after the canonical orchestration and AI-discovery terms.

--- a/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
+++ b/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
@@ -1,6 +1,6 @@
 # GitHub Repository Discoverability Playbook
 
-Use this page as the maintainer source of truth for repository discoverability updates. The canonical metadata values are versioned in `dmtools-core/src/main/resources/github-repository-discoverability.json` and covered by `GitHubRepositoryDiscoverabilityTest`.
+Use this page as the maintainer source of truth for repository discoverability updates. The canonical metadata values are versioned in `dmtools-core/src/main/resources/github-repository-discoverability.json`, and `GitHubRepositoryDiscoverabilityTest` fails when repo-backed GitHub surfaces drift from those values.
 
 ## Canonical repository metadata
 
@@ -9,7 +9,7 @@ Use this page as the maintainer source of truth for repository discoverability u
 | Short description | `Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.` |
 | About text | `DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.` |
 | GitHub topics | `dark-factory`, `delivery-automation`, `workflow-orchestration`, `platform-engineering`, `self-hosted`, `enterprise-ai`, `mcp`, `ai-agents`, `generative-ai`, `workflow-automation` |
-| Supporting release/package keywords | `dmtools`, `dark-factory`, `delivery-automation`, `workflow-orchestration`, `mcp`, `ai-agents`, `generative-ai`, `self-hosted`, then vendor or connector terms such as `cursor`, `claude`, `codex`, `jira`, `azure-devops`, `github` |
+| Supporting release/package keywords | `dmtools`, `dark-factory`, `delivery-automation`, `workflow-orchestration`, `mcp`, `ai-agents`, `generative-ai`, `self-hosted`, `cursor`, `claude`, `codex`, `jira`, `azure-devops`, `github` |
 
 ### Topic strategy
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverability.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverability.java
@@ -47,6 +47,30 @@ public class GitHubRepositoryDiscoverability extends JSONModel {
         return getStringArrayOrEmpty("supportingKeywords");
     }
 
+    public String getBugReportAbout() {
+        return getRepoBackedSurfaceString("bugReportAbout");
+    }
+
+    public String getFeatureRequestAbout() {
+        return getRepoBackedSurfaceString("featureRequestAbout");
+    }
+
+    public String getReleaseNotesLead() {
+        return getRepoBackedSurfaceString("releaseNotesLead");
+    }
+
+    public String getReleaseSkillBullet() {
+        return getRepoBackedSurfaceString("releaseSkillBullet");
+    }
+
+    public String getReleaseSkillPackageDescription() {
+        return getRepoBackedSurfaceString("releaseSkillPackageDescription");
+    }
+
+    public String getReleaseSkillNotesLead() {
+        return getRepoBackedSurfaceString("releaseSkillNotesLead");
+    }
+
     public String getSocialPreviewDirection() {
         return getNestedString("socialPreview", "direction");
     }
@@ -65,6 +89,10 @@ public class GitHubRepositoryDiscoverability extends JSONModel {
             return null;
         }
         return nestedObject.optString(valueKey, null);
+    }
+
+    private String getRepoBackedSurfaceString(String valueKey) {
+        return getNestedString("repoBackedSurfaces", valueKey);
     }
 
     private String[] getNestedStringArray(String objectKey, String arrayKey) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverability.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverability.java
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.github;
+
+import com.github.istin.dmtools.common.model.JSONModel;
+import com.github.istin.dmtools.common.utils.JSONResourceReader;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class GitHubRepositoryDiscoverability extends JSONModel {
+
+    public static final String DEFAULT_RESOURCE = "github-repository-discoverability.json";
+
+    public GitHubRepositoryDiscoverability() {
+    }
+
+    public GitHubRepositoryDiscoverability(String json) {
+        super(json);
+    }
+
+    public GitHubRepositoryDiscoverability(JSONObject json) {
+        super(json);
+    }
+
+    public static GitHubRepositoryDiscoverability loadDefault() {
+        JSONObject jsonObject = JSONResourceReader.getInstance(DEFAULT_RESOURCE).getJsonObject();
+        if (jsonObject == null) {
+            throw new IllegalStateException("GitHub repository discoverability resource is missing: " + DEFAULT_RESOURCE);
+        }
+        return new GitHubRepositoryDiscoverability(jsonObject.toString());
+    }
+
+    public String getShortDescription() {
+        return getString("shortDescription");
+    }
+
+    public String getAboutText() {
+        return getString("aboutText");
+    }
+
+    public String[] getTopics() {
+        return getStringArrayOrEmpty("topics");
+    }
+
+    public String[] getSupportingKeywords() {
+        return getStringArrayOrEmpty("supportingKeywords");
+    }
+
+    public String getSocialPreviewDirection() {
+        return getNestedString("socialPreview", "direction");
+    }
+
+    public String getSocialPreviewValueLine() {
+        return getNestedString("socialPreview", "valueLine");
+    }
+
+    public String[] getSocialPreviewStyleRules() {
+        return getNestedStringArray("socialPreview", "styleRules");
+    }
+
+    private String getNestedString(String objectKey, String valueKey) {
+        JSONObject nestedObject = getJSONObject(objectKey);
+        if (nestedObject == null || nestedObject.isNull(valueKey)) {
+            return null;
+        }
+        return nestedObject.optString(valueKey, null);
+    }
+
+    private String[] getNestedStringArray(String objectKey, String arrayKey) {
+        JSONObject nestedObject = getJSONObject(objectKey);
+        if (nestedObject == null) {
+            return new String[0];
+        }
+        JSONArray jsonArray = nestedObject.optJSONArray(arrayKey);
+        if (jsonArray == null) {
+            return new String[0];
+        }
+        String[] values = new String[jsonArray.length()];
+        for (int i = 0; i < jsonArray.length(); i++) {
+            values[i] = jsonArray.optString(i, null);
+        }
+        return values;
+    }
+
+    private String[] getStringArrayOrEmpty(String key) {
+        String[] values = getStringArray(key);
+        return values == null ? new String[0] : values;
+    }
+}

--- a/dmtools-core/src/main/resources/github-repository-discoverability.json
+++ b/dmtools-core/src/main/resources/github-repository-discoverability.json
@@ -1,0 +1,42 @@
+{
+  "shortDescription": "Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.",
+  "aboutText": "DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
+  "topics": [
+    "dark-factory",
+    "delivery-automation",
+    "workflow-orchestration",
+    "platform-engineering",
+    "self-hosted",
+    "enterprise-ai",
+    "mcp",
+    "ai-agents",
+    "generative-ai",
+    "workflow-automation"
+  ],
+  "supportingKeywords": [
+    "dmtools",
+    "dark-factory",
+    "delivery-automation",
+    "workflow-orchestration",
+    "mcp",
+    "ai-agents",
+    "generative-ai",
+    "self-hosted",
+    "cursor",
+    "claude",
+    "codex",
+    "jira",
+    "azure-devops",
+    "github"
+  ],
+  "socialPreview": {
+    "direction": "Dark hero card with the DMTools wordmark, one short value line, and a subtle orchestration or industrial background.",
+    "valueLine": "Enterprise dark-factory orchestrator",
+    "styleRules": [
+      "Use a dark, high-contrast base with light text and no dense UI screenshots.",
+      "Keep the composition minimal: product name plus one short positioning line only.",
+      "Prefer one restrained accent colour and preserve WCAG AA contrast for any text in the asset.",
+      "Do not use integration collages or feature-list text in the preview image."
+    ]
+  }
+}

--- a/dmtools-core/src/main/resources/github-repository-discoverability.json
+++ b/dmtools-core/src/main/resources/github-repository-discoverability.json
@@ -29,6 +29,14 @@
     "azure-devops",
     "github"
   ],
+  "repoBackedSurfaces": {
+    "bugReportAbout": "Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation",
+    "featureRequestAbout": "Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces",
+    "releaseNotesLead": "This release includes the **DMTools CLI** and **Agent Skill** for enterprise dark-factory orchestration across MCP tools, AI agents, and delivery workflows.",
+    "releaseSkillBullet": "- **AI assistant skill** for MCP, AI agents, and generative-ai-friendly DMTools workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems",
+    "releaseSkillPackageDescription": "DMTools agent skill for enterprise dark-factory orchestration with MCP tools, AI agents, and generative-ai-friendly delivery workflows",
+    "releaseSkillNotesLead": "DMTools agent skill for enterprise dark-factory orchestration across MCP tools, AI agents, and delivery workflows in Cursor, Claude, Codex, and other Agent Skills compatible systems."
+  },
   "socialPreview": {
     "direction": "Dark hero card with the DMTools wordmark, one short value line, and a subtle orchestration or industrial background.",
     "valueLine": "Enterprise dark-factory orchestrator",

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
@@ -5,12 +5,19 @@ package com.github.istin.dmtools.github;
 
 import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class GitHubRepositoryDiscoverabilityTest {
@@ -89,5 +96,65 @@ public class GitHubRepositoryDiscoverabilityTest {
                 },
                 metadata.getSocialPreviewStyleRules()
         );
+    }
+
+    @Test
+    public void testRepoBackedGitHubSurfacesStayAlignedWithCanonicalMetadata() throws IOException {
+        GitHubRepositoryDiscoverability metadata = GitHubRepositoryDiscoverability.loadDefault();
+        Path repositoryRoot = findRepositoryRoot();
+
+        String readme = readRepositoryFile(repositoryRoot, "README.md");
+        String contributing = readRepositoryFile(repositoryRoot, "CONTRIBUTING.md");
+        String playbook = readRepositoryFile(
+                repositoryRoot,
+                "dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md"
+        );
+        String bugReportTemplate = readRepositoryFile(repositoryRoot, ".github/ISSUE_TEMPLATE/bug_report.md");
+        String featureRequestTemplate = readRepositoryFile(repositoryRoot, ".github/ISSUE_TEMPLATE/feature_request.md");
+        String releaseWorkflow = readRepositoryFile(repositoryRoot, ".github/workflows/release.yml");
+        String releaseAiSkillWorkflow = readRepositoryFile(repositoryRoot, ".github/workflows/release-ai-skill.yml");
+
+        assertTrue(readme.contains("\n" + metadata.getShortDescription() + "\n"));
+        assertTrue(contributing.contains("dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md"));
+
+        assertTrue(playbook.contains(metadata.getShortDescription()));
+        assertTrue(playbook.contains(metadata.getAboutText()));
+        assertTrue(playbook.contains(formatMarkdownList(metadata.getTopics())));
+        assertTrue(playbook.contains(formatMarkdownList(metadata.getSupportingKeywords())));
+
+        assertTrue(bugReportTemplate.contains("about: " + metadata.getBugReportAbout()));
+        assertTrue(featureRequestTemplate.contains("about: " + metadata.getFeatureRequestAbout()));
+
+        assertTrue(releaseWorkflow.contains(metadata.getReleaseNotesLead()));
+        assertTrue(releaseWorkflow.contains(metadata.getReleaseSkillBullet()));
+
+        assertTrue(releaseAiSkillWorkflow.contains("\"description\": \"" + metadata.getReleaseSkillPackageDescription() + "\""));
+        assertTrue(releaseAiSkillWorkflow.contains("\"keywords\": " + formatInlineJsonArray(metadata.getSupportingKeywords())));
+        assertTrue(releaseAiSkillWorkflow.contains(metadata.getReleaseSkillNotesLead()));
+    }
+
+    private Path findRepositoryRoot() {
+        Path current = Paths.get("").toAbsolutePath();
+        while (current != null && !Files.exists(current.resolve("settings.gradle"))) {
+            current = current.getParent();
+        }
+        assertNotNull("Repository root not found", current);
+        return current;
+    }
+
+    private String readRepositoryFile(Path repositoryRoot, String relativePath) throws IOException {
+        return Files.readString(repositoryRoot.resolve(relativePath), StandardCharsets.UTF_8);
+    }
+
+    private String formatMarkdownList(String[] values) {
+        return Arrays.stream(values)
+                .map(value -> "`" + value + "`")
+                .collect(Collectors.joining(", "));
+    }
+
+    private String formatInlineJsonArray(String[] values) {
+        return Arrays.stream(values)
+                .map(value -> "\"" + value + "\"")
+                .collect(Collectors.joining(", ", "[", "]"));
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.github;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GitHubRepositoryDiscoverabilityTest {
+
+    @Test
+    public void testLoadDefaultReturnsCanonicalRepositoryCopy() {
+        GitHubRepositoryDiscoverability metadata = GitHubRepositoryDiscoverability.loadDefault();
+
+        assertEquals(
+                "Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.",
+                metadata.getShortDescription()
+        );
+        assertEquals(
+                "DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
+                metadata.getAboutText()
+        );
+    }
+
+    @Test
+    public void testCanonicalTopicsKeepEnterpriseTermsAheadOfAiDiscoveryTerms() {
+        GitHubRepositoryDiscoverability metadata = GitHubRepositoryDiscoverability.loadDefault();
+
+        assertArrayEquals(
+                new String[]{
+                        "dark-factory",
+                        "delivery-automation",
+                        "workflow-orchestration",
+                        "platform-engineering",
+                        "self-hosted",
+                        "enterprise-ai",
+                        "mcp",
+                        "ai-agents",
+                        "generative-ai",
+                        "workflow-automation"
+                },
+                metadata.getTopics()
+        );
+    }
+
+    @Test
+    public void testCanonicalTopicsExcludeVendorSpecificKeywordsWhileSupportingKeywordsRetainThem() {
+        GitHubRepositoryDiscoverability metadata = GitHubRepositoryDiscoverability.loadDefault();
+        List<String> canonicalTopics = Arrays.asList(metadata.getTopics());
+        List<String> supportingKeywords = Arrays.asList(metadata.getSupportingKeywords());
+
+        assertFalse(canonicalTopics.contains("cursor"));
+        assertFalse(canonicalTopics.contains("claude"));
+        assertFalse(canonicalTopics.contains("codex"));
+        assertFalse(canonicalTopics.contains("jira"));
+        assertFalse(canonicalTopics.contains("azure-devops"));
+        assertFalse(canonicalTopics.contains("github"));
+
+        assertTrue(supportingKeywords.contains("cursor"));
+        assertTrue(supportingKeywords.contains("claude"));
+        assertTrue(supportingKeywords.contains("codex"));
+        assertTrue(supportingKeywords.contains("jira"));
+        assertTrue(supportingKeywords.contains("azure-devops"));
+        assertTrue(supportingKeywords.contains("github"));
+    }
+
+    @Test
+    public void testSocialPreviewGuidanceMatchesApprovedDirection() {
+        GitHubRepositoryDiscoverability metadata = GitHubRepositoryDiscoverability.loadDefault();
+
+        assertEquals(
+                "Dark hero card with the DMTools wordmark, one short value line, and a subtle orchestration or industrial background.",
+                metadata.getSocialPreviewDirection()
+        );
+        assertEquals("Enterprise dark-factory orchestrator", metadata.getSocialPreviewValueLine());
+        assertArrayEquals(
+                new String[]{
+                        "Use a dark, high-contrast base with light text and no dense UI screenshots.",
+                        "Keep the composition minimal: product name plus one short positioning line only.",
+                        "Prefer one restrained accent colour and preserve WCAG AA contrast for any text in the asset.",
+                        "Do not use integration collages or feature-list text in the preview image."
+                },
+                metadata.getSocialPreviewStyleRules()
+        );
+    }
+}


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present in the repository root, so the implementation followed the ticket payload in `input/DMC-977/`, the answered PO questions, and the current repository conventions.
- The playbook now defines the manual GitHub updates, but repository About text, topics, homepage, and social preview still need to be applied in the GitHub UI by a maintainer.

## Approach

- Added a versioned, testable source of truth for GitHub discoverability metadata in `dmtools-core` so canonical description copy, topic ordering, supporting keywords, and social preview guidance live in one repo-backed artifact.
- Added a maintainer playbook under `dmtools-ai-docs` that separates repo-backed files from manual GitHub settings and documents the approved orchestration-first, AI-discoverability-second keyword strategy.
- Updated GitHub-facing repository surfaces to point at the playbook and use DMTools-specific positioning: README docs navigation, CONTRIBUTING maintainer guidance, issue templates, and release/package copy.

## Files Modified

- `dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverability.java` - lightweight accessor for canonical discoverability metadata loaded from the classpath resource.
- `dmtools-core/src/main/resources/github-repository-discoverability.json` - canonical GitHub short description, About text, topic list, supporting keywords, and social preview guidance.
- `dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java` - unit coverage for canonical copy, topic ordering, vendor keyword separation, and social preview guidance.
- `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md` - maintainer playbook for discoverability updates and manual GitHub settings.
- `README.md` - added the discoverability playbook to the public documentation map.
- `CONTRIBUTING.md` - added the maintainer entry point to the canonical playbook.
- `.github/ISSUE_TEMPLATE/bug_report.md` - replaced the generic browser/mobile template with DMTools CLI, MCP, job, integration, and workflow-specific bug intake.
- `.github/ISSUE_TEMPLATE/feature_request.md` - aligned feature intake with DMTools workflows, integrations, skills, and GitHub surfaces.
- `.github/workflows/release.yml` - updated release-note copy to reflect orchestration, MCP, AI agents, and generative-AI-friendly positioning.
- `.github/workflows/release-ai-skill.yml` - aligned package description and keywords with the approved hybrid discoverability strategy.

## Test Coverage

- Added `GitHubRepositoryDiscoverabilityTest` to cover:
  - canonical short description and About text loading
  - enterprise-first topic ordering
  - exclusion of vendor-specific keywords from canonical topics while retaining them in supporting package keywords
  - approved social preview direction and style rules
- Verification command: `./gradlew :dmtools-core:compileJava :dmtools-core:test`
