### PR TITLE
DMC-1006 Test: Trigger standalone-release.yml — workflow completes without test-reporter failure

### DIFF
--- a/testing/tests/DMC-1006/README.md
+++ b/testing/tests/DMC-1006/README.md
@@ -1,0 +1,30 @@
+# DMC-1006 automated test
+
+This test validates that the live `standalone-release.yml` workflow on `main`
+finishes successfully, publishes its release body and `GITHUB_STEP_SUMMARY`
+content, and does not fail because of the historical `dorny/test-reporter` /
+`No test report files were found` regression.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1006/test_dmc_1006.py -q
+```
+
+## Environment
+
+GitHub credentials are required. The live test dispatches the real deprecated
+workflow in `epam/dm.ai`, waits for completion, and reads workflow/job/release
+output through the GitHub API.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-1006/config.yaml
+++ b/testing/tests/DMC-1006/config.yaml
@@ -1,0 +1,25 @@
+test_id: DMC-1006
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_ref: main
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 7200
+poll_interval_seconds: 20
+workflow_file: standalone-release.yml
+workflow_name: Create Standalone Release with Flutter SPA
+release_job_name: create-standalone-release
+require_step_summary: true
+required_notice_markers:
+  - deprecated
+  - internal-only
+forbidden_strings:
+  - install.sh
+  - install.ps1
+  - skill-install.sh
+  - supported public installation paths
+test_reporter_failure_markers:
+  - No test report files were found

--- a/testing/tests/DMC-1006/config.yaml
+++ b/testing/tests/DMC-1006/config.yaml
@@ -13,13 +13,5 @@ workflow_file: standalone-release.yml
 workflow_name: Create Standalone Release with Flutter SPA
 release_job_name: create-standalone-release
 require_step_summary: true
-required_notice_markers:
-  - deprecated
-  - internal-only
-forbidden_strings:
-  - install.sh
-  - install.ps1
-  - skill-install.sh
-  - supported public installation paths
 test_reporter_failure_markers:
   - No test report files were found

--- a/testing/tests/DMC-1006/test_dmc_1006.py
+++ b/testing/tests/DMC-1006/test_dmc_1006.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.deprecated_workflow_run_audit_service_factory import (  # noqa: E402
+    create_deprecated_workflow_run_audit_service,
+)
+from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
+    create_github_actions_release_client,
+)
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+from testing.core.models.deprecated_workflow_run_audit import (  # noqa: E402
+    DeprecatedWorkflowRunAudit,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+REQUIRED_NOTICE_MARKERS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["required_notice_markers"]
+)
+FORBIDDEN_STRINGS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
+)
+TEST_REPORTER_FAILURE_MARKERS = tuple(str(value) for value in CONFIG["test_reporter_failure_markers"])
+STABLE_RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+RELEASE_TAG_ENV = "DMC_1006_RELEASE_TAG"
+
+
+def build_github_client() -> GitHubActionsReleaseClient:
+    return create_github_actions_release_client(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def release_tag_for_run(now: datetime | None = None) -> str:
+    configured = os.environ.get(RELEASE_TAG_ENV, "").strip()
+    if configured:
+        return configured
+
+    current = now or datetime.now(timezone.utc)
+    generated = (
+        f"v{current.year}.{current.month:02d}{current.day:02d}."
+        f"{current.hour:02d}{current.minute:02d}{current.second:02d}-standalone"
+    )
+    os.environ[RELEASE_TAG_ENV] = generated
+    return generated
+
+
+def latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
+    for release in client.list_releases(per_page=20):
+        tag_name = str(release.get("tag_name", ""))
+        if STABLE_RELEASE_TAG_PATTERN.match(tag_name):
+            return tag_name
+    raise AssertionError("Expected at least one stable vX.Y.Z release to exist for the standalone workflow.")
+
+
+def build_service(
+    *,
+    release_tag: str,
+    reuse_existing_release: bool = False,
+) -> DeprecatedWorkflowRunAuditService:
+    dispatch_inputs: dict[str, object] | None = None
+    if not reuse_existing_release:
+        dispatch_inputs = {
+            "flutter_release_tag": "latest",
+            "release_tag": release_tag,
+            "fatjar_release_tag": latest_stable_release_tag(build_github_client()),
+            "prerelease": True,
+        }
+
+    return create_deprecated_workflow_run_audit_service(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["workflow_name"]),
+        release_job_name=str(CONFIG["release_job_name"]),
+        release_tag=release_tag,
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+        required_notice_markers=REQUIRED_NOTICE_MARKERS,
+        forbidden_strings=FORBIDDEN_STRINGS,
+        require_step_summary=str(CONFIG["require_step_summary"]).lower() == "true",
+        dispatch_inputs=dispatch_inputs,
+        reuse_existing_release=reuse_existing_release,
+    )
+
+
+def run_live_audit(*, reuse_existing_release: bool = False) -> tuple[DeprecatedWorkflowRunAudit, str]:
+    client = build_github_client()
+    release_tag = release_tag_for_run()
+    service = build_service(
+        release_tag=release_tag,
+        reuse_existing_release=reuse_existing_release,
+    )
+    audit = service.audit()
+    raw_job_log = ""
+    if audit.release_job is not None:
+        raw_job_log = client.workflow_job_logs(audit.release_job.job_id)
+    return audit, raw_job_log
+
+
+def assert_no_test_reporter_failure(raw_job_log: str) -> None:
+    normalized_log = " ".join(raw_job_log.split())
+    for marker in TEST_REPORTER_FAILURE_MARKERS:
+        assert marker not in raw_job_log, (
+            "The standalone release job still surfaced the historical test-reporter failure "
+            f"marker {marker!r}. Recent log excerpt: {normalized_log[-500:] or 'no log output'}"
+        )
+
+
+def test_dmc_1006_live_standalone_release_workflow_completes_without_test_reporter_failure() -> None:
+    audit, raw_job_log = run_live_audit()
+
+    service = build_service(release_tag=release_tag_for_run(), reuse_existing_release=True)
+    assert not audit.failures, service.format_failures(audit.failures)
+    assert audit.workflow_run is not None
+    assert audit.release_job is not None
+    assert audit.release is not None
+    assert audit.release_job.step_summary_markdown.strip()
+    assert audit.release.body.strip()
+    assert_no_test_reporter_failure(raw_job_log)

--- a/testing/tests/DMC-1006/test_dmc_1006.py
+++ b/testing/tests/DMC-1006/test_dmc_1006.py
@@ -126,10 +126,10 @@ def test_dmc_1006_live_standalone_release_workflow_completes_without_test_report
     audit, raw_job_log = run_live_audit()
 
     service = build_service(release_tag=release_tag_for_run(), reuse_existing_release=True)
-    assert not audit.failures, service.format_failures(audit.failures)
     assert audit.workflow_run is not None
     assert audit.release_job is not None
+    assert_no_test_reporter_failure(raw_job_log)
+    assert not audit.failures, service.format_failures(audit.failures)
     assert audit.release is not None
     assert audit.release_job.step_summary_markdown.strip()
     assert audit.release.body.strip()
-    assert_no_test_reporter_failure(raw_job_log)

--- a/testing/tests/DMC-1006/test_dmc_1006.py
+++ b/testing/tests/DMC-1006/test_dmc_1006.py
@@ -31,12 +31,6 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
-REQUIRED_NOTICE_MARKERS = tuple(
-    " ".join(str(value).lower().split()) for value in CONFIG["required_notice_markers"]
-)
-FORBIDDEN_STRINGS = tuple(
-    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
-)
 TEST_REPORTER_FAILURE_MARKERS = tuple(str(value) for value in CONFIG["test_reporter_failure_markers"])
 STABLE_RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
 RELEASE_TAG_ENV = "DMC_1006_RELEASE_TAG"
@@ -97,8 +91,8 @@ def build_service(
         dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
         completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
         poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
-        required_notice_markers=REQUIRED_NOTICE_MARKERS,
-        forbidden_strings=FORBIDDEN_STRINGS,
+        required_notice_markers=(),
+        forbidden_strings=(),
         require_step_summary=str(CONFIG["require_step_summary"]).lower() == "true",
         dispatch_inputs=dispatch_inputs,
         reuse_existing_release=reuse_existing_release,


### PR DESCRIPTION
# DMC-1006 — automated test result

## Result
- Added live regression coverage in `testing/tests/DMC-1006/test_dmc_1006.py`.
- **Status:** Failed against the deployed `main` branch.

## What automation verified
1. Dispatched `standalone-release.yml` on `main` using release tag `v2026.0506.032402-standalone`.
2. Waited for the `create-standalone-release` job to complete.
3. Verified the historical `dorny/test-reporter` / `No test report files were found` failure was not the cause of failure.
4. Expected successful workflow completion with published Release body and `GITHUB_STEP_SUMMARY` output.

## Human-style verification
- Opened the live workflow run page: https://github.com/epam/dm.ai/actions/runs/25414746746
- Observed the run ended in **Failure**.
- Observed the failed step on the page was **Build deprecated compatibility artifact** in `create-standalone-release`.
- Observed `Upload Test Results` succeeded, so the old `test-reporter` regression did not recur.
- Observed `Generate Release Notes`, `Create Release`, and `Summary` were skipped, so the user-facing release body and workflow summary were not published.

## Failure details
- Workflow run: https://github.com/epam/dm.ai/actions/runs/25414746746
- Job: https://github.com/epam/dm.ai/actions/runs/25414746746/job/74543783336
- Failed step: `Build deprecated compatibility artifact`

```text
4097 tests completed, 1 failed, 7 skipped
> Task :dmtools-core:test FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':dmtools-core:test'.
> There were failing tests. See the report at: file:///home/runner/work/dm.ai/dm.ai/dmtools-core/build/reports/tests/test/index.html
BUILD FAILED in 2m 1s
##[error]Process completed with exit code 1.
```

### Exact failing unit test from uploaded artifact
```text
com.github.istin.dmtools.cli.CliCommandExecutorTest
  testExecuteCommand_CommandWithSpecialCharacters_Success
java.io.IOException: Command execution failed: Command failed (exit code 1): git config --get user.name
Output:

Caused by: java.io.IOException: Command failed (exit code 1): git config --get user.name
Output:
```

## Expected vs actual
- **Expected:** workflow completes successfully, does not fail at the test-reporting stage, and publishes Release body + `GITHUB_STEP_SUMMARY`.
- **Actual:** workflow failed earlier in the build/test phase due to a failing unit test, so publication outputs were never produced.
