### PR TITLE
DMC-1010 standalone-release.yml fails before publish when dmtools-core unit test breaks deprecated artifact build

### DIFF
--- a/.github/workflows/standalone-release-auto.yml
+++ b/.github/workflows/standalone-release-auto.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Capture compatibility artifact metadata
         id: compatibility_artifact
         run: |
-          JAR_PATH=$(ls dmtools-core/build/libs/dmtools-v*-all.jar | head -n 1)
+          JAR_PATH=$(ls build/libs/dmtools-v*-all.jar | head -n 1)
 
           if [ -z "${JAR_PATH}" ] || [ ! -f "${JAR_PATH}" ]; then
             echo "ERROR: Expected dmtools-core shadow JAR was not produced"

--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Capture compatibility artifact metadata
         id: compatibility_artifact
         run: |
-          JAR_PATH=$(ls dmtools-core/build/libs/dmtools-v*-all.jar | head -n 1)
+          JAR_PATH=$(ls build/libs/dmtools-v*-all.jar | head -n 1)
 
           if [ -z "${JAR_PATH}" ] || [ ! -f "${JAR_PATH}" ]; then
             echo "ERROR: Expected dmtools-core shadow JAR was not produced"

--- a/testing/tests/DMC-1010/test_dmc_1010.py
+++ b/testing/tests/DMC-1010/test_dmc_1010.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_dmc_1010_standalone_workflows_read_shadowjar_from_root_build_libs() -> None:
+    build_gradle_text = _read("dmtools-core/build.gradle")
+
+    assert 'destinationDirectory.set(file("${project.rootDir}/build/libs"))' in build_gradle_text
+
+    for workflow_path in (
+        ".github/workflows/standalone-release.yml",
+        ".github/workflows/standalone-release-auto.yml",
+    ):
+        workflow_text = _read(workflow_path)
+
+        assert 'JAR_PATH=$(ls build/libs/dmtools-v*-all.jar | head -n 1)' in workflow_text
+        assert 'dmtools-core/build/libs/dmtools-v*-all.jar' not in workflow_text


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
PR #185 fixed the original flaky `CliCommandExecutorTest` failure, but the linked workflow still failed afterward. Both standalone release workflows were looking for the compatibility shadow JAR in `dmtools-core/build/libs`, while `dmtools-core` actually publishes that JAR to the repository root `build/libs/`.

### Previous Attempt
PR #185 changed `CliCommandExecutorTest.testExecuteCommand_CommandWithSpecialCharacters_Success` so the CI build no longer depends on optional git user config. That fixed the first failing step, but it did not catch the next workflow failure in `Capture compatibility artifact metadata`.

### Fix
Updated `.github/workflows/standalone-release.yml` and `.github/workflows/standalone-release-auto.yml` so `Capture compatibility artifact metadata` reads the shadow JAR from `build/libs/dmtools-v*-all.jar`, matching the actual `shadowJar` destination configured in `dmtools-core/build.gradle`.

Added `testing/tests/DMC-1010/test_dmc_1010.py` as a regression test that locks the workflow JAR lookup path to the real shadowJar output directory and prevents the old broken path from coming back.

### Test Coverage
- Reproduction check (pre-fix condition): verified against `HEAD` workflow contents that the new regression assertion failed because the workflows still referenced `dmtools-core/build/libs/dmtools-v*-all.jar`.
- Reproduction test added: `testing/tests/DMC-1010/test_dmc_1010.py` — `test_dmc_1010_standalone_workflows_read_shadowjar_from_root_build_libs`
- Related workflow tests: `testing/tests/DMC-1005/test_dmc_1005.py`
- Full core suite: `./gradlew :dmtools-core:test --no-daemon` — PASSED

### Notes
The linked live failure on run `25432511152` showed the original unit-test problem was already gone and exposed this next workflow-path issue. This fix addresses that remaining release-publication blocker in the standalone workflows.
