### PR TITLE
DMC-991 Canonical discoverability metadata uses outdated About text instead of approved CLI-first wording

### DIFF
--- a/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
+++ b/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
@@ -7,7 +7,7 @@ Use this page as the maintainer source of truth for repository discoverability u
 | Surface | Canonical value |
 |---|---|
 | Short description | `Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.` |
-| About text | `DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.` |
+| About text | `DMTools is a CLI-first orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.` |
 | GitHub topics | `dark-factory`, `delivery-automation`, `workflow-orchestration`, `platform-engineering`, `self-hosted`, `enterprise-ai`, `mcp`, `ai-agents`, `generative-ai`, `workflow-automation` |
 | Supporting release/package keywords | `dmtools`, `dark-factory`, `delivery-automation`, `workflow-orchestration`, `mcp`, `ai-agents`, `generative-ai`, `self-hosted`, `cursor`, `claude`, `codex`, `jira`, `azure-devops`, `github` |
 

--- a/dmtools-core/src/main/resources/github-repository-discoverability.json
+++ b/dmtools-core/src/main/resources/github-repository-discoverability.json
@@ -1,6 +1,6 @@
 {
   "shortDescription": "Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.",
-  "aboutText": "DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
+  "aboutText": "DMTools is a CLI-first orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
   "topics": [
     "dark-factory",
     "delivery-automation",

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java
@@ -30,8 +30,8 @@ public class GitHubRepositoryDiscoverabilityTest {
                 "Enterprise dark-factory orchestrator for automating delivery workflows across trackers, source control, documentation, design systems, AI providers, and CI/CD.",
                 metadata.getShortDescription()
         );
-        assertEquals(
-                "DMTools is the orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
+         assertEquals(
+                "DMTools is a CLI-first orchestration layer for enterprise dark factories: a self-hosted CLI with MCP tools, jobs, and AI agents for delivery workflows across Jira, GitHub, Azure DevOps, documentation, design systems, and CI/CD.",
                 metadata.getAboutText()
         );
     }


### PR DESCRIPTION
# Result

The bug is fixed by updating the canonical discoverability About text to the approved `CLI-first orchestration layer` wording and syncing the maintainer playbook to the same value.

## RCA summary

The failing scenario was caused by stale repository-backed metadata content, not by code behavior. The canonical JSON still said `DMTools is the orchestration layer...`, while the linked DMC-986 test requires `DMTools is a CLI-first orchestration layer...`. The playbook also needed the same update because it is validated against the canonical JSON.

## Fix description

- Updated `dmtools-core/src/main/resources/github-repository-discoverability.json`
- Updated `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md`
- Updated `dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubRepositoryDiscoverabilityTest.java` to assert the approved wording

## Test coverage

- Reproduced failure with `PYTHONPATH=. python3 -m pytest testing/tests/DMC-986/test_dmc_986.py -q`
- Reproduced failure with `./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.github.GitHubRepositoryDiscoverabilityTest.testLoadDefaultReturnsCanonicalRepositoryCopy"`
- Verified fix with `PYTHONPATH=. python3 -m pytest testing/tests/DMC-986/test_dmc_986.py -q`
- Verified no core regressions with `./gradlew :dmtools-core:test`

## Notes

The requested repo-root `instruction.md` file was not present, so the ticket inputs were taken from `input/DMC-991/`.
