### PR TITLE
DMC-1013 Deprecated standalone workflows fail at Upload deprecated compatibility JAR and publish no outputs

### DIFF
--- a/.github/workflows/standalone-release-auto.yml
+++ b/.github/workflows/standalone-release-auto.yml
@@ -101,26 +101,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.extract_tag.outputs.tag_name }}
-          release_name: "DMTools Standalone (Deprecated/Internal) ${{ steps.extract_tag.outputs.tag_name }}"
+          name: "DMTools Standalone (Deprecated/Internal) ${{ steps.extract_tag.outputs.tag_name }}"
           body_path: release_notes.md
           draft: false
           prerelease: false
-          commitish: ${{ github.sha }}
-
-      - name: Upload deprecated compatibility JAR
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.compatibility_artifact.outputs.jar_path }}
-          asset_name: deprecated-${{ steps.extract_tag.outputs.tag_name }}-${{ steps.compatibility_artifact.outputs.jar_name }}
-          asset_content_type: application/java-archive
+          files: |
+            ${{ steps.compatibility_artifact.outputs.jar_path }}
 
       - name: Upload Test Results
         if: always()
@@ -138,7 +129,7 @@ jobs:
         run: |
           echo "## 🚧 Deprecated Standalone Packaging Release Created" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Release:** [${{ steps.extract_tag.outputs.tag_name }}](${{ steps.create_release.outputs.html_url }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release:** [${{ steps.extract_tag.outputs.tag_name }}](https://github.com/${{ github.repository }}/releases/tag/${{ steps.extract_tag.outputs.tag_name }})" >> "$GITHUB_STEP_SUMMARY"
           echo "**Positioning:** Deprecated/internal-only packaging workflow" >> "$GITHUB_STEP_SUMMARY"
           echo "**Flutter SPA source tag:** ${{ steps.flutter_release.outputs.flutter_tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Compatibility asset:** ${{ steps.compatibility_artifact.outputs.jar_name }} (${{ steps.compatibility_artifact.outputs.jar_size }})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -138,26 +138,17 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.event.inputs.release_tag }}
-          release_name: "DMTools Standalone (Deprecated/Internal) ${{ github.event.inputs.release_tag }}"
+          name: "DMTools Standalone (Deprecated/Internal) ${{ github.event.inputs.release_tag }}"
           body_path: release_notes.md
           draft: false
           prerelease: ${{ github.event.inputs.prerelease }}
-          commitish: ${{ github.sha }}
-
-      - name: Upload deprecated compatibility JAR
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.compatibility_artifact.outputs.jar_path }}
-          asset_name: deprecated-${{ github.event.inputs.release_tag }}-${{ steps.compatibility_artifact.outputs.jar_name }}
-          asset_content_type: application/java-archive
+          files: |
+            ${{ steps.compatibility_artifact.outputs.jar_path }}
 
       - name: Upload Test Results
         if: always()
@@ -175,7 +166,7 @@ jobs:
         run: |
           echo "## 🚧 Deprecated Standalone Packaging Release Created" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Release:** [${{ github.event.inputs.release_tag }}](${{ steps.create_release.outputs.html_url }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release:** [${{ github.event.inputs.release_tag }}](https://github.com/${{ github.repository }}/releases/tag/${{ github.event.inputs.release_tag }})" >> "$GITHUB_STEP_SUMMARY"
           echo "**Positioning:** Deprecated/internal-only packaging workflow" >> "$GITHUB_STEP_SUMMARY"
           echo "**Flutter SPA source tag:** ${{ steps.flutter_tag.outputs.flutter_tag }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Compatibility asset:** ${{ steps.compatibility_artifact.outputs.jar_name }} (${{ steps.compatibility_artifact.outputs.jar_size }})" >> "$GITHUB_STEP_SUMMARY"

--- a/testing/tests/DMC-1013/test_dmc_1013.py
+++ b/testing/tests/DMC-1013/test_dmc_1013.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_dmc_1013_standalone_workflows_publish_compatibility_jar_without_legacy_upload_step() -> None:
+    for workflow_path in (
+        ".github/workflows/standalone-release.yml",
+        ".github/workflows/standalone-release-auto.yml",
+    ):
+        workflow_text = _read(workflow_path)
+
+        assert "uses: softprops/action-gh-release@v2" in workflow_text
+        assert "files: |" in workflow_text
+        assert "build/libs/dmtools-v*-all.jar" in workflow_text
+        assert "actions/create-release@v1" not in workflow_text
+        assert "actions/upload-release-asset@v1" not in workflow_text


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
The deprecated standalone workflows still used the legacy `actions/create-release@v1` plus `actions/upload-release-asset@v1` flow. In the failing live runs, GitHub created the release successfully and then rejected the follow-up asset upload with `Cannot upload assets to an immutable release.`, which caused the job to fail before the `Summary` step could publish visible output.

### Fix
Updated `.github/workflows/standalone-release.yml` and `.github/workflows/standalone-release-auto.yml` to use `softprops/action-gh-release@v2` with the compatibility JAR attached via the action's `files` input during release publication. This removes the separate legacy upload step that was failing on immutable releases and keeps the summary link stable by pointing directly at the tagged release URL.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-1013/test_dmc_1013.py` — `test_dmc_1013_standalone_workflows_publish_compatibility_jar_without_legacy_upload_step`
- Full test suite: `:dmtools-core:test` PASSED; workflow regression tests (`DMC-1013`, `DMC-1010`, `DMC-1005`) PASSED

### Notes
The linked `DMC-1009` live audit dispatches workflows from the remote repository branch, so it cannot validate an unmerged workspace-only fix. Final verification therefore used the captured failing live runs (`25442427290`, `25442692157`) for RCA plus local regression tests against the updated workflow definitions.
