### PR TITLE
DMC-1002 Beta release Step Summary omits supported CLI/skill packaging copy and install guidance

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -225,9 +225,4 @@ jobs:
 
       - name: Summary
         run: |
-          echo "## 🧪 Beta Release Created" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Tag:** \`${{ needs.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`${GITHUB_SHA:0:8}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "> ℹ️ Marked as **pre-release** — stable \`latest\` is unaffected." >> $GITHUB_STEP_SUMMARY
+          cat release_notes.md >> $GITHUB_STEP_SUMMARY

--- a/testing/components/services/beta_release_summary_audit_service.py
+++ b/testing/components/services/beta_release_summary_audit_service.py
@@ -409,10 +409,11 @@ class BetaReleaseSummaryAuditService(BetaReleaseSummaryAuditServiceContract):
         release_notes_added = False
         for raw_line in raw_log_text.splitlines():
             line = self._normalize_log_line(raw_line)
+            is_group_wrapper = line.startswith("##[group]Run ")
             candidate = line.removeprefix("##[group]Run ").strip()
             if ">> $GITHUB_STEP_SUMMARY" not in candidate:
                 continue
-            match = self.SUMMARY_ECHO_PATTERN.search(line)
+            match = None if is_group_wrapper else self.SUMMARY_ECHO_PATTERN.search(candidate)
             if not match:
                 if (
                     not release_notes_added

--- a/testing/components/services/beta_release_summary_audit_service.py
+++ b/testing/components/services/beta_release_summary_audit_service.py
@@ -49,6 +49,9 @@ class BetaReleaseSummaryAuditService(BetaReleaseSummaryAuditServiceContract):
         "skill-checksums.sha256",
     )
     SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
+    SUMMARY_RELEASE_NOTES_PATTERN = re.compile(
+        r"cat\s+release_notes\.md\s*>>\s*\$GITHUB_STEP_SUMMARY$"
+    )
     ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
     TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
     RELEASE_URL_PATTERN = re.compile(
@@ -402,17 +405,39 @@ class BetaReleaseSummaryAuditService(BetaReleaseSummaryAuditServiceContract):
 
     def _extract_step_summary_markdown(self, raw_log_text: str) -> str:
         lines: list[str] = []
+        release_notes_markdown = self._extract_release_notes_markdown(raw_log_text)
+        release_notes_added = False
         for raw_line in raw_log_text.splitlines():
             line = self._normalize_log_line(raw_line)
-            if line.startswith("##[group]Run "):
-                continue
-            if ">> $GITHUB_STEP_SUMMARY" not in line:
+            candidate = line.removeprefix("##[group]Run ").strip()
+            if ">> $GITHUB_STEP_SUMMARY" not in candidate:
                 continue
             match = self.SUMMARY_ECHO_PATTERN.search(line)
             if not match:
+                if (
+                    not release_notes_added
+                    and release_notes_markdown
+                    and self.SUMMARY_RELEASE_NOTES_PATTERN.search(candidate)
+                ):
+                    lines.append(release_notes_markdown)
+                    release_notes_added = True
                 continue
             lines.append(self._decode_echo_argument(match.group("argument")))
         return "\n".join(lines).strip()
+
+    def _extract_release_notes_markdown(self, raw_log_text: str) -> str:
+        release_notes_lines: list[str] = []
+        in_release_notes_block = False
+        for raw_line in raw_log_text.splitlines():
+            line = self._normalize_log_line(raw_line)
+            if not in_release_notes_block:
+                if line == "cat > release_notes.md << EOF":
+                    in_release_notes_block = True
+                continue
+            if line == "EOF":
+                break
+            release_notes_lines.append(line)
+        return "\n".join(release_notes_lines).strip()
 
     def _log_excerpt(self, raw_log_text: str, limit: int = 6000) -> str:
         cleaned = "\n".join(self._normalize_log_line(line) for line in raw_log_text.splitlines())

--- a/testing/components/services/deprecated_workflow_output_service.py
+++ b/testing/components/services/deprecated_workflow_output_service.py
@@ -52,6 +52,9 @@ class DeprecatedWorkflowOutputService:
     STEP_SUMMARY_ECHO_PATTERN = re.compile(
         r"""^\s*echo\s+("([^"\\]|\\.)*"|'[^']*')\s*>>\s*\$GITHUB_STEP_SUMMARY\s*$"""
     )
+    STEP_SUMMARY_RELEASE_NOTES_PATTERN = re.compile(
+        r"^\s*cat\s+release_notes\.md\s*>>\s*\$GITHUB_STEP_SUMMARY\s*$"
+    )
 
     def __init__(
         self,
@@ -226,11 +229,14 @@ class DeprecatedWorkflowOutputService:
 
     def _extract_step_summary(self, workflow_text: str) -> str:
         lines: list[str] = []
+        release_notes = self._extract_release_notes_heredoc(workflow_text)
         for workflow_line in workflow_text.splitlines():
             match = self.STEP_SUMMARY_ECHO_PATTERN.match(workflow_line)
-            if not match:
+            if match:
+                lines.append(self._decode_shell_string(match.group(1)))
                 continue
-            lines.append(self._decode_shell_string(match.group(1)))
+            if release_notes and self.STEP_SUMMARY_RELEASE_NOTES_PATTERN.match(workflow_line):
+                lines.append(release_notes)
         return "\n".join(lines).strip()
 
     @staticmethod

--- a/testing/tests/DMC-996/test_dmc_996.py
+++ b/testing/tests/DMC-996/test_dmc_996.py
@@ -207,3 +207,47 @@ def test_dmc_996_service_reads_release_notes_backed_step_summary_from_logs() -> 
     normalized_summary = " ".join(audit.release_job.step_summary_markdown.split())
     normalized_release_notes = " ".join(release_notes.split())
     assert normalized_summary == normalized_release_notes
+
+
+def test_dmc_996_service_does_not_double_count_echo_based_step_summary_logs() -> None:
+    tag = "v1.7.181-beta.43.1"
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    expected_summary = (
+        "## This is a pre-release / beta build\n"
+        "> Stable latest remains available for production installs.\n"
+        "### Install DMTools CLI\n"
+        "curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.181-beta.43.1/install.sh | bash\n"
+        "### Install DMTools Agent Skill\n"
+        "curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.181-beta.43.1/skill-install.sh | bash"
+    )
+    workflow_log_text = (
+        f"Release URL: https://github.com/epam/dm.ai/releases/tag/{tag}\n"
+        "##[group]Run echo \"## This is a pre-release / beta build\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:30Z echo \"## This is a pre-release / beta build\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:31Z echo \"> Stable latest remains available for production installs.\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:32Z echo \"### Install DMTools CLI\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:33Z echo \"curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.181-beta.43.1/install.sh | bash\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:34Z echo \"### Install DMTools Agent Skill\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:35Z echo \"curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.181-beta.43.1/skill-install.sh | bash\" >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:36Z ##[endgroup]\n"
+    )
+    service = BetaReleaseSummaryAuditServiceImpl(
+        github_client=FakeGitHubActionsReleaseClient(
+            workflow_log_text,
+            tag=tag,
+            created_at=created_at,
+        ),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["workflow_name"]),
+        release_job_name=str(CONFIG["release_job_name"]),
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+    )
+
+    audit = service.audit()
+
+    assert audit.release_job is not None
+    assert not audit.failures, service.format_failures(audit.failures)
+    assert audit.release_job.step_summary_markdown == expected_summary

--- a/testing/tests/DMC-996/test_dmc_996.py
+++ b/testing/tests/DMC-996/test_dmc_996.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -19,6 +20,30 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "beta-release.yml"
+SUMMARY_RELEASE_NOTES_COMMAND = "cat release_notes.md >> $GITHUB_STEP_SUMMARY"
+RELEASE_NOTE_REQUIRED_MARKERS = (
+    "pre-release / beta build",
+    "latest stable release",
+    "DMTools CLI",
+    "DMTools Agent Skill",
+    "releases/download/",
+    "install.sh",
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _release_notes_block(workflow_text: str) -> str:
+    match = re.search(
+        r"cat > release_notes\.md << EOF\n(?P<value>.*?)\n\s*EOF",
+        workflow_text,
+        re.DOTALL,
+    )
+    assert match is not None, "Expected beta-release workflow to generate release_notes.md via heredoc"
+    return match.group("value")
 
 
 def build_service(repository_root: Path = REPOSITORY_ROOT) -> BetaReleaseSummaryAuditService:
@@ -45,3 +70,14 @@ def test_dmc_996_beta_release_step_summary_matches_supported_packaging_model() -
     assert audit.release_job is not None
     assert audit.release is not None
     assert not audit.failures, service.format_failures(audit.failures)
+
+
+def test_dmc_996_beta_release_workflow_summary_reuses_supported_release_notes_copy() -> None:
+    workflow_text = _workflow_text()
+    release_notes = _release_notes_block(workflow_text)
+
+    assert SUMMARY_RELEASE_NOTES_COMMAND in workflow_text
+
+    normalized_release_notes = " ".join(release_notes.split())
+    for marker in RELEASE_NOTE_REQUIRED_MARKERS:
+        assert marker in normalized_release_notes

--- a/testing/tests/DMC-996/test_dmc_996.py
+++ b/testing/tests/DMC-996/test_dmc_996.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -11,6 +12,9 @@ if str(REPOSITORY_ROOT) not in sys.path:
 
 from testing.components.factories.beta_release_summary_audit_service_factory import (  # noqa: E402
     create_beta_release_summary_audit_service,
+)
+from testing.components.services.beta_release_summary_audit_service import (  # noqa: E402
+    BetaReleaseSummaryAuditService as BetaReleaseSummaryAuditServiceImpl,
 )
 from testing.core.interfaces.beta_release_summary_audit_service import (  # noqa: E402
     BetaReleaseSummaryAuditService,
@@ -30,6 +34,88 @@ RELEASE_NOTE_REQUIRED_MARKERS = (
     "releases/download/",
     "install.sh",
 )
+
+
+class FakeGitHubActionsReleaseClient:
+    def __init__(self, workflow_log_text: str, *, tag: str, created_at: str) -> None:
+        self._workflow_log_text = workflow_log_text
+        self._tag = tag
+        self._created_at = created_at
+        self._dispatched = False
+        self._run = {
+            "id": 901,
+            "html_url": "https://github.com/epam/dm.ai/actions/runs/901",
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "success",
+            "head_branch": "main",
+            "head_sha": "abc123def456",
+            "created_at": created_at,
+            "run_number": 77,
+        }
+        self._job = {
+            "id": 801,
+            "name": "create-beta-release",
+            "html_url": "https://github.com/epam/dm.ai/actions/runs/901/job/801",
+            "status": "completed",
+            "conclusion": "success",
+        }
+        self._release = {
+            "tag_name": tag,
+            "html_url": f"https://github.com/epam/dm.ai/releases/tag/{tag}",
+            "prerelease": True,
+            "created_at": created_at,
+            "body": _release_notes_block(_workflow_text()),
+            "assets": [
+                {"name": "dmtools-v1.7.181-all.jar"},
+                {"name": "install.sh"},
+                {"name": "install.ps1"},
+                {"name": "dmtools.sh"},
+                {"name": "dmtools-skill-v1.7.181.zip"},
+                {"name": "skill-install.sh"},
+                {"name": "skill-install.ps1"},
+                {"name": "skill-checksums.sha256"},
+            ],
+        }
+
+    def dispatch_workflow(self, workflow_id: str, *, ref: str) -> None:
+        del workflow_id, ref
+        self._dispatched = True
+
+    def branch_head_sha(self, branch: str) -> str:
+        del branch
+        return str(self._run["head_sha"])
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict]:
+        del workflow_id, branch, event, per_page
+        return [self._run] if self._dispatched else []
+
+    def workflow_run(self, run_id: int) -> dict:
+        assert run_id == self._run["id"]
+        return self._run
+
+    def workflow_jobs(self, run_id: int) -> list[dict]:
+        assert run_id == self._run["id"]
+        return [self._job]
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        assert job_id == self._job["id"]
+        return self._workflow_log_text
+
+    def release_by_tag(self, tag: str) -> dict:
+        assert tag == self._tag
+        return self._release
+
+    def list_releases(self, per_page: int = 20) -> list[dict]:
+        del per_page
+        return [self._release]
 
 
 def _workflow_text() -> str:
@@ -81,3 +167,43 @@ def test_dmc_996_beta_release_workflow_summary_reuses_supported_release_notes_co
     normalized_release_notes = " ".join(release_notes.split())
     for marker in RELEASE_NOTE_REQUIRED_MARKERS:
         assert marker in normalized_release_notes
+
+
+def test_dmc_996_service_reads_release_notes_backed_step_summary_from_logs() -> None:
+    release_notes = _release_notes_block(_workflow_text())
+    tag = "v1.7.181-beta.43.1"
+    created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    workflow_log_text = (
+        "##[group]Run VERSION=\"1.7.181-beta.43.1\"\n"
+        "SHORT_SHA=\"abc123de\"\n"
+        "cat > release_notes.md << EOF\n"
+        f"{release_notes}\n"
+        "EOF\n"
+        "Release notes generated\n"
+        f"Release URL: https://github.com/epam/dm.ai/releases/tag/{tag}\n"
+        "##[group]Run cat release_notes.md >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:36Z cat release_notes.md >> $GITHUB_STEP_SUMMARY\n"
+        "2026-05-05T09:59:37Z ##[endgroup]\n"
+    )
+    service = BetaReleaseSummaryAuditServiceImpl(
+        github_client=FakeGitHubActionsReleaseClient(
+            workflow_log_text,
+            tag=tag,
+            created_at=created_at,
+        ),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["workflow_name"]),
+        release_job_name=str(CONFIG["release_job_name"]),
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+    )
+
+    audit = service.audit()
+
+    assert audit.release_job is not None
+    assert not audit.failures, service.format_failures(audit.failures)
+    normalized_summary = " ".join(audit.release_job.step_summary_markdown.split())
+    normalized_release_notes = " ".join(release_notes.split())
+    assert normalized_summary == normalized_release_notes

--- a/testing/tests/DMC-997/test_dmc_997.py
+++ b/testing/tests/DMC-997/test_dmc_997.py
@@ -111,3 +111,34 @@ jobs:
     assert any("customer-facing install heading" in finding.summary for finding in findings)
     assert any("customer-facing install command" in finding.summary for finding in findings)
     assert any("Swagger guidance reference" in finding.summary for finding in findings)
+
+
+def test_dmc_997_service_reads_release_notes_backed_step_summary() -> None:
+    service = DeprecatedWorkflowOutputService(
+        workflow_paths=(".github/workflows/standalone-release.yml",),
+        workflow_text_by_path={
+            ".github/workflows/standalone-release.yml": """
+jobs:
+  release:
+    steps:
+      - name: Generate Release Notes
+        run: |
+          cat > release_notes.md << EOF
+          > **Deprecated / internal-only workflow.**
+          curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash
+          EOF
+      - name: Summarize release
+        run: |
+          cat release_notes.md >> $GITHUB_STEP_SUMMARY
+""".strip()
+        },
+    )
+
+    surfaces = service.output_surfaces()
+
+    assert any(
+        surface.surface_name == "step summary"
+        and "Deprecated / internal-only workflow." in surface.content
+        and "install.sh | bash" in surface.content
+        for surface in surfaces
+    )


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The beta release workflow already generated correct prerelease copy in `release_notes.md`, but the `create-beta-release` job summary was still emitted from an older hard-coded stub. That left the Actions Step Summary without the required DMTools CLI / DMTools Agent Skill packaging text and GitHub Releases install guidance even though the prerelease page itself was correct.

### Fix
Updated `.github/workflows/beta-release.yml` so the publication job writes `release_notes.md` directly into `$GITHUB_STEP_SUMMARY`. This keeps the Step Summary synchronized with the supported beta release copy instead of maintaining a separate stale summary path.

Added a focused local regression test in `testing/tests/DMC-996/test_dmc_996.py` that fails unless the workflow summary reuses `release_notes.md` and that release-notes template contains the required beta packaging/install markers.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-996/test_dmc_996.py` — `test_dmc_996_beta_release_workflow_summary_reuses_supported_release_notes_copy`
- Targeted regression test: PASSED
- Linked live audit before fix: FAILED on remote `main` with missing summary markers in run `25392208976`
- Related Python regression: `testing/tests/DMC-999/test_dmc_999.py` — PASSED
- Full core suite: `./gradlew :dmtools-core:test` — PASSED

### Notes
`testing/tests/DMC-997/test_dmc_997.py::test_dmc_997_live_deprecated_workflow_outputs_are_internal_only` currently fails in the baseline for unrelated standalone-release messaging and was not changed as part of this fix.
