### PR TITLE
DMC-1008 Deprecated standalone workflows fail before publishing release body and summary outputs

### DIFF
--- a/dmtools-core/src/test/java/com/github/istin/dmtools/cli/CliCommandExecutorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/cli/CliCommandExecutorTest.java
@@ -258,10 +258,11 @@ public class CliCommandExecutorTest {
 
     @Test
     public void testExecuteCommand_CommandWithSpecialCharacters_Success() throws IOException, InterruptedException {
-        // Test command with quotes and special characters using a fast, reliable command
-        String result = executor.executeCommand("git config --get user.name", null);
+        // Use quotes and a wildcard so the command still exercises shell-sensitive characters
+        // without depending on optional git user config that may be absent on CI runners.
+        String result = executor.executeCommand("git branch --list \"*\"", null);
         
-        // Should execute without security issues (may return empty if user.name not set)
+        // Should execute without security issues and return the matching branch list.
         assertNotNull("Should handle command execution", result);
     }
 
@@ -541,4 +542,3 @@ public class CliCommandExecutorTest {
         }
     }
 }
-


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The deprecated standalone workflows were not failing because of release-note or summary generation logic. They were stopping in `:dmtools-core:test` because `CliCommandExecutorTest.testExecuteCommand_CommandWithSpecialCharacters_Success` executed `git config --get user.name`, which exits with code `1` on GitHub Actions runners that do not have `user.name` configured.

### Fix
Updated `dmtools-core/src/test/java/com/github/istin/dmtools/cli/CliCommandExecutorTest.java` so the special-characters coverage uses `git branch --list "*"` instead of `git config --get user.name`. The new command still exercises quoting and wildcard handling, but it does not depend on optional git identity configuration, so the workflow build step can complete consistently on CI.

### Test Coverage
- Reproduction evidence: linked live audit `testing/tests/DMC-1003/test_dmc_1003.py` failed on current `main`, and the uploaded JUnit artifact for workflow run `25420751657` identified `CliCommandExecutorTest.testExecuteCommand_CommandWithSpecialCharacters_Success` as the only failing core test.
- Targeted regression check: `./gradlew :dmtools-core:test --tests 'com.github.istin.dmtools.cli.CliCommandExecutorTest.testExecuteCommand_CommandWithSpecialCharacters_Success' --no-daemon -x integrationTest`
- Full core suite: `./gradlew :dmtools-core:test --no-daemon -x integrationTest`
- Workflow-equivalent build: `./gradlew clean :dmtools-core:test :dmtools-core:shadowJar -x integrationTest --no-daemon`
- Linked static workflow checks: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1005/test_dmc_1005.py -q` and `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q`

### Notes
The linked live audit still fails on remote `main` until this change is merged and picked up by GitHub Actions. Also, the requested repo-root `instruction.md` file was not present in this checkout.
