### PR TITLE
DMC-1003 Test: Run deprecated standalone and server workflows — installer scripts and public headers are removed

### DIFF
--- a/testing/tests/DMC-1003/test_dmc_1003.py
+++ b/testing/tests/DMC-1003/test_dmc_1003.py
@@ -95,6 +95,22 @@ def _assert_successful_live_audit(audit: DeprecatedWorkflowRunAudit) -> None:
     assert audit.release is not None
 
 
+def _format_combined_failures(
+    workflow_results: tuple[
+        tuple[str, DeprecatedWorkflowRunAuditService, DeprecatedWorkflowRunAudit],
+        ...,
+    ],
+) -> str:
+    lines = ["Deprecated workflow run outputs did not match the expected live behavior:"]
+    for workflow_file, _, audit in workflow_results:
+        if not audit.failures:
+            continue
+        lines.append(f"Workflow {workflow_file}:")
+        for failure in audit.failures:
+            lines.append(failure.format())
+    return "\n".join(lines)
+
+
 def test_dmc_1003_live_deprecated_workflow_outputs_remove_installer_scripts_and_public_header() -> None:
     client = build_github_client()
     standalone_release_tag = _timestamped_standalone_release_tag()
@@ -126,9 +142,13 @@ def test_dmc_1003_live_deprecated_workflow_outputs_remove_installer_scripts_and_
     )
     standalone_auto_audit = standalone_auto_service.audit()
 
-    assert not standalone_audit.failures, standalone_service.format_failures(standalone_audit.failures)
-    assert not standalone_auto_audit.failures, standalone_auto_service.format_failures(
-        standalone_auto_audit.failures
+    workflow_results = (
+        (str(CONFIG["standalone_workflow_file"]), standalone_service, standalone_audit),
+        (str(CONFIG["standalone_auto_workflow_file"]), standalone_auto_service, standalone_auto_audit),
     )
+
+    combined_failures = _format_combined_failures(workflow_results)
+    assert all(not audit.failures for _, _, audit in workflow_results), combined_failures
+
     _assert_successful_live_audit(standalone_audit)
     _assert_successful_live_audit(standalone_auto_audit)


### PR DESCRIPTION
## DMC-1003 automated test result

**Status:** FAIL

### Test code update
- Updated `testing/tests/DMC-1003/test_dmc_1003.py` to aggregate failures from both deprecated workflows in one assertion, so one run reports the full live result instead of only the first failing workflow.

### Automated coverage
- Reused the existing live audit flow in `testing/tests/DMC-1003/test_dmc_1003.py`.
- Reused `testing.components.services.deprecated_workflow_run_audit_service` and the shared GitHub Actions release client.
- Ran:
  - `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q` → `3 passed`
  - `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003.py -q` → `1 failed`

### What automation checked
1. Open the GitHub Actions workflows for the repository.
2. Dispatch `standalone-release.yml` and `standalone-release-auto.yml` on `main`.
3. Wait for both live workflow runs to complete.
4. Inspect the generated Release body and `GITHUB_STEP_SUMMARY` for each workflow.
5. Verify the visible outputs do **not** contain:
   - `install.sh`
   - `install.ps1`
   - `skill-install.sh`
   - `Supported public installation paths`

### Real user-style verification
- Opened the live workflow run pages a user would inspect:
  - `standalone-release.yml`: https://github.com/epam/dm.ai/actions/runs/25435289624
  - `standalone-release-auto.yml`: https://github.com/epam/dm.ai/actions/runs/25435436379
- Opened the failing publication jobs:
  - `create-standalone-release`: https://github.com/epam/dm.ai/actions/runs/25435289624/job/74611529500
  - `auto-standalone-release`: https://github.com/epam/dm.ai/actions/runs/25435436379/job/74612051895
- Observed that both runs failed at **Capture compatibility artifact metadata**.
- Observed that **Generate Release Notes**, **Create Release**, and **Summary** were skipped in both runs.
- Observed that no visible Release body or `GITHUB_STEP_SUMMARY` was published for either workflow.

### Actual vs expected
- **Expected:** both deprecated workflows complete successfully, publish a Release body and `GITHUB_STEP_SUMMARY`, and those visible outputs omit the installer script names and public installation header.
- **Actual:** both workflows fail before publishing any visible output surfaces, so the installer-string/header assertions cannot be completed against live published outputs.

### Error details
```text
AssertionError: Deprecated workflow run outputs did not match the expected live behavior:
Workflow standalone-release.yml:
Step 2: The Create Standalone Release with Flutter SPA workflow did not finish successfully.
Expected: A completed workflow run with conclusion 'success'.
Actual: Run https://github.com/epam/dm.ai/actions/runs/25435289624 finished with status='completed' and conclusion='failure'. Job excerpt: ... testGetKey PASSED TestCaseTest > testGetStatus PASSED TestCaseTest > testGetPriorityMedium PASSED TestCaseTest > testGetFieldValueAsString PASSED TestCaseTest > testNotEquals PASSED TestCaseTest > testGetWeight PASSED TestCaseTest > testGetAttachments PASSED TestCaseTest > testGetTicketLabelsEmpty PASSED TestCaseTest > testToText PASSED VacationTest >...
Workflow standalone-release-auto.yml:
Step 2: The Auto Standalone Release workflow did not finish successfully.
Expected: A completed workflow run with conclusion 'success'.
Actual: Run https://github.com/epam/dm.ai/actions/runs/25435436379 finished with status='completed' and conclusion='failure'. Job excerpt: ...SED TestCaseTest > testGetStatus PASSED TestCaseTest > testGetPriorityMedium PASSED TestCaseTest > testGetFieldValueAsString PASSED TestCaseTest > testNotEquals PASSED TestCaseTest > testGetWeight PASSED TestCaseTest > testGetAttachments PASSED TestCaseTest > testGetTicketLabelsEmpty PASSED TestCaseTest > testToText PASSED VacationTest > testGetEndDate...
```

### Relevant job log lines
```text
ls: cannot access 'dmtools-core/build/libs/dmtools-v*-all.jar': No such file or directory
ERROR: Expected dmtools-core shadow JAR was not produced
```

Bug details were written to `outputs/bug_description.md`.
