### PR TITLE
DMC-995 Test: Execute stable release workflow — release notes contain only supported CLI and skill install paths

### DIFF
--- a/testing/components/factories/stable_release_install_paths_service_factory.py
+++ b/testing/components/factories/stable_release_install_paths_service_factory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from testing.components.services.stable_release_install_paths_service import (
+    StableReleaseInstallPathsService,
+)
+from testing.frameworks.api.rest.github_publication_gate_client import (
+    GitHubPublicationGateRestClient,
+)
+
+
+def create_stable_release_install_paths_service(
+    repository_root: Path,
+    *,
+    owner: str = "epam",
+    repo: str = "dm.ai",
+    workflow_file: str = "release.yml",
+    workflow_job_name: str = "create-unified-release",
+    release_limit: int = 10,
+    run_limit: int = 20,
+    max_run_match_seconds: int = StableReleaseInstallPathsService.DEFAULT_MAX_RUN_MATCH_SECONDS,
+    token: str | None = None,
+) -> StableReleaseInstallPathsService:
+    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    return StableReleaseInstallPathsService(
+        repository_root=repository_root,
+        github_client=GitHubPublicationGateRestClient(
+            owner=owner,
+            repo=repo,
+            token=github_token,
+        ),
+        owner=owner,
+        repo=repo,
+        workflow_file=workflow_file,
+        workflow_job_name=workflow_job_name,
+        release_limit=release_limit,
+        run_limit=run_limit,
+        max_run_match_seconds=max_run_match_seconds,
+    )

--- a/testing/components/services/stable_release_install_paths_service.py
+++ b/testing/components/services/stable_release_install_paths_service.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from testing.core.interfaces.stable_release_audit_client import StableReleaseAuditClient
+from testing.core.models.stable_release_install_paths_audit import (
+    ReleaseRecord,
+    StableReleaseInstallPathsAudit,
+    StableReleaseInstallPathsFailure,
+    WorkflowJobRecord,
+    WorkflowRunRecord,
+)
+
+
+class StableReleaseInstallPathsService:
+    RAW_GITHUB_PATTERN = re.compile(r"raw\.githubusercontent\.com", re.IGNORECASE)
+    UNSUPPORTED_SERVER_PATTERN = re.compile(r"dmtools-server", re.IGNORECASE)
+    STABLE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+    RELEASE_URL_PATTERN = re.compile(r"https://github\.com/epam/dm\.ai/releases/[^\s)`\"']+")
+    CLI_RELEASE_URL_PATTERN = re.compile(
+        r"https://github\.com/epam/dm\.ai/releases/"
+        r"(?:latest/download|download/v\d+\.\d+\.\d+)/install(?:\.sh|\.bat|\.ps1)?\b"
+    )
+    SKILL_RELEASE_URL_PATTERN = re.compile(
+        r"https://github\.com/epam/dm\.ai/releases/download/v\d+\.\d+\.\d+/skill-install(?:\.sh|\.ps1)\b"
+    )
+    DEFAULT_MAX_RUN_MATCH_SECONDS = 7200
+
+    def __init__(
+        self,
+        repository_root: Path,
+        github_client: StableReleaseAuditClient,
+        *,
+        owner: str = "epam",
+        repo: str = "dm.ai",
+        workflow_file: str = "release.yml",
+        workflow_job_name: str = "create-unified-release",
+        release_limit: int = 10,
+        run_limit: int = 20,
+        max_run_match_seconds: int = DEFAULT_MAX_RUN_MATCH_SECONDS,
+    ) -> None:
+        self.repository_root = repository_root
+        self.github_client = github_client
+        self.owner = owner
+        self.repo = repo
+        self.workflow_file = workflow_file
+        self.workflow_job_name = workflow_job_name
+        self.release_limit = release_limit
+        self.run_limit = run_limit
+        self.max_run_match_seconds = max_run_match_seconds
+
+    def audit(self) -> StableReleaseInstallPathsAudit:
+        failures: list[StableReleaseInstallPathsFailure] = []
+
+        release = self._latest_stable_release()
+        if release is None:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=1,
+                    summary="A stable GitHub release was not available for verification.",
+                    expected=(
+                        f"A recent non-draft, non-prerelease release in {self.owner}/{self.repo} "
+                        "with a semantic tag like v1.2.3."
+                    ),
+                    actual="No stable release was returned by the GitHub Releases API.",
+                )
+            )
+            return StableReleaseInstallPathsAudit(
+                release=None,
+                workflow_run=None,
+                workflow_job=None,
+                release_urls=(),
+                workflow_log_urls=(),
+                release_cli_urls=(),
+                release_skill_urls=(),
+                release_forbidden_lines=(),
+                workflow_log_forbidden_lines=(),
+                failures=tuple(failures),
+            )
+
+        release_urls = tuple(self.RELEASE_URL_PATTERN.findall(release.body))
+        release_cli_urls = tuple(self.CLI_RELEASE_URL_PATTERN.findall(release.body))
+        release_skill_urls = tuple(self.SKILL_RELEASE_URL_PATTERN.findall(release.body))
+        release_forbidden_lines = self._forbidden_lines(release.body)
+
+        if not release_cli_urls:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=2,
+                    summary="The live stable release body does not expose a supported CLI install path.",
+                    expected=(
+                        "At least one GitHub Releases asset URL for the CLI install flow, such as "
+                        "https://github.com/epam/dm.ai/releases/latest/download/install.sh."
+                    ),
+                    actual=self._preview(release.body),
+                )
+            )
+
+        if not release_skill_urls:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=3,
+                    summary="The live stable release body does not expose a supported skill install path.",
+                    expected=(
+                        "At least one GitHub Releases asset URL for the skill install flow, such as "
+                        "https://github.com/epam/dm.ai/releases/download/v1.2.3/skill-install.sh."
+                    ),
+                    actual=self._preview(release.body),
+                )
+            )
+
+        if release_forbidden_lines:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=4,
+                    summary="The live stable release body still references unsupported raw or server paths.",
+                    expected=(
+                        "Only supported GitHub Releases install URLs for CLI and skills, with no "
+                        "raw.githubusercontent.com or dmtools-server references."
+                    ),
+                    actual="\n".join(release_forbidden_lines),
+                )
+            )
+
+        workflow_run = self._matching_workflow_run(release)
+        if workflow_run is None:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=5,
+                    summary="A matching successful release workflow run could not be identified.",
+                    expected=(
+                        f"A successful {self.workflow_file} workflow_dispatch run on main close to "
+                        f"the release publication time for {release.tag_name}."
+                    ),
+                    actual=(
+                        f"No completed successful {self.workflow_file} run on main was found within "
+                        f"{self.max_run_match_seconds} seconds of {release.published_at}."
+                    ),
+                )
+            )
+            return StableReleaseInstallPathsAudit(
+                release=release,
+                workflow_run=None,
+                workflow_job=None,
+                release_urls=release_urls,
+                workflow_log_urls=(),
+                release_cli_urls=release_cli_urls,
+                release_skill_urls=release_skill_urls,
+                release_forbidden_lines=release_forbidden_lines,
+                workflow_log_forbidden_lines=(),
+                failures=tuple(failures),
+            )
+
+        workflow_job = self._workflow_job(workflow_run.run_id)
+        if workflow_job is None:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=6,
+                    summary="The matching release workflow run does not expose the unified-release job.",
+                    expected=(
+                        f"A job named {self.workflow_job_name!r} in the matching release workflow run."
+                    ),
+                    actual=(
+                        f"Run {workflow_run.run_id} did not include a job named "
+                        f"{self.workflow_job_name!r}."
+                    ),
+                )
+            )
+            return StableReleaseInstallPathsAudit(
+                release=release,
+                workflow_run=workflow_run,
+                workflow_job=None,
+                release_urls=release_urls,
+                workflow_log_urls=(),
+                release_cli_urls=release_cli_urls,
+                release_skill_urls=release_skill_urls,
+                release_forbidden_lines=release_forbidden_lines,
+                workflow_log_forbidden_lines=(),
+                failures=tuple(failures),
+            )
+
+        if "Summary" not in workflow_job.step_names:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=7,
+                    summary="The unified-release job is missing the user-visible Summary step.",
+                    expected="A job step named 'Summary' that writes the workflow summary.",
+                    actual=", ".join(workflow_job.step_names) or "No steps were reported for the job.",
+                )
+            )
+
+        workflow_log_urls = tuple(self.RELEASE_URL_PATTERN.findall(workflow_job.log_text))
+        workflow_log_forbidden_lines = self._forbidden_lines(workflow_job.log_text)
+
+        if workflow_log_forbidden_lines:
+            failures.append(
+                StableReleaseInstallPathsFailure(
+                    step=8,
+                    summary="The live release workflow evidence still references unsupported raw or server paths.",
+                    expected=(
+                        "Workflow evidence for the release should not contain raw.githubusercontent.com "
+                        "or dmtools-server references."
+                    ),
+                    actual="\n".join(workflow_log_forbidden_lines),
+                )
+            )
+
+        return StableReleaseInstallPathsAudit(
+            release=release,
+            workflow_run=workflow_run,
+            workflow_job=workflow_job,
+            release_urls=release_urls,
+            workflow_log_urls=workflow_log_urls,
+            release_cli_urls=release_cli_urls,
+            release_skill_urls=release_skill_urls,
+            release_forbidden_lines=release_forbidden_lines,
+            workflow_log_forbidden_lines=workflow_log_forbidden_lines,
+            failures=tuple(failures),
+        )
+
+    @staticmethod
+    def format_failures(
+        failures: tuple[StableReleaseInstallPathsFailure, ...]
+        | list[StableReleaseInstallPathsFailure],
+    ) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def human_observations(self, audit: StableReleaseInstallPathsAudit) -> list[str]:
+        observations: list[str] = []
+        if audit.release is None:
+            observations.append("No stable GitHub Release page was available to inspect.")
+            return observations
+
+        observations.append(
+            f"Release page opened at {audit.release.html_url} for {audit.release.tag_name}, "
+            f"published {audit.release.published_at}."
+        )
+        observations.append(
+            "Release page body visibly shows these install URLs: "
+            + (", ".join(audit.release_urls[:6]) if audit.release_urls else "none")
+        )
+        if audit.release_forbidden_lines:
+            observations.append(
+                "Release page body still shows unsupported markers: "
+                + " | ".join(audit.release_forbidden_lines)
+            )
+        else:
+            observations.append(
+                "Release page body did not show raw.githubusercontent.com or dmtools-server."
+            )
+
+        if audit.workflow_run is None:
+            observations.append("No matching release workflow run could be opened.")
+            return observations
+
+        observations.append(
+            f"Matching workflow run opened at {audit.workflow_run.html_url} "
+            f"({audit.workflow_run.status}/{audit.workflow_run.conclusion})."
+        )
+        if audit.workflow_job is None:
+            observations.append(
+                f"The workflow run did not expose the {self.workflow_job_name} job for inspection."
+            )
+            return observations
+
+        observations.append(
+            f"Unified release job visible at {audit.workflow_job.html_url} with steps: "
+            + ", ".join(audit.workflow_job.step_names)
+        )
+        if audit.workflow_log_forbidden_lines:
+            observations.append(
+                "Unified release job log still shows unsupported markers: "
+                + " | ".join(audit.workflow_log_forbidden_lines)
+            )
+        else:
+            observations.append(
+                "Unified release job log did not show raw.githubusercontent.com or dmtools-server."
+            )
+        return observations
+
+    def _latest_stable_release(self) -> ReleaseRecord | None:
+        for release_payload in self.github_client.list_releases(limit=self.release_limit):
+            tag_name = str(release_payload.get("tag_name") or "").strip()
+            if not tag_name or not self.STABLE_TAG_PATTERN.fullmatch(tag_name):
+                continue
+            if bool(release_payload.get("draft")) or bool(release_payload.get("prerelease")):
+                continue
+
+            assets = release_payload.get("assets") or []
+            asset_names = tuple(
+                str(asset.get("name") or "").strip()
+                for asset in assets
+                if isinstance(asset, dict) and str(asset.get("name") or "").strip()
+            )
+            return ReleaseRecord(
+                tag_name=tag_name,
+                html_url=str(release_payload.get("html_url") or "").strip(),
+                published_at=str(release_payload.get("published_at") or "").strip(),
+                body=str(release_payload.get("body") or ""),
+                asset_names=asset_names,
+            )
+        return None
+
+    def _matching_workflow_run(self, release: ReleaseRecord) -> WorkflowRunRecord | None:
+        release_published_at = self._parse_github_datetime(release.published_at)
+        candidates: list[tuple[float, WorkflowRunRecord]] = []
+
+        for run_payload in self.github_client.workflow_runs(
+            self.workflow_file,
+            branch="main",
+            event="workflow_dispatch",
+            status="completed",
+            limit=self.run_limit,
+        ):
+            if str(run_payload.get("conclusion") or "").lower() != "success":
+                continue
+
+            updated_at = str(run_payload.get("updated_at") or "").strip()
+            created_at = str(run_payload.get("created_at") or "").strip()
+            if not updated_at or not created_at:
+                continue
+
+            updated_at_dt = self._parse_github_datetime(updated_at)
+            distance_seconds = abs((updated_at_dt - release_published_at).total_seconds())
+            if distance_seconds > self.max_run_match_seconds:
+                continue
+
+            candidates.append(
+                (
+                    distance_seconds,
+                    WorkflowRunRecord(
+                        run_id=int(run_payload["id"]),
+                        html_url=str(run_payload.get("html_url") or "").strip(),
+                        status=str(run_payload.get("status") or "").strip(),
+                        conclusion=str(run_payload.get("conclusion") or "").strip(),
+                        created_at=created_at,
+                        updated_at=updated_at,
+                        head_branch=str(run_payload.get("head_branch") or "").strip(),
+                    ),
+                )
+            )
+
+        if not candidates:
+            return None
+
+        candidates.sort(key=lambda item: item[0])
+        return candidates[0][1]
+
+    def _workflow_job(self, run_id: int) -> WorkflowJobRecord | None:
+        for job_payload in self.github_client.workflow_jobs(run_id):
+            if str(job_payload.get("name") or "").strip() != self.workflow_job_name:
+                continue
+            step_names = tuple(
+                str(step.get("name") or "").strip()
+                for step in (job_payload.get("steps") or [])
+                if isinstance(step, dict) and str(step.get("name") or "").strip()
+            )
+            job_id = int(job_payload["id"])
+            return WorkflowJobRecord(
+                job_id=job_id,
+                name=self.workflow_job_name,
+                html_url=str(job_payload.get("html_url") or "").strip(),
+                step_names=step_names,
+                log_text=self.github_client.workflow_job_logs(job_id),
+            )
+        return None
+
+    def _forbidden_lines(self, text: str) -> tuple[str, ...]:
+        lines: list[str] = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if self.RAW_GITHUB_PATTERN.search(line) or self.UNSUPPORTED_SERVER_PATTERN.search(line):
+                lines.append(line)
+        return tuple(lines)
+
+    @staticmethod
+    def _preview(text: str, limit: int = 400) -> str:
+        collapsed = " ".join(text.split())
+        if len(collapsed) <= limit:
+            return collapsed
+        return collapsed[: limit - 3] + "..."
+
+    @staticmethod
+    def _parse_github_datetime(value: str) -> datetime:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)

--- a/testing/components/services/stable_release_install_paths_service.py
+++ b/testing/components/services/stable_release_install_paths_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from testing.core.models.stable_release_install_paths_audit import (
 
 
 class StableReleaseInstallPathsService:
+    ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
     RAW_GITHUB_PATTERN = re.compile(r"raw\.githubusercontent\.com", re.IGNORECASE)
     UNSUPPORTED_SERVER_PATTERN = re.compile(r"dmtools-server", re.IGNORECASE)
     STABLE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
@@ -72,11 +74,13 @@ class StableReleaseInstallPathsService:
                 workflow_run=None,
                 workflow_job=None,
                 release_urls=(),
-                workflow_log_urls=(),
+                workflow_summary_urls=(),
                 release_cli_urls=(),
                 release_skill_urls=(),
+                workflow_summary_cli_urls=(),
+                workflow_summary_skill_urls=(),
                 release_forbidden_lines=(),
-                workflow_log_forbidden_lines=(),
+                workflow_summary_forbidden_lines=(),
                 failures=tuple(failures),
             )
 
@@ -145,11 +149,13 @@ class StableReleaseInstallPathsService:
                 workflow_run=None,
                 workflow_job=None,
                 release_urls=release_urls,
-                workflow_log_urls=(),
+                workflow_summary_urls=(),
                 release_cli_urls=release_cli_urls,
                 release_skill_urls=release_skill_urls,
+                workflow_summary_cli_urls=(),
+                workflow_summary_skill_urls=(),
                 release_forbidden_lines=release_forbidden_lines,
-                workflow_log_forbidden_lines=(),
+                workflow_summary_forbidden_lines=(),
                 failures=tuple(failures),
             )
 
@@ -173,11 +179,13 @@ class StableReleaseInstallPathsService:
                 workflow_run=workflow_run,
                 workflow_job=None,
                 release_urls=release_urls,
-                workflow_log_urls=(),
+                workflow_summary_urls=(),
                 release_cli_urls=release_cli_urls,
                 release_skill_urls=release_skill_urls,
+                workflow_summary_cli_urls=(),
+                workflow_summary_skill_urls=(),
                 release_forbidden_lines=release_forbidden_lines,
-                workflow_log_forbidden_lines=(),
+                workflow_summary_forbidden_lines=(),
                 failures=tuple(failures),
             )
 
@@ -191,32 +199,83 @@ class StableReleaseInstallPathsService:
                 )
             )
 
-        workflow_log_urls = tuple(self.RELEASE_URL_PATTERN.findall(workflow_job.log_text))
-        workflow_log_forbidden_lines = self._forbidden_lines(workflow_job.log_text)
+        workflow_summary_urls = tuple(self.RELEASE_URL_PATTERN.findall(workflow_job.summary_text))
+        workflow_summary_cli_urls = tuple(self.CLI_RELEASE_URL_PATTERN.findall(workflow_job.summary_text))
+        workflow_summary_skill_urls = tuple(
+            self.SKILL_RELEASE_URL_PATTERN.findall(workflow_job.summary_text)
+        )
+        workflow_summary_forbidden_lines = self._forbidden_lines(workflow_job.summary_text)
 
-        if workflow_log_forbidden_lines:
+        if "Summary" in workflow_job.step_names and not workflow_job.summary_text.strip():
             failures.append(
                 StableReleaseInstallPathsFailure(
                     step=8,
-                    summary="The live release workflow evidence still references unsupported raw or server paths.",
+                    summary="The live release workflow Summary output could not be reconstructed.",
                     expected=(
-                        "Workflow evidence for the release should not contain raw.githubusercontent.com "
-                        "or dmtools-server references."
+                        "A user-visible Summary step body showing the generated release copy for CLI "
+                        "and skill installs."
                     ),
-                    actual="\n".join(workflow_log_forbidden_lines),
+                    actual=self._preview(workflow_job.log_text),
                 )
             )
+        elif "Summary" in workflow_job.step_names:
+            if not workflow_summary_cli_urls:
+                failures.append(
+                    StableReleaseInstallPathsFailure(
+                        step=9,
+                        summary=(
+                            "The live release workflow Summary does not expose a supported CLI install path."
+                        ),
+                        expected=(
+                            "At least one GitHub Releases asset URL for the CLI install flow, such as "
+                            "https://github.com/epam/dm.ai/releases/latest/download/install.sh."
+                        ),
+                        actual=self._preview(workflow_job.summary_text),
+                    )
+                )
+
+            if not workflow_summary_skill_urls:
+                failures.append(
+                    StableReleaseInstallPathsFailure(
+                        step=10,
+                        summary=(
+                            "The live release workflow Summary does not expose a supported skill install path."
+                        ),
+                        expected=(
+                            "At least one GitHub Releases asset URL for the skill install flow, such as "
+                            "https://github.com/epam/dm.ai/releases/download/v1.2.3/skill-install.sh."
+                        ),
+                        actual=self._preview(workflow_job.summary_text),
+                    )
+                )
+
+            if workflow_summary_forbidden_lines:
+                failures.append(
+                    StableReleaseInstallPathsFailure(
+                        step=11,
+                        summary=(
+                            "The live release workflow Summary still references unsupported raw or server paths."
+                        ),
+                        expected=(
+                            "Workflow Summary output for the release should not contain "
+                            "raw.githubusercontent.com or dmtools-server references."
+                        ),
+                        actual="\n".join(workflow_summary_forbidden_lines),
+                    )
+                )
 
         return StableReleaseInstallPathsAudit(
             release=release,
             workflow_run=workflow_run,
             workflow_job=workflow_job,
             release_urls=release_urls,
-            workflow_log_urls=workflow_log_urls,
+            workflow_summary_urls=workflow_summary_urls,
             release_cli_urls=release_cli_urls,
             release_skill_urls=release_skill_urls,
+            workflow_summary_cli_urls=workflow_summary_cli_urls,
+            workflow_summary_skill_urls=workflow_summary_skill_urls,
             release_forbidden_lines=release_forbidden_lines,
-            workflow_log_forbidden_lines=workflow_log_forbidden_lines,
+            workflow_summary_forbidden_lines=workflow_summary_forbidden_lines,
             failures=tuple(failures),
         )
 
@@ -269,14 +328,14 @@ class StableReleaseInstallPathsService:
             f"Unified release job visible at {audit.workflow_job.html_url} with steps: "
             + ", ".join(audit.workflow_job.step_names)
         )
-        if audit.workflow_log_forbidden_lines:
+        if audit.workflow_summary_forbidden_lines:
             observations.append(
-                "Unified release job log still shows unsupported markers: "
-                + " | ".join(audit.workflow_log_forbidden_lines)
+                "Workflow Summary still shows unsupported markers: "
+                + " | ".join(audit.workflow_summary_forbidden_lines)
             )
         else:
             observations.append(
-                "Unified release job log did not show raw.githubusercontent.com or dmtools-server."
+                "Workflow Summary did not show raw.githubusercontent.com or dmtools-server."
             )
         return observations
 
@@ -358,12 +417,14 @@ class StableReleaseInstallPathsService:
                 if isinstance(step, dict) and str(step.get("name") or "").strip()
             )
             job_id = int(job_payload["id"])
+            log_text = self.github_client.workflow_job_logs(job_id)
             return WorkflowJobRecord(
                 job_id=job_id,
                 name=self.workflow_job_name,
                 html_url=str(job_payload.get("html_url") or "").strip(),
                 step_names=step_names,
-                log_text=self.github_client.workflow_job_logs(job_id),
+                log_text=log_text,
+                summary_text=self._extract_step_summary(log_text),
             )
         return None
 
@@ -383,6 +444,64 @@ class StableReleaseInstallPathsService:
         if len(collapsed) <= limit:
             return collapsed
         return collapsed[: limit - 3] + "..."
+
+    @staticmethod
+    def _strip_log_prefix(line: str) -> str:
+        without_prefix = re.sub(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+", "", line)
+        return StableReleaseInstallPathsService.ANSI_ESCAPE_PATTERN.sub("", without_prefix)
+
+    @classmethod
+    def _extract_step_summary(cls, log_text: str) -> str:
+        summary_lines: list[str] = []
+        in_summary_group = False
+
+        for raw_line in log_text.splitlines():
+            stripped = cls._strip_log_prefix(raw_line).strip()
+            if not stripped:
+                continue
+
+            if stripped.startswith("##[group]Run ") and "$GITHUB_STEP_SUMMARY" in stripped:
+                in_summary_group = True
+                continue
+
+            if in_summary_group and stripped.startswith("##[endgroup]"):
+                break
+
+            if not in_summary_group or "$GITHUB_STEP_SUMMARY" not in stripped:
+                continue
+
+            content = cls._extract_summary_write_content(stripped)
+            if content is not None:
+                summary_lines.append(content)
+
+        if not summary_lines:
+            for raw_line in log_text.splitlines():
+                stripped = cls._strip_log_prefix(raw_line).strip()
+                if "$GITHUB_STEP_SUMMARY" not in stripped or stripped.startswith("##[group]Run "):
+                    continue
+                content = cls._extract_summary_write_content(stripped)
+                if content is not None:
+                    summary_lines.append(content)
+
+        return "\n".join(summary_lines)
+
+    @staticmethod
+    def _extract_summary_write_content(line: str) -> str | None:
+        normalized = re.sub(r'\s*>>\s*"?\$GITHUB_STEP_SUMMARY"?\s*$', "", line).strip()
+        if not normalized.startswith("echo "):
+            return None
+
+        try:
+            parts = shlex.split(normalized, posix=True)
+        except ValueError:
+            return None
+
+        if not parts or parts[0] != "echo":
+            return None
+
+        if len(parts) == 1:
+            return ""
+        return " ".join(parts[1:])
 
     @staticmethod
     def _parse_github_datetime(value: str) -> datetime:

--- a/testing/core/interfaces/stable_release_audit_client.py
+++ b/testing/core/interfaces/stable_release_audit_client.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class StableReleaseAuditClient(Protocol):
+    def list_releases(self, limit: int = 20) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def workflow_runs(
+        self,
+        workflow_file: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def workflow_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        raise NotImplementedError

--- a/testing/core/models/stable_release_install_paths_audit.py
+++ b/testing/core/models/stable_release_install_paths_audit.py
@@ -45,6 +45,7 @@ class WorkflowJobRecord:
     html_url: str
     step_names: tuple[str, ...]
     log_text: str
+    summary_text: str
 
 
 @dataclass(frozen=True)
@@ -53,9 +54,11 @@ class StableReleaseInstallPathsAudit:
     workflow_run: WorkflowRunRecord | None
     workflow_job: WorkflowJobRecord | None
     release_urls: tuple[str, ...]
-    workflow_log_urls: tuple[str, ...]
+    workflow_summary_urls: tuple[str, ...]
     release_cli_urls: tuple[str, ...]
     release_skill_urls: tuple[str, ...]
+    workflow_summary_cli_urls: tuple[str, ...]
+    workflow_summary_skill_urls: tuple[str, ...]
     release_forbidden_lines: tuple[str, ...]
-    workflow_log_forbidden_lines: tuple[str, ...]
+    workflow_summary_forbidden_lines: tuple[str, ...]
     failures: tuple[StableReleaseInstallPathsFailure, ...]

--- a/testing/core/models/stable_release_install_paths_audit.py
+++ b/testing/core/models/stable_release_install_paths_audit.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class StableReleaseInstallPathsFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class ReleaseRecord:
+    tag_name: str
+    html_url: str
+    published_at: str
+    body: str
+    asset_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class WorkflowRunRecord:
+    run_id: int
+    html_url: str
+    status: str
+    conclusion: str
+    created_at: str
+    updated_at: str
+    head_branch: str
+
+
+@dataclass(frozen=True)
+class WorkflowJobRecord:
+    job_id: int
+    name: str
+    html_url: str
+    step_names: tuple[str, ...]
+    log_text: str
+
+
+@dataclass(frozen=True)
+class StableReleaseInstallPathsAudit:
+    release: ReleaseRecord | None
+    workflow_run: WorkflowRunRecord | None
+    workflow_job: WorkflowJobRecord | None
+    release_urls: tuple[str, ...]
+    workflow_log_urls: tuple[str, ...]
+    release_cli_urls: tuple[str, ...]
+    release_skill_urls: tuple[str, ...]
+    release_forbidden_lines: tuple[str, ...]
+    workflow_log_forbidden_lines: tuple[str, ...]
+    failures: tuple[StableReleaseInstallPathsFailure, ...]

--- a/testing/frameworks/api/rest/github_publication_gate_client.py
+++ b/testing/frameworks/api/rest/github_publication_gate_client.py
@@ -50,6 +50,15 @@ class GitHubPublicationGateRestClient(PublicationGateClient):
             raise AssertionError(f"Expected a list of pull requests, got: {type(response)!r}")
         return response
 
+    def list_releases(self, limit: int = 20) -> list[dict[str, Any]]:
+        response = self._get_json(
+            f"/repos/{self.owner}/{self.repo}/releases",
+            {"per_page": limit},
+        )
+        if not isinstance(response, list):
+            raise AssertionError(f"Expected a list of releases, got: {type(response)!r}")
+        return response
+
     def pull_request_files(self, number: int) -> list[dict[str, Any]]:
         response = self._get_json(
             f"/repos/{self.owner}/{self.repo}/pulls/{number}/files",
@@ -87,6 +96,34 @@ class GitHubPublicationGateRestClient(PublicationGateClient):
         response = self._get_json(
             f"/repos/{self.owner}/{self.repo}/actions/runs",
             {"head_sha": head_sha, "status": "completed", "per_page": 100},
+        )
+        if not isinstance(response, dict):
+            raise AssertionError(f"Expected a workflow-runs payload dict, got: {type(response)!r}")
+        workflow_runs = response.get("workflow_runs", [])
+        if not isinstance(workflow_runs, list):
+            raise AssertionError(f"Expected a list of workflow runs, got: {type(workflow_runs)!r}")
+        return workflow_runs
+
+    def workflow_runs(
+        self,
+        workflow_file: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        query: dict[str, str | int] = {"per_page": limit}
+        if branch:
+            query["branch"] = branch
+        if event:
+            query["event"] = event
+        if status:
+            query["status"] = status
+
+        response = self._get_json(
+            f"/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_file}/runs",
+            query,
         )
         if not isinstance(response, dict):
             raise AssertionError(f"Expected a workflow-runs payload dict, got: {type(response)!r}")

--- a/testing/tests/DMC-995/README.md
+++ b/testing/tests/DMC-995/README.md
@@ -1,0 +1,32 @@
+# DMC-995 automated test
+
+This test audits the latest live stable GitHub Release in `epam/dm.ai` together
+with the nearest successful `release.yml` workflow run on `main`. It verifies the
+user-visible release copy exposes only supported GitHub Releases install paths for
+the DMTools CLI and Agent Skill, and that the matching unified-release workflow
+evidence does not reference raw bootstrap URLs or unsupported `dmtools-server`
+distribution paths.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-995/test_dmc_995.py -q
+```
+
+## Environment
+
+The live test reads public GitHub release and GitHub Actions metadata for
+`epam/dm.ai`. If available, `GH_TOKEN` or `GITHUB_TOKEN` can be set to raise API
+rate limits.
+
+## Expected passing output
+
+```text
+3 passed
+```

--- a/testing/tests/DMC-995/config.yaml
+++ b/testing/tests/DMC-995/config.yaml
@@ -1,0 +1,12 @@
+test_id: DMC-995
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_file: release.yml
+workflow_job_name: create-unified-release
+release_limit: 10
+run_limit: 20
+max_run_match_seconds: 7200

--- a/testing/tests/DMC-995/test_dmc_995.py
+++ b/testing/tests/DMC-995/test_dmc_995.py
@@ -122,9 +122,24 @@ def test_dmc_995_service_accepts_supported_release_asset_paths_only() -> None:
         },
         workflow_logs={
             801: (
-                "2026-05-05T09:59:00Z Release notes generated with "
-                "https://github.com/epam/dm.ai/releases/latest/download/install.sh\n"
-                "2026-05-05T09:59:30Z Summary step completed successfully.\n"
+                "2026-05-05T09:59:00Z Release notes generated.\n"
+                "##[group]Run echo \"### Install DMTools CLI\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:30Z echo \"### Install DMTools CLI\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:31Z echo \"curl -fsSL "
+                "https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash\" "
+                ">> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:32Z echo \"irm "
+                "https://github.com/epam/dm.ai/releases/latest/download/install.ps1 | iex\" "
+                ">> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:33Z echo \"### Install DMTools Agent Skill\" "
+                ">> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:34Z echo \"curl -fsSL "
+                "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.sh | bash\" "
+                ">> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:35Z echo \"irm "
+                "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.ps1 | iex\" "
+                ">> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-05T09:59:36Z ##[endgroup]\n"
             )
         },
     )
@@ -145,6 +160,14 @@ def test_dmc_995_service_accepts_supported_release_asset_paths_only() -> None:
     assert audit.release is not None
     assert audit.workflow_run is not None
     assert audit.workflow_job is not None
+    assert audit.workflow_job.summary_text == (
+        "### Install DMTools CLI\n"
+        "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash\n"
+        "irm https://github.com/epam/dm.ai/releases/latest/download/install.ps1 | iex\n"
+        "### Install DMTools Agent Skill\n"
+        "curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.sh | bash\n"
+        "irm https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.ps1 | iex"
+    )
     assert audit.release_cli_urls == (
         "https://github.com/epam/dm.ai/releases/latest/download/install.sh",
         "https://github.com/epam/dm.ai/releases/latest/download/install.ps1",
@@ -153,6 +176,9 @@ def test_dmc_995_service_accepts_supported_release_asset_paths_only() -> None:
         "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.sh",
         "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.ps1",
     )
+    assert audit.workflow_summary_cli_urls == audit.release_cli_urls
+    assert audit.workflow_summary_skill_urls == audit.release_skill_urls
+    assert audit.workflow_summary_forbidden_lines == ()
 
 
 def test_dmc_995_service_reports_raw_and_server_references() -> None:
@@ -203,6 +229,12 @@ def test_dmc_995_service_reports_raw_and_server_references() -> None:
             74120196514: (
                 "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.sh | bash\n"
                 "# API_MACOS_ARM_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-aarch64.zip | cut -f1)\n"
+                "##[group]Run echo \"**CLI Tools:**\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-03T14:30:03.5720038Z echo \"**CLI Tools:**\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-03T14:30:03.5721704Z echo \"- install.sh (macOS/Linux)\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-03T14:30:03.5723491Z echo \"**Agent Skill:**\" >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-03T14:30:03.5725940Z echo \"- skill-install.sh (automatic installer, macOS/Linux)\"  >> $GITHUB_STEP_SUMMARY\n"
+                "2026-05-03T14:30:03.5749190Z ##[endgroup]\n"
             )
         },
     )
@@ -219,18 +251,26 @@ def test_dmc_995_service_reports_raw_and_server_references() -> None:
 
     audit = service.audit()
 
-    assert len(audit.failures) == 3
+    assert len(audit.failures) == 4
     assert audit.failures[0].step == 2
+    assert audit.failures[1].step == 4
+    assert audit.failures[2].step == 9
+    assert audit.failures[3].step == 10
     assert audit.release_forbidden_lines == (
         "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install | bash",
     )
-    assert audit.workflow_log_forbidden_lines == (
-        "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.sh | bash",
-        "# API_MACOS_ARM_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-aarch64.zip | cut -f1)",
+    assert audit.workflow_summary_forbidden_lines == ()
+    assert audit.workflow_job is not None
+    assert audit.workflow_job.summary_text == (
+        "**CLI Tools:**\n"
+        "- install.sh (macOS/Linux)\n"
+        "**Agent Skill:**\n"
+        "- skill-install.sh (automatic installer, macOS/Linux)"
     )
     assert "supported cli install path" in audit.failures[0].summary.lower()
     assert "unsupported raw or server paths" in audit.failures[1].summary.lower()
-    assert "workflow evidence" in audit.failures[2].summary.lower()
+    assert "workflow summary does not expose a supported cli" in audit.failures[2].summary.lower()
+    assert "workflow summary does not expose a supported skill" in audit.failures[3].summary.lower()
 
 
 def test_dmc_995_live_stable_release_workflow_uses_only_supported_cli_and_skill_paths() -> None:

--- a/testing/tests/DMC-995/test_dmc_995.py
+++ b/testing/tests/DMC-995/test_dmc_995.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.stable_release_install_paths_service_factory import (  # noqa: E402
+    create_stable_release_install_paths_service,
+)
+from testing.components.services.stable_release_install_paths_service import (  # noqa: E402
+    StableReleaseInstallPathsService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+
+
+class FakeGitHubClient:
+    def __init__(
+        self,
+        *,
+        releases: list[dict],
+        workflow_runs: list[dict],
+        workflow_jobs: dict[int, list[dict]],
+        workflow_logs: dict[int, str],
+    ) -> None:
+        self._releases = releases
+        self._workflow_runs = workflow_runs
+        self._workflow_jobs = workflow_jobs
+        self._workflow_logs = workflow_logs
+
+    def list_releases(self, limit: int = 20) -> list[dict]:
+        return self._releases[:limit]
+
+    def workflow_runs(
+        self,
+        workflow_file: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+    ) -> list[dict]:
+        del workflow_file, branch, event, status
+        return self._workflow_runs[:limit]
+
+    def workflow_jobs(self, run_id: int) -> list[dict]:
+        return self._workflow_jobs.get(run_id, [])
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        return self._workflow_logs[job_id]
+
+
+def build_live_service() -> StableReleaseInstallPathsService:
+    return create_stable_release_install_paths_service(
+        repository_root=REPOSITORY_ROOT,
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_job_name=str(CONFIG["workflow_job_name"]),
+        release_limit=int(str(CONFIG["release_limit"])),
+        run_limit=int(str(CONFIG["run_limit"])),
+        max_run_match_seconds=int(str(CONFIG["max_run_match_seconds"])),
+    )
+
+
+def test_dmc_995_service_accepts_supported_release_asset_paths_only() -> None:
+    fake_client = FakeGitHubClient(
+        releases=[
+            {
+                "tag_name": "v1.7.200",
+                "draft": False,
+                "prerelease": False,
+                "published_at": "2026-05-05T10:00:00Z",
+                "html_url": "https://github.com/epam/dm.ai/releases/tag/v1.7.200",
+                "body": (
+                    "### Install DMTools CLI\n"
+                    "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash\n"
+                    "irm https://github.com/epam/dm.ai/releases/latest/download/install.ps1 | iex\n"
+                    "### Install DMTools Agent Skill\n"
+                    "curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.sh | bash\n"
+                    "irm https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.ps1 | iex\n"
+                ),
+                "assets": [
+                    {"name": "install.sh"},
+                    {"name": "install.ps1"},
+                    {"name": "skill-install.sh"},
+                    {"name": "skill-install.ps1"},
+                ],
+            }
+        ],
+        workflow_runs=[
+            {
+                "id": 501,
+                "html_url": "https://github.com/epam/dm.ai/actions/runs/501",
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-05-05T09:55:00Z",
+                "updated_at": "2026-05-05T09:59:59Z",
+                "head_branch": "main",
+            }
+        ],
+        workflow_jobs={
+            501: [
+                {
+                    "id": 801,
+                    "name": "create-unified-release",
+                    "html_url": "https://github.com/epam/dm.ai/actions/runs/501/job/801",
+                    "steps": [
+                        {"name": "Generate Release Notes"},
+                        {"name": "Create Unified Release"},
+                        {"name": "Summary"},
+                    ],
+                }
+            ]
+        },
+        workflow_logs={
+            801: (
+                "2026-05-05T09:59:00Z Release notes generated with "
+                "https://github.com/epam/dm.ai/releases/latest/download/install.sh\n"
+                "2026-05-05T09:59:30Z Summary step completed successfully.\n"
+            )
+        },
+    )
+
+    service = StableReleaseInstallPathsService(
+        REPOSITORY_ROOT,
+        github_client=fake_client,
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_job_name=str(CONFIG["workflow_job_name"]),
+        release_limit=1,
+        run_limit=1,
+        max_run_match_seconds=120,
+    )
+
+    audit = service.audit()
+
+    assert audit.failures == ()
+    assert audit.release is not None
+    assert audit.workflow_run is not None
+    assert audit.workflow_job is not None
+    assert audit.release_cli_urls == (
+        "https://github.com/epam/dm.ai/releases/latest/download/install.sh",
+        "https://github.com/epam/dm.ai/releases/latest/download/install.ps1",
+    )
+    assert audit.release_skill_urls == (
+        "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.sh",
+        "https://github.com/epam/dm.ai/releases/download/v1.7.200/skill-install.ps1",
+    )
+
+
+def test_dmc_995_service_reports_raw_and_server_references() -> None:
+    fake_client = FakeGitHubClient(
+        releases=[
+            {
+                "tag_name": "v1.7.181",
+                "draft": False,
+                "prerelease": False,
+                "published_at": "2026-05-03T14:30:03Z",
+                "html_url": "https://github.com/epam/dm.ai/releases/tag/v1.7.181",
+                "body": (
+                    "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install | bash\n"
+                    "curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.181/skill-install.sh | bash\n"
+                ),
+                "assets": [
+                    {"name": "install.sh"},
+                    {"name": "skill-install.sh"},
+                ],
+            }
+        ],
+        workflow_runs=[
+            {
+                "id": 25281750669,
+                "html_url": "https://github.com/epam/dm.ai/actions/runs/25281750669",
+                "status": "completed",
+                "conclusion": "success",
+                "created_at": "2026-05-03T14:26:15Z",
+                "updated_at": "2026-05-03T14:30:06Z",
+                "head_branch": "main",
+            }
+        ],
+        workflow_jobs={
+            25281750669: [
+                {
+                    "id": 74120196514,
+                    "name": "create-unified-release",
+                    "html_url": "https://github.com/epam/dm.ai/actions/runs/25281750669/job/74120196514",
+                    "steps": [
+                        {"name": "Generate Release Notes"},
+                        {"name": "Create Unified Release"},
+                        {"name": "Summary"},
+                    ],
+                }
+            ]
+        },
+        workflow_logs={
+            74120196514: (
+                "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.sh | bash\n"
+                "# API_MACOS_ARM_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-aarch64.zip | cut -f1)\n"
+            )
+        },
+    )
+
+    service = StableReleaseInstallPathsService(
+        REPOSITORY_ROOT,
+        github_client=fake_client,
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_job_name=str(CONFIG["workflow_job_name"]),
+        release_limit=1,
+        run_limit=1,
+        max_run_match_seconds=int(str(CONFIG["max_run_match_seconds"])),
+    )
+
+    audit = service.audit()
+
+    assert len(audit.failures) == 3
+    assert audit.failures[0].step == 2
+    assert audit.release_forbidden_lines == (
+        "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install | bash",
+    )
+    assert audit.workflow_log_forbidden_lines == (
+        "curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.sh | bash",
+        "# API_MACOS_ARM_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-aarch64.zip | cut -f1)",
+    )
+    assert "supported cli install path" in audit.failures[0].summary.lower()
+    assert "unsupported raw or server paths" in audit.failures[1].summary.lower()
+    assert "workflow evidence" in audit.failures[2].summary.lower()
+
+
+def test_dmc_995_live_stable_release_workflow_uses_only_supported_cli_and_skill_paths() -> None:
+    service = build_live_service()
+
+    audit = service.audit()
+
+    assert audit.release is not None, "The GitHub API did not return a stable release to inspect."
+    assert audit.workflow_run is not None, "The matching release workflow run could not be located."
+    assert audit.workflow_job is not None, "The matching unified release job could not be located."
+    assert not audit.failures, service.format_failures(audit.failures)


### PR DESCRIPTION
# DMC-995 automated test result: **FAILED**

## Automation added

- Test file: `testing/tests/DMC-995/test_dmc_995.py`
- Config: `testing/tests/DMC-995/config.yaml`
- Result: `2 passed, 1 failed`
- Command: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-995/test_dmc_995.py -q`

## What automation checked

1. Selected the latest live stable GitHub Release in `epam/dm.ai`.
2. Matched it to the nearest successful `.github/workflows/release.yml` workflow run on `main`.
3. Inspected the release body for supported CLI and skill install URLs.
4. Inspected the matching `create-unified-release` job evidence for unsupported `raw.githubusercontent.com` or `dmtools-server` references.

## Real human-style verification

- Release page opened: https://github.com/epam/dm.ai/releases/tag/v1.7.181
- Workflow run opened: https://github.com/epam/dm.ai/actions/runs/25281750669
- Unified-release job opened: https://github.com/epam/dm.ai/actions/runs/25281750669/job/74120196514
- Observed on the release page:
  - skill install URLs correctly point to GitHub Releases assets
  - CLI install examples still point to raw GitHub bootstrap URLs
- Observed in the matching workflow evidence:
  - raw installer URLs are still present
  - commented `dmtools-server-api-*` references are still present

This does **not** match the expected result. The deployed stable release still advertises unsupported raw/bootstrap and server-related paths instead of only GitHub Releases asset URLs for CLI and skill installs.

## Step-by-step result against the ticket

1. Trigger `.github/workflows/release.yml` manually with a semantic version — the deployed stable release evidence for `v1.7.181` / run `25281750669` was available for inspection. **PASS**
2. Wait for the workflow to complete — run status was `completed/success`. **PASS**
3. Open the newly created GitHub Release for the provided tag — release page opened successfully. **PASS**
4. Inspect the release body and the workflow evidence — **FAIL**. The release body still contains raw GitHub bootstrap URLs, and the unified-release job evidence still contains raw URLs plus `dmtools-server` references.
5. Search for `raw.githubusercontent.com` and `dmtools-server` — **FAIL**. Both markers were found in the live deployed surfaces.

## Failure details

```text
E       AssertionError: Step 2: The live stable release body does not expose a supported CLI install path.
E         Expected: At least one GitHub Releases asset URL for the CLI install flow, such as https://github.com/epam/dm.ai/releases/latest/download/install.sh.
E         Actual: # 🚀 DMTools Release v1.7.181 This release includes the **DMTools CLI** and **Agent Skill** for AI assistants. ## 📦 What's Included ### 🖥️ DMTools CLI - **Command-line interface** for DMTools operations - **Java-based** automation and integration tools - **Cross-platform install scripts** for easy setup (`install`, `install.sh`, `install.bat`, `install.ps1`) - **Wrapper script** (`dmtools.sh`) #...
E
E         Step 4: The live stable release body still references unsupported raw or server paths.
E         Expected: Only supported GitHub Releases install URLs for CLI and skills, with no raw.githubusercontent.com or dmtools-server references.
E         Actual: curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install | bash
E         curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
E         curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v1.7.181/install.sh | bash -s v1.7.181
E         set DMTOOLS_VERSION=v1.7.181 && curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v1.7.181/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
E         Invoke-RestMethod -Uri "https://raw.githubusercontent.com/epam/dm.ai/v1.7.181/install.ps1" | Invoke-Expression
E
E         Step 8: The live release workflow evidence still references unsupported raw or server paths.
E         Expected: Workflow evidence for the release should not contain raw.githubusercontent.com or dmtools-server references.
E         Actual: 2026-05-03T14:29:54.4396819Z # API_MACOS_ARM_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-aarch64.zip | cut -f1)
E         2026-05-03T14:29:54.4397475Z # API_MACOS_X64_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-x64.zip | cut -f1)
E         2026-05-03T14:29:54.4398124Z # API_WINDOWS_X64_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-windows-x64.zip | cut -f1)
E         2026-05-03T14:29:54.4407006Z curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install | bash
E         2026-05-03T14:29:54.4408903Z curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/main/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
E         2026-05-03T14:29:54.4421091Z curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.sh | bash -s v${VERSION}
E         2026-05-03T14:29:54.4422849Z set DMTOOLS_VERSION=v${VERSION} && curl -fsSL https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.bat -o "%TEMP%\dmtools-install.bat" && "%TEMP%\dmtools-install.bat"
E         2026-05-03T14:29:54.4425149Z Invoke-RestMethod -Uri "https://raw.githubusercontent.com/epam/dm.ai/v${VERSION}/install.ps1" | Invoke-Expression
```
