### PR TITLE
DMC-993 CONTRIBUTING.md does not provide a clickable Markdown link to the maintainer playbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ cp dmtools.env.example dmtools.env
 
 ## Maintainer discoverability checklist
 
-For repository positioning, GitHub About metadata, release-facing keyword alignment, and the split between repo-backed updates and manual GitHub settings, use the canonical playbook in `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md`.
+For repository positioning, GitHub About metadata, release-facing keyword alignment, and the split between repo-backed updates and manual GitHub settings, use the canonical playbook in [github-repository-discoverability-playbook.md](dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md).
 
 ## Adding a New MCP Tool
 


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`CONTRIBUTING.md` referenced the maintainer discoverability playbook as inline code instead of a Markdown link under `## Maintainer discoverability checklist`. The repository validation service only accepts an actual Markdown link to `dmtools-ai-docs/references/workflows/github-repository-discoverability-playbook.md`, so step 2 of the linked regression test failed even though the README link and playbook sections were already correct.

### Fix
Updated `CONTRIBUTING.md` to replace the inline-code playbook path with a clickable Markdown link to the canonical playbook, preserving the existing maintainer guidance and matching the entry-point format already used in `README.md`.

### Test Coverage
- Reproduction test used: `testing/tests/DMC-987/test_dmc_987.py::test_dmc_987_maintainer_playbook_entry_points_and_sections_are_kept_in_sync`
- Linked test file: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-987/test_dmc_987.py -q` — PASSED
- Full suite: `./gradlew :dmtools-core:test` — PASSED

### Notes
- `instruction.md` was not present at the repository root, so implementation proceeded from the ticket bundle plus the reproduced failing test.
