### PR TITLE
DMC-1007 Test: Trigger standalone-release-auto.yml — workflow completes without Gradle project resolution error

### DIFF
--- a/testing/tests/DMC-1007/README.md
+++ b/testing/tests/DMC-1007/README.md
@@ -1,0 +1,25 @@
+# DMC-1007 automated test
+
+This test dispatches the live `standalone-release-auto.yml` workflow on `main`
+and verifies the run completes successfully without the removed-project Gradle
+resolution error for `:dmtools-automation:test`. It also confirms the workflow
+still publishes the release body and visible `GITHUB_STEP_SUMMARY` output that
+depend on successful completion.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1007/test_dmc_1007.py -q
+```
+
+## Environment
+
+GitHub credentials are required. The test dispatches a real workflow run in
+`epam/dm.ai`, waits for completion through the GitHub API, and inspects the
+resulting job log plus published release surfaces.

--- a/testing/tests/DMC-1007/config.yaml
+++ b/testing/tests/DMC-1007/config.yaml
@@ -1,0 +1,26 @@
+test_id: DMC-1007
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_ref: main
+required_notice_markers:
+  - deprecated
+  - internal-only
+forbidden_strings:
+  - install.sh
+  - install.ps1
+  - skill-install.sh
+  - supported public installation paths
+forbidden_log_fragments:
+  - Cannot locate excluded tasks that match ':dmtools-automation:test'
+  - project 'dmtools-automation' not found in root project
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 7200
+poll_interval_seconds: 20
+standalone_auto_workflow_file: standalone-release-auto.yml
+standalone_auto_workflow_name: Auto Standalone Release
+standalone_auto_release_job_name: auto-standalone-release
+standalone_auto_require_step_summary: true

--- a/testing/tests/DMC-1007/config.yaml
+++ b/testing/tests/DMC-1007/config.yaml
@@ -6,14 +6,6 @@ dependencies: []
 owner: epam
 repo: dm.ai
 workflow_ref: main
-required_notice_markers:
-  - deprecated
-  - internal-only
-forbidden_strings:
-  - install.sh
-  - install.ps1
-  - skill-install.sh
-  - supported public installation paths
 forbidden_log_fragments:
   - Cannot locate excluded tasks that match ':dmtools-automation:test'
   - project 'dmtools-automation' not found in root project

--- a/testing/tests/DMC-1007/test_dmc_1007.py
+++ b/testing/tests/DMC-1007/test_dmc_1007.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.deprecated_workflow_run_audit_service_factory import (  # noqa: E402
+    create_deprecated_workflow_run_audit_service,
+)
+from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
+    create_github_actions_release_client,
+)
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+from testing.core.models.deprecated_workflow_run_audit import (  # noqa: E402
+    DeprecatedWorkflowRunAudit,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+FORBIDDEN_LOG_FRAGMENTS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_log_fragments"]
+)
+FORBIDDEN_OUTPUT_STRINGS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
+)
+REQUIRED_NOTICE_MARKERS = tuple(
+    " ".join(str(value).lower().split()) for value in CONFIG["required_notice_markers"]
+)
+
+
+def build_github_client() -> GitHubActionsReleaseClient:
+    return create_github_actions_release_client(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def build_service() -> DeprecatedWorkflowRunAuditService:
+    return create_deprecated_workflow_run_audit_service(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=str(CONFIG["standalone_auto_workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["standalone_auto_workflow_name"]),
+        release_job_name=str(CONFIG["standalone_auto_release_job_name"]),
+        release_tag="",
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+        required_notice_markers=REQUIRED_NOTICE_MARKERS,
+        forbidden_strings=FORBIDDEN_OUTPUT_STRINGS,
+        require_step_summary=str(CONFIG["standalone_auto_require_step_summary"]).lower() == "true",
+    )
+
+
+def _assert_successful_audit(audit: DeprecatedWorkflowRunAudit) -> None:
+    assert audit.workflow_run is not None
+    assert audit.release_job is not None
+    assert audit.release is not None
+
+
+def _normalize_visible_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+def test_dmc_1007_live_auto_standalone_workflow_completes_without_removed_project_gradle_errors() -> None:
+    client = build_github_client()
+    service = build_service()
+
+    audit = service.audit()
+
+    assert not audit.failures, service.format_failures(audit.failures)
+    _assert_successful_audit(audit)
+
+    job_log_text = client.workflow_job_logs(audit.release_job.job_id)
+    normalized_job_log = _normalize_visible_text(job_log_text)
+
+    for forbidden_fragment in FORBIDDEN_LOG_FRAGMENTS:
+        assert forbidden_fragment not in normalized_job_log, (
+            "Expected the completed auto-standalone-release job log to exclude the removed-project "
+            f"Gradle failure {forbidden_fragment!r}, but it was present in {audit.release_job.html_url}."
+        )
+
+    assert audit.workflow_run.conclusion == "success"
+    assert audit.release_job.conclusion == "success"
+    assert audit.release.html_url
+    assert audit.release.body.strip()
+    assert audit.release_job.step_summary_markdown.strip()

--- a/testing/tests/DMC-1007/test_dmc_1007.py
+++ b/testing/tests/DMC-1007/test_dmc_1007.py
@@ -29,14 +29,17 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+
+
+def _normalized_config_list(key: str) -> tuple[str, ...]:
+    values = CONFIG.get(key, [])
+    if not isinstance(values, list):
+        raise TypeError(f"Expected {key!r} to be a list in {TEST_DIRECTORY / 'config.yaml'}.")
+    return tuple(" ".join(str(value).lower().split()) for value in values)
+
+
 FORBIDDEN_LOG_FRAGMENTS = tuple(
-    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_log_fragments"]
-)
-FORBIDDEN_OUTPUT_STRINGS = tuple(
-    " ".join(str(value).lower().split()) for value in CONFIG["forbidden_strings"]
-)
-REQUIRED_NOTICE_MARKERS = tuple(
-    " ".join(str(value).lower().split()) for value in CONFIG["required_notice_markers"]
+    _normalized_config_list("forbidden_log_fragments")
 )
 
 
@@ -60,8 +63,8 @@ def build_service() -> DeprecatedWorkflowRunAuditService:
         dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
         completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
         poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
-        required_notice_markers=REQUIRED_NOTICE_MARKERS,
-        forbidden_strings=FORBIDDEN_OUTPUT_STRINGS,
+        required_notice_markers=_normalized_config_list("required_notice_markers"),
+        forbidden_strings=_normalized_config_list("forbidden_strings"),
         require_step_summary=str(CONFIG["standalone_auto_require_step_summary"]).lower() == "true",
     )
 


### PR DESCRIPTION
## Summary

- Added `testing/tests/DMC-1007/test_dmc_1007.py` and `testing/tests/DMC-1007/config.yaml`.
- Reused the existing deprecated workflow live-audit service to dispatch `standalone-release-auto.yml` on `main`.
- The automation verifies workflow completion, absence of the removed-project Gradle error, and publication of the release body plus visible `$GITHUB_STEP_SUMMARY` output.

## Live result

- **Status:** Failed
- **Workflow run:** [25414751448](https://github.com/epam/dm.ai/actions/runs/25414751448)
- **Failed job:** [auto-standalone-release](https://github.com/epam/dm.ai/actions/runs/25414751448/job/74543796802)
- **Branch / commit:** `main` / `4a0eda9fb19004e042523c4c66d9350a47d41fce`

## What automation checked

1. Dispatched `standalone-release-auto.yml` on `main`.
2. Waited for the live `auto-standalone-release` job to finish.
3. Expected a successful workflow run, no removed-project Gradle error about `:dmtools-automation:test`, and published release body / step-summary output.

## Human-style verification

1. Viewed the live GitHub Actions run as a user would.
2. Confirmed the workflow started and reached **Build deprecated compatibility artifact**.
3. Observed that this step failed, then **Capture compatibility artifact metadata**, **Extract Tag Name**, **Generate Release Notes**, **Create Release**, and **Summary** were skipped.
4. Confirmed no release page and no visible Step Summary were published because the workflow failed before those user-facing outputs were created.
5. Confirmed the original fixed bug text `Cannot locate excluded tasks that match ':dmtools-automation:test'` was **not** present in the captured logs.

## Expected vs actual

- **Expected:** the workflow completes successfully without the removed-project Gradle error and publishes the required release outputs.
- **Actual:** the workflow failed because `:dmtools-core:test` had 1 failing unit test: `CliCommandExecutorTest.testExecuteCommand_CommandWithSpecialCharacters_Success`.

```text
java.io.IOException: Command execution failed: Command failed (exit code 1): git config --get user.name
Output:
```

Because the build step failed, the workflow never reached release publication, so the expected release body and `$GITHUB_STEP_SUMMARY` outputs were not visible.

## Evidence

- Test report artifact: [auto-standalone-build-test-results](https://github.com/epam/dm.ai/actions/runs/25414751448/artifacts/6822079782)
- Extracted report file: `/tmp/dmc1007-artifact/dmtools-core/build/test-results/test/TEST-com.github.istin.dmtools.cli.CliCommandExecutorTest.xml`
- Captured failed-job log export: `/tmp/1778038059460-copilot-tool-output-z6d0dm.txt`
