### PR TITLE
DMC-1006 Test: Trigger standalone-release.yml — workflow completes without test-reporter failure

### DIFF
--- a/testing/tests/DMC-1006/test_dmc_1006.py
+++ b/testing/tests/DMC-1006/test_dmc_1006.py
@@ -58,12 +58,12 @@ def release_tag_for_run(now: datetime | None = None) -> str:
     return generated
 
 
-def latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
-    for release in client.list_releases(per_page=20):
+def latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str | None:
+    for release in client.list_releases(per_page=100):
         tag_name = str(release.get("tag_name", ""))
         if STABLE_RELEASE_TAG_PATTERN.match(tag_name):
             return tag_name
-    raise AssertionError("Expected at least one stable vX.Y.Z release to exist for the standalone workflow.")
+    return None
 
 
 def build_service(
@@ -73,12 +73,14 @@ def build_service(
 ) -> DeprecatedWorkflowRunAuditService:
     dispatch_inputs: dict[str, object] | None = None
     if not reuse_existing_release:
+        fatjar_release_tag = latest_stable_release_tag(build_github_client())
         dispatch_inputs = {
             "flutter_release_tag": "latest",
             "release_tag": release_tag,
-            "fatjar_release_tag": latest_stable_release_tag(build_github_client()),
             "prerelease": True,
         }
+        if fatjar_release_tag:
+            dispatch_inputs["fatjar_release_tag"] = fatjar_release_tag
 
     return create_deprecated_workflow_run_audit_service(
         owner=str(CONFIG["owner"]),


### PR DESCRIPTION
## DMC-1006 automated test result

**Status:** **FAILED**  
**Automated test updated:** `testing/tests/DMC-1006/test_dmc_1006.py`  
**Run command:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1006/test_dmc_1006.py -q`  
**Workflow run:** [25456386200](https://github.com/epam/dm.ai/actions/runs/25456386200)  
**Job:** [create-standalone-release](https://github.com/epam/dm.ai/actions/runs/25456386200/job/74686872058)  
**Release:** [v2026.0506.192634-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0506.192634-standalone)

### Test automation update

Reused the existing API automation in `testing/tests/DMC-1006/test_dmc_1006.py` and fixed the test setup so it no longer aborts before the live workflow starts when the latest stable fat-JAR release is older than the 20 most recent releases. The test now scans a larger release window and treats the optional `fatjar_release_tag` input as optional when no stable tag is found.

### What automation checked

- Triggered `standalone-release.yml` on `main`.
- Waited for `create-standalone-release` to finish.
- Read the live job log and verified the historical `dorny/test-reporter` / `No test report files were found` regression did **not** recur.
- Verified the user-visible outcome required by the ticket: successful workflow completion, published Release body, and published `GITHUB_STEP_SUMMARY`.

### Human-style verification

- Opened the live GitHub Actions run result as a user would and observed the run status is **Failure**.
- Observed these visible job steps:
  - **Build deprecated compatibility artifact** — **Passed**
  - **Create Release** — **Failed**
  - **Upload Test Results** — **Passed**
  - **Summary** — **Skipped**
- Opened the prerelease page and observed the release body is published and readable, but the release is immutable and has **no uploaded assets**.
- Observed the workflow never published visible `GITHUB_STEP_SUMMARY` content because the **Summary** step was skipped.

### Step-by-step result

1. **Passed** — opened the repository Actions flow by creating and inspecting workflow run [25456386200](https://github.com/epam/dm.ai/actions/runs/25456386200) on `main`.
2. **Passed** — triggered `standalone-release.yml` with release tag `v2026.0506.192634-standalone`.
3. **Failed** — the job passed the test-reporting phase (`Upload Test Results` succeeded and the log did not contain `No test report files were found`), but the workflow still finished with **Failure** because **Create Release** failed while uploading `dmtools-v1.7.181-all.jar` to an immutable release, so the expected successful completion and `GITHUB_STEP_SUMMARY` publication did not happen.

### Failure details

```text
AssertionError: Deprecated workflow run outputs did not match the expected live behavior:
Step 2: The Create Standalone Release with Flutter SPA workflow did not finish successfully.
Expected: A completed workflow run with conclusion 'success'.
Actual: Run https://github.com/epam/dm.ai/actions/runs/25456386200 finished with status='completed' and conclusion='failure'.
```

```text
2026-05-06T19:29:09.8342124Z 👩‍🏭 Creating new GitHub release for tag v2026.0506.192634-standalone...
2026-05-06T19:29:11.7724167Z ⬆️ Uploading dmtools-v1.7.181-all.jar...
2026-05-06T19:29:12.3956240Z ##[error]Cannot upload asset dmtools-v1.7.181-all.jar to an immutable release. GitHub only allows asset uploads before a release is published, but draft prereleases publish with the release.published event instead of release.prereleased. If you need prereleases with assets on an immutable-release repository, keep the release as a draft with draft: true, then publish it later from that draft and subscribe downstream workflows to release.published.
```

### Expected vs actual

**Expected:** the workflow completes successfully; the historical test-reporter failure does not recur; the Release body and `GITHUB_STEP_SUMMARY` are both published.

**Actual:** the historical test-reporter failure did not recur, and the Release body was published, but the workflow still failed at **Create Release** because GitHub rejected the asset upload to the immutable prerelease. The **Summary** step was skipped, so the overall expected result was not met.
