### PR TITLE
DMC-1001 Stable release outputs still publish raw installer links and omit supported asset URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,22 +534,19 @@ jobs:
           echo "**Version:** v${{ needs.version-and-tag.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Previous Version:** ${{ needs.version-and-tag.outputs.current_version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📦 Artifacts Included" >> $GITHUB_STEP_SUMMARY
+          echo "### Install DMTools CLI" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**CLI Tools:**" >> $GITHUB_STEP_SUMMARY
-          echo "- CLI JAR (dmtools-v${{ needs.version-and-tag.outputs.version }}-all.jar)" >> $GITHUB_STEP_SUMMARY
-          echo "- install (cross-platform wrapper)" >> $GITHUB_STEP_SUMMARY
-          echo "- install.sh (macOS/Linux)" >> $GITHUB_STEP_SUMMARY
-          echo "- install.bat (Windows cmd.exe)" >> $GITHUB_STEP_SUMMARY
-          echo "- install.ps1 (Windows PowerShell)" >> $GITHUB_STEP_SUMMARY
-          echo "- dmtools.sh" >> $GITHUB_STEP_SUMMARY
+          echo "curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash" >> $GITHUB_STEP_SUMMARY
+          echo "irm https://github.com/${{ github.repository }}/releases/latest/download/install.ps1 | iex" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Agent Skill:**" >> $GITHUB_STEP_SUMMARY
-          echo "- Skill ZIP (dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.zip)" >> $GITHUB_STEP_SUMMARY
-          echo "- Skill TAR (dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz)" >> $GITHUB_STEP_SUMMARY
-          echo "- Focused packages: dmtools-jira-skill, dmtools-github-skill, dmtools-ado-skill, dmtools-testrail-skill" >> $GITHUB_STEP_SUMMARY
-          echo "- skill-install.sh (automatic installer, macOS/Linux)"  >> $GITHUB_STEP_SUMMARY
-          echo "- skill-install.ps1 (automatic installer, Windows PowerShell)" >> $GITHUB_STEP_SUMMARY
-          echo "- skill-checksums.sha256 (checksums)" >> $GITHUB_STEP_SUMMARY
+          echo "### Install DMTools Agent Skill" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "curl -fsSL https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-and-tag.outputs.version }}/skill-install.sh | bash" >> $GITHUB_STEP_SUMMARY
+          echo "irm https://github.com/${{ github.repository }}/releases/download/v${{ needs.version-and-tag.outputs.version }}/skill-install.ps1 | iex" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📦 Included Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**CLI Tools:** CLI JAR, install wrapper, install.sh, install.bat, install.ps1, dmtools.sh" >> $GITHUB_STEP_SUMMARY
+          echo "**Agent Skill:** Skill ZIP, Skill TAR, focused skill packages, skill-install.sh, skill-install.ps1, skill-checksums.sha256" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "✅ All artifacts compiled, tested, and packaged successfully!" >> $GITHUB_STEP_SUMMARY

--- a/testing/tests/DMC-995/test_dmc_995.py
+++ b/testing/tests/DMC-995/test_dmc_995.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -19,6 +20,17 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+RELEASE_WORKFLOW_PATH = REPOSITORY_ROOT / ".github/workflows/release.yml"
+
+
+def release_summary_step_text() -> str:
+    workflow_text = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+    summary_start = workflow_text.rfind("      - name: Summary")
+    assert summary_start != -1, "release.yml must define the create-unified-release Summary step."
+    summary_text = workflow_text[summary_start:]
+    match = re.search(r"run:\s*\|\n(?P<body>(?: {10,}.*\n?)*)", summary_text)
+    assert match is not None, "release.yml Summary step must use a multiline run block."
+    return match.group("body")
 
 
 class FakeGitHubClient:
@@ -271,6 +283,23 @@ def test_dmc_995_service_reports_raw_and_server_references() -> None:
     assert "unsupported raw or server paths" in audit.failures[1].summary.lower()
     assert "workflow summary does not expose a supported cli" in audit.failures[2].summary.lower()
     assert "workflow summary does not expose a supported skill" in audit.failures[3].summary.lower()
+
+
+def test_dmc_995_release_workflow_summary_step_uses_supported_install_urls() -> None:
+    summary_step_text = release_summary_step_text()
+
+    assert "https://github.com/${{ github.repository }}/releases/latest/download/install.sh" in summary_step_text
+    assert "https://github.com/${{ github.repository }}/releases/latest/download/install.ps1" in summary_step_text
+    assert (
+        "https://github.com/${{ github.repository }}/releases/download/"
+        "v${{ needs.version-and-tag.outputs.version }}/skill-install.sh"
+    ) in summary_step_text
+    assert (
+        "https://github.com/${{ github.repository }}/releases/download/"
+        "v${{ needs.version-and-tag.outputs.version }}/skill-install.ps1"
+    ) in summary_step_text
+    assert "raw.githubusercontent.com" not in summary_step_text
+    assert "dmtools-server" not in summary_step_text
 
 
 def test_dmc_995_live_stable_release_workflow_uses_only_supported_cli_and_skill_paths() -> None:


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The checked-in stable release workflow had drifted between its two user-visible output surfaces. `Generate Release Notes` already emitted supported GitHub Releases asset URLs, but the later `Summary` step in `.github/workflows/release.yml` still wrote artifact-name bullets only, so DMC-995 kept failing on the workflow-summary surface. The current live failure against `v1.7.181` also reflects an already-published release created before the release-body copy was corrected, so that historical release page still contains raw bootstrap links.

### Fix
Updated `.github/workflows/release.yml` so the stable-release Summary now prints supported GitHub Releases install commands for both the DMTools CLI and Agent Skill before the artifact inventory. Added a deterministic regression test in `testing/tests/DMC-995/test_dmc_995.py` that reads the checked-in Summary block and asserts the required CLI/skill URLs are present and forbidden `raw.githubusercontent.com` / `dmtools-server` markers are absent.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-995/test_dmc_995.py` — `test_dmc_995_release_workflow_summary_step_uses_supported_install_urls`
- Deterministic DMC-995 checks: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-995/test_dmc_995.py -q -k 'not live'` — passed
- Core suite: `./gradlew :dmtools-core:test` — passed
- Live linked test: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-995/test_dmc_995.py -q` — still fails against the already-published `v1.7.181` release/output on `main`

### Notes
The remaining live failure is not from the checked-in workflow anymore; it persists because this branch cannot retroactively rewrite the published `v1.7.181` GitHub Release body or its historical workflow summary. Running the stable release workflow after this change is merged is required for DMC-995 to pass end-to-end against live GitHub state.
