### PR TITLE
DMC-988 Test: Align GitHub entry surfaces — issue templates reflect orchestrator narrative

### DIFF
--- a/testing/components/services/github_issue_template_positioning_service.py
+++ b/testing/components/services/github_issue_template_positioning_service.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class TemplateObservation:
+    label: str
+    path: Path
+    about: str
+    about_line_number: int
+    prompt_headings: tuple[str, ...]
+    visible_text: str
+    signal_hits: tuple[str, ...]
+    generic_placeholder_matches: tuple[str, ...]
+
+
+class GitHubIssueTemplatePositioningService:
+    FEATURE_TEMPLATE_LABEL = "feature request template"
+    BUG_TEMPLATE_LABEL = "bug report template"
+    _METADATA_RELATIVE_PATH = "dmtools-core/src/main/resources/github-repository-discoverability.json"
+    _TEMPLATE_SPECS = {
+        FEATURE_TEMPLATE_LABEL: (
+            ".github/ISSUE_TEMPLATE/feature_request.md",
+            "featureRequestAbout",
+        ),
+        BUG_TEMPLATE_LABEL: (
+            ".github/ISSUE_TEMPLATE/bug_report.md",
+            "bugReportAbout",
+        ),
+    }
+    _PROMPT_HEADING_PATTERN = re.compile(r"^\*\*(.+?)\*\*$")
+    _GENERIC_PLACEHOLDER_PATTERNS = {
+        "Describe the bug": re.compile(r"\bdescribe the bug\b", re.IGNORECASE),
+        "A clear and concise description of what the bug is.": re.compile(
+            r"\ba clear and concise description of what the bug is\b",
+            re.IGNORECASE,
+        ),
+        "A clear and concise description of what you expected to happen.": re.compile(
+            r"\ba clear and concise description of what you expected to happen\b",
+            re.IGNORECASE,
+        ),
+        "Describe the solution you'd like": re.compile(
+            r"\bdescribe the solution you(?:'|’)d like\b",
+            re.IGNORECASE,
+        ),
+        "Describe alternatives you've considered": re.compile(
+            r"\bdescribe alternatives you(?:'|’)ve considered\b",
+            re.IGNORECASE,
+        ),
+        "If applicable, add screenshots to help explain your problem.": re.compile(
+            r"\bif applicable, add screenshots to help explain your problem\b",
+            re.IGNORECASE,
+        ),
+        "A clear and concise description of what the problem is.": re.compile(
+            r"\ba clear and concise description of what the problem is\b",
+            re.IGNORECASE,
+        ),
+    }
+    _SIGNAL_PATTERNS = {
+        "workflow": re.compile(r"\bworkflow(?:s)?\b", re.IGNORECASE),
+        "cli": re.compile(r"\bcli\b", re.IGNORECASE),
+        "mcp": re.compile(r"\bmcp\b", re.IGNORECASE),
+        "jobs_or_agents": re.compile(r"\b(?:job|jobs|agent|agents)\b", re.IGNORECASE),
+        "integrations": re.compile(r"\bintegration(?:s)?\b", re.IGNORECASE),
+        "github": re.compile(r"\bgithub\b", re.IGNORECASE),
+        "docs": re.compile(r"\b(?:docs|documentation)\b", re.IGNORECASE),
+    }
+
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        metadata = json.loads(
+            (repository_root / self._METADATA_RELATIVE_PATH).read_text(encoding="utf-8")
+        )
+        self._repo_backed_surfaces = metadata["repoBackedSurfaces"]
+        self._observations = {
+            label: self._observe_template(label)
+            for label in self._TEMPLATE_SPECS
+        }
+
+    def validate(self) -> list[ValidationFailure]:
+        failures: list[ValidationFailure] = []
+
+        for label, (_, metadata_key) in self._TEMPLATE_SPECS.items():
+            observation = self.observation_for_label(label)
+            expected_about = self.expected_about_for_label(label)
+
+            if observation.about != expected_about:
+                failures.append(
+                    ValidationFailure(
+                        step=3,
+                        summary=f"{label.capitalize()} front-matter is not synced with the metadata source.",
+                        expected=expected_about,
+                        actual=(
+                            f"{observation.path.relative_to(self.repository_root)}:"
+                            f"L{observation.about_line_number} -> {observation.about}"
+                        ),
+                    )
+                )
+
+            if "dmtools" not in observation.visible_text.casefold():
+                failures.append(
+                    ValidationFailure(
+                        step=3,
+                        summary=f"{label.capitalize()} does not visibly describe DMTools.",
+                        expected=(
+                            "Contributor-facing prompts should name DMTools and frame the issue "
+                            "around DMTools workflows or surfaces."
+                        ),
+                        actual=self._preview(observation.visible_text),
+                    )
+                )
+
+            if "workflow" not in observation.signal_hits or len(observation.signal_hits) < 4:
+                failures.append(
+                    ValidationFailure(
+                        step=3,
+                        summary=f"{label.capitalize()} is not visibly CLI-first/orchestration focused.",
+                        expected=(
+                            "Visible prompts should emphasize workflows plus several DMTools entry "
+                            "surfaces such as CLI, MCP, jobs/agents, integrations, docs, or GitHub."
+                        ),
+                        actual=(
+                            "Observed signal hits: "
+                            + (", ".join(observation.signal_hits) if observation.signal_hits else "none")
+                        ),
+                    )
+                )
+
+            if observation.generic_placeholder_matches:
+                failures.append(
+                    ValidationFailure(
+                        step=4,
+                        summary=f"{label.capitalize()} still contains generic GitHub template placeholders.",
+                        expected=(
+                            "Issue templates should use DMTools-specific workflow prompts instead of "
+                            "generic starter copy."
+                        ),
+                        actual=", ".join(observation.generic_placeholder_matches),
+                    )
+                )
+
+        return failures
+
+    @staticmethod
+    def format_failures(failures: list[ValidationFailure]) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def expected_about_for_label(self, label: str) -> str:
+        _, metadata_key = self._TEMPLATE_SPECS[label]
+        return self._repo_backed_surfaces[metadata_key]
+
+    def observation_for_label(self, label: str) -> TemplateObservation:
+        return self._observations[label]
+
+    def _observe_template(self, label: str) -> TemplateObservation:
+        relative_path, _ = self._TEMPLATE_SPECS[label]
+        path = self.repository_root / relative_path
+        lines = path.read_text(encoding="utf-8").splitlines()
+        frontmatter, body_start_index = self._parse_frontmatter(lines, path)
+        visible_lines = [line.strip() for line in lines[body_start_index:] if line.strip()]
+        visible_text = " ".join(visible_lines)
+
+        prompt_headings = tuple(
+            match.group(1).strip()
+            for line in visible_lines
+            if (match := self._PROMPT_HEADING_PATTERN.match(line))
+        )
+        signal_hits = tuple(
+            label_name
+            for label_name, pattern in self._SIGNAL_PATTERNS.items()
+            if pattern.search(visible_text) is not None
+        )
+        placeholder_matches = tuple(
+            phrase
+            for phrase, pattern in self._GENERIC_PLACEHOLDER_PATTERNS.items()
+            if pattern.search(visible_text) is not None
+        )
+
+        about_line_number, about = frontmatter["about"]
+        return TemplateObservation(
+            label=label,
+            path=path,
+            about=about,
+            about_line_number=about_line_number,
+            prompt_headings=prompt_headings,
+            visible_text=visible_text,
+            signal_hits=signal_hits,
+            generic_placeholder_matches=placeholder_matches,
+        )
+
+    @staticmethod
+    def _parse_frontmatter(
+        lines: list[str],
+        path: Path,
+    ) -> tuple[dict[str, tuple[int, str]], int]:
+        if not lines or lines[0].strip() != "---":
+            raise AssertionError(f"{path.as_posix()} is missing YAML front-matter.")
+
+        closing_index = next(
+            (index for index in range(1, len(lines)) if lines[index].strip() == "---"),
+            None,
+        )
+        if closing_index is None:
+            raise AssertionError(f"{path.as_posix()} has an unterminated YAML front-matter block.")
+
+        frontmatter: dict[str, tuple[int, str]] = {}
+        for index in range(1, closing_index):
+            stripped = lines[index].strip()
+            if not stripped or ":" not in stripped:
+                continue
+            key, value = stripped.split(":", 1)
+            frontmatter[key.strip()] = (index + 1, value.strip().strip("'\""))
+
+        if "about" not in frontmatter:
+            raise AssertionError(f"{path.as_posix()} is missing the 'about' front-matter field.")
+
+        return frontmatter, closing_index + 1
+
+    @staticmethod
+    def _preview(text: str, limit: int = 260) -> str:
+        compact = re.sub(r"\s+", " ", text).strip()
+        if len(compact) <= limit:
+            return compact
+        return compact[: limit - 3] + "..."

--- a/testing/components/services/github_issue_template_positioning_service.py
+++ b/testing/components/services/github_issue_template_positioning_service.py
@@ -30,12 +30,15 @@ class TemplateObservation:
     prompt_headings: tuple[str, ...]
     visible_text: str
     signal_hits: tuple[str, ...]
+    opening_prompt_body_text: str
+    opening_prompt_signal_hits: tuple[str, ...]
     generic_placeholder_matches: tuple[str, ...]
 
 
 class GitHubIssueTemplatePositioningService:
     FEATURE_TEMPLATE_LABEL = "feature request template"
     BUG_TEMPLATE_LABEL = "bug report template"
+    _OPENING_PROMPT_COUNT = 3
     _METADATA_RELATIVE_PATH = "dmtools-core/src/main/resources/github-repository-discoverability.json"
     _TEMPLATE_SPECS = {
         FEATURE_TEMPLATE_LABEL: (
@@ -76,7 +79,9 @@ class GitHubIssueTemplatePositioningService:
         ),
     }
     _SIGNAL_PATTERNS = {
+        "automation": re.compile(r"\bautomation\b", re.IGNORECASE),
         "workflow": re.compile(r"\bworkflow(?:s)?\b", re.IGNORECASE),
+        "surface": re.compile(r"\bsurface(?:s)?\b", re.IGNORECASE),
         "cli": re.compile(r"\bcli\b", re.IGNORECASE),
         "mcp": re.compile(r"\bmcp\b", re.IGNORECASE),
         "jobs_or_agents": re.compile(r"\b(?:job|jobs|agent|agents)\b", re.IGNORECASE),
@@ -116,31 +121,38 @@ class GitHubIssueTemplatePositioningService:
                     )
                 )
 
-            if "dmtools" not in observation.visible_text.casefold():
+            if "dmtools" not in observation.opening_prompt_body_text.casefold():
                 failures.append(
                     ValidationFailure(
                         step=3,
-                        summary=f"{label.capitalize()} does not visibly describe DMTools.",
+                        summary=f"{label.capitalize()} opening prompt copy does not visibly describe DMTools.",
                         expected=(
-                            "Contributor-facing prompts should name DMTools and frame the issue "
-                            "around DMTools workflows or surfaces."
+                            "The introductory prompt descriptions should name DMTools and frame "
+                            "the issue around DMTools workflows or surfaces."
                         ),
-                        actual=self._preview(observation.visible_text),
+                        actual=self._preview(observation.opening_prompt_body_text),
                     )
                 )
 
-            if "workflow" not in observation.signal_hits or len(observation.signal_hits) < 4:
+            if not {"automation", "workflow", "surface"} & set(
+                observation.opening_prompt_signal_hits
+            ):
                 failures.append(
                     ValidationFailure(
                         step=3,
-                        summary=f"{label.capitalize()} is not visibly CLI-first/orchestration focused.",
+                        summary=f"{label.capitalize()} opening prompt copy is not orchestration focused.",
                         expected=(
-                            "Visible prompts should emphasize workflows plus several DMTools entry "
-                            "surfaces such as CLI, MCP, jobs/agents, integrations, docs, or GitHub."
+                            "The introductory prompt descriptions should guide contributors toward "
+                            "DMTools workflows, automation, or affected surfaces rather than generic "
+                            "project wording."
                         ),
                         actual=(
-                            "Observed signal hits: "
-                            + (", ".join(observation.signal_hits) if observation.signal_hits else "none")
+                            "Observed opening-prompt signal hits: "
+                            + (
+                                ", ".join(observation.opening_prompt_signal_hits)
+                                if observation.opening_prompt_signal_hits
+                                else "none"
+                            )
                         ),
                     )
                 )
@@ -178,16 +190,22 @@ class GitHubIssueTemplatePositioningService:
         frontmatter, body_start_index = self._parse_frontmatter(lines, path)
         visible_lines = [line.strip() for line in lines[body_start_index:] if line.strip()]
         visible_text = " ".join(visible_lines)
-
-        prompt_headings = tuple(
-            match.group(1).strip()
-            for line in visible_lines
-            if (match := self._PROMPT_HEADING_PATTERN.match(line))
+        prompt_blocks = self._collect_prompt_blocks(visible_lines)
+        prompt_headings = tuple(heading for heading, _ in prompt_blocks)
+        opening_prompt_body_text = " ".join(
+            line
+            for _, block_lines in prompt_blocks[: self._OPENING_PROMPT_COUNT]
+            for line in block_lines
         )
         signal_hits = tuple(
             label_name
             for label_name, pattern in self._SIGNAL_PATTERNS.items()
             if pattern.search(visible_text) is not None
+        )
+        opening_prompt_signal_hits = tuple(
+            label_name
+            for label_name, pattern in self._SIGNAL_PATTERNS.items()
+            if pattern.search(opening_prompt_body_text) is not None
         )
         placeholder_matches = tuple(
             phrase
@@ -204,8 +222,35 @@ class GitHubIssueTemplatePositioningService:
             prompt_headings=prompt_headings,
             visible_text=visible_text,
             signal_hits=signal_hits,
+            opening_prompt_body_text=opening_prompt_body_text,
+            opening_prompt_signal_hits=opening_prompt_signal_hits,
             generic_placeholder_matches=placeholder_matches,
         )
+
+    def _collect_prompt_blocks(
+        self,
+        visible_lines: list[str],
+    ) -> tuple[tuple[str, tuple[str, ...]], ...]:
+        prompt_blocks: list[tuple[str, tuple[str, ...]]] = []
+        current_heading: str | None = None
+        current_lines: list[str] = []
+
+        for line in visible_lines:
+            match = self._PROMPT_HEADING_PATTERN.match(line)
+            if match is not None:
+                if current_heading is not None:
+                    prompt_blocks.append((current_heading, tuple(current_lines)))
+                current_heading = match.group(1).strip()
+                current_lines = []
+                continue
+
+            if current_heading is not None:
+                current_lines.append(line)
+
+        if current_heading is not None:
+            prompt_blocks.append((current_heading, tuple(current_lines)))
+
+        return tuple(prompt_blocks)
 
     @staticmethod
     def _parse_frontmatter(

--- a/testing/tests/DMC-988/README.md
+++ b/testing/tests/DMC-988/README.md
@@ -1,0 +1,28 @@
+# DMC-988 automated test
+
+This test validates that the GitHub issue templates are aligned with the
+repository discoverability metadata and present DMTools as a CLI-first
+orchestration toolkit instead of a generic project.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-988/test_dmc_988.py -q
+```
+
+## Environment
+
+No environment variables are required. The test reads the checked-out
+repository files directly.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-988/config.yaml
+++ b/testing/tests/DMC-988/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-988
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-988/test_dmc_988.py
+++ b/testing/tests/DMC-988/test_dmc_988.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+from testing.components.services.github_issue_template_positioning_service import (
+    GitHubIssueTemplatePositioningService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_988_issue_templates_match_discoverability_metadata_and_orchestrator_narrative() -> None:
+    service = GitHubIssueTemplatePositioningService(REPOSITORY_ROOT)
+
+    failures = service.validate()
+
+    assert not failures, service.format_failures(failures)
+
+    feature_observation = service.observation_for_label(service.FEATURE_TEMPLATE_LABEL)
+    bug_observation = service.observation_for_label(service.BUG_TEMPLATE_LABEL)
+
+    assert feature_observation.about == service.expected_about_for_label(
+        service.FEATURE_TEMPLATE_LABEL
+    )
+    assert bug_observation.about == service.expected_about_for_label(
+        service.BUG_TEMPLATE_LABEL
+    )
+    assert feature_observation.prompt_headings[:3] == (
+        "What workflow are you trying to improve?",
+        "What outcome do you want?",
+        "Describe the proposed solution",
+    )
+    assert bug_observation.prompt_headings[:3] == (
+        "What broke",
+        "To Reproduce",
+        "Expected behavior",
+    )
+    assert "cli" in feature_observation.signal_hits
+    assert "mcp" in feature_observation.signal_hits
+    assert "github" in feature_observation.signal_hits
+    assert "cli" in bug_observation.signal_hits
+    assert "mcp" in bug_observation.signal_hits
+    assert "github" in bug_observation.signal_hits
+
+
+def test_dmc_988_service_accepts_dmtools_specific_issue_templates(tmp_path: Path) -> None:
+    repository_root = tmp_path / "repo"
+    _write_metadata(
+        repository_root,
+        bug_about="Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation",
+        feature_about="Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces",
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/feature_request.md",
+        """
+        ---
+        name: DMTools feature request
+        about: Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces
+        ---
+
+        **What workflow are you trying to improve?**
+        Describe the DMTools workflow and CLI/MCP surface that needs to change.
+
+        **Describe the proposed solution**
+        Explain the job, agent, integration, docs, or GitHub update you want.
+        """,
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/bug_report.md",
+        """
+        ---
+        name: DMTools bug report
+        about: Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation
+        ---
+
+        **What broke**
+        Describe the affected DMTools workflow, CLI command, or GitHub automation surface.
+
+        **Affected surface**
+        - CLI
+        - MCP
+        - Job or agent
+        - Integration
+        - Docs
+        """,
+    )
+
+    service = GitHubIssueTemplatePositioningService(repository_root)
+
+    assert service.validate() == []
+
+
+def test_dmc_988_service_rejects_metadata_mismatch_and_generic_placeholders(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    _write_metadata(
+        repository_root,
+        bug_about="Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation",
+        feature_about="Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces",
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/feature_request.md",
+        """
+        ---
+        name: Feature request
+        about: Suggest an improvement for your project
+        ---
+
+        **Describe the solution you'd like**
+        A clear and concise description of what the problem is.
+        """,
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/bug_report.md",
+        """
+        ---
+        name: Bug report
+        about: Report a bug for your project
+        ---
+
+        **Describe the bug**
+        A clear and concise description of what the bug is.
+
+        **Expected behavior**
+        A clear and concise description of what you expected to happen.
+        """,
+    )
+
+    service = GitHubIssueTemplatePositioningService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [3, 3, 3, 4, 3, 3, 3, 4]
+    assert failures[0].summary == (
+        "Feature request template front-matter is not synced with the metadata source."
+    )
+    assert "Suggest an improvement for DMTools CLI workflows" in failures[0].expected
+    assert failures[1].summary == (
+        "Feature request template does not visibly describe DMTools."
+    )
+    assert failures[2].summary == (
+        "Feature request template is not visibly CLI-first/orchestration focused."
+    )
+    assert failures[3].summary == (
+        "Feature request template still contains generic GitHub template placeholders."
+    )
+    assert "Describe the solution you'd like" in failures[3].actual
+    assert failures[4].summary == (
+        "Bug report template front-matter is not synced with the metadata source."
+    )
+    assert failures[5].summary == "Bug report template does not visibly describe DMTools."
+    assert failures[6].summary == (
+        "Bug report template is not visibly CLI-first/orchestration focused."
+    )
+    assert failures[7].summary == (
+        "Bug report template still contains generic GitHub template placeholders."
+    )
+    assert "Describe the bug" in failures[7].actual
+
+
+def _write_metadata(repository_root: Path, *, bug_about: str, feature_about: str) -> None:
+    metadata_path = (
+        repository_root / "dmtools-core/src/main/resources/github-repository-discoverability.json"
+    )
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "repoBackedSurfaces": {
+                    "bugReportAbout": bug_about,
+                    "featureRequestAbout": feature_about,
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content).strip() + "\n", encoding="utf-8")

--- a/testing/tests/DMC-988/test_dmc_988.py
+++ b/testing/tests/DMC-988/test_dmc_988.py
@@ -38,12 +38,15 @@ def test_dmc_988_issue_templates_match_discoverability_metadata_and_orchestrator
         "To Reproduce",
         "Expected behavior",
     )
-    assert "cli" in feature_observation.signal_hits
-    assert "mcp" in feature_observation.signal_hits
-    assert "github" in feature_observation.signal_hits
-    assert "cli" in bug_observation.signal_hits
-    assert "mcp" in bug_observation.signal_hits
-    assert "github" in bug_observation.signal_hits
+    assert "dmtools" in feature_observation.opening_prompt_body_text.casefold()
+    assert "workflow" in feature_observation.opening_prompt_signal_hits
+    assert "automation" in feature_observation.opening_prompt_signal_hits
+    assert "cli" in feature_observation.opening_prompt_signal_hits
+    assert "mcp" in feature_observation.opening_prompt_signal_hits
+    assert "github" in feature_observation.opening_prompt_signal_hits
+    assert "dmtools" in bug_observation.opening_prompt_body_text.casefold()
+    assert "workflow" in bug_observation.opening_prompt_signal_hits
+    assert "surface" in bug_observation.opening_prompt_signal_hits
 
 
 def test_dmc_988_service_accepts_dmtools_specific_issue_templates(tmp_path: Path) -> None:
@@ -140,10 +143,10 @@ def test_dmc_988_service_rejects_metadata_mismatch_and_generic_placeholders(
     )
     assert "Suggest an improvement for DMTools CLI workflows" in failures[0].expected
     assert failures[1].summary == (
-        "Feature request template does not visibly describe DMTools."
+        "Feature request template opening prompt copy does not visibly describe DMTools."
     )
     assert failures[2].summary == (
-        "Feature request template is not visibly CLI-first/orchestration focused."
+        "Feature request template opening prompt copy is not orchestration focused."
     )
     assert failures[3].summary == (
         "Feature request template still contains generic GitHub template placeholders."
@@ -152,14 +155,97 @@ def test_dmc_988_service_rejects_metadata_mismatch_and_generic_placeholders(
     assert failures[4].summary == (
         "Bug report template front-matter is not synced with the metadata source."
     )
-    assert failures[5].summary == "Bug report template does not visibly describe DMTools."
+    assert failures[5].summary == (
+        "Bug report template opening prompt copy does not visibly describe DMTools."
+    )
     assert failures[6].summary == (
-        "Bug report template is not visibly CLI-first/orchestration focused."
+        "Bug report template opening prompt copy is not orchestration focused."
     )
     assert failures[7].summary == (
         "Bug report template still contains generic GitHub template placeholders."
     )
     assert "Describe the bug" in failures[7].actual
+
+
+def test_dmc_988_service_does_not_let_later_sections_mask_generic_opening_prompts(
+    tmp_path: Path,
+) -> None:
+    repository_root = tmp_path / "repo"
+    _write_metadata(
+        repository_root,
+        bug_about="Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation",
+        feature_about="Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces",
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/feature_request.md",
+        """
+        ---
+        name: DMTools feature request
+        about: Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces
+        ---
+
+        **What workflow are you trying to improve?**
+        Describe what you want to change.
+
+        **What outcome do you want?**
+        Describe the result you want.
+
+        **Describe the proposed solution**
+        Share the approach you prefer.
+
+        **Which DMTools surfaces are involved?**
+        - CLI or wrapper
+        - MCP tools or integrations
+        - Jobs or agents
+        - GitHub Actions or CI workflows
+        - AI assistant skills or docs
+        """,
+    )
+    _write_file(
+        repository_root / ".github/ISSUE_TEMPLATE/bug_report.md",
+        """
+        ---
+        name: DMTools bug report
+        about: Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation
+        ---
+
+        **What broke**
+        Describe the issue.
+
+        **To Reproduce**
+        1.
+        2.
+        3.
+
+        **Expected behavior**
+        Describe what you expected.
+
+        **Affected surface**
+        - CLI command or wrapper
+        - MCP tool or integration
+        - Job or agent configuration
+        - GitHub Actions or CI workflow
+        - Documentation or discoverability surface
+        """,
+    )
+
+    service = GitHubIssueTemplatePositioningService(repository_root)
+
+    feature_observation = service.observation_for_label(service.FEATURE_TEMPLATE_LABEL)
+    bug_observation = service.observation_for_label(service.BUG_TEMPLATE_LABEL)
+    failures = service.validate()
+    failure_summaries = {failure.summary for failure in failures}
+
+    assert "cli" in feature_observation.signal_hits
+    assert "github" in bug_observation.signal_hits
+    assert "dmtools" not in feature_observation.opening_prompt_body_text.casefold()
+    assert "dmtools" not in bug_observation.opening_prompt_body_text.casefold()
+    assert feature_observation.opening_prompt_signal_hits == ()
+    assert bug_observation.opening_prompt_signal_hits == ()
+    assert "Feature request template opening prompt copy does not visibly describe DMTools." in failure_summaries
+    assert "Feature request template opening prompt copy is not orchestration focused." in failure_summaries
+    assert "Bug report template opening prompt copy does not visibly describe DMTools." in failure_summaries
+    assert "Bug report template opening prompt copy is not orchestration focused." in failure_summaries
 
 
 def _write_metadata(repository_root: Path, *, bug_about: str, feature_about: str) -> None:


### PR DESCRIPTION
# DMC-988 automated test result

**Status:** PASSED

**Command executed**

```bash
python3 -m pytest testing/tests/DMC-988/test_dmc_988.py -q
```

## What automation checked

- Compared `.github/ISSUE_TEMPLATE/feature_request.md` and `.github/ISSUE_TEMPLATE/bug_report.md` against `dmtools-core/src/main/resources/github-repository-discoverability.json`.
- Confirmed the `about` front-matter matches the metadata source exactly.
- Confirmed the feature request template opens with:
  - `What workflow are you trying to improve?`
  - `What outcome do you want?`
  - `Describe the proposed solution`
- Confirmed the bug report template opens with:
  - `What broke`
  - `To Reproduce`
  - `Expected behavior`
- Confirmed the templates keep DMTools-specific workflow/CLI/MCP/GitHub wording and do not fall back to generic GitHub starter placeholders such as `Describe the bug` or `Describe the solution you'd like`.

## Human-style verification

- Read the live contributor-facing issue template copy as a GitHub user would experience it.
- Observed feature template `about`: `Suggest an improvement for DMTools CLI workflows, MCP tools, jobs, integrations, AI assistant skills, or GitHub surfaces`
- Observed bug template `about`: `Report a bug in the DMTools CLI, MCP tools, jobs, integrations, or GitHub workflow automation`
- Observed that the visible prompts guide contributors toward DMTools workflows, affected surfaces, and orchestration entry points rather than generic project wording.

## Result

The observed behavior matched the expected result: the issue templates are aligned with the metadata source and present DMTools as a CLI-first orchestration toolkit.
