### PR TITLE
DMC-987 Test: Verify maintainer playbook entry points and separation — README and CONTRIBUTING links lead to segmented guidance

### DIFF
--- a/testing/components/services/repository_discoverability_playbook_service.py
+++ b/testing/components/services/repository_discoverability_playbook_service.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.components.services.documentation_cross_link_service import (
+    DocumentationCrossLinkService,
+    MarkdownLink,
+)
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class PlaybookLinkObservation:
+    source_path: Path
+    section_heading: str
+    text: str
+    target: str
+    line_number: int
+    line_text: str
+
+    def display(self) -> str:
+        return (
+            f"{self.source_path.name} line {self.line_number}: "
+            f"[{self.text}]({self.target}) in {self.line_text.strip()}"
+        )
+
+
+@dataclass(frozen=True)
+class PlaybookSectionObservation:
+    heading: str
+    start_line: int
+    body: str
+
+
+class RepositoryDiscoverabilityPlaybookService:
+    PLAYBOOK_RELATIVE_PATH = (
+        "dmtools-ai-docs/references/workflows/"
+        "github-repository-discoverability-playbook.md"
+    )
+    README_SECTION_HEADING = "## Documentation map"
+    CONTRIBUTING_SECTION_HEADING = "## Maintainer discoverability checklist"
+    MANUAL_SETTINGS_HEADING = "## Manual GitHub settings"
+    REPO_BACKED_SECTION_HEADING = "## Repo-backed files that must stay aligned"
+    MAINTAINER_CHECKLIST_HEADING = "## Maintainer checklist"
+
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.readme_path = repository_root / "README.md"
+        self.contributing_path = repository_root / "CONTRIBUTING.md"
+        self.playbook_path = repository_root / self.PLAYBOOK_RELATIVE_PATH
+        self.cross_link_service = DocumentationCrossLinkService(repository_root)
+
+    def validate(self) -> list[ValidationFailure]:
+        failures: list[ValidationFailure] = []
+
+        readme_observation = self.readme_playbook_link()
+        if readme_observation is None:
+            failures.append(
+                ValidationFailure(
+                    step=1,
+                    summary="README documentation map does not expose the maintainer playbook.",
+                    expected=(
+                        "README.md should link to the canonical repository discoverability "
+                        "playbook from the documentation map."
+                    ),
+                    actual=(
+                        f"No link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
+                        f"{self.README_SECTION_HEADING}."
+                    ),
+                )
+            )
+
+        contributing_observation = self.contributing_playbook_link()
+        if contributing_observation is None:
+            failures.append(
+                ValidationFailure(
+                    step=2,
+                    summary="CONTRIBUTING does not point maintainers to the canonical playbook.",
+                    expected=(
+                        "CONTRIBUTING.md should direct maintainers to the discoverability "
+                        "playbook from the maintainer checklist section."
+                    ),
+                    actual=(
+                        f"No link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
+                        f"{self.CONTRIBUTING_SECTION_HEADING}."
+                    ),
+                )
+            )
+
+        manual_section = self.playbook_section(self.MANUAL_SETTINGS_HEADING)
+        repo_backed_section = self.playbook_section(self.REPO_BACKED_SECTION_HEADING)
+        checklist_section = self.playbook_section(self.MAINTAINER_CHECKLIST_HEADING)
+
+        if manual_section is None:
+            failures.append(
+                ValidationFailure(
+                    step=3,
+                    summary="The playbook is missing the manual GitHub settings section.",
+                    expected=(
+                        "The playbook should include a dedicated section for GitHub UI-only "
+                        "settings such as About metadata, homepage, and social preview."
+                    ),
+                    actual=f"Missing heading: {self.MANUAL_SETTINGS_HEADING}",
+                )
+            )
+        else:
+            missing_manual_terms = self._missing_terms(
+                manual_section.body,
+                ("about", "topics", "social preview"),
+            )
+            if missing_manual_terms:
+                failures.append(
+                    ValidationFailure(
+                        step=3,
+                        summary="The playbook manual-settings section does not cover the required GitHub UI surfaces.",
+                        expected=(
+                            "Manual GitHub settings guidance should mention About metadata, "
+                            "topics, and social preview so maintainers know which changes must "
+                            "be applied in the GitHub UI."
+                        ),
+                        actual=(
+                            f"{self.MANUAL_SETTINGS_HEADING} is missing: "
+                            + ", ".join(missing_manual_terms)
+                        ),
+                    )
+                )
+
+        if repo_backed_section is None:
+            failures.append(
+                ValidationFailure(
+                    step=4,
+                    summary="The playbook is missing the repo-backed updates section.",
+                    expected=(
+                        "The playbook should include a dedicated section for repository-managed "
+                        "files such as README, templates, and release copy."
+                    ),
+                    actual=f"Missing heading: {self.REPO_BACKED_SECTION_HEADING}",
+                )
+            )
+        else:
+            missing_repo_backed_terms = self._missing_terms(
+                repo_backed_section.body,
+                ("README.md", ".github/ISSUE_TEMPLATE/", "release"),
+            )
+            if missing_repo_backed_terms:
+                failures.append(
+                    ValidationFailure(
+                        step=4,
+                        summary="The playbook repo-backed section does not cover the required versioned update surfaces.",
+                        expected=(
+                            "Repo-backed guidance should explicitly call out README, templates, "
+                            "and release-facing copy so maintainers keep versioned assets aligned."
+                        ),
+                        actual=(
+                            f"{self.REPO_BACKED_SECTION_HEADING} is missing: "
+                            + ", ".join(missing_repo_backed_terms)
+                        ),
+                    )
+                )
+
+        if checklist_section is None:
+            failures.append(
+                ValidationFailure(
+                    step=5,
+                    summary="The playbook is missing the maintainer checklist section.",
+                    expected=(
+                        "The playbook should include a repeatable checklist for repository "
+                        "metadata refreshes."
+                    ),
+                    actual=f"Missing heading: {self.MAINTAINER_CHECKLIST_HEADING}",
+                )
+            )
+        else:
+            checklist_items = self._numbered_items(checklist_section.body)
+            if len(checklist_items) < 5:
+                failures.append(
+                    ValidationFailure(
+                        step=5,
+                        summary="The maintainer checklist is not repeatable enough for metadata refreshes.",
+                        expected=(
+                            "Maintainers should have a multi-step checklist that covers the "
+                            "repo-backed and manual GitHub refresh workflow."
+                        ),
+                        actual=(
+                            f"{self.MAINTAINER_CHECKLIST_HEADING} contains only "
+                            f"{len(checklist_items)} numbered item(s): "
+                            + "; ".join(checklist_items or ("none",))
+                        ),
+                    )
+                )
+
+        return failures
+
+    @staticmethod
+    def format_failures(failures: list[ValidationFailure]) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def readme_playbook_link(self) -> PlaybookLinkObservation | None:
+        return self._playbook_link_observation(self.readme_path, self.README_SECTION_HEADING)
+
+    def contributing_playbook_link(self) -> PlaybookLinkObservation | None:
+        return self._playbook_link_observation(
+            self.contributing_path,
+            self.CONTRIBUTING_SECTION_HEADING,
+        )
+
+    def playbook_section(self, heading: str) -> PlaybookSectionObservation | None:
+        try:
+            start_line, body = self.cross_link_service.section_content(self.playbook_path, heading)
+        except ValueError:
+            return None
+        return PlaybookSectionObservation(heading=heading, start_line=start_line, body=body)
+
+    def _playbook_link_observation(
+        self,
+        source_path: Path,
+        section_heading: str,
+    ) -> PlaybookLinkObservation | None:
+        try:
+            start_line, body = self.cross_link_service.section_content(source_path, section_heading)
+        except ValueError:
+            return None
+
+        lines = source_path.read_text(encoding="utf-8").splitlines()
+        for link in self.cross_link_service.parse_markdown_links(body, start_line=start_line):
+            if link.target == self.PLAYBOOK_RELATIVE_PATH:
+                return PlaybookLinkObservation(
+                    source_path=source_path,
+                    section_heading=section_heading,
+                    text=link.text,
+                    target=link.target,
+                    line_number=link.line_number,
+                    line_text=lines[link.line_number - 1],
+                )
+
+        body_lines = body.splitlines()
+        for offset, line in enumerate(body_lines, start=0):
+            line_number = start_line + offset
+            if self.PLAYBOOK_RELATIVE_PATH in line:
+                return PlaybookLinkObservation(
+                    source_path=source_path,
+                    section_heading=section_heading,
+                    text=self.PLAYBOOK_RELATIVE_PATH,
+                    target=self.PLAYBOOK_RELATIVE_PATH,
+                    line_number=line_number,
+                    line_text=line,
+                )
+        return None
+
+    @staticmethod
+    def _missing_terms(content: str, required_terms: tuple[str, ...]) -> list[str]:
+        normalized = content.lower()
+        return [term for term in required_terms if term.lower() not in normalized]
+
+    @staticmethod
+    def _numbered_items(content: str) -> list[str]:
+        items: list[str] = []
+        for line in content.splitlines():
+            stripped_line = line.strip()
+            if stripped_line[:2].isdigit() and ". " in stripped_line:
+                items.append(stripped_line)
+            elif stripped_line and stripped_line[0].isdigit() and ". " in stripped_line:
+                items.append(stripped_line)
+        return items

--- a/testing/components/services/repository_discoverability_playbook_service.py
+++ b/testing/components/services/repository_discoverability_playbook_service.py
@@ -121,7 +121,7 @@ class RepositoryDiscoverabilityPlaybookService:
         else:
             missing_manual_terms = self._missing_terms(
                 manual_section.body,
-                ("about", "topics", "social preview"),
+                ("about", "topics", "homepage", "social preview"),
             )
             if missing_manual_terms:
                 failures.append(
@@ -130,8 +130,8 @@ class RepositoryDiscoverabilityPlaybookService:
                         summary="The playbook manual-settings section does not cover the required GitHub UI surfaces.",
                         expected=(
                             "Manual GitHub settings guidance should mention About metadata, "
-                            "topics, and social preview so maintainers know which changes must "
-                            "be applied in the GitHub UI."
+                            "homepage, topics, and social preview so maintainers know which "
+                            "changes must be applied in the GitHub UI."
                         ),
                         actual=(
                             f"{self.MANUAL_SETTINGS_HEADING} is missing: "

--- a/testing/components/services/repository_discoverability_playbook_service.py
+++ b/testing/components/services/repository_discoverability_playbook_service.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from testing.components.services.documentation_cross_link_service import (
     DocumentationCrossLinkService,
-    MarkdownLink,
 )
 
 
@@ -79,7 +78,7 @@ class RepositoryDiscoverabilityPlaybookService:
                         "playbook from the documentation map."
                     ),
                     actual=(
-                        f"No link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
+                        f"No Markdown link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
                         f"{self.README_SECTION_HEADING}."
                     ),
                 )
@@ -96,7 +95,7 @@ class RepositoryDiscoverabilityPlaybookService:
                         "playbook from the maintainer checklist section."
                     ),
                     actual=(
-                        f"No link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
+                        f"No Markdown link to {self.PLAYBOOK_RELATIVE_PATH} was found under "
                         f"{self.CONTRIBUTING_SECTION_HEADING}."
                     ),
                 )
@@ -246,19 +245,6 @@ class RepositoryDiscoverabilityPlaybookService:
                     target=link.target,
                     line_number=link.line_number,
                     line_text=lines[link.line_number - 1],
-                )
-
-        body_lines = body.splitlines()
-        for offset, line in enumerate(body_lines, start=0):
-            line_number = start_line + offset
-            if self.PLAYBOOK_RELATIVE_PATH in line:
-                return PlaybookLinkObservation(
-                    source_path=source_path,
-                    section_heading=section_heading,
-                    text=self.PLAYBOOK_RELATIVE_PATH,
-                    target=self.PLAYBOOK_RELATIVE_PATH,
-                    line_number=line_number,
-                    line_text=line,
                 )
         return None
 

--- a/testing/tests/DMC-987/README.md
+++ b/testing/tests/DMC-987/README.md
@@ -1,0 +1,28 @@
+# DMC-987 automated test
+
+This test validates that the maintainer-facing GitHub repository discoverability
+playbook is reachable from both `README.md` and `CONTRIBUTING.md`, and that the
+playbook separates repo-backed updates from manual GitHub UI settings.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-987/test_dmc_987.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads the checked-out repository
+documentation directly.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-987/README.md
+++ b/testing/tests/DMC-987/README.md
@@ -24,5 +24,5 @@ documentation directly.
 ## Expected passing output
 
 ```text
-3 passed
+5 passed
 ```

--- a/testing/tests/DMC-987/config.yaml
+++ b/testing/tests/DMC-987/config.yaml
@@ -1,0 +1,6 @@
+test_id: DMC-987
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []
+

--- a/testing/tests/DMC-987/test_dmc_987.py
+++ b/testing/tests/DMC-987/test_dmc_987.py
@@ -26,10 +26,14 @@ def test_dmc_987_maintainer_playbook_entry_points_and_sections_are_kept_in_sync(
     assert readme_observation is not None
     assert readme_observation.section_heading == service.README_SECTION_HEADING
     assert readme_observation.text == "references/workflows/github-repository-discoverability-playbook.md"
+    assert "[references/workflows/github-repository-discoverability-playbook.md](" in (
+        readme_observation.line_text
+    )
     assert "GitHub repository discoverability" in readme_observation.line_text
 
     assert contributing_observation is not None
     assert contributing_observation.section_heading == service.CONTRIBUTING_SECTION_HEADING
+    assert "[github-repository-discoverability-playbook.md](" in contributing_observation.line_text
     assert "canonical playbook" in contributing_observation.line_text
 
     assert manual_section is not None
@@ -210,4 +214,63 @@ def test_dmc_987_service_reports_when_homepage_leaves_manual_settings_section(
     )
     assert failures[0].actual == (
         f"{service.MANUAL_SETTINGS_HEADING} is missing: homepage"
+    )
+
+
+def test_dmc_987_service_rejects_plain_text_playbook_paths_without_markdown_links(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    workflow_dir = repository_root / "dmtools-ai-docs/references/workflows"
+    workflow_dir.mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "## Documentation map\n\n"
+        "| Topic | Link |\n"
+        "|---|---|\n"
+        "| GitHub repository discoverability | "
+        "dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md |\n"
+        "\n"
+        "## Quick start\n",
+        encoding="utf-8",
+    )
+    (repository_root / "CONTRIBUTING.md").write_text(
+        "# Contributing to DMTools\n\n"
+        "## Maintainer discoverability checklist\n\n"
+        "Use the canonical playbook in "
+        "dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md.\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "github-repository-discoverability-playbook.md").write_text(
+        "# GitHub Repository Discoverability Playbook\n\n"
+        "## Manual GitHub settings\n\n"
+        "1. Update About description and topics in the GitHub UI.\n"
+        "2. Refresh the homepage target if needed.\n"
+        "3. Replace the social preview hero card when positioning changes.\n\n"
+        "## Repo-backed files that must stay aligned\n\n"
+        "- `README.md`\n"
+        "- `.github/ISSUE_TEMPLATE/bug.yml`\n"
+        "- `.github/workflows/release.yml`\n\n"
+        "## Maintainer checklist\n\n"
+        "1. Review the canonical metadata.\n"
+        "2. Keep README and contributor links pointing to this playbook.\n"
+        "3. Update issue templates.\n"
+        "4. Refresh release copy.\n"
+        "5. Apply About, topics, homepage, and social preview updates in the GitHub UI.\n",
+        encoding="utf-8",
+    )
+
+    service = RepositoryDiscoverabilityPlaybookService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [1, 2]
+    assert failures[0].actual == (
+        f"No Markdown link to {service.PLAYBOOK_RELATIVE_PATH} was found under "
+        f"{service.README_SECTION_HEADING}."
+    )
+    assert failures[1].actual == (
+        f"No Markdown link to {service.PLAYBOOK_RELATIVE_PATH} was found under "
+        f"{service.CONTRIBUTING_SECTION_HEADING}."
     )

--- a/testing/tests/DMC-987/test_dmc_987.py
+++ b/testing/tests/DMC-987/test_dmc_987.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.repository_discoverability_playbook_service import (
+    RepositoryDiscoverabilityPlaybookService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_987_maintainer_playbook_entry_points_and_sections_are_kept_in_sync() -> None:
+    service = RepositoryDiscoverabilityPlaybookService(REPOSITORY_ROOT)
+
+    failures = service.validate()
+
+    assert not failures, service.format_failures(failures)
+
+    readme_observation = service.readme_playbook_link()
+    contributing_observation = service.contributing_playbook_link()
+    manual_section = service.playbook_section(service.MANUAL_SETTINGS_HEADING)
+    repo_backed_section = service.playbook_section(service.REPO_BACKED_SECTION_HEADING)
+    checklist_section = service.playbook_section(service.MAINTAINER_CHECKLIST_HEADING)
+
+    assert readme_observation is not None
+    assert readme_observation.section_heading == service.README_SECTION_HEADING
+    assert readme_observation.text == "references/workflows/github-repository-discoverability-playbook.md"
+    assert "GitHub repository discoverability" in readme_observation.line_text
+
+    assert contributing_observation is not None
+    assert contributing_observation.section_heading == service.CONTRIBUTING_SECTION_HEADING
+    assert "canonical playbook" in contributing_observation.line_text
+
+    assert manual_section is not None
+    assert "About description and topics" in manual_section.body
+    assert "Social preview" in manual_section.body
+
+    assert repo_backed_section is not None
+    assert "README.md" in repo_backed_section.body
+    assert ".github/ISSUE_TEMPLATE/*" in repo_backed_section.body
+    assert ".github/workflows/release.yml" in repo_backed_section.body
+
+    assert checklist_section is not None
+    assert "1. Update `github-repository-discoverability.json`" in checklist_section.body
+    assert "5. Apply any required About, topics, homepage, and social-preview changes" in (
+        checklist_section.body
+    )
+
+
+def test_dmc_987_service_accepts_a_playbook_with_split_manual_and_repo_backed_guidance(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    workflow_dir = repository_root / "dmtools-ai-docs/references/workflows"
+    workflow_dir.mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "## Documentation map\n\n"
+        "| Topic | Link |\n"
+        "|---|---|\n"
+        "| GitHub repository discoverability | "
+        "[references/workflows/github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md) |\n"
+        "\n"
+        "## Quick start\n",
+        encoding="utf-8",
+    )
+    (repository_root / "CONTRIBUTING.md").write_text(
+        "# Contributing to DMTools\n\n"
+        "## Maintainer discoverability checklist\n\n"
+        "Use the canonical playbook in "
+        "[github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md).\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "github-repository-discoverability-playbook.md").write_text(
+        "# GitHub Repository Discoverability Playbook\n\n"
+        "## Manual GitHub settings\n\n"
+        "1. Update About description and topics in the GitHub UI.\n"
+        "2. Refresh the homepage target if needed.\n"
+        "3. Replace the social preview hero card when positioning changes.\n\n"
+        "## Repo-backed files that must stay aligned\n\n"
+        "- `README.md`\n"
+        "- `.github/ISSUE_TEMPLATE/bug.yml`\n"
+        "- `.github/workflows/release.yml`\n\n"
+        "## Maintainer checklist\n\n"
+        "1. Review the canonical metadata.\n"
+        "2. Keep README and contributor links pointing to this playbook.\n"
+        "3. Update issue templates.\n"
+        "4. Refresh release copy.\n"
+        "5. Apply About, topics, homepage, and social preview updates in the GitHub UI.\n",
+        encoding="utf-8",
+    )
+
+    service = RepositoryDiscoverabilityPlaybookService(repository_root)
+
+    assert service.validate() == []
+
+
+def test_dmc_987_service_reports_missing_manual_or_repo_backed_sections(tmp_path: Path) -> None:
+    repository_root = tmp_path / "repo"
+    workflow_dir = repository_root / "dmtools-ai-docs/references/workflows"
+    workflow_dir.mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "## Documentation map\n\n"
+        "| Topic | Link |\n"
+        "|---|---|\n"
+        "| GitHub repository discoverability | "
+        "[references/workflows/github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md) |\n"
+        "\n"
+        "## Quick start\n",
+        encoding="utf-8",
+    )
+    (repository_root / "CONTRIBUTING.md").write_text(
+        "# Contributing to DMTools\n\n"
+        "## Maintainer discoverability checklist\n\n"
+        "Use the canonical playbook in "
+        "[github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md).\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "github-repository-discoverability-playbook.md").write_text(
+        "# GitHub Repository Discoverability Playbook\n\n"
+        "## Manual GitHub settings\n\n"
+        "1. Update the homepage target when needed.\n\n"
+        "## Maintainer checklist\n\n"
+        "1. Review metadata.\n"
+        "2. Update links.\n",
+        encoding="utf-8",
+    )
+
+    service = RepositoryDiscoverabilityPlaybookService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [3, 4, 5]
+    assert failures[0].summary == (
+        "The playbook manual-settings section does not cover the required GitHub UI surfaces."
+    )
+    assert "about" in failures[0].actual
+    assert "topics" in failures[0].actual
+    assert "social preview" in failures[0].actual
+    assert failures[1].summary == (
+        "The playbook is missing the repo-backed updates section."
+    )
+    assert service.REPO_BACKED_SECTION_HEADING in failures[1].actual
+    assert failures[2].summary == (
+        "The maintainer checklist is not repeatable enough for metadata refreshes."
+    )
+

--- a/testing/tests/DMC-987/test_dmc_987.py
+++ b/testing/tests/DMC-987/test_dmc_987.py
@@ -34,6 +34,7 @@ def test_dmc_987_maintainer_playbook_entry_points_and_sections_are_kept_in_sync(
 
     assert manual_section is not None
     assert "About description and topics" in manual_section.body
+    assert "homepage" in manual_section.body.lower()
     assert "Social preview" in manual_section.body
 
     assert repo_backed_section is not None
@@ -153,3 +154,60 @@ def test_dmc_987_service_reports_missing_manual_or_repo_backed_sections(tmp_path
         "The maintainer checklist is not repeatable enough for metadata refreshes."
     )
 
+
+def test_dmc_987_service_reports_when_homepage_leaves_manual_settings_section(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    workflow_dir = repository_root / "dmtools-ai-docs/references/workflows"
+    workflow_dir.mkdir(parents=True)
+
+    (repository_root / "README.md").write_text(
+        "# DMTools\n\n"
+        "## Documentation map\n\n"
+        "| Topic | Link |\n"
+        "|---|---|\n"
+        "| GitHub repository discoverability | "
+        "[references/workflows/github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md) |\n"
+        "\n"
+        "## Quick start\n",
+        encoding="utf-8",
+    )
+    (repository_root / "CONTRIBUTING.md").write_text(
+        "# Contributing to DMTools\n\n"
+        "## Maintainer discoverability checklist\n\n"
+        "Use the canonical playbook in "
+        "[github-repository-discoverability-playbook.md]"
+        "(dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md).\n",
+        encoding="utf-8",
+    )
+    (workflow_dir / "github-repository-discoverability-playbook.md").write_text(
+        "# GitHub Repository Discoverability Playbook\n\n"
+        "## Manual GitHub settings\n\n"
+        "1. Update About description and topics in the GitHub UI.\n"
+        "2. Refresh the social preview hero card when positioning changes.\n\n"
+        "## Repo-backed files that must stay aligned\n\n"
+        "- `README.md`\n"
+        "- `.github/ISSUE_TEMPLATE/bug.yml`\n"
+        "- `.github/workflows/release.yml`\n\n"
+        "## Maintainer checklist\n\n"
+        "1. Review the canonical metadata.\n"
+        "2. Keep README and contributor links pointing to this playbook.\n"
+        "3. Update issue templates.\n"
+        "4. Refresh release copy.\n"
+        "5. Apply About, topics, homepage, and social preview updates in the GitHub UI.\n",
+        encoding="utf-8",
+    )
+
+    service = RepositoryDiscoverabilityPlaybookService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [3]
+    assert failures[0].summary == (
+        "The playbook manual-settings section does not cover the required GitHub UI surfaces."
+    )
+    assert failures[0].actual == (
+        f"{service.MANUAL_SETTINGS_HEADING} is missing: homepage"
+    )


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-987 — Verify maintainer playbook entry points and separation — README and CONTRIBUTING links lead to segmented guidance

## What was automated
- Added `testing/components/services/repository_discoverability_playbook_service.py` to validate the maintainer playbook entry points and the split between manual GitHub settings and repo-backed updates.
- Added `testing/tests/DMC-987/test_dmc_987.py` with repository and synthetic-fixture coverage for README, CONTRIBUTING, and playbook structure.
- Added the required ticket-level `README.md` and `config.yaml` in `testing/tests/DMC-987/`.

## Result
- Automation passed: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-987/test_dmc_987.py -q` returned `3 passed in 0.03s`.
- Human-style verification passed by reading the live markdown content as a maintainer would:
  - `README.md` shows the **GitHub repository discoverability** row in the documentation map and links it to `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md`.
  - `CONTRIBUTING.md` points maintainers to the same canonical playbook under **Maintainer discoverability checklist**.
  - The playbook visibly separates **Manual GitHub settings** from **Repo-backed files that must stay aligned** and includes the expected manual items (About/topics, Homepage, Social preview) plus a repeatable six-step maintainer checklist.
- Observed behavior matched the expected result.

## How to run
```bash
PYTHONPATH=. python3 -m pytest testing/tests/DMC-987/test_dmc_987.py -q
```

