### PR TITLE
DMC-1009 Test: Trigger standalone workflows with dmtools-core test failures — workflows complete and publish outputs

### DIFF
--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -390,6 +390,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             conclusion=str(payload.get("conclusion", "")),
             step_summary_markdown=self._extract_step_summary_markdown(log_text),
             log_excerpt=self._log_excerpt(log_text),
+            step_conclusions=self._extract_step_conclusions(payload),
+            raw_log_text=log_text,
         )
 
     def _find_release_observation(
@@ -437,7 +439,7 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         for value in (
             self.release_tag,
             self._release_tag_from_text(release_job.step_summary_markdown),
-            self._release_tag_from_text(release_job.log_excerpt),
+            self._release_tag_from_text(release_job.raw_log_text or release_job.log_excerpt),
         ):
             normalized = value.strip()
             if normalized and normalized not in candidates:
@@ -474,6 +476,17 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
                 continue
             lines.append(self._decode_echo_argument(match.group("argument")))
         return "\n".join(lines).strip()
+
+    @staticmethod
+    def _extract_step_conclusions(job_payload: dict[str, Any]) -> dict[str, str]:
+        steps = job_payload.get("steps", [])
+        if not isinstance(steps, list):
+            return {}
+        return {
+            str(step.get("name", "")): str(step.get("conclusion", ""))
+            for step in steps
+            if isinstance(step, dict) and str(step.get("name", ""))
+        }
 
     def _log_excerpt(self, raw_log_text: str, limit: int = 6000) -> str:
         cleaned = "\n".join(self._normalize_log_line(line) for line in raw_log_text.splitlines())

--- a/testing/core/models/deprecated_workflow_run_audit.py
+++ b/testing/core/models/deprecated_workflow_run_audit.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -40,6 +40,8 @@ class DeprecatedWorkflowJobObservation:
     conclusion: str
     step_summary_markdown: str
     log_excerpt: str
+    step_conclusions: dict[str, str] = field(default_factory=dict)
+    raw_log_text: str = ""
 
 
 @dataclass(frozen=True)

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -298,3 +298,75 @@ def test_service_discovers_release_tag_from_logs_when_not_predicted() -> None:
     assert audit.release is not None
     assert audit.release.tag_name == "v2099.05.06-standalone-abcdef1"
     assert audit.failures == ()
+
+
+def test_service_exposes_release_job_steps_and_full_log_text() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 20,
+            "html_url": "https://example.test/runs/20",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-06T10:00:00Z",
+            "run_number": 20,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[20] = {
+        "id": 20,
+        "html_url": "https://example.test/runs/20",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-06T10:00:00Z",
+        "run_number": 20,
+    }
+    client.jobs_by_run_id[20] = [
+        {
+            "id": 104,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/104",
+            "status": "completed",
+            "conclusion": "success",
+            "steps": [
+                {"name": "Build deprecated compatibility artifact", "conclusion": "success"},
+                {"name": "Summary", "conclusion": "success"},
+            ],
+        }
+    ]
+    client.logs_by_job_id[104] = (
+        "2099-05-06T10:00:01Z Task :dmtools-core:test FAILED\n"
+        '2099-05-06T10:00:02Z echo "Deprecated/internal-only packaging workflow" >> $GITHUB_STEP_SUMMARY\n'
+        "2099-05-06T10:00:03Z tag_name=v2099.05.06-standalone-abcdef2\n"
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef2"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef2",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef2",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T10:00:04Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="",
+        require_step_summary=True,
+    ).audit()
+
+    assert audit.release_job is not None
+    assert audit.release_job.raw_log_text == client.logs_by_job_id[104]
+    assert audit.release_job.step_conclusions == {
+        "Build deprecated compatibility artifact": "success",
+        "Summary": "success",
+    }

--- a/testing/tests/DMC-1009/README.md
+++ b/testing/tests/DMC-1009/README.md
@@ -1,0 +1,24 @@
+# DMC-1009 automated test
+
+This test dispatches the live deprecated standalone workflows on `main` and
+verifies that the `Build deprecated compatibility artifact` step completes
+without blocking publication of the release body and visible
+`GITHUB_STEP_SUMMARY` outputs.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1009/test_dmc_1009.py -q -s
+```
+
+## Environment
+
+GitHub credentials are required. The live test dispatches real workflow runs in
+`epam/dm.ai`, waits for completion, and inspects the resulting job steps, logs,
+release bodies, and visible step summaries through the GitHub API.

--- a/testing/tests/DMC-1009/config.yaml
+++ b/testing/tests/DMC-1009/config.yaml
@@ -1,0 +1,34 @@
+test_id: DMC-1009
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_ref: main
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 7200
+poll_interval_seconds: 20
+required_successful_steps:
+  - Build deprecated compatibility artifact
+  - Capture compatibility artifact metadata
+  - Generate Release Notes
+  - Create Release
+  - Summary
+failure_markers:
+  - Task :dmtools-core:test FAILED
+  - There were failing tests.
+user_visible_release_markers:
+  - deprecated / internal-only workflow
+  - do not treat this release body as installation guidance
+user_visible_summary_markers:
+  - deprecated/internal-only packaging workflow
+  - do not reuse this workflow summary as customer-facing installation guidance
+standalone_workflow_file: standalone-release.yml
+standalone_workflow_name: Create Standalone Release with Flutter SPA
+standalone_release_job_name: create-standalone-release
+standalone_require_step_summary: true
+standalone_auto_workflow_file: standalone-release-auto.yml
+standalone_auto_workflow_name: Auto Standalone Release
+standalone_auto_release_job_name: auto-standalone-release
+standalone_auto_require_step_summary: true

--- a/testing/tests/DMC-1009/config.yaml
+++ b/testing/tests/DMC-1009/config.yaml
@@ -17,6 +17,7 @@ required_successful_steps:
   - Summary
 failure_markers:
   - Task :dmtools-core:test FAILED
+  - Execution failed for task ':dmtools-core:test'.
   - There were failing tests.
 user_visible_release_markers:
   - deprecated / internal-only workflow

--- a/testing/tests/DMC-1009/test_dmc_1009.py
+++ b/testing/tests/DMC-1009/test_dmc_1009.py
@@ -59,6 +59,7 @@ class WorkflowValidationObservation:
     release_body_excerpt: str
     dmtools_core_test_command_present: bool
     observed_failure_markers: list[str]
+    missing_failure_markers: list[str]
     failures: list[str]
 
 
@@ -248,6 +249,12 @@ def _validate_workflow(
         )
 
     observed_failure_markers = [marker for marker in FAILURE_MARKERS if marker in raw_job_log]
+    missing_failure_markers = [marker for marker in FAILURE_MARKERS if marker not in raw_job_log]
+    if missing_failure_markers:
+        failures.append(
+            "Expected the live job log to include dmtools-core test failure markers "
+            f"{missing_failure_markers!r}. Observed excerpt: {_preview_text(raw_job_log, limit=500)}"
+        )
 
     normalized_release_body = _normalize_visible_text(release_body)
     for marker in USER_VISIBLE_RELEASE_MARKERS:
@@ -285,6 +292,7 @@ def _validate_workflow(
         release_body_excerpt=_preview_text(release_body),
         dmtools_core_test_command_present=dmtools_core_test_command_present,
         observed_failure_markers=observed_failure_markers,
+        missing_failure_markers=missing_failure_markers,
         failures=failures,
     )
 

--- a/testing/tests/DMC-1009/test_dmc_1009.py
+++ b/testing/tests/DMC-1009/test_dmc_1009.py
@@ -7,7 +7,6 @@ import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
@@ -142,17 +141,6 @@ def _preview_text(value: str, *, limit: int = 300) -> str:
     return f"{collapsed[:limit]}..."
 
 
-def _step_payloads_by_name(job_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    steps = job_payload.get("steps", [])
-    if not isinstance(steps, list):
-        return {}
-    return {
-        str(step.get("name", "")): step
-        for step in steps
-        if isinstance(step, dict) and str(step.get("name", ""))
-    }
-
-
 def _scenario_definitions(client: GitHubActionsReleaseClient) -> tuple[WorkflowScenario, ...]:
     standalone_release_tag = _timestamped_release_tag()
     fatjar_release_tag = _latest_stable_release_tag(client)
@@ -182,7 +170,6 @@ def _scenario_definitions(client: GitHubActionsReleaseClient) -> tuple[WorkflowS
 
 
 def _validate_workflow(
-    client: GitHubActionsReleaseClient,
     scenario: WorkflowScenario,
 ) -> WorkflowValidationObservation:
     service = _build_service(
@@ -207,40 +194,20 @@ def _validate_workflow(
     release_tag = audit.release.tag_name if audit.release is not None else scenario.release_tag
     release_body = audit.release.body if audit.release is not None else ""
     step_summary = audit.release_job.step_summary_markdown if audit.release_job is not None else ""
-    raw_job_log = ""
-    step_conclusions: dict[str, str] = {}
+    raw_job_log = audit.release_job.raw_log_text if audit.release_job is not None else ""
+    step_conclusions = dict(audit.release_job.step_conclusions) if audit.release_job is not None else {}
 
-    if audit.workflow_run is not None:
-        job_payload = next(
-            (
-                payload
-                for payload in client.workflow_jobs(audit.workflow_run.run_id)
-                if str(payload.get("name", "")) == scenario.release_job_name
-            ),
-            None,
-        )
-        if job_payload is None:
+    for step_name in REQUIRED_SUCCESSFUL_STEPS:
+        conclusion = step_conclusions.get(step_name)
+        if conclusion is None:
             failures.append(
-                f"Expected job {scenario.release_job_name!r} in run {workflow_run_url}, but it was not listed."
+                f"Expected step {step_name!r} in job {scenario.release_job_name!r}, but it was missing."
             )
-        else:
-            step_payloads = _step_payloads_by_name(job_payload)
-            for step_name in REQUIRED_SUCCESSFUL_STEPS:
-                step_payload = step_payloads.get(step_name)
-                if step_payload is None:
-                    failures.append(
-                        f"Expected step {step_name!r} in job {scenario.release_job_name!r}, but it was missing."
-                    )
-                    continue
-                conclusion = str(step_payload.get("conclusion", ""))
-                step_conclusions[step_name] = conclusion
-                if conclusion != "success":
-                    failures.append(
-                        f"Expected step {step_name!r} to conclude with 'success', got {conclusion!r}."
-                    )
-
-    if audit.release_job is not None:
-        raw_job_log = client.workflow_job_logs(audit.release_job.job_id)
+            continue
+        if conclusion != "success":
+            failures.append(
+                f"Expected step {step_name!r} to conclude with 'success', got {conclusion!r}."
+            )
 
     dmtools_core_test_command_present = ":dmtools-core:test" in raw_job_log
     if not dmtools_core_test_command_present:
@@ -250,10 +217,10 @@ def _validate_workflow(
 
     observed_failure_markers = [marker for marker in FAILURE_MARKERS if marker in raw_job_log]
     missing_failure_markers = [marker for marker in FAILURE_MARKERS if marker not in raw_job_log]
-    if missing_failure_markers:
+    if not observed_failure_markers:
         failures.append(
-            "Expected the live job log to include dmtools-core test failure markers "
-            f"{missing_failure_markers!r}. Observed excerpt: {_preview_text(raw_job_log, limit=500)}"
+            "Expected the live job log to include at least one configured dmtools-core test failure "
+            f"marker {list(FAILURE_MARKERS)!r}. Observed excerpt: {_preview_text(raw_job_log, limit=500)}"
         )
 
     normalized_release_body = _normalize_visible_text(release_body)
@@ -299,7 +266,7 @@ def _validate_workflow(
 
 def run_live_validation() -> list[WorkflowValidationObservation]:
     client = build_github_client()
-    return [_validate_workflow(client, scenario) for scenario in _scenario_definitions(client)]
+    return [_validate_workflow(scenario) for scenario in _scenario_definitions(client)]
 
 
 def _format_observation_failures(observation: WorkflowValidationObservation) -> list[str]:

--- a/testing/tests/DMC-1009/test_dmc_1009.py
+++ b/testing/tests/DMC-1009/test_dmc_1009.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.deprecated_workflow_run_audit_service_factory import (  # noqa: E402
+    create_deprecated_workflow_run_audit_service,
+)
+from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
+    create_github_actions_release_client,
+)
+from testing.core.interfaces.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+STABLE_RELEASE_TAG_PATTERN = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+@dataclass(frozen=True)
+class WorkflowScenario:
+    workflow_file: str
+    workflow_name: str
+    release_job_name: str
+    require_step_summary: bool
+    dispatch_inputs: dict[str, object] | None
+    release_tag: str
+
+
+@dataclass(frozen=True)
+class WorkflowValidationObservation:
+    workflow_file: str
+    workflow_name: str
+    workflow_run_url: str
+    workflow_conclusion: str
+    release_job_url: str
+    release_job_conclusion: str
+    release_url: str
+    release_tag: str
+    step_conclusions: dict[str, str]
+    step_summary_excerpt: str
+    release_body_excerpt: str
+    dmtools_core_test_command_present: bool
+    observed_failure_markers: list[str]
+    failures: list[str]
+
+
+def _config_list(key: str) -> tuple[str, ...]:
+    values = CONFIG.get(key, [])
+    if not isinstance(values, list):
+        raise TypeError(f"Expected {key!r} to be a list in {TEST_DIRECTORY / 'config.yaml'}.")
+    return tuple(str(value) for value in values)
+
+
+REQUIRED_SUCCESSFUL_STEPS = _config_list("required_successful_steps")
+FAILURE_MARKERS = _config_list("failure_markers")
+USER_VISIBLE_RELEASE_MARKERS = tuple(
+    " ".join(marker.lower().split()) for marker in _config_list("user_visible_release_markers")
+)
+USER_VISIBLE_SUMMARY_MARKERS = tuple(
+    " ".join(marker.lower().split()) for marker in _config_list("user_visible_summary_markers")
+)
+
+
+def build_github_client() -> GitHubActionsReleaseClient:
+    return create_github_actions_release_client(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def _timestamped_release_tag(now: datetime | None = None) -> str:
+    current = now or datetime.now(timezone.utc)
+    return (
+        f"v{current.year}.{current.month:02d}{current.day:02d}."
+        f"{current.hour:02d}{current.minute:02d}{current.second:02d}-standalone"
+    )
+
+
+def _latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
+    for release in client.list_releases(per_page=20):
+        tag_name = str(release.get("tag_name", ""))
+        if STABLE_RELEASE_TAG_PATTERN.match(tag_name):
+            return tag_name
+    raise AssertionError("Expected at least one stable vX.Y.Z release to exist for standalone dispatch.")
+
+
+def _build_service(
+    *,
+    workflow_file: str,
+    workflow_name: str,
+    release_job_name: str,
+    release_tag: str,
+    require_step_summary: bool,
+    dispatch_inputs: dict[str, object] | None = None,
+) -> DeprecatedWorkflowRunAuditService:
+    return create_deprecated_workflow_run_audit_service(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=workflow_file,
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=workflow_name,
+        release_job_name=release_job_name,
+        release_tag=release_tag,
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+        required_notice_markers=(),
+        forbidden_strings=(),
+        require_step_summary=require_step_summary,
+        dispatch_inputs=dispatch_inputs,
+    )
+
+
+def _normalize_visible_text(value: str) -> str:
+    return " ".join(value.lower().split())
+
+
+def _preview_text(value: str, *, limit: int = 300) -> str:
+    collapsed = " ".join(value.split())
+    if len(collapsed) <= limit:
+        return collapsed
+    return f"{collapsed[:limit]}..."
+
+
+def _step_payloads_by_name(job_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    steps = job_payload.get("steps", [])
+    if not isinstance(steps, list):
+        return {}
+    return {
+        str(step.get("name", "")): step
+        for step in steps
+        if isinstance(step, dict) and str(step.get("name", ""))
+    }
+
+
+def _scenario_definitions(client: GitHubActionsReleaseClient) -> tuple[WorkflowScenario, ...]:
+    standalone_release_tag = _timestamped_release_tag()
+    fatjar_release_tag = _latest_stable_release_tag(client)
+    return (
+        WorkflowScenario(
+            workflow_file=str(CONFIG["standalone_workflow_file"]),
+            workflow_name=str(CONFIG["standalone_workflow_name"]),
+            release_job_name=str(CONFIG["standalone_release_job_name"]),
+            require_step_summary=str(CONFIG["standalone_require_step_summary"]).lower() == "true",
+            dispatch_inputs={
+                "flutter_release_tag": "latest",
+                "release_tag": standalone_release_tag,
+                "fatjar_release_tag": fatjar_release_tag,
+                "prerelease": True,
+            },
+            release_tag=standalone_release_tag,
+        ),
+        WorkflowScenario(
+            workflow_file=str(CONFIG["standalone_auto_workflow_file"]),
+            workflow_name=str(CONFIG["standalone_auto_workflow_name"]),
+            release_job_name=str(CONFIG["standalone_auto_release_job_name"]),
+            require_step_summary=str(CONFIG["standalone_auto_require_step_summary"]).lower() == "true",
+            dispatch_inputs=None,
+            release_tag="",
+        ),
+    )
+
+
+def _validate_workflow(
+    client: GitHubActionsReleaseClient,
+    scenario: WorkflowScenario,
+) -> WorkflowValidationObservation:
+    service = _build_service(
+        workflow_file=scenario.workflow_file,
+        workflow_name=scenario.workflow_name,
+        release_job_name=scenario.release_job_name,
+        release_tag=scenario.release_tag,
+        require_step_summary=scenario.require_step_summary,
+        dispatch_inputs=scenario.dispatch_inputs,
+    )
+    audit = service.audit()
+
+    failures: list[str] = []
+    if audit.failures:
+        failures.append(service.format_failures(audit.failures))
+
+    workflow_run_url = audit.workflow_run.html_url if audit.workflow_run is not None else ""
+    workflow_conclusion = audit.workflow_run.conclusion if audit.workflow_run is not None else ""
+    release_job_url = audit.release_job.html_url if audit.release_job is not None else ""
+    release_job_conclusion = audit.release_job.conclusion if audit.release_job is not None else ""
+    release_url = audit.release.html_url if audit.release is not None else ""
+    release_tag = audit.release.tag_name if audit.release is not None else scenario.release_tag
+    release_body = audit.release.body if audit.release is not None else ""
+    step_summary = audit.release_job.step_summary_markdown if audit.release_job is not None else ""
+    raw_job_log = ""
+    step_conclusions: dict[str, str] = {}
+
+    if audit.workflow_run is not None:
+        job_payload = next(
+            (
+                payload
+                for payload in client.workflow_jobs(audit.workflow_run.run_id)
+                if str(payload.get("name", "")) == scenario.release_job_name
+            ),
+            None,
+        )
+        if job_payload is None:
+            failures.append(
+                f"Expected job {scenario.release_job_name!r} in run {workflow_run_url}, but it was not listed."
+            )
+        else:
+            step_payloads = _step_payloads_by_name(job_payload)
+            for step_name in REQUIRED_SUCCESSFUL_STEPS:
+                step_payload = step_payloads.get(step_name)
+                if step_payload is None:
+                    failures.append(
+                        f"Expected step {step_name!r} in job {scenario.release_job_name!r}, but it was missing."
+                    )
+                    continue
+                conclusion = str(step_payload.get("conclusion", ""))
+                step_conclusions[step_name] = conclusion
+                if conclusion != "success":
+                    failures.append(
+                        f"Expected step {step_name!r} to conclude with 'success', got {conclusion!r}."
+                    )
+
+    if audit.release_job is not None:
+        raw_job_log = client.workflow_job_logs(audit.release_job.job_id)
+
+    dmtools_core_test_command_present = ":dmtools-core:test" in raw_job_log
+    if not dmtools_core_test_command_present:
+        failures.append(
+            "Expected the live job log to show the deprecated compatibility build invoking ':dmtools-core:test'."
+        )
+
+    observed_failure_markers = [marker for marker in FAILURE_MARKERS if marker in raw_job_log]
+
+    normalized_release_body = _normalize_visible_text(release_body)
+    for marker in USER_VISIBLE_RELEASE_MARKERS:
+        if marker not in normalized_release_body:
+            failures.append(
+                f"Expected visible release body text to include {marker!r}. "
+                f"Observed: {_preview_text(release_body)}"
+            )
+
+    normalized_step_summary = _normalize_visible_text(step_summary)
+    for marker in USER_VISIBLE_SUMMARY_MARKERS:
+        if marker not in normalized_step_summary:
+            failures.append(
+                f"Expected visible step summary text to include {marker!r}. "
+                f"Observed: {_preview_text(step_summary)}"
+            )
+
+    if scenario.require_step_summary and not step_summary.strip():
+        failures.append("Expected a non-empty GITHUB_STEP_SUMMARY, but no summary content was captured.")
+
+    if not release_body.strip():
+        failures.append("Expected a non-empty release body, but the published release body was empty.")
+
+    return WorkflowValidationObservation(
+        workflow_file=scenario.workflow_file,
+        workflow_name=scenario.workflow_name,
+        workflow_run_url=workflow_run_url,
+        workflow_conclusion=workflow_conclusion,
+        release_job_url=release_job_url,
+        release_job_conclusion=release_job_conclusion,
+        release_url=release_url,
+        release_tag=release_tag,
+        step_conclusions=step_conclusions,
+        step_summary_excerpt=_preview_text(step_summary),
+        release_body_excerpt=_preview_text(release_body),
+        dmtools_core_test_command_present=dmtools_core_test_command_present,
+        observed_failure_markers=observed_failure_markers,
+        failures=failures,
+    )
+
+
+def run_live_validation() -> list[WorkflowValidationObservation]:
+    client = build_github_client()
+    return [_validate_workflow(client, scenario) for scenario in _scenario_definitions(client)]
+
+
+def _format_observation_failures(observation: WorkflowValidationObservation) -> list[str]:
+    return [
+        f"{observation.workflow_file}: {failure}"
+        for failure in observation.failures
+    ]
+
+
+def test_dmc_1009_live_deprecated_workflows_publish_outputs_after_compatibility_build_step() -> None:
+    observations = run_live_validation()
+
+    print(
+        "DMC1009_OBSERVATIONS="
+        + json.dumps([asdict(observation) for observation in observations], sort_keys=True)
+    )
+
+    failure_messages: list[str] = []
+    for observation in observations:
+        failure_messages.extend(_format_observation_failures(observation))
+
+    assert not failure_messages, "\n\n".join(failure_messages)


### PR DESCRIPTION
## Test result: FAILED

- **Automated test file:** `testing/tests/DMC-1009/test_dmc_1009.py`
- **Automated command:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1009/test_dmc_1009.py -q -s`
- **Related baseline check:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q` -> `3 passed`

## What automation checked

1. Triggered the live `standalone-release.yml` and `standalone-release-auto.yml` workflows on `main`.
2. Verified the publication job executed `Build deprecated compatibility artifact` and that the live job log still included `:dmtools-core:test`.
3. Checked the downstream publication path a user depends on: `Capture compatibility artifact metadata`, `Generate Release Notes`, `Create Release`, and `Summary`.
4. Verified whether the run published a Release body and visible `GITHUB_STEP_SUMMARY` content.
5. Checked the expected user-facing deprecated/internal-only wording in those visible output surfaces.

## Human-style verification

I validated the scenario from the user’s perspective in live GitHub Actions data:

- In both workflows, `Build deprecated compatibility artifact` is visibly green/success.
- In both workflows, the very next step `Capture compatibility artifact metadata` is visibly red/failure.
- `Generate Release Notes`, `Create Release`, and `Summary` are skipped after that failure.
- Because those output-producing steps are skipped, there is no published Release body and no visible `GITHUB_STEP_SUMMARY` content to review.

This does **not** match the expected result.

## Live run details

| Workflow | Run | Job | Observed step states |
| --- | --- | --- | --- |
| `standalone-release.yml` | [25432511152](https://github.com/epam/dm.ai/actions/runs/25432511152) | [create-standalone-release](https://github.com/epam/dm.ai/actions/runs/25432511152/job/74602065000) | Build compatibility artifact = success; Capture compatibility artifact metadata = failure; Generate Release Notes = skipped; Create Release = skipped; Summary = skipped |
| `standalone-release-auto.yml` | [25432669223](https://github.com/epam/dm.ai/actions/runs/25432669223) | [auto-standalone-release](https://github.com/epam/dm.ai/actions/runs/25432669223/job/74602592655) | Build compatibility artifact = success; Capture compatibility artifact metadata = failure; Generate Release Notes = skipped; Create Release = skipped; Summary = skipped |

## Failing evidence

```text
standalone-release.yml
BUILD SUCCESSFUL in 1m 55s
Run JAR_PATH=$(ls dmtools-core/build/libs/dmtools-v*-all.jar | head -n 1)
ls: cannot access 'dmtools-core/build/libs/dmtools-v*-all.jar': No such file or directory
ERROR: Expected dmtools-core shadow JAR was not produced

standalone-release-auto.yml
BUILD SUCCESSFUL in 2m 7s
Run JAR_PATH=$(ls dmtools-core/build/libs/dmtools-v*-all.jar | head -n 1)
ls: cannot access 'dmtools-core/build/libs/dmtools-v*-all.jar': No such file or directory
ERROR: Expected dmtools-core shadow JAR was not produced
```

## Pytest assertion output

```text
FAILED testing/tests/DMC-1009/test_dmc_1009.py::test_dmc_1009_live_deprecated_workflows_publish_outputs_after_compatibility_build_step - AssertionError: standalone-release.yml: Deprecated workflow run outputs did not match the expected live behavior:
  Step 2: The Create Standalone Release with Flutter SPA workflow did not finish successfully.
  Expected: A completed workflow run with conclusion 'success'.
  Actual: Run https://github.com/epam/dm.ai/actions/runs/25432511152 finished with status='completed' and conclusion='failure'. Job excerpt: ... testGetKey PASSED TestCaseTest > testGetStatus PASSED TestCaseTest > testGetPriorityMedium PASSED TestCaseTest > testGetFieldValueAsString PASSED TestCaseTest > testNotEquals PASSED TestCaseTest > testGetWeight PASSED TestCaseTest > testGetAttachments PASSED TestCaseTest > testGetTicketLabelsEmpty PASSED TestCaseTest > testToText PASSED VacationTest >...

  standalone-release.yml: Expected step 'Capture compatibility artifact metadata' to conclude with 'success', got 'failure'.
  standalone-release.yml: Expected step 'Generate Release Notes' to conclude with 'success', got 'skipped'.
  standalone-release.yml: Expected step 'Create Release' to conclude with 'success', got 'skipped'.
  standalone-release.yml: Expected step 'Summary' to conclude with 'success', got 'skipped'.
  standalone-release.yml: Expected a non-empty GITHUB_STEP_SUMMARY, but no summary content was captured.
  standalone-release.yml: Expected a non-empty release body, but the published release body was empty.

  standalone-release-auto.yml: Deprecated workflow run outputs did not match the expected live behavior:
  Step 2: The Auto Standalone Release workflow did not finish successfully.
  Expected: A completed workflow run with conclusion 'success'.
  Actual: Run https://github.com/epam/dm.ai/actions/runs/25432669223 finished with status='completed' and conclusion='failure'. Job excerpt: ...SSED TestCaseTest > testGetStatus PASSED TestCaseTest > testGetPriorityMedium PASSED TestCaseTest > testGetFieldValueAsString PASSED TestCaseTest > testNotEquals PASSED TestCaseTest > testGetWeight PASSED TestCaseTest > testGetAttachments PASSED TestCaseTest > testGetTicketLabelsEmpty PASSED TestCaseTest > testToText PASSED VacationTest > testGetEndDat...

  standalone-release-auto.yml: Expected step 'Capture compatibility artifact metadata' to conclude with 'success', got 'failure'.
  standalone-release-auto.yml: Expected step 'Generate Release Notes' to conclude with 'success', got 'skipped'.
  standalone-release-auto.yml: Expected step 'Create Release' to conclude with 'success', got 'skipped'.
  standalone-release-auto.yml: Expected step 'Summary' to conclude with 'success', got 'skipped'.
  standalone-release-auto.yml: Expected a non-empty GITHUB_STEP_SUMMARY, but no summary content was captured.
  standalone-release-auto.yml: Expected a non-empty release body, but the published release body was empty.
```
