### PR TITLE
DMC-997 Test: Verify deprecated workflow output — standalone and server workflows emit internal-only notices

### DIFF
--- a/testing/components/services/deprecated_workflow_output_service.py
+++ b/testing/components/services/deprecated_workflow_output_service.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class WorkflowOutputSurface:
+    workflow_path: str
+    surface_name: str
+    source: str
+    content: str
+
+
+@dataclass(frozen=True)
+class WorkflowOutputFinding:
+    workflow_path: str
+    surface_name: str
+    summary: str
+    expected: str
+    actual: str
+
+
+class DeprecatedWorkflowOutputService:
+    REQUIRED_NOTICE_PATTERN = re.compile(r"\b(?:deprecated|internal[- ]only)\b", re.IGNORECASE)
+    FORBIDDEN_REFERENCE_PATTERNS = (
+        ("Flutter external release reference", re.compile(r"istin/dmtools-flutter", re.IGNORECASE)),
+        ("Swagger guidance reference", re.compile(r"\bswagger\b", re.IGNORECASE)),
+        ("localhost login guidance reference", re.compile(r"\blocalhost\b", re.IGNORECASE)),
+    )
+    CUSTOMER_FACING_INSTALL_PATTERNS = (
+        (
+            "customer-facing install heading",
+            re.compile(r"supported public install(?:ation)? paths?", re.IGNORECASE),
+        ),
+        (
+            "customer-facing install command",
+            re.compile(r"curl\s+-fsSL\s+https://github\.com/.+/install\.sh", re.IGNORECASE),
+        ),
+        (
+            "Windows installer command",
+            re.compile(r"\binstall\.ps1\b", re.IGNORECASE),
+        ),
+        (
+            "agent skill install command",
+            re.compile(r"\bskill-install\.sh\b", re.IGNORECASE),
+        ),
+    )
+    STEP_SUMMARY_ECHO_PATTERN = re.compile(
+        r"""^\s*echo\s+("([^"\\]|\\.)*"|'[^']*')\s*>>\s*\$GITHUB_STEP_SUMMARY\s*$"""
+    )
+
+    def __init__(
+        self,
+        *,
+        workflow_paths: Iterable[str],
+        owner: str = "epam",
+        repo: str = "dm.ai",
+        ref: str = "main",
+        repository_root: Path | None = None,
+        workflow_text_by_path: dict[str, str] | None = None,
+    ) -> None:
+        self.workflow_paths = tuple(workflow_paths)
+        self.owner = owner
+        self.repo = repo
+        self.ref = ref
+        self.repository_root = repository_root
+        self.workflow_text_by_path = dict(workflow_text_by_path or {})
+
+    def output_surfaces(self) -> list[WorkflowOutputSurface]:
+        surfaces: list[WorkflowOutputSurface] = []
+        for workflow_path in self.workflow_paths:
+            source_label, workflow_text = self._load_workflow_text(workflow_path)
+
+            release_body = self._extract_release_body(workflow_text)
+            if release_body:
+                surfaces.append(
+                    WorkflowOutputSurface(
+                        workflow_path=workflow_path,
+                        surface_name="release body",
+                        source=source_label,
+                        content=release_body,
+                    )
+                )
+
+            step_summary = self._extract_step_summary(workflow_text)
+            if step_summary:
+                surfaces.append(
+                    WorkflowOutputSurface(
+                        workflow_path=workflow_path,
+                        surface_name="step summary",
+                        source=source_label,
+                        content=step_summary,
+                    )
+                )
+
+        return surfaces
+
+    def audit(self) -> list[WorkflowOutputFinding]:
+        findings: list[WorkflowOutputFinding] = []
+        for surface in self.output_surfaces():
+            findings.extend(self._audit_surface(surface))
+        return findings
+
+    def human_observations(self) -> list[str]:
+        observations: list[str] = []
+        surfaces = self.output_surfaces()
+        surfaced_workflows = {surface.workflow_path for surface in surfaces}
+
+        for workflow_path in self.workflow_paths:
+            matching_surfaces = [surface for surface in surfaces if surface.workflow_path == workflow_path]
+            if matching_surfaces:
+                for surface in matching_surfaces:
+                    observations.append(
+                        f"{workflow_path} {surface.surface_name} visible content: "
+                        f"{self._preview_text(surface.content)}"
+                    )
+            elif workflow_path not in surfaced_workflows:
+                observations.append(
+                    f"{workflow_path} does not define a release body or step summary, so it does not "
+                    "publish a customer-facing workflow message by itself."
+                )
+
+        return observations
+
+    @staticmethod
+    def format_findings(findings: list[WorkflowOutputFinding]) -> str:
+        lines = [
+            "Deprecated workflow outputs still publish customer-facing or legacy messaging:"
+        ]
+        for finding in findings:
+            lines.append(f"- {finding.workflow_path} [{finding.surface_name}] {finding.summary}")
+            lines.append(f"  Expected: {finding.expected}")
+            lines.append(f"  Actual: {finding.actual}")
+        return "\n".join(lines)
+
+    def _audit_surface(self, surface: WorkflowOutputSurface) -> list[WorkflowOutputFinding]:
+        findings: list[WorkflowOutputFinding] = []
+
+        if not self.REQUIRED_NOTICE_PATTERN.search(surface.content):
+            findings.append(
+                WorkflowOutputFinding(
+                    workflow_path=surface.workflow_path,
+                    surface_name=surface.surface_name,
+                    summary="is missing an explicit deprecated/internal-only notice.",
+                    expected=(
+                        "The published output should clearly position the workflow as deprecated or "
+                        "internal-only."
+                    ),
+                    actual=self._preview_text(surface.content),
+                )
+            )
+
+        findings.extend(
+            self._find_pattern_matches(
+                surface,
+                self.FORBIDDEN_REFERENCE_PATTERNS,
+                expected=(
+                    "The published output must not mention Flutter external releases, Swagger guidance, "
+                    "or localhost login instructions."
+                ),
+            )
+        )
+        findings.extend(
+            self._find_pattern_matches(
+                surface,
+                self.CUSTOMER_FACING_INSTALL_PATTERNS,
+                expected=(
+                    "The published output must not include customer-facing installation headings or "
+                    "actionable install commands."
+                ),
+            )
+        )
+        return findings
+
+    def _find_pattern_matches(
+        self,
+        surface: WorkflowOutputSurface,
+        patterns: tuple[tuple[str, re.Pattern[str]], ...],
+        *,
+        expected: str,
+    ) -> list[WorkflowOutputFinding]:
+        findings: list[WorkflowOutputFinding] = []
+        for label, pattern in patterns:
+            match = self._first_matching_line(surface.content, pattern)
+            if match is None:
+                continue
+            findings.append(
+                WorkflowOutputFinding(
+                    workflow_path=surface.workflow_path,
+                    surface_name=surface.surface_name,
+                    summary=f"still contains {label}.",
+                    expected=expected,
+                    actual=match,
+                )
+            )
+        return findings
+
+    def _load_workflow_text(self, workflow_path: str) -> tuple[str, str]:
+        if workflow_path in self.workflow_text_by_path:
+            return f"in-memory:{workflow_path}", self.workflow_text_by_path[workflow_path]
+
+        if self.repository_root is not None:
+            local_path = self.repository_root / workflow_path
+            return local_path.as_posix(), local_path.read_text(encoding="utf-8")
+
+        raw_url = (
+            f"https://raw.githubusercontent.com/{self.owner}/{self.repo}/{self.ref}/{workflow_path}"
+        )
+        request = Request(
+            raw_url,
+            headers={"User-Agent": "dm-ai-testing-deprecated-workflow-audit"},
+        )
+        with urlopen(request, timeout=30) as response:
+            return raw_url, response.read().decode("utf-8")
+
+    @staticmethod
+    def _extract_release_body(workflow_text: str) -> str:
+        literal_block = DeprecatedWorkflowOutputService._extract_literal_block(workflow_text, "body")
+        if literal_block:
+            return literal_block
+        return DeprecatedWorkflowOutputService._extract_release_notes_heredoc(workflow_text)
+
+    def _extract_step_summary(self, workflow_text: str) -> str:
+        lines: list[str] = []
+        for workflow_line in workflow_text.splitlines():
+            match = self.STEP_SUMMARY_ECHO_PATTERN.match(workflow_line)
+            if not match:
+                continue
+            lines.append(self._decode_shell_string(match.group(1)))
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _extract_literal_block(workflow_text: str, key: str) -> str:
+        lines = workflow_text.splitlines()
+        key_pattern = re.compile(rf"^\s*{re.escape(key)}:\s*\|\s*$")
+
+        for index, line in enumerate(lines):
+            if not key_pattern.match(line):
+                continue
+
+            content_indent: int | None = None
+            block_lines: list[str] = []
+
+            for candidate in lines[index + 1 :]:
+                if content_indent is None:
+                    if not candidate.strip():
+                        continue
+                    content_indent = len(candidate) - len(candidate.lstrip(" "))
+
+                if candidate.strip():
+                    current_indent = len(candidate) - len(candidate.lstrip(" "))
+                    if current_indent < content_indent:
+                        break
+                    block_lines.append(candidate[content_indent:])
+                else:
+                    block_lines.append("")
+
+            return "\n".join(block_lines).strip()
+
+        return ""
+
+    @staticmethod
+    def _extract_release_notes_heredoc(workflow_text: str) -> str:
+        lines = workflow_text.splitlines()
+
+        for index, line in enumerate(lines):
+            if "cat > release_notes.md << EOF" not in line:
+                continue
+
+            block_lines: list[str] = []
+            for candidate in lines[index + 1 :]:
+                if candidate.strip() == "EOF":
+                    break
+                block_lines.append(candidate)
+            return "\n".join(block_lines).strip()
+
+        return ""
+
+    @staticmethod
+    def _decode_shell_string(token: str) -> str:
+        if token.startswith("'") and token.endswith("'"):
+            return token[1:-1]
+        value = token[1:-1]
+        return (
+            value.replace(r"\\", "\\")
+            .replace(r"\"", '"')
+            .replace(r"\`", "`")
+            .replace(r"\$", "$")
+        )
+
+    @staticmethod
+    def _first_matching_line(content: str, pattern: re.Pattern[str]) -> str | None:
+        for line in content.splitlines():
+            if pattern.search(line):
+                return line.strip()
+        return None
+
+    @staticmethod
+    def _preview_text(content: str, limit: int = 220) -> str:
+        normalized = re.sub(r"\s+", " ", content).strip()
+        if len(normalized) <= limit:
+            return normalized
+        return normalized[: limit - 3] + "..."

--- a/testing/tests/DMC-997/README.md
+++ b/testing/tests/DMC-997/README.md
@@ -1,0 +1,30 @@
+# DMC-997 automated test
+
+This test audits the live `main`-branch workflow output definitions for the
+deprecated standalone/server packaging flows in `epam/dm.ai`. It inspects only
+published output surfaces (release bodies and GitHub step summaries), then
+verifies that they include a deprecated/internal-only notice and do not include
+customer-facing install guidance or legacy Flutter/Swagger/localhost references.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-997/test_dmc_997.py -q
+```
+
+## Environment
+
+No credentials are required. The live test fetches the public workflow files
+from `https://raw.githubusercontent.com/epam/dm.ai/main/...`.
+
+## Expected passing output
+
+```text
+4 passed
+```

--- a/testing/tests/DMC-997/config.yaml
+++ b/testing/tests/DMC-997/config.yaml
@@ -1,0 +1,12 @@
+test_id: DMC-997
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+ref: main
+workflow_paths:
+  - .github/workflows/package-standalone.yml
+  - .github/workflows/standalone-release.yml
+  - .github/workflows/standalone-release-auto.yml

--- a/testing/tests/DMC-997/test_dmc_997.py
+++ b/testing/tests/DMC-997/test_dmc_997.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.deprecated_workflow_output_service import (  # noqa: E402
+    DeprecatedWorkflowOutputService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+WORKFLOW_PATHS = tuple(str(path) for path in CONFIG["workflow_paths"])
+
+
+def build_live_service() -> DeprecatedWorkflowOutputService:
+    return DeprecatedWorkflowOutputService(
+        workflow_paths=WORKFLOW_PATHS,
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        ref=str(CONFIG["ref"]),
+    )
+
+
+def test_dmc_997_live_deprecated_workflow_outputs_are_internal_only() -> None:
+    service = build_live_service()
+
+    findings = service.audit()
+
+    assert not findings, service.format_findings(findings)
+
+
+def test_dmc_997_service_ignores_internal_flutter_fetch_logic_when_it_is_not_published() -> None:
+    service = DeprecatedWorkflowOutputService(
+        workflow_paths=(".github/workflows/package-standalone.yml",),
+        workflow_text_by_path={
+            ".github/workflows/package-standalone.yml": """
+name: Package Standalone (Reusable)
+jobs:
+  package:
+    steps:
+      - name: Download Flutter SPA Release
+        run: |
+          curl -s https://api.github.com/repos/IstiN/dmtools-flutter/releases/latest
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+""".strip()
+        },
+    )
+
+    assert service.output_surfaces() == []
+    assert service.audit() == []
+
+
+def test_dmc_997_service_accepts_a_deprecated_internal_only_release_body_without_install_guidance() -> None:
+    service = DeprecatedWorkflowOutputService(
+        workflow_paths=(".github/workflows/standalone-release-auto.yml",),
+        workflow_text_by_path={
+            ".github/workflows/standalone-release-auto.yml": """
+jobs:
+  release:
+    steps:
+      - name: Create Release
+        with:
+          body: |
+            # Internal packaging note
+
+            > **Deprecated / internal-only workflow.**
+            > Standalone artifacts remain available only for compatibility testing.
+
+            Do not use this workflow output as product installation guidance.
+""".strip()
+        },
+    )
+
+    assert service.audit() == []
+
+
+def test_dmc_997_service_reports_customer_facing_install_guidance_and_swagger_mentions() -> None:
+    service = DeprecatedWorkflowOutputService(
+        workflow_paths=(".github/workflows/standalone-release.yml",),
+        workflow_text_by_path={
+            ".github/workflows/standalone-release.yml": """
+jobs:
+  release:
+    steps:
+      - name: Create Release
+        with:
+          body: |
+            > **Deprecated / internal-only workflow.**
+            ## Supported public install paths
+            curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
+            Do not copy Swagger guidance from legacy standalone docs.
+      - name: Summarize release
+        run: |
+          echo "**Positioning:** Deprecated/internal-only packaging workflow" >> $GITHUB_STEP_SUMMARY
+          echo "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash" >> $GITHUB_STEP_SUMMARY
+""".strip()
+        },
+    )
+
+    findings = service.audit()
+
+    assert len(findings) == 4
+    assert any("customer-facing install heading" in finding.summary for finding in findings)
+    assert any("customer-facing install command" in finding.summary for finding in findings)
+    assert any("Swagger guidance reference" in finding.summary for finding in findings)


### PR DESCRIPTION
# DMC-997 test automation result: FAILED

**Automation summary:** `3 passed, 1 failed`  
**Executed test:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-997/test_dmc_997.py -q`

## What automation checked

- Added a pytest audit in `testing/tests/DMC-997/test_dmc_997.py`.
- Fetched the live `main`-branch workflow definitions for:
  - `https://raw.githubusercontent.com/epam/dm.ai/main/.github/workflows/package-standalone.yml`
  - `https://raw.githubusercontent.com/epam/dm.ai/main/.github/workflows/standalone-release.yml`
  - `https://raw.githubusercontent.com/epam/dm.ai/main/.github/workflows/standalone-release-auto.yml`
- Audited only published output surfaces (`release body` / `GITHUB_STEP_SUMMARY`), not internal implementation lines.
- Verified that deprecated workflows:
  - include an explicit deprecated/internal-only notice;
  - do not publish customer-facing install guidance;
  - do not mention Flutter external release links, Swagger guidance, or localhost login instructions.

## Human-style verification

Reviewed the visible workflow-output text a GitHub user would read from the deployed workflow definitions on `main`.

- `package-standalone.yml` has no release body or step summary, so it does not publish a customer-facing workflow message by itself.
- `standalone-release.yml` release body still shows `## ✅ Supported public installation paths`, `curl -fsSL .../install.sh | bash`, `irm .../install.ps1 | iex`, `curl -fsSL .../skill-install.sh | bash`, and a positioning note that still contains `Swagger`.
- `standalone-release.yml` step summary still shows `### ✅ Supported public install paths` plus install commands for `install.sh` and `skill-install.sh`.
- `standalone-release-auto.yml` release body still shows `## ✅ Supported public installation paths`, `install.sh`, `install.ps1`, and `skill-install.sh` commands.

**Observed result:** the outputs are labeled deprecated/internal-only, but they still publish customer-facing installation guidance, and one output still contains a Swagger reference.  
**Expected result:** deprecated workflow outputs should contain only internal-only/deprecated positioning and should suppress customer-facing install guidance plus legacy references.  
**Match:** No.

## Step-by-step outcome

1. **Open and trigger any of the following workflows:** `package-standalone.yml`, `standalone-release.yml`, or `standalone-release-auto.yml`  
   Opened the deployed workflow output definitions on `main`. The release-producing workflows were not dispatched because they create repository releases and assets as side effects. `package-standalone.yml` had no release body/step summary; `standalone-release.yml` and `standalone-release-auto.yml` exposed published output text. **PASS**
2. **Inspect the generated output (release body or step summary).**  
   `standalone-release.yml` and `standalone-release-auto.yml` still show public installation sections and installer commands in the output text. **FAIL**
3. **Check for references to `IstiN/dmtools-flutter`, Swagger guidance, or localhost login instructions.**  
   No published `IstiN/dmtools-flutter` or `localhost` string was found in the audited output surfaces, but `standalone-release.yml` release body still contains `Swagger`, and both live release outputs still include customer-facing installer commands. **FAIL**

## Failure details

```text
F...                                                                                                             [100%]
======================================================= FAILURES =======================================================
___________________________ test_dmc_997_live_deprecated_workflow_outputs_are_internal_only ____________________________

    def test_dmc_997_live_deprecated_workflow_outputs_are_internal_only() -> None:
        service = build_live_service()

        findings = service.audit()

>       assert not findings, service.format_findings(findings)
E       AssertionError: Deprecated workflow outputs still publish customer-facing or legacy messaging:
E         - .github/workflows/standalone-release.yml [release body] still contains Swagger guidance reference.
E           Expected: The published output must not mention Flutter external releases, Swagger guidance, or localhost login instructions.
E           Actual: - Do not copy standalone bundle, local-auth, Swagger, or external Flutter repository guidance into customer-facing release communication from this workflow.
E         - .github/workflows/standalone-release.yml [release body] still contains customer-facing install heading.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: ## ✅ Supported public installation paths
E         - .github/workflows/standalone-release.yml [release body] still contains customer-facing install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash
E         - .github/workflows/standalone-release.yml [release body] still contains Windows installer command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: irm https://github.com/${{ github.repository }}/releases/latest/download/install.ps1 | iex
E         - .github/workflows/standalone-release.yml [release body] still contains agent skill install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/skill-install.sh | bash
E         - .github/workflows/standalone-release.yml [step summary] still contains customer-facing install heading.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: ### ✅ Supported public install paths
E         - .github/workflows/standalone-release.yml [step summary] still contains customer-facing install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash
E         - .github/workflows/standalone-release.yml [step summary] still contains agent skill install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/skill-install.sh | bash
E         - .github/workflows/standalone-release-auto.yml [release body] still contains customer-facing install heading.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: ## ✅ Supported public installation paths
E         - .github/workflows/standalone-release-auto.yml [release body] still contains customer-facing install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash
E         - .github/workflows/standalone-release-auto.yml [release body] still contains Windows installer command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: irm https://github.com/${{ github.repository }}/releases/latest/download/install.ps1 | iex
E         - .github/workflows/standalone-release-auto.yml [release body] still contains agent skill install command.
E           Expected: The published output must not include customer-facing installation headings or actionable install commands.
E           Actual: curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/skill-install.sh | bash

testing/tests/DMC-997/test_dmc_997.py:36: AssertionError
=============================================== short test summary info ================================================
FAILED testing/tests/DMC-997/test_dmc_997.py::test_dmc_997_live_deprecated_workflow_outputs_are_internal_only
1 failed, 3 passed in 0.14s
```

## Environment

- OS: Linux
- Framework: pytest 8.x
- Repository: `epam/dm.ai`
- Branch audited: `main`
