### PR TITLE
DMC-996 Test: Execute beta-release workflow — GITHUB_STEP_SUMMARY aligns with supported packaging model

### DIFF
--- a/testing/components/factories/beta_release_summary_audit_service_factory.py
+++ b/testing/components/factories/beta_release_summary_audit_service_factory.py
@@ -4,6 +4,9 @@ import os
 from pathlib import Path
 
 from testing.components.services.beta_release_summary_audit_service import (
+    BetaReleaseSummaryAuditService as BetaReleaseSummaryAuditServiceImpl,
+)
+from testing.core.interfaces.beta_release_summary_audit_service import (
     BetaReleaseSummaryAuditService,
 )
 from testing.frameworks.api.rest.github_actions_release_client import (
@@ -28,7 +31,7 @@ def create_beta_release_summary_audit_service(
     github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
         "GITHUB_TOKEN"
     )
-    return BetaReleaseSummaryAuditService(
+    return BetaReleaseSummaryAuditServiceImpl(
         github_client=GitHubActionsReleaseRestClient(
             owner=owner,
             repo=repo,

--- a/testing/components/factories/beta_release_summary_audit_service_factory.py
+++ b/testing/components/factories/beta_release_summary_audit_service_factory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from testing.components.services.beta_release_summary_audit_service import (
+    BetaReleaseSummaryAuditService,
+)
+from testing.frameworks.api.rest.github_actions_release_client import (
+    GitHubActionsReleaseRestClient,
+)
+
+
+def create_beta_release_summary_audit_service(
+    repository_root: Path,
+    *,
+    owner: str,
+    repo: str,
+    workflow_file: str,
+    workflow_ref: str,
+    workflow_name: str,
+    release_job_name: str,
+    dispatch_timeout_seconds: int,
+    completion_timeout_seconds: int,
+    poll_interval_seconds: int,
+    token: str | None = None,
+) -> BetaReleaseSummaryAuditService:
+    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    return BetaReleaseSummaryAuditService(
+        github_client=GitHubActionsReleaseRestClient(
+            owner=owner,
+            repo=repo,
+            token=github_token,
+        ),
+        workflow_file=workflow_file,
+        workflow_ref=workflow_ref,
+        workflow_name=workflow_name,
+        release_job_name=release_job_name,
+        dispatch_timeout_seconds=dispatch_timeout_seconds,
+        completion_timeout_seconds=completion_timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+    )

--- a/testing/components/services/beta_release_summary_audit_service.py
+++ b/testing/components/services/beta_release_summary_audit_service.py
@@ -6,6 +6,12 @@ from threading import Event
 from typing import Any
 from urllib.error import HTTPError
 
+from testing.core.interfaces.beta_release_summary_audit_service import (
+    BetaReleaseSummaryAuditService as BetaReleaseSummaryAuditServiceContract,
+)
+from testing.core.interfaces.github_actions_release_client import (
+    GitHubActionsReleaseClient,
+)
 from testing.core.models.beta_release_summary_audit import (
     BetaReleaseAuditFailure,
     BetaReleaseJobObservation,
@@ -13,12 +19,9 @@ from testing.core.models.beta_release_summary_audit import (
     BetaReleaseRunObservation,
     BetaReleaseSummaryAudit,
 )
-from testing.frameworks.api.rest.github_actions_release_client import (
-    GitHubActionsReleaseRestClient,
-)
 
 
-class BetaReleaseSummaryAuditService:
+class BetaReleaseSummaryAuditService(BetaReleaseSummaryAuditServiceContract):
     RELEASE_BODY_MARKERS = (
         "this is a pre-release / beta build",
         "dmtools cli",
@@ -54,7 +57,7 @@ class BetaReleaseSummaryAuditService:
 
     def __init__(
         self,
-        github_client: GitHubActionsReleaseRestClient,
+        github_client: GitHubActionsReleaseClient,
         *,
         workflow_file: str,
         workflow_ref: str,

--- a/testing/components/services/beta_release_summary_audit_service.py
+++ b/testing/components/services/beta_release_summary_audit_service.py
@@ -1,0 +1,486 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from threading import Event
+from typing import Any
+from urllib.error import HTTPError
+
+from testing.core.models.beta_release_summary_audit import (
+    BetaReleaseAuditFailure,
+    BetaReleaseJobObservation,
+    BetaReleaseReleaseObservation,
+    BetaReleaseRunObservation,
+    BetaReleaseSummaryAudit,
+)
+from testing.frameworks.api.rest.github_actions_release_client import (
+    GitHubActionsReleaseRestClient,
+)
+
+
+class BetaReleaseSummaryAuditService:
+    RELEASE_BODY_MARKERS = (
+        "this is a pre-release / beta build",
+        "dmtools cli",
+        "dmtools agent skill",
+        "releases/download/",
+        "install.sh",
+        "install.ps1",
+    )
+    SUMMARY_REQUIRED_MARKERS = (
+        "pre-release",
+        "latest",
+        "dmtools cli",
+        "dmtools agent skill",
+        "releases/download/",
+        "install.sh",
+    )
+    REQUIRED_ASSET_MARKERS = (
+        "dmtools-v",
+        "install.sh",
+        "install.ps1",
+        "dmtools.sh",
+        "dmtools-skill-v",
+        "skill-install.sh",
+        "skill-install.ps1",
+        "skill-checksums.sha256",
+    )
+    SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
+    ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+    TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
+    RELEASE_URL_PATTERN = re.compile(
+        r"https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/releases/tag/(?P<tag>[^\s\"']+)"
+    )
+
+    def __init__(
+        self,
+        github_client: GitHubActionsReleaseRestClient,
+        *,
+        workflow_file: str,
+        workflow_ref: str,
+        workflow_name: str,
+        release_job_name: str,
+        dispatch_timeout_seconds: int,
+        completion_timeout_seconds: int,
+        poll_interval_seconds: int,
+    ) -> None:
+        self.github_client = github_client
+        self.workflow_file = workflow_file
+        self.workflow_ref = workflow_ref
+        self.workflow_name = workflow_name
+        self.release_job_name = release_job_name
+        self.dispatch_timeout_seconds = dispatch_timeout_seconds
+        self.completion_timeout_seconds = completion_timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self._waiter = Event()
+
+    def audit(self) -> BetaReleaseSummaryAudit:
+        failures: list[BetaReleaseAuditFailure] = []
+
+        dispatch_started_at = datetime.now(timezone.utc)
+        target_head_sha = self.github_client.branch_head_sha(self.workflow_ref)
+        existing_run_ids = {
+            int(run["id"])
+            for run in self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                per_page=20,
+            )
+            if run.get("id") is not None
+        }
+
+        self.github_client.dispatch_workflow(self.workflow_file, ref=self.workflow_ref)
+        workflow_run = self._wait_for_dispatched_run(
+            existing_run_ids=existing_run_ids,
+            target_head_sha=target_head_sha,
+            dispatch_started_at=dispatch_started_at,
+        )
+        if workflow_run is None:
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=1,
+                    summary="The beta-release workflow did not appear after dispatch.",
+                    expected=(
+                        f"A new {self.workflow_name!r} run triggered by workflow_dispatch on "
+                        f"{self.workflow_ref!r}."
+                    ),
+                    actual=(
+                        f"No new workflow_dispatch run was listed for {self.workflow_file!r} "
+                        f"within {self.dispatch_timeout_seconds} seconds."
+                    ),
+                )
+            )
+            return BetaReleaseSummaryAudit(
+                workflow_run=None,
+                release_job=None,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        workflow_run = self._wait_for_completion(workflow_run.run_id)
+        if workflow_run.status != "completed" or workflow_run.conclusion != "success":
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=2,
+                    summary="The dispatched beta-release workflow did not finish successfully.",
+                    expected="A completed workflow run with conclusion 'success'.",
+                    actual=(
+                        f"Run {workflow_run.html_url} finished with status={workflow_run.status!r} "
+                        f"and conclusion={workflow_run.conclusion!r}."
+                    ),
+                )
+            )
+            return BetaReleaseSummaryAudit(
+                workflow_run=workflow_run,
+                release_job=None,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release_job_payload = self._find_release_job_payload(workflow_run.run_id)
+        if release_job_payload is None:
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=3,
+                    summary="The completed workflow run does not expose the publication job.",
+                    expected=f"A job named {self.release_job_name!r} in the completed workflow run.",
+                    actual=f"No job matched {self.release_job_name!r} in run {workflow_run.html_url}.",
+                )
+            )
+            return BetaReleaseSummaryAudit(
+                workflow_run=workflow_run,
+                release_job=None,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release_job = self._build_release_job_observation(release_job_payload)
+        if release_job.status != "completed" or release_job.conclusion != "success":
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=3,
+                    summary="The publication job did not finish successfully.",
+                    expected="A completed create-beta-release job with conclusion 'success'.",
+                    actual=(
+                        f"Job {release_job.html_url} finished with status={release_job.status!r} "
+                        f"and conclusion={release_job.conclusion!r}."
+                    ),
+                )
+            )
+            return BetaReleaseSummaryAudit(
+                workflow_run=workflow_run,
+                release_job=release_job,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release = self._find_release_observation(release_job, dispatch_started_at)
+        if release is None:
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=4,
+                    summary="The beta release was not discoverable after the workflow succeeded.",
+                    expected=(
+                        "A prerelease created by the publication job, with a release tag URL "
+                        "visible in the job logs or a matching recent prerelease in GitHub Releases."
+                    ),
+                    actual=(
+                        f"Job {release_job.html_url} completed successfully, but no matching "
+                        "prerelease could be resolved."
+                    ),
+                )
+            )
+            return BetaReleaseSummaryAudit(
+                workflow_run=workflow_run,
+                release_job=release_job,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        missing_release_markers = self._missing_markers(release.body, self.RELEASE_BODY_MARKERS)
+        missing_assets = self._missing_asset_markers(release.asset_names)
+        if not release.is_prerelease or missing_release_markers or missing_assets:
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=4,
+                    summary=(
+                        "The live beta release page does not fully match the supported prerelease "
+                        "packaging model."
+                    ),
+                    expected=(
+                        "A prerelease release page that clearly describes the DMTools CLI and "
+                        "DMTools Agent Skill, uses GitHub Releases install examples, and publishes "
+                        "the maintained installer assets."
+                    ),
+                    actual=(
+                        f"Release {release.html_url} prerelease={release.is_prerelease!r}; "
+                        f"missing body markers: {missing_release_markers or ['none']}; "
+                        f"missing asset markers: {missing_assets or ['none']}. "
+                        f"Visible body preview: {self._preview_text(release.body, limit=420)}"
+                    ),
+                )
+            )
+
+        missing_summary_markers = self._missing_markers(
+            release_job.step_summary_markdown,
+            self.SUMMARY_REQUIRED_MARKERS,
+        )
+        if missing_summary_markers:
+            failures.append(
+                BetaReleaseAuditFailure(
+                    step=5,
+                    summary=(
+                        "The publication job Step Summary does not mirror the supported packaging "
+                        "copy with beta-specific framing."
+                    ),
+                    expected=(
+                        "The Step Summary should visibly mention the DMTools CLI and DMTools Agent "
+                        "Skill, include GitHub Releases install guidance, and keep the prerelease/"
+                        "stable-latest framing."
+                    ),
+                    actual=(
+                        f"Job {release_job.html_url} produced summary markdown missing markers "
+                        f"{missing_summary_markers}. Summary preview: "
+                        f"{self._preview_text(release_job.step_summary_markdown, limit=420)}"
+                    ),
+                )
+            )
+
+        return BetaReleaseSummaryAudit(
+            workflow_run=workflow_run,
+            release_job=release_job,
+            release=release,
+            failures=tuple(failures),
+        )
+
+    @staticmethod
+    def format_failures(
+        failures: tuple[BetaReleaseAuditFailure, ...] | list[BetaReleaseAuditFailure],
+    ) -> str:
+        return "\n\n".join(failure.format() for failure in failures)
+
+    def human_observations(self, audit: BetaReleaseSummaryAudit) -> list[str]:
+        observations: list[str] = []
+        if audit.workflow_run is not None:
+            observations.append(
+                f"Triggered live workflow run #{audit.workflow_run.run_number}: "
+                f"{audit.workflow_run.html_url}"
+            )
+        if audit.release_job is not None:
+            observations.append(
+                f"Publication job visible in Actions UI: {audit.release_job.html_url}"
+            )
+            observations.append(
+                "Observed Step Summary markdown generated by the job: "
+                + self._preview_text(audit.release_job.step_summary_markdown, limit=300)
+            )
+        if audit.release is not None:
+            observations.append(f"Observed prerelease page: {audit.release.html_url}")
+            observations.append(
+                "Visible release notes preview: "
+                + self._preview_text(audit.release.body, limit=300)
+            )
+            observations.append(
+                "Published asset names: " + ", ".join(audit.release.asset_names[:8])
+            )
+        return observations
+
+    def _wait_for_dispatched_run(
+        self,
+        *,
+        existing_run_ids: set[int],
+        target_head_sha: str,
+        dispatch_started_at: datetime,
+    ) -> BetaReleaseRunObservation | None:
+        deadline = self._deadline(self.dispatch_timeout_seconds)
+        while datetime.now(timezone.utc) < deadline:
+            runs = self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                event="workflow_dispatch",
+                per_page=20,
+            )
+            for run in runs:
+                run_id = run.get("id")
+                if run_id is None:
+                    continue
+                if int(run_id) in existing_run_ids:
+                    continue
+                if str(run.get("head_sha", "")) != target_head_sha:
+                    continue
+                created_at = self._parse_github_datetime(str(run.get("created_at", "")))
+                if created_at is None or created_at < dispatch_started_at - timedelta(minutes=1):
+                    continue
+                return self._build_run_observation(run)
+            self._waiter.wait(self.poll_interval_seconds)
+        return None
+
+    def _wait_for_completion(self, run_id: int) -> BetaReleaseRunObservation:
+        deadline = self._deadline(self.completion_timeout_seconds)
+        last_seen = self._build_run_observation(self.github_client.workflow_run(run_id))
+        while datetime.now(timezone.utc) < deadline:
+            current = self._build_run_observation(self.github_client.workflow_run(run_id))
+            last_seen = current
+            if current.status == "completed":
+                return current
+            self._waiter.wait(self.poll_interval_seconds)
+        return last_seen
+
+    def _find_release_job_payload(self, run_id: int) -> dict[str, Any] | None:
+        for job in self.github_client.workflow_jobs(run_id):
+            name = str(job.get("name", ""))
+            if name == self.release_job_name:
+                return job
+        return None
+
+    def _build_release_job_observation(self, payload: dict[str, Any]) -> BetaReleaseJobObservation:
+        job_id = int(payload["id"])
+        log_text = self.github_client.workflow_job_logs(job_id)
+        step_summary_markdown = self._extract_step_summary_markdown(log_text)
+        return BetaReleaseJobObservation(
+            job_id=job_id,
+            name=str(payload.get("name", "")),
+            html_url=str(payload.get("html_url", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            step_summary_markdown=step_summary_markdown,
+            log_excerpt=self._log_excerpt(log_text),
+        )
+
+    def _find_release_observation(
+        self,
+        release_job: BetaReleaseJobObservation,
+        dispatch_started_at: datetime,
+    ) -> BetaReleaseReleaseObservation | None:
+        tag = self._release_tag_from_text(release_job.step_summary_markdown) or self._release_tag_from_text(
+            release_job.log_excerpt
+        )
+        release_payload: dict[str, Any] | None = None
+        lookup_deadline = self._deadline(self.poll_interval_seconds * 3)
+        while datetime.now(timezone.utc) < lookup_deadline and release_payload is None:
+            if tag:
+                try:
+                    release_payload = self.github_client.release_by_tag(tag)
+                except HTTPError as error:
+                    if error.code != 404:
+                        raise
+
+            if release_payload is None:
+                for release in self.github_client.list_releases(per_page=20):
+                    if not bool(release.get("prerelease", False)):
+                        continue
+                    created_at = self._parse_github_datetime(str(release.get("created_at", "")))
+                    if created_at is None or created_at < dispatch_started_at:
+                        continue
+                    if tag and str(release.get("tag_name", "")) != tag:
+                        continue
+                    release_payload = release
+                    break
+
+            if release_payload is None:
+                self._waiter.wait(self.poll_interval_seconds)
+
+        if release_payload is None:
+            return None
+
+        assets = release_payload.get("assets", [])
+        asset_names = tuple(
+            str(asset.get("name", ""))
+            for asset in assets
+            if isinstance(asset, dict) and str(asset.get("name", "")).strip()
+        )
+        return BetaReleaseReleaseObservation(
+            tag_name=str(release_payload.get("tag_name", "")),
+            html_url=str(release_payload.get("html_url", "")),
+            is_prerelease=bool(release_payload.get("prerelease", False)),
+            body=str(release_payload.get("body", "")),
+            asset_names=asset_names,
+        )
+
+    def _extract_step_summary_markdown(self, raw_log_text: str) -> str:
+        lines: list[str] = []
+        for raw_line in raw_log_text.splitlines():
+            line = self._normalize_log_line(raw_line)
+            if line.startswith("##[group]Run "):
+                continue
+            if ">> $GITHUB_STEP_SUMMARY" not in line:
+                continue
+            match = self.SUMMARY_ECHO_PATTERN.search(line)
+            if not match:
+                continue
+            lines.append(self._decode_echo_argument(match.group("argument")))
+        return "\n".join(lines).strip()
+
+    def _log_excerpt(self, raw_log_text: str, limit: int = 6000) -> str:
+        cleaned = "\n".join(self._normalize_log_line(line) for line in raw_log_text.splitlines())
+        if len(cleaned) <= limit:
+            return cleaned
+        return cleaned[: limit - 3] + "..."
+
+    @classmethod
+    def _normalize_log_line(cls, line: str) -> str:
+        without_ansi = cls.ANSI_PATTERN.sub("", line)
+        return cls.TIMESTAMP_PREFIX_PATTERN.sub("", without_ansi).strip()
+
+    @staticmethod
+    def _decode_echo_argument(argument: str) -> str:
+        value = argument.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        return (
+            value.replace(r"\\", "\\")
+            .replace(r"\"", '"')
+            .replace(r"\`", "`")
+            .replace(r"\$", "$")
+        )
+
+    @classmethod
+    def _release_tag_from_text(cls, text: str) -> str:
+        match = cls.RELEASE_URL_PATTERN.search(text)
+        if match:
+            return match.group("tag")
+        tag_match = re.search(r"\bv\d+\.\d+\.\d+(?:-beta\.\d+\.\d+)?\b", text)
+        return tag_match.group(0) if tag_match else ""
+
+    @staticmethod
+    def _missing_markers(text: str, markers: tuple[str, ...]) -> list[str]:
+        normalized = " ".join(text.lower().split())
+        return [marker for marker in markers if marker not in normalized]
+
+    @classmethod
+    def _missing_asset_markers(cls, asset_names: tuple[str, ...]) -> list[str]:
+        normalized_assets = " ".join(name.lower() for name in asset_names)
+        return [marker for marker in cls.REQUIRED_ASSET_MARKERS if marker not in normalized_assets]
+
+    @staticmethod
+    def _preview_text(value: str, *, limit: int) -> str:
+        compact = " ".join(value.split())
+        if not compact:
+            return "no visible text"
+        if len(compact) <= limit:
+            return compact
+        return compact[: limit - 3] + "..."
+
+    @staticmethod
+    def _build_run_observation(payload: dict[str, Any]) -> BetaReleaseRunObservation:
+        return BetaReleaseRunObservation(
+            run_id=int(payload["id"]),
+            html_url=str(payload.get("html_url", "")),
+            event=str(payload.get("event", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            head_branch=str(payload.get("head_branch", "")),
+            head_sha=str(payload.get("head_sha", "")),
+            created_at=str(payload.get("created_at", "")),
+            run_number=int(payload.get("run_number", 0)),
+        )
+
+    @staticmethod
+    def _parse_github_datetime(value: str) -> datetime | None:
+        if not value:
+            return None
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+    @staticmethod
+    def _deadline(timeout_seconds: int) -> datetime:
+        return datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=timeout_seconds)

--- a/testing/core/interfaces/beta_release_summary_audit_service.py
+++ b/testing/core/interfaces/beta_release_summary_audit_service.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.beta_release_summary_audit import (
+    BetaReleaseAuditFailure,
+    BetaReleaseSummaryAudit,
+)
+
+
+class BetaReleaseSummaryAuditService(Protocol):
+    def audit(self) -> BetaReleaseSummaryAudit:
+        raise NotImplementedError
+
+    def format_failures(
+        self,
+        failures: tuple[BetaReleaseAuditFailure, ...] | list[BetaReleaseAuditFailure],
+    ) -> str:
+        raise NotImplementedError
+
+    def human_observations(self, audit: BetaReleaseSummaryAudit) -> list[str]:
+        raise NotImplementedError

--- a/testing/core/interfaces/github_actions_release_client.py
+++ b/testing/core/interfaces/github_actions_release_client.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from testing.core.interfaces.publication_gate_client import PublicationGateClient
+
+
+class GitHubActionsReleaseClient(PublicationGateClient, Protocol):
+    def dispatch_workflow(self, workflow_id: str, *, ref: str) -> None:
+        raise NotImplementedError
+
+    def branch_head_sha(self, branch: str) -> str:
+        raise NotImplementedError
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def workflow_run(self, run_id: int) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, Any]]:
+        raise NotImplementedError
+
+    def release_by_tag(self, tag: str) -> dict[str, Any]:
+        raise NotImplementedError

--- a/testing/core/models/beta_release_summary_audit.py
+++ b/testing/core/models/beta_release_summary_audit.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BetaReleaseAuditFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class BetaReleaseRunObservation:
+    run_id: int
+    html_url: str
+    event: str
+    status: str
+    conclusion: str
+    head_branch: str
+    head_sha: str
+    created_at: str
+    run_number: int
+
+
+@dataclass(frozen=True)
+class BetaReleaseJobObservation:
+    job_id: int
+    name: str
+    html_url: str
+    status: str
+    conclusion: str
+    step_summary_markdown: str
+    log_excerpt: str
+
+
+@dataclass(frozen=True)
+class BetaReleaseReleaseObservation:
+    tag_name: str
+    html_url: str
+    is_prerelease: bool
+    body: str
+    asset_names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BetaReleaseSummaryAudit:
+    workflow_run: BetaReleaseRunObservation | None
+    release_job: BetaReleaseJobObservation | None
+    release: BetaReleaseReleaseObservation | None
+    failures: tuple[BetaReleaseAuditFailure, ...]

--- a/testing/frameworks/api/rest/github_actions_release_client.py
+++ b/testing/frameworks/api/rest/github_actions_release_client.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from testing.frameworks.api.rest.github_publication_gate_client import (
+    GitHubPublicationGateRestClient,
+)
+
+
+@dataclass(frozen=True)
+class GitHubActionsReleaseRestClient(GitHubPublicationGateRestClient):
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        query: dict[str, str | int] | None = None,
+        payload: dict[str, object] | None = None,
+    ) -> tuple[int, str]:
+        url = f"{self.API_ROOT}{path}"
+        if query:
+            url = f"{url}?{urlencode(query)}"
+
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "User-Agent": "dm-ai-testing-beta-release",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+
+        request = Request(url, headers=headers, data=data, method=method)
+        with urlopen(request, timeout=30) as response:
+            return response.getcode(), response.read().decode("utf-8", errors="replace")
+
+    def dispatch_workflow(self, workflow_id: str, *, ref: str) -> None:
+        status_code, _ = self._request(
+            "POST",
+            f"/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_id}/dispatches",
+            payload={"ref": ref},
+        )
+        if status_code != 204:
+            raise AssertionError(f"Expected workflow dispatch to return 204, got {status_code}.")
+
+    def branch_head_sha(self, branch: str) -> str:
+        response = self._get_json(f"/repos/{self.owner}/{self.repo}/branches/{branch}")
+        if not isinstance(response, dict):
+            raise AssertionError(f"Expected a branch payload dict, got: {type(response)!r}")
+        sha = str((response.get("commit") or {}).get("sha", ""))
+        if not sha:
+            raise AssertionError(f"Branch {branch!r} did not include a commit SHA.")
+        return sha
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, object]]:
+        query: dict[str, str | int] = {"per_page": per_page}
+        if branch:
+            query["branch"] = branch
+        if event:
+            query["event"] = event
+
+        response = self._get_json(
+            f"/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_id}/runs",
+            query,
+        )
+        if not isinstance(response, dict):
+            raise AssertionError(f"Expected a workflow-runs payload dict, got: {type(response)!r}")
+        workflow_runs = response.get("workflow_runs", [])
+        if not isinstance(workflow_runs, list):
+            raise AssertionError(f"Expected a list of workflow runs, got: {type(workflow_runs)!r}")
+        return workflow_runs
+
+    def workflow_run(self, run_id: int) -> dict[str, object]:
+        response = self._get_json(f"/repos/{self.owner}/{self.repo}/actions/runs/{run_id}")
+        if not isinstance(response, dict):
+            raise AssertionError(f"Expected a workflow-run payload dict, got: {type(response)!r}")
+        return response
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, object]]:
+        response = self._get_json(
+            f"/repos/{self.owner}/{self.repo}/releases",
+            {"per_page": per_page},
+        )
+        if not isinstance(response, list):
+            raise AssertionError(f"Expected a list of releases, got: {type(response)!r}")
+        return response
+
+    def release_by_tag(self, tag: str) -> dict[str, object]:
+        response = self._get_json(f"/repos/{self.owner}/{self.repo}/releases/tags/{tag}")
+        if not isinstance(response, dict):
+            raise AssertionError(f"Expected a release payload dict, got: {type(response)!r}")
+        return response

--- a/testing/frameworks/api/rest/github_actions_release_client.py
+++ b/testing/frameworks/api/rest/github_actions_release_client.py
@@ -5,13 +5,14 @@ from dataclasses import dataclass
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from testing.core.interfaces.github_actions_release_client import GitHubActionsReleaseClient
 from testing.frameworks.api.rest.github_publication_gate_client import (
     GitHubPublicationGateRestClient,
 )
 
 
 @dataclass(frozen=True)
-class GitHubActionsReleaseRestClient(GitHubPublicationGateRestClient):
+class GitHubActionsReleaseRestClient(GitHubPublicationGateRestClient, GitHubActionsReleaseClient):
     def _request(
         self,
         method: str,

--- a/testing/tests/DMC-996/README.md
+++ b/testing/tests/DMC-996/README.md
@@ -1,0 +1,35 @@
+# DMC-996 automated test
+
+This test triggers the live `beta-release.yml` workflow on `main`, waits for the
+publication flow to finish, then verifies two user-visible surfaces:
+
+1. the published prerelease page exposes the maintained DMTools CLI and DMTools
+   Agent Skill assets with GitHub Releases install guidance; and
+2. the publication-job `GITHUB_STEP_SUMMARY` mirrors that supported packaging
+   model while keeping beta/prerelease framing.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-996/test_dmc_996.py -q
+```
+
+## Environment
+
+The live workflow dispatch requires repository access through `GH_TOKEN` or
+`GITHUB_TOKEN`. In CI those credentials are injected automatically; when running
+locally, use a token that can dispatch workflows and read Actions logs/releases
+for `epam/dm.ai`.
+
+## Expected passing output
+
+```text
+.                                                                        [100%]
+1 passed
+```

--- a/testing/tests/DMC-996/config.yaml
+++ b/testing/tests/DMC-996/config.yaml
@@ -1,0 +1,14 @@
+test_id: DMC-996
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_file: beta-release.yml
+workflow_ref: main
+workflow_name: Beta Release
+release_job_name: create-beta-release
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 3600
+poll_interval_seconds: 20

--- a/testing/tests/DMC-996/test_dmc_996.py
+++ b/testing/tests/DMC-996/test_dmc_996.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.beta_release_summary_audit_service_factory import (  # noqa: E402
+    create_beta_release_summary_audit_service,
+)
+from testing.components.services.beta_release_summary_audit_service import (  # noqa: E402
+    BetaReleaseSummaryAuditService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+
+
+def build_service(repository_root: Path = REPOSITORY_ROOT) -> BetaReleaseSummaryAuditService:
+    return create_beta_release_summary_audit_service(
+        repository_root=repository_root,
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["workflow_name"]),
+        release_job_name=str(CONFIG["release_job_name"]),
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+    )
+
+
+def test_dmc_996_beta_release_step_summary_matches_supported_packaging_model() -> None:
+    service = build_service()
+
+    audit = service.audit()
+
+    assert audit.workflow_run is not None
+    assert audit.release_job is not None
+    assert audit.release is not None
+    assert not audit.failures, service.format_failures(audit.failures)

--- a/testing/tests/DMC-996/test_dmc_996.py
+++ b/testing/tests/DMC-996/test_dmc_996.py
@@ -11,7 +11,7 @@ if str(REPOSITORY_ROOT) not in sys.path:
 from testing.components.factories.beta_release_summary_audit_service_factory import (  # noqa: E402
     create_beta_release_summary_audit_service,
 )
-from testing.components.services.beta_release_summary_audit_service import (  # noqa: E402
+from testing.core.interfaces.beta_release_summary_audit_service import (  # noqa: E402
     BetaReleaseSummaryAuditService,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402


### PR DESCRIPTION
# DMC-996 — Test automation result: **FAILED**

## Result

- **Workflow run:** [Beta Release run 25378293215](https://github.com/epam/dm.ai/actions/runs/25378293215)
- **Publication job:** [create-beta-release](https://github.com/epam/dm.ai/actions/runs/25378293215/job/74419717089)
- **Prerelease page checked:** [v1.7.181-beta.43.1](https://github.com/epam/dm.ai/releases/tag/v1.7.181-beta.43.1)
- **Pytest result:** `1 failed`

## What automation checked

1. Triggered `.github/workflows/beta-release.yml` on `main` with `workflow_dispatch`.
2. Waited for the live GitHub Actions run to complete successfully.
3. Verified the published prerelease page exposed the DMTools CLI and DMTools Agent Skill assets with GitHub Releases install commands.
4. Reconstructed the publication-job `GITHUB_STEP_SUMMARY` markdown from the live job log and checked that it reflected the supported packaging model with beta-specific framing.

## Human-style verification

From a user perspective, the visible prerelease page looked correct:

- beta framing was present;
- DMTools CLI and DMTools Agent Skill sections were present;
- GitHub Releases install commands were present on the prerelease page.

But the publication-job Step Summary a user would open from the Actions run did **not** include that packaging-model copy. It only showed:

```md
## 🧪 Beta Release Created

**Tag:** `v1.7.181-beta.43.1`
**Commit:** `${GITHUB_SHA:0:8}`

> ℹ️ Marked as **pre-release** — stable `latest` is unaffected.
```

## Expected vs actual

| Surface | Expected | Actual |
| --- | --- | --- |
| Publication job Step Summary | DMTools CLI + DMTools Agent Skill descriptions, plus GitHub Releases install guidance, with beta/prerelease framing | Only heading, tag, commit placeholder, and prerelease note |
| Live prerelease page | Beta framing and supported packaging/install model | Matched expectation |

## Assertion failure

```text
AssertionError: Step 5: The publication job Step Summary does not mirror the supported packaging copy with beta-specific framing.
Expected: The Step Summary should visibly mention the DMTools CLI and DMTools Agent Skill, include GitHub Releases install guidance, and keep the prerelease/stable-latest framing.
Actual: Job https://github.com/epam/dm.ai/actions/runs/25378293215/job/74419717089 produced summary markdown missing markers ['dmtools cli', 'dmtools agent skill', 'releases/download/', 'install.sh']. Summary preview: ## 🧪 Beta Release Created **Tag:** `v1.7.181-beta.43.1` **Commit:** `${GITHUB_SHA:0:8}` > ℹ️ Marked as **pre-release** — stable `latest` is unaffected.
```
