### PR TITLE
DMC-989 Test: Validate social preview asset and visual quality — SVG source and contrast compliance

### DIFF
--- a/testing/components/services/social_preview_asset_service.py
+++ b/testing/components/services/social_preview_asset_service.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from xml.etree import ElementTree
+
+
+STYLE_DECLARATION_PATTERN = re.compile(r"\s*([^:]+):\s*([^;]+)\s*")
+NON_ALPHANUMERIC_PATTERN = re.compile(r"[^a-z0-9]+")
+SVG_NAMESPACE = "{http://www.w3.org/2000/svg}"
+
+
+@dataclass(frozen=True)
+class ValidationFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class TextContrastObservation:
+    text: str
+    fill_hex: str
+    contrast_ratio: float
+
+    def format(self) -> str:
+        return f"{self.text!r} ({self.fill_hex}) -> {self.contrast_ratio:.2f}:1"
+
+
+@dataclass(frozen=True)
+class SocialPreviewObservation:
+    asset_path: Path
+    hero_fill_hex: str | None
+    wordmark_texts: tuple[str, ...]
+    decorative_background_count: int
+    text_contrast_observations: tuple[TextContrastObservation, ...]
+
+
+class SocialPreviewAssetService:
+    PLAYBOOK_RELATIVE_PATH = Path(
+        "dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md"
+    )
+    PRIMARY_FILENAME_HINTS = (
+        "social-preview",
+        "social_preview",
+        "socialpreview",
+    )
+    SECONDARY_FILENAME_HINTS = (
+        "social",
+        "preview",
+        "open-graph",
+        "open_graph",
+        "opengraph",
+        "github-preview",
+        "github_preview",
+        "social-card",
+        "social_card",
+    )
+    IGNORED_DIRECTORIES = {
+        ".git",
+        ".gradle",
+        ".idea",
+        ".pytest_cache",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+        "outputs",
+        "testing",
+    }
+    SHAPE_TAGS = {"rect", "path", "line", "polyline", "polygon", "circle", "ellipse"}
+
+    def __init__(self, repository_root: Path) -> None:
+        self.repository_root = repository_root
+        self.playbook_path = repository_root / self.PLAYBOOK_RELATIVE_PATH
+
+    def validate(self) -> list[ValidationFailure]:
+        failures: list[ValidationFailure] = []
+
+        asset_path = self.locate_social_preview_asset()
+        if asset_path is None:
+            failures.extend(
+                [
+                    ValidationFailure(
+                        step=1,
+                        summary="The repository does not contain a versioned social-preview SVG source asset.",
+                        expected=(
+                            "A committed SVG asset whose filename clearly identifies it as the "
+                            "repository social preview source."
+                        ),
+                        actual=(
+                            "No matching SVG file was found for the social-preview naming hints "
+                            f"{self.PRIMARY_FILENAME_HINTS + self.SECONDARY_FILENAME_HINTS}."
+                        ),
+                    ),
+                    ValidationFailure(
+                        step=2,
+                        summary="The social preview composition cannot be reviewed because the SVG source is missing.",
+                        expected=(
+                            "A versioned SVG that visibly contains a dark hero card, the DMTools "
+                            "wordmark, and a subtle industrial background."
+                        ),
+                        actual="Step 1 did not locate any committed social-preview SVG source asset.",
+                    ),
+                    ValidationFailure(
+                        step=3,
+                        summary="Text contrast cannot be inspected because the SVG source is missing.",
+                        expected=(
+                            "A committed SVG source whose rendered text colors can be checked "
+                            "against the hero-card background."
+                        ),
+                        actual="Step 1 did not locate any committed social-preview SVG source asset.",
+                    ),
+                ]
+            )
+        else:
+            observation = self.inspect_asset(asset_path)
+            composition_failures = self._validate_composition(observation)
+            contrast_failures = self._validate_contrast(observation)
+            failures.extend(composition_failures)
+            failures.extend(contrast_failures)
+
+        if not self.playbook_documents_export_requirements():
+            failures.append(
+                ValidationFailure(
+                    step=4,
+                    summary="The discoverability playbook does not document the required PNG export sizes.",
+                    expected=(
+                        "The social preview guidance should state that PNG exports are "
+                        "1280x640 minimum and 2560x1280 recommended."
+                    ),
+                    actual=self.playbook_social_preview_excerpt(),
+                )
+            )
+
+        return failures
+
+    @staticmethod
+    def format_failures(failures: list[ValidationFailure]) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def locate_social_preview_asset(self) -> Path | None:
+        ranked_matches: list[tuple[int, Path]] = []
+        for candidate in self._svg_candidates():
+            rank = self._candidate_rank(candidate)
+            if rank is None:
+                continue
+            ranked_matches.append((rank, candidate))
+
+        if not ranked_matches:
+            return None
+
+        ranked_matches.sort(key=lambda item: (item[0], item[1].as_posix()))
+        return ranked_matches[0][1]
+
+    def inspect_asset(self, asset_path: Path) -> SocialPreviewObservation:
+        root = ElementTree.fromstring(asset_path.read_text(encoding="utf-8"))
+        hero_rect, hero_fill = self._hero_rect(root)
+        hero_fill_hex = self._format_rgb(hero_fill) if hero_fill else None
+
+        wordmark_texts: list[str] = []
+        text_contrasts: list[TextContrastObservation] = []
+        for element in root.iter():
+            if self._tag_name(element) != "text":
+                continue
+
+            text = " ".join(part.strip() for part in element.itertext() if part.strip())
+            if not text:
+                continue
+
+            if "dmtools" in self._normalize(text):
+                wordmark_texts.append(text)
+
+            fill = self._parse_color(self._presentation_attribute(element, "fill"))
+            if fill is None:
+                fill = (0, 0, 0)
+            if hero_fill is None:
+                continue
+
+            text_contrasts.append(
+                TextContrastObservation(
+                    text=text,
+                    fill_hex=self._format_rgb(fill),
+                    contrast_ratio=self._contrast_ratio(fill, hero_fill),
+                )
+            )
+
+        decorative_background_count = 0
+        for element in root.iter():
+            tag_name = self._tag_name(element)
+            if tag_name not in self.SHAPE_TAGS:
+                continue
+            if hero_rect is not None and element is hero_rect:
+                continue
+            if self._is_subtle_background_shape(element):
+                decorative_background_count += 1
+
+        return SocialPreviewObservation(
+            asset_path=asset_path,
+            hero_fill_hex=hero_fill_hex,
+            wordmark_texts=tuple(wordmark_texts),
+            decorative_background_count=decorative_background_count,
+            text_contrast_observations=tuple(text_contrasts),
+        )
+
+    def playbook_documents_export_requirements(self) -> bool:
+        normalized = self._normalize(self.playbook_path.read_text(encoding="utf-8"))
+        return (
+            "1280x640" in normalized
+            and "2560x1280" in normalized
+            and "minimum" in normalized
+            and "recommended" in normalized
+        )
+
+    def playbook_social_preview_excerpt(self) -> str:
+        lines = self.playbook_path.read_text(encoding="utf-8").splitlines()
+        start_index = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if line.strip() == "### Social preview asset guidance"
+            ),
+            None,
+        )
+        if start_index is None:
+            return f"{self.PLAYBOOK_RELATIVE_PATH.as_posix()} is missing the social preview guidance section."
+
+        collected: list[str] = []
+        for line in lines[start_index : start_index + 10]:
+            stripped = line.strip()
+            if stripped:
+                collected.append(stripped)
+        return " ".join(collected)
+
+    def _validate_composition(
+        self, observation: SocialPreviewObservation
+    ) -> list[ValidationFailure]:
+        missing_parts: list[str] = []
+        hero_fill_rgb = self._parse_color(observation.hero_fill_hex)
+        if hero_fill_rgb is None:
+            missing_parts.append("dark hero card")
+        elif self._relative_luminance(hero_fill_rgb) > 0.2:
+            missing_parts.append(f"dark hero card (observed fill {observation.hero_fill_hex})")
+
+        if not observation.wordmark_texts:
+            missing_parts.append("DMTools wordmark")
+
+        if observation.decorative_background_count == 0:
+            missing_parts.append("subtle industrial background")
+
+        if not missing_parts:
+            return []
+
+        return [
+            ValidationFailure(
+                step=2,
+                summary="The social preview SVG does not satisfy the required visual composition.",
+                expected=(
+                    "A dark hero card, a visible DMTools wordmark, and at least one subtle "
+                    "industrial background element."
+                ),
+                actual=(
+                    f"{self.relative_path(observation.asset_path)} is missing or does not prove: "
+                    + ", ".join(missing_parts)
+                    + "."
+                ),
+            )
+        ]
+
+    def _validate_contrast(
+        self, observation: SocialPreviewObservation
+    ) -> list[ValidationFailure]:
+        if observation.hero_fill_hex is None:
+            return [
+                ValidationFailure(
+                    step=3,
+                    summary="Text contrast could not be calculated because the hero-card background was not detected.",
+                    expected="A dominant dark hero-card background rectangle behind the text.",
+                    actual=f"No large background rectangle with a parseable fill was found in {self.relative_path(observation.asset_path)}.",
+                )
+            ]
+
+        if not observation.text_contrast_observations:
+            return [
+                ValidationFailure(
+                    step=3,
+                    summary="Text contrast could not be calculated because no SVG text elements were found.",
+                    expected="Visible text layers in the SVG source that can be checked for WCAG AA contrast.",
+                    actual=f"No <text> elements were found in {self.relative_path(observation.asset_path)}.",
+                )
+            ]
+
+        low_contrast = [
+            observation
+            for observation in observation.text_contrast_observations
+            if observation.contrast_ratio < 4.5
+        ]
+        if not low_contrast:
+            return []
+
+        return [
+            ValidationFailure(
+                step=3,
+                summary="One or more social-preview text layers are below the required 4.5:1 contrast ratio.",
+                expected="Every rendered text element in the social preview should meet or exceed 4.5:1 contrast.",
+                actual="; ".join(item.format() for item in low_contrast),
+            )
+        ]
+
+    def _svg_candidates(self) -> list[Path]:
+        candidates: list[Path] = []
+        for path in self.repository_root.rglob("*.svg"):
+            if any(part in self.IGNORED_DIRECTORIES for part in path.parts):
+                continue
+            if not path.is_file():
+                continue
+            candidates.append(path)
+        return sorted(candidates)
+
+    def _candidate_rank(self, path: Path) -> int | None:
+        raw_name = path.stem.casefold()
+        normalized_name = self._normalize(path.stem)
+        if any(hint in raw_name for hint in self.PRIMARY_FILENAME_HINTS):
+            return 0
+        if all(hint in normalized_name for hint in ("social", "preview")):
+            return 1
+        if any(hint in raw_name for hint in self.SECONDARY_FILENAME_HINTS) or any(
+            hint in normalized_name for hint in ("open graph", "github preview", "social card")
+        ):
+            return 2
+
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        normalized_text = self._normalize(text)
+        if "dmtools" in normalized_text and "social" in normalized_text:
+            return 3
+        if "dmtools" in normalized_text and "dark factory orchestrator" in normalized_text:
+            return 4
+        return None
+
+    def _hero_rect(
+        self, root: ElementTree.Element
+    ) -> tuple[ElementTree.Element | None, tuple[int, int, int] | None]:
+        fallback_width, fallback_height = self._root_dimensions(root)
+        largest_rect: ElementTree.Element | None = None
+        largest_area = -1.0
+        largest_fill: tuple[int, int, int] | None = None
+
+        for element in root.iter():
+            if self._tag_name(element) != "rect":
+                continue
+            fill = self._parse_color(self._presentation_attribute(element, "fill"))
+            if fill is None:
+                continue
+
+            width = self._parse_length(element.get("width")) or fallback_width
+            height = self._parse_length(element.get("height")) or fallback_height
+            if width is None or height is None:
+                continue
+
+            area = width * height
+            if area <= largest_area:
+                continue
+
+            largest_rect = element
+            largest_area = area
+            largest_fill = fill
+
+        return largest_rect, largest_fill
+
+    def _root_dimensions(self, root: ElementTree.Element) -> tuple[float | None, float | None]:
+        width = self._parse_length(root.get("width"))
+        height = self._parse_length(root.get("height"))
+        if width is not None and height is not None:
+            return width, height
+
+        view_box = root.get("viewBox")
+        if not view_box:
+            return width, height
+
+        parts = [part for part in view_box.replace(",", " ").split() if part]
+        if len(parts) != 4:
+            return width, height
+
+        try:
+            return float(parts[2]), float(parts[3])
+        except ValueError:
+            return width, height
+
+    def _is_subtle_background_shape(self, element: ElementTree.Element) -> bool:
+        opacity = self._parse_float(self._presentation_attribute(element, "opacity"))
+        fill_opacity = self._parse_float(self._presentation_attribute(element, "fill-opacity"))
+        stroke_opacity = self._parse_float(self._presentation_attribute(element, "stroke-opacity"))
+        subtle_opacity = min(
+            value
+            for value in (opacity, fill_opacity, stroke_opacity)
+            if value is not None
+        ) if any(value is not None for value in (opacity, fill_opacity, stroke_opacity)) else None
+
+        has_fill_or_stroke = (
+            self._parse_color(self._presentation_attribute(element, "fill")) is not None
+            or self._parse_color(self._presentation_attribute(element, "stroke")) is not None
+        )
+        return has_fill_or_stroke and subtle_opacity is not None and subtle_opacity <= 0.35
+
+    def _presentation_attribute(self, element: ElementTree.Element, name: str) -> str | None:
+        direct = element.get(name)
+        if direct:
+            return direct
+
+        style = element.get("style")
+        if not style:
+            return None
+
+        for declaration in style.split(";"):
+            match = STYLE_DECLARATION_PATTERN.fullmatch(declaration)
+            if not match:
+                continue
+            key = match.group(1).strip()
+            value = match.group(2).strip()
+            if key == name:
+                return value
+        return None
+
+    @staticmethod
+    def _tag_name(tag: ElementTree.Element | str) -> str:
+        if isinstance(tag, ElementTree.Element):
+            tag = tag.tag
+        if tag.startswith(SVG_NAMESPACE):
+            return tag[len(SVG_NAMESPACE) :]
+        return tag.rsplit("}", 1)[-1]
+
+    @staticmethod
+    def _parse_length(raw_value: str | None) -> float | None:
+        if raw_value is None:
+            return None
+        match = re.fullmatch(r"\s*([0-9]+(?:\.[0-9]+)?)", raw_value.strip().removesuffix("px"))
+        if match is None:
+            return None
+        return float(match.group(1))
+
+    @staticmethod
+    def _parse_float(raw_value: str | None) -> float | None:
+        if raw_value is None:
+            return None
+        try:
+            return float(raw_value)
+        except ValueError:
+            return None
+
+    @classmethod
+    def _parse_color(cls, raw_value: str | None) -> tuple[int, int, int] | None:
+        if raw_value is None:
+            return None
+
+        value = raw_value.strip().lower()
+        if not value or value == "none":
+            return None
+        if value in {"#fff", "#ffffff", "white"}:
+            return 255, 255, 255
+        if value in {"#000", "#000000", "black"}:
+            return 0, 0, 0
+        if value.startswith("#") and len(value) == 4:
+            return tuple(int(channel * 2, 16) for channel in value[1:])  # type: ignore[return-value]
+        if value.startswith("#") and len(value) == 7:
+            return (
+                int(value[1:3], 16),
+                int(value[3:5], 16),
+                int(value[5:7], 16),
+            )
+
+        rgb_match = re.fullmatch(
+            r"rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)",
+            value,
+        )
+        if rgb_match is None:
+            return None
+
+        channels = tuple(int(rgb_match.group(index)) for index in range(1, 4))
+        if any(channel < 0 or channel > 255 for channel in channels):
+            return None
+        return channels
+
+    @staticmethod
+    def _format_rgb(color: tuple[int, int, int]) -> str:
+        return "#{:02X}{:02X}{:02X}".format(*color)
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return NON_ALPHANUMERIC_PATTERN.sub(" ", text.casefold()).strip()
+
+    def relative_path(self, path: Path) -> str:
+        return path.relative_to(self.repository_root).as_posix()
+
+    @classmethod
+    def _contrast_ratio(
+        cls, foreground: tuple[int, int, int], background: tuple[int, int, int]
+    ) -> float:
+        foreground_luminance = cls._relative_luminance(foreground)
+        background_luminance = cls._relative_luminance(background)
+        lighter = max(foreground_luminance, background_luminance)
+        darker = min(foreground_luminance, background_luminance)
+        return (lighter + 0.05) / (darker + 0.05)
+
+    @staticmethod
+    def _relative_luminance(color: tuple[int, int, int]) -> float:
+        def _channel_luminance(channel: int) -> float:
+            normalized = channel / 255.0
+            if normalized <= 0.03928:
+                return normalized / 12.92
+            return ((normalized + 0.055) / 1.055) ** 2.4
+
+        red, green, blue = color
+        return (
+            0.2126 * _channel_luminance(red)
+            + 0.7152 * _channel_luminance(green)
+            + 0.0722 * _channel_luminance(blue)
+        )

--- a/testing/components/services/social_preview_asset_service.py
+++ b/testing/components/services/social_preview_asset_service.py
@@ -54,17 +54,6 @@ class SocialPreviewAssetService:
         "social_preview",
         "socialpreview",
     )
-    SECONDARY_FILENAME_HINTS = (
-        "social",
-        "preview",
-        "open-graph",
-        "open_graph",
-        "opengraph",
-        "github-preview",
-        "github_preview",
-        "social-card",
-        "social_card",
-    )
     IGNORED_DIRECTORIES = {
         ".git",
         ".gradle",
@@ -94,12 +83,12 @@ class SocialPreviewAssetService:
                         step=1,
                         summary="The repository does not contain a versioned social-preview SVG source asset.",
                         expected=(
-                            "A committed SVG asset whose filename clearly identifies it as the "
-                            "repository social preview source."
+                            "A committed, versioned SVG asset whose filename clearly identifies "
+                            "it as the repository social preview source."
                         ),
                         actual=(
-                            "No matching SVG file was found for the social-preview naming hints "
-                            f"{self.PRIMARY_FILENAME_HINTS + self.SECONDARY_FILENAME_HINTS}."
+                            "No versioned SVG file matching the social-preview naming contract "
+                            "(for example, social-preview.v1.svg) was found."
                         ),
                     ),
                     ValidationFailure(
@@ -149,18 +138,12 @@ class SocialPreviewAssetService:
         return "\n\n".join(failure.format() for failure in failures)
 
     def locate_social_preview_asset(self) -> Path | None:
-        ranked_matches: list[tuple[int, Path]] = []
-        for candidate in self._svg_candidates():
-            rank = self._candidate_rank(candidate)
-            if rank is None:
-                continue
-            ranked_matches.append((rank, candidate))
-
-        if not ranked_matches:
+        matches = [
+            candidate for candidate in self._svg_candidates() if self._is_versioned_social_preview(candidate)
+        ]
+        if not matches:
             return None
-
-        ranked_matches.sort(key=lambda item: (item[0], item[1].as_posix()))
-        return ranked_matches[0][1]
+        return sorted(matches, key=lambda path: path.as_posix())[0]
 
     def inspect_asset(self, asset_path: Path) -> SocialPreviewObservation:
         root = ElementTree.fromstring(asset_path.read_text(encoding="utf-8"))
@@ -213,7 +196,7 @@ class SocialPreviewAssetService:
         )
 
     def playbook_documents_export_requirements(self) -> bool:
-        normalized = self._normalize(self.playbook_path.read_text(encoding="utf-8"))
+        normalized = self._normalize(self.playbook_social_preview_excerpt())
         return (
             "1280x640" in normalized
             and "2560x1280" in normalized
@@ -222,6 +205,9 @@ class SocialPreviewAssetService:
         )
 
     def playbook_social_preview_excerpt(self) -> str:
+        if not self.playbook_path.is_file():
+            return f"{self.PLAYBOOK_RELATIVE_PATH.as_posix()} is missing."
+
         lines = self.playbook_path.read_text(encoding="utf-8").splitlines()
         start_index = next(
             (
@@ -235,8 +221,10 @@ class SocialPreviewAssetService:
             return f"{self.PLAYBOOK_RELATIVE_PATH.as_posix()} is missing the social preview guidance section."
 
         collected: list[str] = []
-        for line in lines[start_index : start_index + 10]:
+        for line in lines[start_index:]:
             stripped = line.strip()
+            if collected and stripped.startswith("#"):
+                break
             if stripped:
                 collected.append(stripped)
         return " ".join(collected)
@@ -326,25 +314,16 @@ class SocialPreviewAssetService:
             candidates.append(path)
         return sorted(candidates)
 
-    def _candidate_rank(self, path: Path) -> int | None:
+    def _is_versioned_social_preview(self, path: Path) -> bool:
         raw_name = path.stem.casefold()
         normalized_name = self._normalize(path.stem)
-        if any(hint in raw_name for hint in self.PRIMARY_FILENAME_HINTS):
-            return 0
-        if all(hint in normalized_name for hint in ("social", "preview")):
-            return 1
-        if any(hint in raw_name for hint in self.SECONDARY_FILENAME_HINTS) or any(
-            hint in normalized_name for hint in ("open graph", "github preview", "social card")
-        ):
-            return 2
+        has_social_preview_name = any(hint in raw_name for hint in self.PRIMARY_FILENAME_HINTS) or (
+            "social preview" in normalized_name
+        )
+        if not has_social_preview_name:
+            return False
 
-        text = path.read_text(encoding="utf-8", errors="ignore")
-        normalized_text = self._normalize(text)
-        if "dmtools" in normalized_text and "social" in normalized_text:
-            return 3
-        if "dmtools" in normalized_text and "dark factory orchestrator" in normalized_text:
-            return 4
-        return None
+        return bool(re.search(r"(^|[.\-_])v(?:ersion)?[0-9]+($|[.\-_])", raw_name))
 
     def _hero_rect(
         self, root: ElementTree.Element

--- a/testing/components/services/social_preview_asset_service.py
+++ b/testing/components/services/social_preview_asset_service.py
@@ -147,6 +147,7 @@ class SocialPreviewAssetService:
 
     def inspect_asset(self, asset_path: Path) -> SocialPreviewObservation:
         root = ElementTree.fromstring(asset_path.read_text(encoding="utf-8"))
+        parent_map = self._parent_map(root)
         hero_rect, hero_fill = self._hero_rect(root)
         hero_fill_hex = self._format_rgb(hero_fill) if hero_fill else None
 
@@ -163,7 +164,9 @@ class SocialPreviewAssetService:
             if "dmtools" in self._normalize(text):
                 wordmark_texts.append(text)
 
-            fill = self._parse_color(self._presentation_attribute(element, "fill"))
+            fill = self._parse_color(
+                self._effective_presentation_attribute(element, "fill", parent_map)
+            )
             if fill is None:
                 fill = (0, 0, 0)
             if hero_fill is None:
@@ -408,6 +411,24 @@ class SocialPreviewAssetService:
             if key == name:
                 return value
         return None
+
+    def _effective_presentation_attribute(
+        self,
+        element: ElementTree.Element,
+        name: str,
+        parent_map: dict[ElementTree.Element, ElementTree.Element],
+    ) -> str | None:
+        current: ElementTree.Element | None = element
+        while current is not None:
+            value = self._presentation_attribute(current, name)
+            if value is not None:
+                return value
+            current = parent_map.get(current)
+        return None
+
+    @staticmethod
+    def _parent_map(root: ElementTree.Element) -> dict[ElementTree.Element, ElementTree.Element]:
+        return {child: parent for parent in root.iter() for child in parent}
 
     @staticmethod
     def _tag_name(tag: ElementTree.Element | str) -> str:

--- a/testing/tests/DMC-989/README.md
+++ b/testing/tests/DMC-989/README.md
@@ -25,5 +25,5 @@ repository checkout.
 ## Expected passing output
 
 ```text
-3 passed
+6 passed
 ```

--- a/testing/tests/DMC-989/README.md
+++ b/testing/tests/DMC-989/README.md
@@ -1,0 +1,29 @@
+# DMC-989 automated test
+
+This test validates the repository-backed social preview contract. It checks that
+the repository contains a committed SVG social preview source, that the SVG
+expresses the approved DMTools composition with accessible contrast, and that the
+discoverability playbook documents the required PNG export sizes.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-989/test_dmc_989.py -q
+```
+
+## Environment
+
+No environment variables are required. The test inspects files directly from this
+repository checkout.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-989/config.yaml
+++ b/testing/tests/DMC-989/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-989
+type: documentation
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-989/test_dmc_989.py
+++ b/testing/tests/DMC-989/test_dmc_989.py
@@ -58,31 +58,97 @@ def test_dmc_989_service_reports_missing_export_guidance_and_low_contrast_text(
     assert "1280x640 minimum and 2560x1280 recommended" in failure_message
 
 
+def test_dmc_989_service_rejects_generic_svg_names_without_a_versioned_social_preview_source(
+    tmp_path: Path,
+) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        include_social_preview_asset=False,
+        include_export_sizes=True,
+        extra_svg_files={
+            "assets/social.svg": [
+                '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640">',
+                '  <rect width="1280" height="640" fill="#0F172A" />',
+                '  <text x="96" y="280" fill="#F8FAFC">DMTools</text>',
+                "</svg>",
+            ],
+            "assets/preview.svg": [
+                '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640">',
+                '  <rect width="1280" height="640" fill="#0F172A" />',
+                '  <text x="96" y="280" fill="#F8FAFC">DMTools</text>',
+                "</svg>",
+            ],
+        },
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [1, 2, 3]
+    assert service.locate_social_preview_asset() is None
+    assert "versioned SVG file matching the social-preview naming contract" in failures[0].actual
+
+
+def test_dmc_989_service_requires_export_sizes_inside_social_preview_guidance_section(
+    tmp_path: Path,
+) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        include_export_sizes=False,
+        playbook_extra_sections=[
+            "### Release checklist",
+            "",
+            "- Export screenshots at 1280x640 minimum.",
+            "- Archive masters at 2560x1280 recommended.",
+        ],
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    failures = service.validate()
+
+    assert [failure.step for failure in failures] == [4]
+    assert "### Social preview asset guidance" in failures[0].actual
+    assert "### Release checklist" not in failures[0].actual
+
+
 def _build_fixture_repository(
     tmp_path: Path,
     *,
-    svg_fill: str,
+    svg_fill: str = "#F8FAFC",
     include_export_sizes: bool,
+    include_social_preview_asset: bool = True,
+    social_preview_asset_path: str = "assets/social-preview.v1.svg",
+    extra_svg_files: dict[str, list[str]] | None = None,
+    playbook_extra_sections: list[str] | None = None,
 ) -> Path:
     repository_root = tmp_path / "repo"
     repository_root.mkdir()
 
-    social_preview_path = repository_root / "assets/social-preview.v1.svg"
-    social_preview_path.parent.mkdir(parents=True, exist_ok=True)
-    social_preview_path.write_text(
-        "\n".join(
-            [
-                '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640">',
-                '  <rect width="1280" height="640" fill="#0F172A" />',
-                '  <path d="M96 112 H1184 M96 176 H1184" stroke="#94A3B8" stroke-width="4" opacity="0.18" />',
-                f'  <text x="96" y="280" fill="{svg_fill}" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
-                '  <text x="96" y="360" fill="#E2E8F0" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
-                "</svg>",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
+    if include_social_preview_asset:
+        social_preview_path = repository_root / social_preview_asset_path
+        social_preview_path.parent.mkdir(parents=True, exist_ok=True)
+        social_preview_path.write_text(
+            "\n".join(
+                [
+                    '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640">',
+                    '  <rect width="1280" height="640" fill="#0F172A" />',
+                    '  <path d="M96 112 H1184 M96 176 H1184" stroke="#94A3B8" stroke-width="4" opacity="0.18" />',
+                    f'  <text x="96" y="280" fill="{svg_fill}" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
+                    '  <text x="96" y="360" fill="#E2E8F0" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
+                    "</svg>",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    if extra_svg_files:
+        for relative_path, lines in extra_svg_files.items():
+            asset_path = repository_root / relative_path
+            asset_path.parent.mkdir(parents=True, exist_ok=True)
+            asset_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     playbook_path = (
         repository_root
@@ -107,5 +173,7 @@ def _build_fixture_repository(
                 "- Export a PNG at 2560x1280 recommended.",
             ]
         )
+    if playbook_extra_sections:
+        playbook_lines.extend(["", *playbook_extra_sections])
     playbook_path.write_text("\n".join(playbook_lines) + "\n", encoding="utf-8")
     return repository_root

--- a/testing/tests/DMC-989/test_dmc_989.py
+++ b/testing/tests/DMC-989/test_dmc_989.py
@@ -19,7 +19,7 @@ def test_dmc_989_social_preview_svg_and_playbook_meet_repository_standards() -> 
 def test_dmc_989_service_accepts_a_compliant_social_preview_fixture(tmp_path: Path) -> None:
     repository_root = _build_fixture_repository(
         tmp_path,
-        svg_fill="#F8FAFC",
+        text_fill="#F8FAFC",
         include_export_sizes=True,
     )
 
@@ -43,7 +43,7 @@ def test_dmc_989_service_reports_missing_export_guidance_and_low_contrast_text(
 ) -> None:
     repository_root = _build_fixture_repository(
         tmp_path,
-        svg_fill="#475569",
+        text_fill="#475569",
         include_export_sizes=False,
     )
 
@@ -113,15 +113,39 @@ def test_dmc_989_service_requires_export_sizes_inside_social_preview_guidance_se
     assert "### Release checklist" not in failures[0].actual
 
 
+def test_dmc_989_service_resolves_inherited_text_fill_for_contrast(tmp_path: Path) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        text_fill="#F8FAFC",
+        include_export_sizes=True,
+        inherit_text_fill=True,
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    failures = service.validate()
+    asset_path = service.locate_social_preview_asset()
+
+    assert failures == [], service.format_failures(failures)
+    assert asset_path is not None
+    observation = service.inspect_asset(asset_path)
+    assert [item.fill_hex for item in observation.text_contrast_observations] == [
+        "#F8FAFC",
+        "#F8FAFC",
+    ]
+    assert all(item.contrast_ratio >= 4.5 for item in observation.text_contrast_observations)
+
+
 def _build_fixture_repository(
     tmp_path: Path,
     *,
-    svg_fill: str = "#F8FAFC",
+    text_fill: str = "#F8FAFC",
     include_export_sizes: bool,
     include_social_preview_asset: bool = True,
     social_preview_asset_path: str = "assets/social-preview.v1.svg",
     extra_svg_files: dict[str, list[str]] | None = None,
     playbook_extra_sections: list[str] | None = None,
+    inherit_text_fill: bool = False,
 ) -> Path:
     repository_root = tmp_path / "repo"
     repository_root.mkdir()
@@ -129,14 +153,24 @@ def _build_fixture_repository(
     if include_social_preview_asset:
         social_preview_path = repository_root / social_preview_asset_path
         social_preview_path.parent.mkdir(parents=True, exist_ok=True)
+        text_lines = [
+            f'  <text x="96" y="280" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
+            '  <text x="96" y="360" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
+        ]
+        if inherit_text_fill:
+            text_block = [f'  <g fill="{text_fill}">', *[f"    {line.strip()}" for line in text_lines], "  </g>"]
+        else:
+            text_block = [
+                f'  <text x="96" y="280" fill="{text_fill}" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
+                '  <text x="96" y="360" fill="#E2E8F0" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
+            ]
         social_preview_path.write_text(
             "\n".join(
                 [
                     '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640">',
                     '  <rect width="1280" height="640" fill="#0F172A" />',
                     '  <path d="M96 112 H1184 M96 176 H1184" stroke="#94A3B8" stroke-width="4" opacity="0.18" />',
-                    f'  <text x="96" y="280" fill="{svg_fill}" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
-                    '  <text x="96" y="360" fill="#E2E8F0" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
+                    *text_block,
                     "</svg>",
                     "",
                 ]

--- a/testing/tests/DMC-989/test_dmc_989.py
+++ b/testing/tests/DMC-989/test_dmc_989.py
@@ -1,0 +1,111 @@
+from pathlib import Path
+
+from testing.components.services.social_preview_asset_service import (
+    SocialPreviewAssetService,
+)
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dmc_989_social_preview_svg_and_playbook_meet_repository_standards() -> None:
+    service = SocialPreviewAssetService(REPOSITORY_ROOT)
+
+    failures = service.validate()
+
+    assert not failures, service.format_failures(failures)
+
+
+def test_dmc_989_service_accepts_a_compliant_social_preview_fixture(tmp_path: Path) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        svg_fill="#F8FAFC",
+        include_export_sizes=True,
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    failures = service.validate()
+    asset_path = service.locate_social_preview_asset()
+
+    assert failures == [], service.format_failures(failures)
+    assert asset_path is not None
+    observation = service.inspect_asset(asset_path)
+    assert service.relative_path(observation.asset_path) == "assets/social-preview.v1.svg"
+    assert observation.hero_fill_hex == "#0F172A"
+    assert observation.wordmark_texts == ("DMTools",)
+    assert observation.decorative_background_count == 1
+    assert all(item.contrast_ratio >= 4.5 for item in observation.text_contrast_observations)
+
+
+def test_dmc_989_service_reports_missing_export_guidance_and_low_contrast_text(
+    tmp_path: Path,
+) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        svg_fill="#475569",
+        include_export_sizes=False,
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    failures = service.validate()
+    failure_message = service.format_failures(failures)
+
+    assert [failure.step for failure in failures] == [3, 4]
+    assert "below the required 4.5:1 contrast ratio" in failure_message
+    assert "'DMTools' (#475569)" in failure_message
+    assert "1280x640 minimum and 2560x1280 recommended" in failure_message
+
+
+def _build_fixture_repository(
+    tmp_path: Path,
+    *,
+    svg_fill: str,
+    include_export_sizes: bool,
+) -> Path:
+    repository_root = tmp_path / "repo"
+    repository_root.mkdir()
+
+    social_preview_path = repository_root / "assets/social-preview.v1.svg"
+    social_preview_path.parent.mkdir(parents=True, exist_ok=True)
+    social_preview_path.write_text(
+        "\n".join(
+            [
+                '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640">',
+                '  <rect width="1280" height="640" fill="#0F172A" />',
+                '  <path d="M96 112 H1184 M96 176 H1184" stroke="#94A3B8" stroke-width="4" opacity="0.18" />',
+                f'  <text x="96" y="280" fill="{svg_fill}" font-size="96" font-family="Inter, sans-serif">DMTools</text>',
+                '  <text x="96" y="360" fill="#E2E8F0" font-size="40" font-family="Inter, sans-serif">Enterprise dark-factory orchestrator</text>',
+                "</svg>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    playbook_path = (
+        repository_root
+        / "dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md"
+    )
+    playbook_path.parent.mkdir(parents=True, exist_ok=True)
+    playbook_lines = [
+        "# GitHub Repository Discoverability Playbook",
+        "",
+        "### Social preview asset guidance",
+        "",
+        "- Use a dark, high-contrast base with light text.",
+        "- Keep the text to the product name plus one short positioning line only.",
+        "- Preferred value line: `Enterprise dark-factory orchestrator`.",
+        "- Use at most one restrained accent colour.",
+        "- Any text rendered into the image must meet WCAG AA contrast guidance.",
+    ]
+    if include_export_sizes:
+        playbook_lines.extend(
+            [
+                "- Export a PNG at 1280x640 minimum.",
+                "- Export a PNG at 2560x1280 recommended.",
+            ]
+        )
+    playbook_path.write_text("\n".join(playbook_lines) + "\n", encoding="utf-8")
+    return repository_root


### PR DESCRIPTION
## Test Automation Result

**Status:** ❌ FAILED  
**Test Case:** DMC-989 — Validate social preview asset and visual quality — SVG source and contrast compliance

## What was automated
- Added `testing/tests/DMC-989/test_dmc_989.py` and `testing/components/services/social_preview_asset_service.py`.
- Automated the live repository audit for a committed social-preview SVG source, required visual composition, WCAG AA text contrast, and the playbook’s PNG export guidance.
- Added two synthetic fixture checks so the SVG parsing and contrast logic are validated independently of the live repository content.

## Result
- Pytest result: **1 failed, 2 passed**.
- The live repository check failed because no committed SVG social-preview source asset exists anywhere in the checkout.
- Because the SVG source is missing, the composition and contrast requirements could not be verified on the real repository content.
- The playbook section `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md` is present, but it does not mention the required PNG export sizes: `1280x640` minimum and `2560x1280` recommended.

## Real user-style verification
- Searched the committed repository files the way a maintainer would and observed that there are no `.svg` files to review as the social-preview source.
- Read the visible “Social preview asset guidance” section in the playbook and observed that it includes contrast guidance but omits the export-size requirements.
- The observed repository state does not match the expected result.

## How to run
```bash
python3 -m pytest testing/tests/DMC-989/test_dmc_989.py -q -r a
```
