### PR TITLE
DMC-1003 Test: Run deprecated standalone and server workflows — installer scripts and public headers are removed

### DIFF
--- a/testing/components/factories/beta_release_summary_audit_service_factory.py
+++ b/testing/components/factories/beta_release_summary_audit_service_factory.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
+from testing.components.factories.github_actions_release_client_factory import (
+    create_github_actions_release_client,
+)
 from testing.components.services.beta_release_summary_audit_service import (
     BetaReleaseSummaryAuditService as BetaReleaseSummaryAuditServiceImpl,
 )
 from testing.core.interfaces.beta_release_summary_audit_service import (
     BetaReleaseSummaryAuditService,
-)
-from testing.frameworks.api.rest.github_actions_release_client import (
-    GitHubActionsReleaseRestClient,
 )
 
 
@@ -28,14 +27,11 @@ def create_beta_release_summary_audit_service(
     poll_interval_seconds: int,
     token: str | None = None,
 ) -> BetaReleaseSummaryAuditService:
-    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
-        "GITHUB_TOKEN"
-    )
     return BetaReleaseSummaryAuditServiceImpl(
-        github_client=GitHubActionsReleaseRestClient(
+        github_client=create_github_actions_release_client(
             owner=owner,
             repo=repo,
-            token=github_token,
+            token=token,
         ),
         workflow_file=workflow_file,
         workflow_ref=workflow_ref,

--- a/testing/components/factories/deprecated_workflow_run_audit_service_factory.py
+++ b/testing/components/factories/deprecated_workflow_run_audit_service_factory.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-import os
-
+from testing.components.factories.github_actions_release_client_factory import (
+    create_github_actions_release_client,
+)
 from testing.components.services.deprecated_workflow_run_audit_service import (
     DeprecatedWorkflowRunAuditService as DeprecatedWorkflowRunAuditServiceImpl,
 )
 from testing.core.interfaces.deprecated_workflow_run_audit_service import (
     DeprecatedWorkflowRunAuditService,
-)
-from testing.frameworks.api.rest.github_actions_release_client import (
-    GitHubActionsReleaseRestClient,
 )
 
 
@@ -32,14 +30,11 @@ def create_deprecated_workflow_run_audit_service(
     reuse_existing_release: bool = False,
     token: str | None = None,
 ) -> DeprecatedWorkflowRunAuditService:
-    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
-        "GITHUB_TOKEN"
-    )
     return DeprecatedWorkflowRunAuditServiceImpl(
-        github_client=GitHubActionsReleaseRestClient(
+        github_client=create_github_actions_release_client(
             owner=owner,
             repo=repo,
-            token=github_token,
+            token=token,
         ),
         workflow_file=workflow_file,
         workflow_ref=workflow_ref,

--- a/testing/components/factories/deprecated_workflow_run_audit_service_factory.py
+++ b/testing/components/factories/deprecated_workflow_run_audit_service_factory.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+
+from testing.components.services.deprecated_workflow_run_audit_service import (
+    DeprecatedWorkflowRunAuditService as DeprecatedWorkflowRunAuditServiceImpl,
+)
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.frameworks.api.rest.github_actions_release_client import (
+    GitHubActionsReleaseRestClient,
+)
+
+
+def create_deprecated_workflow_run_audit_service(
+    *,
+    owner: str,
+    repo: str,
+    workflow_file: str,
+    workflow_ref: str,
+    workflow_name: str,
+    release_job_name: str,
+    release_tag: str,
+    dispatch_timeout_seconds: int,
+    completion_timeout_seconds: int,
+    poll_interval_seconds: int,
+    required_notice_markers: tuple[str, ...],
+    forbidden_strings: tuple[str, ...],
+    require_step_summary: bool,
+    dispatch_inputs: dict[str, object] | None = None,
+    reuse_existing_release: bool = False,
+    token: str | None = None,
+) -> DeprecatedWorkflowRunAuditService:
+    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    return DeprecatedWorkflowRunAuditServiceImpl(
+        github_client=GitHubActionsReleaseRestClient(
+            owner=owner,
+            repo=repo,
+            token=github_token,
+        ),
+        workflow_file=workflow_file,
+        workflow_ref=workflow_ref,
+        workflow_name=workflow_name,
+        release_job_name=release_job_name,
+        release_tag=release_tag,
+        dispatch_timeout_seconds=dispatch_timeout_seconds,
+        completion_timeout_seconds=completion_timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        required_notice_markers=required_notice_markers,
+        forbidden_strings=forbidden_strings,
+        require_step_summary=require_step_summary,
+        dispatch_inputs=dispatch_inputs,
+        reuse_existing_release=reuse_existing_release,
+    )

--- a/testing/components/factories/github_actions_release_client_factory.py
+++ b/testing/components/factories/github_actions_release_client_factory.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import os
+
+from testing.core.interfaces.github_actions_release_client import GitHubActionsReleaseClient
+from testing.frameworks.api.rest.github_actions_release_client import (
+    GitHubActionsReleaseRestClient,
+)
+
+
+def create_github_actions_release_client(
+    *,
+    owner: str,
+    repo: str,
+    token: str | None = None,
+) -> GitHubActionsReleaseClient:
+    github_token = token if token is not None else os.environ.get("GH_TOKEN") or os.environ.get(
+        "GITHUB_TOKEN"
+    )
+    return GitHubActionsReleaseRestClient(
+        owner=owner,
+        repo=repo,
+        token=github_token,
+    )

--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from threading import Event
+from typing import Any
+from urllib.error import HTTPError
+
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (
+    DeprecatedWorkflowRunAuditService as DeprecatedWorkflowRunAuditServiceContract,
+)
+from testing.core.interfaces.github_actions_release_client import GitHubActionsReleaseClient
+from testing.core.models.deprecated_workflow_run_audit import (
+    DeprecatedWorkflowAuditFailure,
+    DeprecatedWorkflowJobObservation,
+    DeprecatedWorkflowReleaseObservation,
+    DeprecatedWorkflowRunAudit,
+    DeprecatedWorkflowRunObservation,
+)
+
+
+class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContract):
+    SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
+    ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+    TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
+
+    def __init__(
+        self,
+        github_client: GitHubActionsReleaseClient,
+        *,
+        workflow_file: str,
+        workflow_ref: str,
+        workflow_name: str,
+        release_job_name: str,
+        release_tag: str,
+        dispatch_timeout_seconds: int,
+        completion_timeout_seconds: int,
+        poll_interval_seconds: int,
+        required_notice_markers: tuple[str, ...],
+        forbidden_strings: tuple[str, ...],
+        require_step_summary: bool,
+        dispatch_inputs: dict[str, object] | None = None,
+        reuse_existing_release: bool = False,
+    ) -> None:
+        self.github_client = github_client
+        self.workflow_file = workflow_file
+        self.workflow_ref = workflow_ref
+        self.workflow_name = workflow_name
+        self.release_job_name = release_job_name
+        self.release_tag = release_tag
+        self.dispatch_timeout_seconds = dispatch_timeout_seconds
+        self.completion_timeout_seconds = completion_timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self.required_notice_markers = required_notice_markers
+        self.forbidden_strings = forbidden_strings
+        self.require_step_summary = require_step_summary
+        self.dispatch_inputs = dict(dispatch_inputs or {})
+        self.reuse_existing_release = reuse_existing_release
+        self._waiter = Event()
+
+    def audit(self) -> DeprecatedWorkflowRunAudit:
+        failures: list[DeprecatedWorkflowAuditFailure] = []
+        target_head_sha = self.github_client.branch_head_sha(self.workflow_ref)
+
+        if self.reuse_existing_release:
+            existing_audit = self._audit_existing_successful_run(target_head_sha)
+            if existing_audit is not None:
+                return existing_audit
+
+        dispatch_started_at = datetime.now(timezone.utc)
+        existing_run_ids = {
+            int(run["id"])
+            for run in self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                per_page=20,
+            )
+            if run.get("id") is not None
+        }
+
+        self.github_client.dispatch_workflow(
+            self.workflow_file,
+            ref=self.workflow_ref,
+            inputs=self.dispatch_inputs,
+        )
+        workflow_run = self._wait_for_dispatched_run(
+            existing_run_ids=existing_run_ids,
+            target_head_sha=target_head_sha,
+            dispatch_started_at=dispatch_started_at,
+        )
+        if workflow_run is None:
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=1,
+                    summary=f"The {self.workflow_name} workflow did not appear after dispatch.",
+                    expected=(
+                        f"A new {self.workflow_name!r} run triggered by workflow_dispatch on "
+                        f"{self.workflow_ref!r}."
+                    ),
+                    actual=(
+                        f"No new workflow_dispatch run was listed for {self.workflow_file!r} "
+                        f"within {self.dispatch_timeout_seconds} seconds."
+                    ),
+                )
+            )
+            return DeprecatedWorkflowRunAudit(
+                workflow_run=None,
+                release_job=None,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        return self._complete_audit(workflow_run=workflow_run, dispatch_started_at=dispatch_started_at)
+
+    @staticmethod
+    def format_failures(
+        failures: tuple[DeprecatedWorkflowAuditFailure, ...] | list[DeprecatedWorkflowAuditFailure],
+    ) -> str:
+        lines = ["Deprecated workflow run outputs did not match the expected live behavior:"]
+        for failure in failures:
+            lines.append(failure.format())
+        return "\n".join(lines)
+
+    def _audit_existing_successful_run(
+        self,
+        target_head_sha: str,
+    ) -> DeprecatedWorkflowRunAudit | None:
+        try:
+            release_payload = self.github_client.release_by_tag(self.release_tag)
+        except HTTPError as error:
+            if error.code != 404:
+                raise
+            return None
+
+        workflow_run: DeprecatedWorkflowRunObservation | None = None
+        for run in self.github_client.workflow_runs_for_workflow(
+            self.workflow_file,
+            branch=self.workflow_ref,
+            per_page=20,
+        ):
+            if str(run.get("head_sha", "")) != target_head_sha:
+                continue
+            if str(run.get("status", "")) != "completed":
+                continue
+            if str(run.get("conclusion", "")) != "success":
+                continue
+            workflow_run = self._build_run_observation(run)
+            break
+
+        if workflow_run is None:
+            return None
+
+        return self._complete_audit(
+            workflow_run=workflow_run,
+            dispatch_started_at=self._parse_github_datetime(workflow_run.created_at)
+            or datetime.now(timezone.utc),
+            release_payload=release_payload,
+        )
+
+    def _complete_audit(
+        self,
+        *,
+        workflow_run: DeprecatedWorkflowRunObservation,
+        dispatch_started_at: datetime,
+        release_payload: dict[str, Any] | None = None,
+    ) -> DeprecatedWorkflowRunAudit:
+        failures: list[DeprecatedWorkflowAuditFailure] = []
+        release_job_payload = None
+        release_job = None
+
+        workflow_run = self._wait_for_completion(workflow_run.run_id)
+        if workflow_run.status != "completed" or workflow_run.conclusion != "success":
+            release_job_payload = self._find_release_job_payload(workflow_run.run_id)
+            if release_job_payload is not None:
+                release_job = self._build_release_job_observation(release_job_payload)
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=2,
+                    summary=f"The {self.workflow_name} workflow did not finish successfully.",
+                    expected="A completed workflow run with conclusion 'success'.",
+                    actual=(
+                        f"Run {workflow_run.html_url} finished with status={workflow_run.status!r} "
+                        f"and conclusion={workflow_run.conclusion!r}. "
+                        + (
+                            f"Job excerpt: {self._preview_text(release_job.log_excerpt, limit=360)}"
+                            if release_job is not None
+                            else "No publication job log was available."
+                        )
+                    ),
+                )
+            )
+            return DeprecatedWorkflowRunAudit(
+                workflow_run=workflow_run,
+                release_job=release_job,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release_job_payload = self._find_release_job_payload(workflow_run.run_id)
+        if release_job_payload is None:
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=3,
+                    summary="The completed workflow run does not expose the publication job.",
+                    expected=f"A job named {self.release_job_name!r} in the completed workflow run.",
+                    actual=f"No job matched {self.release_job_name!r} in run {workflow_run.html_url}.",
+                )
+            )
+            return DeprecatedWorkflowRunAudit(
+                workflow_run=workflow_run,
+                release_job=None,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release_job = self._build_release_job_observation(release_job_payload)
+        if release_job.status != "completed" or release_job.conclusion != "success":
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=3,
+                    summary="The publication job did not finish successfully.",
+                    expected=f"A completed {self.release_job_name} job with conclusion 'success'.",
+                    actual=(
+                        f"Job {release_job.html_url} finished with status={release_job.status!r} "
+                        f"and conclusion={release_job.conclusion!r}. "
+                        f"Job excerpt: {self._preview_text(release_job.log_excerpt, limit=360)}"
+                    ),
+                )
+            )
+            return DeprecatedWorkflowRunAudit(
+                workflow_run=workflow_run,
+                release_job=release_job,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        release = self._find_release_observation(
+            release_payload=release_payload,
+            dispatch_started_at=dispatch_started_at,
+        )
+        if release is None:
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=4,
+                    summary="The workflow release page was not discoverable after the workflow succeeded.",
+                    expected=(
+                        f"A GitHub release tagged {self.release_tag!r} created by the completed "
+                        "workflow run."
+                    ),
+                    actual=(
+                        f"Job {release_job.html_url} completed successfully, but release "
+                        f"{self.release_tag!r} was not discoverable."
+                    ),
+                )
+            )
+            return DeprecatedWorkflowRunAudit(
+                workflow_run=workflow_run,
+                release_job=release_job,
+                release=None,
+                failures=tuple(failures),
+            )
+
+        failures.extend(self._audit_surface("release body", release.body))
+        if self.require_step_summary:
+            if not release_job.step_summary_markdown.strip():
+                failures.append(
+                    DeprecatedWorkflowAuditFailure(
+                        step=5,
+                        summary="The publication job did not publish any Step Summary content.",
+                        expected="Visible GITHUB_STEP_SUMMARY content for the completed run.",
+                        actual=f"Job {release_job.html_url} produced no captured summary lines.",
+                    )
+                )
+            else:
+                failures.extend(self._audit_surface("step summary", release_job.step_summary_markdown))
+        elif release_job.step_summary_markdown.strip():
+            failures.extend(self._audit_surface("step summary", release_job.step_summary_markdown))
+
+        return DeprecatedWorkflowRunAudit(
+            workflow_run=workflow_run,
+            release_job=release_job,
+            release=release,
+            failures=tuple(failures),
+        )
+
+    def _audit_surface(
+        self,
+        surface_name: str,
+        content: str,
+    ) -> list[DeprecatedWorkflowAuditFailure]:
+        normalized_content = self._normalize_visible_text(content)
+        failures: list[DeprecatedWorkflowAuditFailure] = []
+
+        missing_markers = [
+            marker for marker in self.required_notice_markers if marker not in normalized_content
+        ]
+        if missing_markers:
+            failures.append(
+                DeprecatedWorkflowAuditFailure(
+                    step=5,
+                    summary=f"The published {surface_name} is missing the deprecated/internal-only notice.",
+                    expected=(
+                        "Live workflow output should clearly position the workflow as deprecated "
+                        "and internal-only."
+                    ),
+                    actual=(
+                        f"Missing markers {missing_markers}. Visible content: "
+                        f"{self._preview_text(content, limit=360)}"
+                    ),
+                )
+            )
+
+        for forbidden in self.forbidden_strings:
+            if forbidden in normalized_content:
+                failures.append(
+                    DeprecatedWorkflowAuditFailure(
+                        step=5,
+                        summary=f"The published {surface_name} still exposes removed install guidance.",
+                        expected=(
+                            "Live workflow output must not mention installer scripts or the removed "
+                            "public installation header."
+                        ),
+                        actual=(
+                            f"Found {forbidden!r}. Visible content: "
+                            f"{self._preview_text(content, limit=360)}"
+                        ),
+                    )
+                )
+        return failures
+
+    def _wait_for_dispatched_run(
+        self,
+        *,
+        existing_run_ids: set[int],
+        target_head_sha: str,
+        dispatch_started_at: datetime,
+    ) -> DeprecatedWorkflowRunObservation | None:
+        deadline = self._deadline(self.dispatch_timeout_seconds)
+        while datetime.now(timezone.utc) < deadline:
+            runs = self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                event="workflow_dispatch",
+                per_page=20,
+            )
+            for run in runs:
+                run_id = run.get("id")
+                if run_id is None or int(run_id) in existing_run_ids:
+                    continue
+                if str(run.get("head_sha", "")) != target_head_sha:
+                    continue
+                created_at = self._parse_github_datetime(str(run.get("created_at", "")))
+                if created_at is None or created_at < dispatch_started_at - timedelta(minutes=1):
+                    continue
+                return self._build_run_observation(run)
+            self._waiter.wait(self.poll_interval_seconds)
+        return None
+
+    def _wait_for_completion(self, run_id: int) -> DeprecatedWorkflowRunObservation:
+        deadline = self._deadline(self.completion_timeout_seconds)
+        last_seen = self._build_run_observation(self.github_client.workflow_run(run_id))
+        while datetime.now(timezone.utc) < deadline:
+            current = self._build_run_observation(self.github_client.workflow_run(run_id))
+            last_seen = current
+            if current.status == "completed":
+                return current
+            self._waiter.wait(self.poll_interval_seconds)
+        return last_seen
+
+    def _find_release_job_payload(self, run_id: int) -> dict[str, Any] | None:
+        for job in self.github_client.workflow_jobs(run_id):
+            if str(job.get("name", "")) == self.release_job_name:
+                return job
+        return None
+
+    def _build_release_job_observation(self, payload: dict[str, Any]) -> DeprecatedWorkflowJobObservation:
+        job_id = int(payload["id"])
+        log_text = self.github_client.workflow_job_logs(job_id)
+        return DeprecatedWorkflowJobObservation(
+            job_id=job_id,
+            name=str(payload.get("name", "")),
+            html_url=str(payload.get("html_url", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            step_summary_markdown=self._extract_step_summary_markdown(log_text),
+            log_excerpt=self._log_excerpt(log_text),
+        )
+
+    def _find_release_observation(
+        self,
+        *,
+        release_payload: dict[str, Any] | None,
+        dispatch_started_at: datetime,
+    ) -> DeprecatedWorkflowReleaseObservation | None:
+        payload = release_payload
+        lookup_deadline = self._deadline(self.poll_interval_seconds * 3)
+        while datetime.now(timezone.utc) < lookup_deadline and payload is None:
+            try:
+                payload = self.github_client.release_by_tag(self.release_tag)
+            except HTTPError as error:
+                if error.code != 404:
+                    raise
+            if payload is None:
+                self._waiter.wait(self.poll_interval_seconds)
+
+        if payload is None:
+            return None
+
+        created_at = self._parse_github_datetime(str(payload.get("created_at", "")))
+        if created_at is not None and created_at < dispatch_started_at - timedelta(minutes=5):
+            return None
+
+        return DeprecatedWorkflowReleaseObservation(
+            tag_name=str(payload.get("tag_name", "")),
+            html_url=str(payload.get("html_url", "")),
+            body=str(payload.get("body", "")),
+        )
+
+    def _extract_step_summary_markdown(self, raw_log_text: str) -> str:
+        lines: list[str] = []
+        for raw_line in raw_log_text.splitlines():
+            line = self._normalize_log_line(raw_line)
+            if line.startswith("##[group]Run "):
+                continue
+            if ">> $GITHUB_STEP_SUMMARY" not in line:
+                continue
+            match = self.SUMMARY_ECHO_PATTERN.search(line)
+            if not match:
+                continue
+            lines.append(self._decode_echo_argument(match.group("argument")))
+        return "\n".join(lines).strip()
+
+    def _log_excerpt(self, raw_log_text: str, limit: int = 6000) -> str:
+        cleaned = "\n".join(self._normalize_log_line(line) for line in raw_log_text.splitlines())
+        if len(cleaned) <= limit:
+            return cleaned
+        return "..." + cleaned[-(limit - 3) :]
+
+    @classmethod
+    def _normalize_log_line(cls, line: str) -> str:
+        without_ansi = cls.ANSI_PATTERN.sub("", line)
+        return cls.TIMESTAMP_PREFIX_PATTERN.sub("", without_ansi).strip()
+
+    @staticmethod
+    def _decode_echo_argument(argument: str) -> str:
+        value = argument.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        return (
+            value.replace(r"\\", "\\")
+            .replace(r"\"", '"')
+            .replace(r"\`", "`")
+            .replace(r"\$", "$")
+        )
+
+    @staticmethod
+    def _normalize_visible_text(value: str) -> str:
+        return " ".join(value.lower().split())
+
+    @staticmethod
+    def _preview_text(value: str, *, limit: int) -> str:
+        compact = " ".join(value.split())
+        if not compact:
+            return "no visible text"
+        if len(compact) <= limit:
+            return compact
+        return compact[: limit - 3] + "..."
+
+    @staticmethod
+    def _build_run_observation(payload: dict[str, Any]) -> DeprecatedWorkflowRunObservation:
+        return DeprecatedWorkflowRunObservation(
+            run_id=int(payload["id"]),
+            html_url=str(payload.get("html_url", "")),
+            event=str(payload.get("event", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            head_branch=str(payload.get("head_branch", "")),
+            head_sha=str(payload.get("head_sha", "")),
+            created_at=str(payload.get("created_at", "")),
+            run_number=int(payload.get("run_number", 0)),
+        )
+
+    @staticmethod
+    def _parse_github_datetime(value: str) -> datetime | None:
+        if not value:
+            return None
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+    @staticmethod
+    def _deadline(timeout_seconds: int) -> datetime:
+        return datetime.now(timezone.utc).replace(microsecond=0) + timedelta(seconds=timeout_seconds)

--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -23,6 +23,9 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
     SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
     ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
     TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
+    RELEASE_URL_PATTERN = re.compile(r"/releases/tag/(?P<tag>[^)\s]+)")
+    RELEASE_TAG_OUTPUT_PATTERN = re.compile(r"(?:^|\b)tag_name=(?P<tag>v[0-9A-Za-z.\-]+)")
+    USING_TAG_PATTERN = re.compile(r"Using tag:\s*(?P<tag>v[0-9A-Za-z.\-]+)")
 
     def __init__(
         self,
@@ -125,6 +128,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         self,
         target_head_sha: str,
     ) -> DeprecatedWorkflowRunAudit | None:
+        if not self.release_tag:
+            return None
         try:
             release_payload = self.github_client.release_by_tag(self.release_tag)
         except HTTPError as error:
@@ -235,21 +240,22 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             )
 
         release = self._find_release_observation(
+            release_job=release_job,
             release_payload=release_payload,
             dispatch_started_at=dispatch_started_at,
         )
         if release is None:
+            expected_release = self.release_tag or "the release emitted by the completed workflow run"
             failures.append(
                 DeprecatedWorkflowAuditFailure(
                     step=4,
                     summary="The workflow release page was not discoverable after the workflow succeeded.",
                     expected=(
-                        f"A GitHub release tagged {self.release_tag!r} created by the completed "
-                        "workflow run."
+                        f"A GitHub release for {expected_release} created by the completed workflow run."
                     ),
                     actual=(
-                        f"Job {release_job.html_url} completed successfully, but release "
-                        f"{self.release_tag!r} was not discoverable."
+                        f"Job {release_job.html_url} completed successfully, but no matching release "
+                        "was discoverable from the emitted run outputs."
                     ),
                 )
             )
@@ -389,17 +395,27 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
     def _find_release_observation(
         self,
         *,
+        release_job: DeprecatedWorkflowJobObservation,
         release_payload: dict[str, Any] | None,
         dispatch_started_at: datetime,
     ) -> DeprecatedWorkflowReleaseObservation | None:
         payload = release_payload
+        candidate_tags = self._candidate_release_tags(release_job)
         lookup_deadline = self._deadline(self.poll_interval_seconds * 3)
         while datetime.now(timezone.utc) < lookup_deadline and payload is None:
-            try:
-                payload = self.github_client.release_by_tag(self.release_tag)
-            except HTTPError as error:
-                if error.code != 404:
-                    raise
+            for tag in candidate_tags:
+                try:
+                    payload = self.github_client.release_by_tag(tag)
+                except HTTPError as error:
+                    if error.code != 404:
+                        raise
+                if payload is not None:
+                    break
+            if payload is None:
+                payload = self._find_recent_release_payload(
+                    candidate_tags=candidate_tags,
+                    dispatch_started_at=dispatch_started_at,
+                )
             if payload is None:
                 self._waiter.wait(self.poll_interval_seconds)
 
@@ -415,6 +431,35 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             html_url=str(payload.get("html_url", "")),
             body=str(payload.get("body", "")),
         )
+
+    def _candidate_release_tags(self, release_job: DeprecatedWorkflowJobObservation) -> tuple[str, ...]:
+        candidates: list[str] = []
+        for value in (
+            self.release_tag,
+            self._release_tag_from_text(release_job.step_summary_markdown),
+            self._release_tag_from_text(release_job.log_excerpt),
+        ):
+            normalized = value.strip()
+            if normalized and normalized not in candidates:
+                candidates.append(normalized)
+        return tuple(candidates)
+
+    def _find_recent_release_payload(
+        self,
+        *,
+        candidate_tags: tuple[str, ...],
+        dispatch_started_at: datetime,
+    ) -> dict[str, Any] | None:
+        for release in self.github_client.list_releases(per_page=20):
+            tag_name = str(release.get("tag_name", "")).strip()
+            if candidate_tags and tag_name not in candidate_tags:
+                continue
+            created_at = self._parse_github_datetime(str(release.get("created_at", "")))
+            if created_at is None or created_at < dispatch_started_at - timedelta(minutes=5):
+                continue
+            if candidate_tags or self._release_looks_like_deprecated_workflow_output(release):
+                return release
+        return None
 
     def _extract_step_summary_markdown(self, raw_log_text: str) -> str:
         lines: list[str] = []
@@ -456,6 +501,20 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
     @staticmethod
     def _normalize_visible_text(value: str) -> str:
         return " ".join(value.lower().split())
+
+    @classmethod
+    def _release_tag_from_text(cls, text: str) -> str:
+        for pattern in (cls.RELEASE_URL_PATTERN, cls.RELEASE_TAG_OUTPUT_PATTERN, cls.USING_TAG_PATTERN):
+            match = pattern.search(text)
+            if match:
+                return match.group("tag")
+        return ""
+
+    def _release_looks_like_deprecated_workflow_output(self, payload: dict[str, Any]) -> bool:
+        body = self._normalize_visible_text(str(payload.get("body", "")))
+        if not body:
+            return False
+        return all(marker in body for marker in self.required_notice_markers)
 
     @staticmethod
     def _preview_text(value: str, *, limit: int) -> str:

--- a/testing/core/interfaces/deprecated_workflow_run_audit_service.py
+++ b/testing/core/interfaces/deprecated_workflow_run_audit_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.deprecated_workflow_run_audit import (
+    DeprecatedWorkflowAuditFailure,
+    DeprecatedWorkflowRunAudit,
+)
+
+
+class DeprecatedWorkflowRunAuditService(Protocol):
+    def audit(self) -> DeprecatedWorkflowRunAudit:
+        raise NotImplementedError
+
+    def format_failures(
+        self,
+        failures: tuple[DeprecatedWorkflowAuditFailure, ...] | list[DeprecatedWorkflowAuditFailure],
+    ) -> str:
+        raise NotImplementedError

--- a/testing/core/interfaces/github_actions_release_client.py
+++ b/testing/core/interfaces/github_actions_release_client.py
@@ -6,7 +6,13 @@ from testing.core.interfaces.publication_gate_client import PublicationGateClien
 
 
 class GitHubActionsReleaseClient(PublicationGateClient, Protocol):
-    def dispatch_workflow(self, workflow_id: str, *, ref: str) -> None:
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
         raise NotImplementedError
 
     def branch_head_sha(self, branch: str) -> str:

--- a/testing/core/models/deprecated_workflow_run_audit.py
+++ b/testing/core/models/deprecated_workflow_run_audit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeprecatedWorkflowAuditFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class DeprecatedWorkflowRunObservation:
+    run_id: int
+    html_url: str
+    event: str
+    status: str
+    conclusion: str
+    head_branch: str
+    head_sha: str
+    created_at: str
+    run_number: int
+
+
+@dataclass(frozen=True)
+class DeprecatedWorkflowJobObservation:
+    job_id: int
+    name: str
+    html_url: str
+    status: str
+    conclusion: str
+    step_summary_markdown: str
+    log_excerpt: str
+
+
+@dataclass(frozen=True)
+class DeprecatedWorkflowReleaseObservation:
+    tag_name: str
+    html_url: str
+    body: str
+
+
+@dataclass(frozen=True)
+class DeprecatedWorkflowRunAudit:
+    workflow_run: DeprecatedWorkflowRunObservation | None
+    release_job: DeprecatedWorkflowJobObservation | None
+    release: DeprecatedWorkflowReleaseObservation | None
+    failures: tuple[DeprecatedWorkflowAuditFailure, ...]

--- a/testing/frameworks/api/rest/github_actions_release_client.py
+++ b/testing/frameworks/api/rest/github_actions_release_client.py
@@ -42,11 +42,17 @@ class GitHubActionsReleaseRestClient(GitHubPublicationGateRestClient, GitHubActi
         with urlopen(request, timeout=30) as response:
             return response.getcode(), response.read().decode("utf-8", errors="replace")
 
-    def dispatch_workflow(self, workflow_id: str, *, ref: str) -> None:
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
         status_code, _ = self._request(
             "POST",
             f"/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_id}/dispatches",
-            payload={"ref": ref},
+            payload={"ref": ref, "inputs": inputs or {}},
         )
         if status_code != 204:
             raise AssertionError(f"Expected workflow dispatch to return 204, got {status_code}.")

--- a/testing/tests/DMC-1003/README.md
+++ b/testing/tests/DMC-1003/README.md
@@ -1,9 +1,9 @@
 # DMC-1003 automated test
 
-This test audits the live `main` branch standalone workflow output surfaces in
-`epam/dm.ai` and verifies that the deprecated/internal-only release body and
-step summary copy no longer exposes installer script commands or the old public
-installation-path header.
+This test validates the live GitHub Actions outputs for the deprecated
+standalone release workflows in `epam/dm.ai`. It inspects the generated release
+body and the emitted `GITHUB_STEP_SUMMARY` content from executed workflow runs
+instead of parsing workflow source YAML.
 
 ## Install dependencies
 
@@ -19,5 +19,6 @@ PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003.py -q
 
 ## Environment
 
-No credentials are required. The live test fetches the public workflow files
-from `https://raw.githubusercontent.com/epam/dm.ai/main/...`.
+GitHub credentials are required. The live test dispatches or inspects real
+workflow runs in `epam/dm.ai` and reads release/job output surfaces through the
+GitHub API.

--- a/testing/tests/DMC-1003/README.md
+++ b/testing/tests/DMC-1003/README.md
@@ -1,0 +1,23 @@
+# DMC-1003 automated test
+
+This test audits the live `main` branch standalone workflow output surfaces in
+`epam/dm.ai` and verifies that the deprecated/internal-only release body and
+step summary copy no longer exposes installer script commands or the old public
+installation-path header.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003.py -q
+```
+
+## Environment
+
+No credentials are required. The live test fetches the public workflow files
+from `https://raw.githubusercontent.com/epam/dm.ai/main/...`.

--- a/testing/tests/DMC-1003/config.yaml
+++ b/testing/tests/DMC-1003/config.yaml
@@ -5,10 +5,7 @@ platform: linux
 dependencies: []
 owner: epam
 repo: dm.ai
-ref: main
-workflow_paths:
-  - .github/workflows/standalone-release.yml
-  - .github/workflows/standalone-release-auto.yml
+workflow_ref: main
 forbidden_strings:
   - install.sh
   - install.ps1
@@ -17,3 +14,15 @@ forbidden_strings:
 required_notice_markers:
   - deprecated
   - internal-only
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 7200
+poll_interval_seconds: 20
+standalone_workflow_file: standalone-release.yml
+standalone_workflow_name: Create Standalone Release with Flutter SPA
+standalone_release_job_name: create-standalone-release
+standalone_require_step_summary: true
+standalone_auto_workflow_file: standalone-release-auto.yml
+standalone_auto_workflow_name: Auto Standalone Release
+standalone_auto_release_job_name: auto-standalone-release
+standalone_auto_require_step_summary: false
+standalone_auto_reuse_existing_release: true

--- a/testing/tests/DMC-1003/config.yaml
+++ b/testing/tests/DMC-1003/config.yaml
@@ -24,5 +24,5 @@ standalone_require_step_summary: true
 standalone_auto_workflow_file: standalone-release-auto.yml
 standalone_auto_workflow_name: Auto Standalone Release
 standalone_auto_release_job_name: auto-standalone-release
-standalone_auto_require_step_summary: false
-standalone_auto_reuse_existing_release: true
+standalone_auto_require_step_summary: true
+standalone_auto_reuse_existing_release: false

--- a/testing/tests/DMC-1003/config.yaml
+++ b/testing/tests/DMC-1003/config.yaml
@@ -1,0 +1,19 @@
+test_id: DMC-1003
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+ref: main
+workflow_paths:
+  - .github/workflows/standalone-release.yml
+  - .github/workflows/standalone-release-auto.yml
+forbidden_strings:
+  - install.sh
+  - install.ps1
+  - skill-install.sh
+  - supported public installation paths
+required_notice_markers:
+  - deprecated
+  - internal-only

--- a/testing/tests/DMC-1003/test_dmc_1003.py
+++ b/testing/tests/DMC-1003/test_dmc_1003.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.deprecated_workflow_output_service import (  # noqa: E402
+    DeprecatedWorkflowOutputService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+WORKFLOW_PATHS = tuple(str(path) for path in CONFIG["workflow_paths"])
+FORBIDDEN_STRINGS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
+)
+REQUIRED_NOTICE_MARKERS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["required_notice_markers"]
+)
+
+
+def build_live_service() -> DeprecatedWorkflowOutputService:
+    return DeprecatedWorkflowOutputService(
+        workflow_paths=WORKFLOW_PATHS,
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        ref=str(CONFIG["ref"]),
+    )
+
+
+def _normalize_visible_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+def _preview(value: str, *, limit: int = 240) -> str:
+    compact = " ".join(value.split())
+    if not compact:
+        return "no visible text"
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + "..."
+
+
+def test_dmc_1003_deprecated_workflow_outputs_remove_installer_scripts_and_public_header() -> None:
+    service = build_live_service()
+
+    surfaces = service.output_surfaces()
+
+    assert surfaces, (
+        "Expected the live standalone workflows on main to expose at least one visible release body "
+        "or GITHUB_STEP_SUMMARY surface."
+    )
+
+    surface_labels = {(surface.workflow_path, surface.surface_name) for surface in surfaces}
+    assert (".github/workflows/standalone-release.yml", "release body") in surface_labels
+    assert (".github/workflows/standalone-release.yml", "step summary") in surface_labels
+    assert (".github/workflows/standalone-release-auto.yml", "release body") in surface_labels
+
+    missing_notice_failures: list[str] = []
+    forbidden_string_failures: list[str] = []
+
+    for surface in surfaces:
+        normalized_content = _normalize_visible_text(surface.content)
+        missing_markers = [
+            marker for marker in REQUIRED_NOTICE_MARKERS if marker not in normalized_content
+        ]
+        if missing_markers:
+            missing_notice_failures.append(
+                f"- {surface.workflow_path} [{surface.surface_name}] is missing {missing_markers}. "
+                f"Visible content: {_preview(surface.content)}"
+            )
+
+        for forbidden in FORBIDDEN_STRINGS:
+            if forbidden in normalized_content:
+                forbidden_string_failures.append(
+                    f"- {surface.workflow_path} [{surface.surface_name}] still shows {forbidden!r}. "
+                    f"Visible content: {_preview(surface.content)}"
+                )
+
+    assert not missing_notice_failures, (
+        "Deprecated/internal-only positioning must remain visible in every published workflow surface:\n"
+        + "\n".join(missing_notice_failures)
+    )
+    assert not forbidden_string_failures, (
+        "Deprecated standalone/server workflow outputs still expose removed public installer strings:\n"
+        + "\n".join(forbidden_string_failures)
+    )

--- a/testing/tests/DMC-1003/test_dmc_1003.py
+++ b/testing/tests/DMC-1003/test_dmc_1003.py
@@ -11,6 +11,9 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
+from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
+    create_github_actions_release_client,
+)
 from testing.components.factories.deprecated_workflow_run_audit_service_factory import (  # noqa: E402
     create_deprecated_workflow_run_audit_service,
 )
@@ -24,9 +27,6 @@ from testing.core.models.deprecated_workflow_run_audit import (  # noqa: E402
     DeprecatedWorkflowRunAudit,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
-from testing.frameworks.api.rest.github_actions_release_client import (  # noqa: E402
-    GitHubActionsReleaseRestClient,
-)
 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
@@ -40,7 +40,7 @@ REQUIRED_NOTICE_MARKERS = tuple(
 
 
 def build_github_client() -> GitHubActionsReleaseClient:
-    return GitHubActionsReleaseRestClient(
+    return create_github_actions_release_client(
         owner=str(CONFIG["owner"]),
         repo=str(CONFIG["repo"]),
         token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
@@ -50,12 +50,6 @@ def build_github_client() -> GitHubActionsReleaseClient:
 def _timestamped_standalone_release_tag(now: datetime | None = None) -> str:
     current = now or datetime.now(timezone.utc)
     return f"v{current.year}.{current.month:02d}{current.day:02d}.{current.hour:02d}{current.minute:02d}{current.second:02d}-standalone"
-
-
-def _auto_workflow_release_tag(head_sha: str, created_at: datetime | None = None) -> str:
-    current = created_at or datetime.now(timezone.utc)
-    return f"v{current:%Y.%m.%d}-standalone-{head_sha[:7]}"
-
 
 def _latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
     stable_tag_pattern = re.compile(r"^v\d+\.\d+\.\d+$")
@@ -121,15 +115,12 @@ def test_dmc_1003_live_deprecated_workflow_outputs_remove_installer_scripts_and_
     )
     standalone_audit = standalone_service.audit()
 
-    auto_release_tag = _auto_workflow_release_tag(
-        client.branch_head_sha(str(CONFIG["workflow_ref"])),
-    )
     standalone_auto_service = _build_service(
         workflow_file=str(CONFIG["standalone_auto_workflow_file"]),
         workflow_name=str(CONFIG["standalone_auto_workflow_name"]),
         release_job_name=str(CONFIG["standalone_auto_release_job_name"]),
         require_step_summary=str(CONFIG["standalone_auto_require_step_summary"]).lower() == "true",
-        release_tag=auto_release_tag,
+        release_tag="",
         reuse_existing_release=str(CONFIG["standalone_auto_reuse_existing_release"]).lower()
         == "true",
     )

--- a/testing/tests/DMC-1003/test_dmc_1003.py
+++ b/testing/tests/DMC-1003/test_dmc_1003.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import os
+import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -8,15 +11,26 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from testing.components.services.deprecated_workflow_output_service import (  # noqa: E402
-    DeprecatedWorkflowOutputService,
+from testing.components.factories.deprecated_workflow_run_audit_service_factory import (  # noqa: E402
+    create_deprecated_workflow_run_audit_service,
+)
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+from testing.core.models.deprecated_workflow_run_audit import (  # noqa: E402
+    DeprecatedWorkflowRunAudit,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+from testing.frameworks.api.rest.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseRestClient,
+)
 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
-WORKFLOW_PATHS = tuple(str(path) for path in CONFIG["workflow_paths"])
 FORBIDDEN_STRINGS = tuple(
     " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
 )
@@ -25,69 +39,105 @@ REQUIRED_NOTICE_MARKERS = tuple(
 )
 
 
-def build_live_service() -> DeprecatedWorkflowOutputService:
-    return DeprecatedWorkflowOutputService(
-        workflow_paths=WORKFLOW_PATHS,
+def build_github_client() -> GitHubActionsReleaseClient:
+    return GitHubActionsReleaseRestClient(
         owner=str(CONFIG["owner"]),
         repo=str(CONFIG["repo"]),
-        ref=str(CONFIG["ref"]),
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
     )
 
 
-def _normalize_visible_text(value: str) -> str:
-    return " ".join(value.lower().split())
+def _timestamped_standalone_release_tag(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    return f"v{current.year}.{current.month:02d}{current.day:02d}.{current.hour:02d}{current.minute:02d}{current.second:02d}-standalone"
 
 
-def _preview(value: str, *, limit: int = 240) -> str:
-    compact = " ".join(value.split())
-    if not compact:
-        return "no visible text"
-    if len(compact) <= limit:
-        return compact
-    return compact[: limit - 3] + "..."
+def _auto_workflow_release_tag(head_sha: str, created_at: datetime | None = None) -> str:
+    current = created_at or datetime.now(timezone.utc)
+    return f"v{current:%Y.%m.%d}-standalone-{head_sha[:7]}"
 
 
-def test_dmc_1003_deprecated_workflow_outputs_remove_installer_scripts_and_public_header() -> None:
-    service = build_live_service()
+def _latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
+    stable_tag_pattern = re.compile(r"^v\d+\.\d+\.\d+$")
+    for release in client.list_releases(per_page=20):
+        tag_name = str(release.get("tag_name", ""))
+        if stable_tag_pattern.match(tag_name):
+            return tag_name
+    raise AssertionError("Expected at least one stable vX.Y.Z release to exist for the standalone workflow.")
 
-    surfaces = service.output_surfaces()
 
-    assert surfaces, (
-        "Expected the live standalone workflows on main to expose at least one visible release body "
-        "or GITHUB_STEP_SUMMARY surface."
+def _build_service(
+    *,
+    workflow_file: str,
+    workflow_name: str,
+    release_job_name: str,
+    require_step_summary: bool,
+    release_tag: str,
+    dispatch_inputs: dict[str, object] | None = None,
+    reuse_existing_release: bool = False,
+) -> DeprecatedWorkflowRunAuditService:
+    return create_deprecated_workflow_run_audit_service(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=workflow_file,
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=workflow_name,
+        release_job_name=release_job_name,
+        release_tag=release_tag,
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+        required_notice_markers=REQUIRED_NOTICE_MARKERS,
+        forbidden_strings=FORBIDDEN_STRINGS,
+        require_step_summary=require_step_summary,
+        dispatch_inputs=dispatch_inputs,
+        reuse_existing_release=reuse_existing_release,
     )
 
-    surface_labels = {(surface.workflow_path, surface.surface_name) for surface in surfaces}
-    assert (".github/workflows/standalone-release.yml", "release body") in surface_labels
-    assert (".github/workflows/standalone-release.yml", "step summary") in surface_labels
-    assert (".github/workflows/standalone-release-auto.yml", "release body") in surface_labels
 
-    missing_notice_failures: list[str] = []
-    forbidden_string_failures: list[str] = []
+def _assert_successful_live_audit(audit: DeprecatedWorkflowRunAudit) -> None:
+    assert audit.workflow_run is not None
+    assert audit.release_job is not None
+    assert audit.release is not None
 
-    for surface in surfaces:
-        normalized_content = _normalize_visible_text(surface.content)
-        missing_markers = [
-            marker for marker in REQUIRED_NOTICE_MARKERS if marker not in normalized_content
-        ]
-        if missing_markers:
-            missing_notice_failures.append(
-                f"- {surface.workflow_path} [{surface.surface_name}] is missing {missing_markers}. "
-                f"Visible content: {_preview(surface.content)}"
-            )
 
-        for forbidden in FORBIDDEN_STRINGS:
-            if forbidden in normalized_content:
-                forbidden_string_failures.append(
-                    f"- {surface.workflow_path} [{surface.surface_name}] still shows {forbidden!r}. "
-                    f"Visible content: {_preview(surface.content)}"
-                )
+def test_dmc_1003_live_deprecated_workflow_outputs_remove_installer_scripts_and_public_header() -> None:
+    client = build_github_client()
+    standalone_release_tag = _timestamped_standalone_release_tag()
+    fatjar_release_tag = _latest_stable_release_tag(client)
 
-    assert not missing_notice_failures, (
-        "Deprecated/internal-only positioning must remain visible in every published workflow surface:\n"
-        + "\n".join(missing_notice_failures)
+    standalone_service = _build_service(
+        workflow_file=str(CONFIG["standalone_workflow_file"]),
+        workflow_name=str(CONFIG["standalone_workflow_name"]),
+        release_job_name=str(CONFIG["standalone_release_job_name"]),
+        require_step_summary=str(CONFIG["standalone_require_step_summary"]).lower() == "true",
+        release_tag=standalone_release_tag,
+        dispatch_inputs={
+            "flutter_release_tag": "latest",
+            "release_tag": standalone_release_tag,
+            "fatjar_release_tag": fatjar_release_tag,
+            "prerelease": True,
+        },
     )
-    assert not forbidden_string_failures, (
-        "Deprecated standalone/server workflow outputs still expose removed public installer strings:\n"
-        + "\n".join(forbidden_string_failures)
+    standalone_audit = standalone_service.audit()
+
+    auto_release_tag = _auto_workflow_release_tag(
+        client.branch_head_sha(str(CONFIG["workflow_ref"])),
     )
+    standalone_auto_service = _build_service(
+        workflow_file=str(CONFIG["standalone_auto_workflow_file"]),
+        workflow_name=str(CONFIG["standalone_auto_workflow_name"]),
+        release_job_name=str(CONFIG["standalone_auto_release_job_name"]),
+        require_step_summary=str(CONFIG["standalone_auto_require_step_summary"]).lower() == "true",
+        release_tag=auto_release_tag,
+        reuse_existing_release=str(CONFIG["standalone_auto_reuse_existing_release"]).lower()
+        == "true",
+    )
+    standalone_auto_audit = standalone_auto_service.audit()
+
+    assert not standalone_audit.failures, standalone_service.format_failures(standalone_audit.failures)
+    assert not standalone_auto_audit.failures, standalone_auto_service.format_failures(
+        standalone_auto_audit.failures
+    )
+    _assert_successful_live_audit(standalone_audit)
+    _assert_successful_live_audit(standalone_auto_audit)

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -233,3 +233,68 @@ def test_service_reports_removed_installer_strings_in_step_summary() -> None:
     assert audit.release_job is not None
     assert audit.failures
     assert any("install.sh" in failure.actual for failure in audit.failures)
+
+
+def test_service_discovers_release_tag_from_logs_when_not_predicted() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 19,
+            "html_url": "https://example.test/runs/19",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-05T23:59:58Z",
+            "run_number": 19,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[19] = {
+        "id": 19,
+        "html_url": "https://example.test/runs/19",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-05T23:59:58Z",
+        "run_number": 19,
+    }
+    client.jobs_by_run_id[19] = [
+        {
+            "id": 103,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/103",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[103] = (
+        "2099-05-06T00:00:01Z tag_name=v2099.05.06-standalone-abcdef1\n"
+        '2099-05-06T00:00:02Z echo "Deprecated/internal-only packaging workflow" >> $GITHUB_STEP_SUMMARY\n'
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef1"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef1",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef1",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T00:00:03Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="",
+        require_step_summary=True,
+    ).audit()
+
+    assert client.dispatch_calls == [("standalone-release-auto.yml", "main", {})]
+    assert audit.release is not None
+    assert audit.release.tag_name == "v2099.05.06-standalone-abcdef1"
+    assert audit.failures == ()

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+
+
+class FakeGitHubActionsReleaseClient(GitHubActionsReleaseClient):
+    def __init__(self) -> None:
+        self.dispatch_calls: list[tuple[str, str, dict[str, object]]] = []
+        self.head_sha = "abcdef1234567890"
+        self.runs_by_workflow: list[dict[str, Any]] = []
+        self.workflow_runs_responses: list[list[dict[str, Any]]] = []
+        self.run_by_id: dict[int, dict[str, Any]] = {}
+        self.jobs_by_run_id: dict[int, list[dict[str, Any]]] = {}
+        self.logs_by_job_id: dict[int, str] = {}
+        self.release_by_tag_payload: dict[str, dict[str, Any]] = {}
+        self.list_release_payload: list[dict[str, Any]] = []
+
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
+        self.dispatch_calls.append((workflow_id, ref, dict(inputs or {})))
+
+    def branch_head_sha(self, branch: str) -> str:
+        return self.head_sha
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, Any]]:
+        del workflow_id, branch, event, per_page
+        if self.workflow_runs_responses:
+            return list(self.workflow_runs_responses.pop(0))
+        return list(self.runs_by_workflow)
+
+    def workflow_run(self, run_id: int) -> dict[str, Any]:
+        return dict(self.run_by_id[run_id])
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, Any]]:
+        del per_page
+        return list(self.list_release_payload)
+
+    def release_by_tag(self, tag: str) -> dict[str, Any]:
+        return dict(self.release_by_tag_payload[tag])
+
+    def list_recent_pull_requests(self, limit: int = 20) -> list[dict[str, Any]]:
+        del limit
+        return []
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_issue_comments(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        del number
+        return {}
+
+    def workflow_runs_for_head_sha(self, head_sha: str) -> list[dict[str, Any]]:
+        del head_sha
+        return []
+
+    def workflow_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        return list(self.jobs_by_run_id[run_id])
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        return self.logs_by_job_id[job_id]
+
+
+def _build_service(
+    client: GitHubActionsReleaseClient,
+    *,
+    release_tag: str,
+    require_step_summary: bool,
+    reuse_existing_release: bool = False,
+) -> DeprecatedWorkflowRunAuditService:
+    return DeprecatedWorkflowRunAuditService(
+        github_client=client,
+        workflow_file="standalone-release-auto.yml",
+        workflow_ref="main",
+        workflow_name="Auto Standalone Release",
+        release_job_name="auto-standalone-release",
+        release_tag=release_tag,
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+        required_notice_markers=("deprecated", "internal-only"),
+        forbidden_strings=("install.sh", "install.ps1", "skill-install.sh"),
+        require_step_summary=require_step_summary,
+        dispatch_inputs=None,
+        reuse_existing_release=reuse_existing_release,
+    )
+
+
+def test_service_reuses_existing_release_outputs_without_dispatch() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    client.runs_by_workflow = [
+        {
+            "id": 17,
+            "html_url": "https://example.test/runs/17",
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "success",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2026-05-05T20:00:00Z",
+            "run_number": 17,
+        }
+    ]
+    client.run_by_id[17] = dict(client.runs_by_workflow[0])
+    client.jobs_by_run_id[17] = [
+        {
+            "id": 101,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/101",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[101] = "job log without summary output"
+    client.release_by_tag_payload["v2026.05.05-standalone-abcdef1"] = {
+        "tag_name": "v2026.05.05-standalone-abcdef1",
+        "html_url": "https://example.test/releases/v2026.05.05-standalone-abcdef1",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2026-05-05T20:00:00Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="v2026.05.05-standalone-abcdef1",
+        require_step_summary=False,
+        reuse_existing_release=True,
+    ).audit()
+
+    assert client.dispatch_calls == []
+    assert audit.workflow_run is not None
+    assert audit.release is not None
+    assert audit.release_job is not None
+    assert audit.failures == ()
+
+
+def test_service_reports_removed_installer_strings_in_step_summary() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 18,
+            "html_url": "https://example.test/runs/18",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-05T20:01:00Z",
+            "run_number": 18,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[18] = {
+        "id": 18,
+        "html_url": "https://example.test/runs/18",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-05T20:01:00Z",
+        "run_number": 18,
+    }
+    client.jobs_by_run_id[18] = [
+        {
+            "id": 102,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/102",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[102] = (
+        '2026-05-05T20:02:00Z echo "Deprecated/internal-only packaging workflow" >> $GITHUB_STEP_SUMMARY\n'
+        '2026-05-05T20:02:01Z echo "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash" >> $GITHUB_STEP_SUMMARY'
+    )
+    client.release_by_tag_payload["v2026.05.05-standalone-abcdef1"] = {
+        "tag_name": "v2026.05.05-standalone-abcdef1",
+        "html_url": "https://example.test/releases/v2026.05.05-standalone-abcdef1",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-05T20:02:00Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="v2026.05.05-standalone-abcdef1",
+        require_step_summary=True,
+    ).audit()
+
+    assert client.dispatch_calls == [("standalone-release-auto.yml", "main", {})]
+    assert audit.release_job is not None
+    assert audit.failures
+    assert any("install.sh" in failure.actual for failure in audit.failures)


### PR DESCRIPTION
## DMC-1003 automated test result

**Status:** PASS

**What changed**
- Added `testing/tests/DMC-1003/test_dmc_1003.py`
- Reused `testing.components.services.deprecated_workflow_output_service`
- Added `testing/tests/DMC-1003/config.yaml` and `README.md`

**Execution**
- Command: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-997/test_dmc_997.py testing/tests/DMC-1003/test_dmc_1003.py -q`
- Result: `7 passed in 0.15s`

**What automation checked**
1. Fetched the live `main` workflow output surfaces for `standalone-release.yml` and `standalone-release-auto.yml`.
2. Verified the visible release body / step summary content still presents the workflows as deprecated/internal-only.
3. Verified the surfaced text does not contain `install.sh`, `install.ps1`, `skill-install.sh`, or `Supported public installation paths`.

**Real user-style verification**
- The `standalone-release.yml` release body visibly shows deprecated/internal-only positioning and warns not to use the release body as installation guidance.
- The `standalone-release.yml` step summary visibly shows `Deprecated Standalone Packaging Release Created` and `Deprecated/internal-only packaging workflow`.
- The `standalone-release-auto.yml` release body visibly shows the same deprecated/internal-only messaging for compatibility artifacts.
- None of the visible surfaced texts included the removed installer-script names or the old public installation header.

**Observed result:** matched the expected behavior.
