### PR TITLE
DMC-992 Repository lacks versioned social-preview SVG and required PNG export guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ node_modules
 package.json
 package-lock.json
 .agentic-config
+.repo-sandboxes/
 dmtools-core/temp
 dmtools-core/cacheTestableJiraClient
 .gradle-tmp

--- a/assets/social-preview.v1.svg
+++ b/assets/social-preview.v1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title desc">
+  <title id="title">DMTools social preview</title>
+  <desc id="desc">Dark hero card with the DMTools wordmark and a subtle industrial background grid.</desc>
+  <rect width="1280" height="640" fill="#0F172A" />
+  <g stroke-width="4">
+    <path d="M88 132H1192" stroke="#38BDF8" opacity="0.18" />
+    <path d="M88 196H1192" stroke="#38BDF8" opacity="0.18" />
+    <path d="M980 104V536" stroke="#38BDF8" opacity="0.18" />
+  </g>
+  <g fill="#F8FAFC" font-family="Inter, Arial, sans-serif">
+    <text x="96" y="296" font-size="96" font-weight="700">DMTools</text>
+    <text x="96" y="372" font-size="40" fill="#E2E8F0">Enterprise dark-factory orchestrator</text>
+  </g>
+</svg>

--- a/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
+++ b/dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md
@@ -32,6 +32,8 @@ These settings are not stored in the repository and must be applied in the GitHu
 - Preferred value line: `Enterprise dark-factory orchestrator`.
 - Use at most one restrained accent colour.
 - Any text rendered into the image must meet WCAG AA contrast guidance.
+- Export a PNG at 1280x640 minimum.
+- Export a PNG at 2560x1280 recommended.
 - Do not use screenshots, integration collages, or feature-list text in the image.
 
 ## Repo-backed files that must stay aligned

--- a/testing/components/services/social_preview_asset_service.py
+++ b/testing/components/services/social_preview_asset_service.py
@@ -58,6 +58,7 @@ class SocialPreviewAssetService:
         ".git",
         ".gradle",
         ".idea",
+        ".repo-sandboxes",
         ".pytest_cache",
         "__pycache__",
         "build",

--- a/testing/tests/DMC-989/test_dmc_989.py
+++ b/testing/tests/DMC-989/test_dmc_989.py
@@ -136,6 +136,38 @@ def test_dmc_989_service_resolves_inherited_text_fill_for_contrast(tmp_path: Pat
     assert all(item.contrast_ratio >= 4.5 for item in observation.text_contrast_observations)
 
 
+def test_dmc_989_service_ignores_repo_sandbox_svg_candidates(tmp_path: Path) -> None:
+    repository_root = _build_fixture_repository(
+        tmp_path,
+        text_fill="#F8FAFC",
+        include_export_sizes=True,
+    )
+    sandbox_asset = (
+        repository_root
+        / ".repo-sandboxes/dmc-897-el4mhgbe/workspace/assets/social-preview.v1.svg"
+    )
+    sandbox_asset.parent.mkdir(parents=True, exist_ok=True)
+    sandbox_asset.write_text(
+        "\n".join(
+            [
+                '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640">',
+                '  <rect width="1280" height="640" fill="#0F172A" />',
+                '  <text x="96" y="280" fill="#F8FAFC">DMTools</text>',
+                "</svg>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    service = SocialPreviewAssetService(repository_root)
+
+    asset_path = service.locate_social_preview_asset()
+
+    assert asset_path is not None
+    assert service.relative_path(asset_path) == "assets/social-preview.v1.svg"
+
+
 def _build_fixture_repository(
     tmp_path: Path,
     *,


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The repository was missing the canonical versioned social preview SVG source, and the discoverability playbook's `Social preview asset guidance` section did not include the required PNG export sizes. In this shared workspace, validation could also pick up temporary `.repo-sandboxes/` SVG files before the real asset because sandbox directories were not excluded from SVG discovery.

### Fix
Added `assets/social-preview.v1.svg` with the required dark hero card, DMTools wordmark, subtle industrial background, and high-contrast text. Updated `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md` to document `1280x640` minimum and `2560x1280` recommended PNG exports. Hardened `testing/components/services/social_preview_asset_service.py` to ignore `.repo-sandboxes/` and added regression coverage in `testing/tests/DMC-989/test_dmc_989.py` so temporary workspace assets cannot shadow the committed source asset.

### Test Coverage
- Reproduction test passed: `testing/tests/DMC-989/test_dmc_989.py` — `test_dmc_989_social_preview_svg_and_playbook_meet_repository_standards`
- Regression test added: `testing/tests/DMC-989/test_dmc_989.py` — `test_dmc_989_service_ignores_repo_sandbox_svg_candidates`
- `./gradlew :dmtools-core:test` — PASSED
- `python3 -m pytest testing/tests -q -r a` — 14 failed, 161 passed; failures are pre-existing and unrelated to this bug (for example DMC-893, DMC-899, DMC-902, DMC-903, DMC-906, DMC-910, DMC-911, DMC-933, DMC-940, DMC-987)

### Notes
Added `.repo-sandboxes/` to `.gitignore` so temporary sandbox workspaces are not staged with repository changes.
