### PR TITLE
DMC-1009 Test: Trigger standalone workflows with dmtools-core test failures — workflows complete and publish outputs

### DIFF
--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -20,7 +20,9 @@ from testing.core.models.deprecated_workflow_run_audit import (
 
 
 class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContract):
-    SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
+    SUMMARY_ECHO_PATTERN = re.compile(
+        r'echo (?P<argument>.+?) >> ["\']?\$GITHUB_STEP_SUMMARY["\']?$'
+    )
     ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
     TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
     RELEASE_URL_PATTERN = re.compile(r"/releases/tag/(?P<tag>[^)\s]+)")
@@ -403,7 +405,7 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
     ) -> DeprecatedWorkflowReleaseObservation | None:
         payload = release_payload
         candidate_tags = self._candidate_release_tags(release_job)
-        lookup_deadline = self._deadline(self.poll_interval_seconds * 3)
+        lookup_deadline = self._deadline(max(self.poll_interval_seconds * 6, 120))
         while datetime.now(timezone.utc) < lookup_deadline and payload is None:
             for tag in candidate_tags:
                 try:
@@ -452,7 +454,7 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         candidate_tags: tuple[str, ...],
         dispatch_started_at: datetime,
     ) -> dict[str, Any] | None:
-        for release in self.github_client.list_releases(per_page=20):
+        for release in self.github_client.list_releases(per_page=100):
             tag_name = str(release.get("tag_name", "")).strip()
             if candidate_tags and tag_name not in candidate_tags:
                 continue
@@ -469,7 +471,7 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             line = self._normalize_log_line(raw_line)
             if line.startswith("##[group]Run "):
                 continue
-            if ">> $GITHUB_STEP_SUMMARY" not in line:
+            if "$GITHUB_STEP_SUMMARY" not in line:
                 continue
             match = self.SUMMARY_ECHO_PATTERN.search(line)
             if not match:

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -370,3 +370,69 @@ def test_service_exposes_release_job_steps_and_full_log_text() -> None:
         "Build deprecated compatibility artifact": "success",
         "Summary": "success",
     }
+
+
+def test_service_extracts_step_summary_lines_when_github_summary_path_is_quoted() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 21,
+            "html_url": "https://example.test/runs/21",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-06T11:00:00Z",
+            "run_number": 21,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[21] = {
+        "id": 21,
+        "html_url": "https://example.test/runs/21",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-06T11:00:00Z",
+        "run_number": 21,
+    }
+    client.jobs_by_run_id[21] = [
+        {
+            "id": 105,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/105",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[105] = (
+        '2099-05-06T11:00:01Z echo "Deprecated/internal-only packaging workflow" >> "$GITHUB_STEP_SUMMARY"\n'
+        '2099-05-06T11:00:02Z echo "> Do not reuse this workflow summary as customer-facing installation guidance." >> "$GITHUB_STEP_SUMMARY"\n'
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef3"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef3",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef3",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T11:00:03Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="v2099.05.06-standalone-abcdef3",
+        require_step_summary=True,
+    ).audit()
+
+    assert audit.release_job is not None
+    assert audit.release_job.step_summary_markdown == (
+        "Deprecated/internal-only packaging workflow\n"
+        "> Do not reuse this workflow summary as customer-facing installation guidance."
+    )

--- a/testing/tests/DMC-1009/test_dmc_1009.py
+++ b/testing/tests/DMC-1009/test_dmc_1009.py
@@ -96,7 +96,7 @@ def _timestamped_release_tag(now: datetime | None = None) -> str:
 
 
 def _latest_stable_release_tag(client: GitHubActionsReleaseClient) -> str:
-    for release in client.list_releases(per_page=20):
+    for release in client.list_releases(per_page=100):
         tag_name = str(release.get("tag_name", ""))
         if STABLE_RELEASE_TAG_PATTERN.match(tag_name):
             return tag_name


### PR DESCRIPTION
## Result: failed

### Test automation changes

- Updated `testing/tests/DMC-1009/test_dmc_1009.py` to search more release history for the stable fatJAR reference tag used by the live workflow dispatch.
- Updated `testing/components/services/deprecated_workflow_run_audit_service.py` to parse quoted `"$GITHUB_STEP_SUMMARY"` log writes and broaden live release polling.
- Added unit coverage in `testing/tests/DMC-1003/test_dmc_1003_service.py` for quoted step-summary extraction.

### Automated checks

- Ran `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q` -> `5 passed`
- Ran `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1009/test_dmc_1009.py -q -s` -> `1 failed in 332.87s`

### What automation verified

- Dispatched the live `standalone-release.yml` and `standalone-release-auto.yml` workflows on `main`
- Confirmed `Build deprecated compatibility artifact` completed
- Checked downstream publication steps, release-body publication, and visible `GITHUB_STEP_SUMMARY`
- Checked for real `:dmtools-core:test` failure evidence in the live job logs

### Human-style verification

- `standalone-release.yml` run [`25456848628`](https://github.com/epam/dm.ai/actions/runs/25456848628) failed in job [`create-standalone-release`](https://github.com/epam/dm.ai/actions/runs/25456848628/job/74688498190) after:
  - `Build deprecated compatibility artifact = success`
  - `Capture compatibility artifact metadata = success`
  - `Generate Release Notes = success`
  - `Create Release = failure`
  - `Summary = skipped`
- The exact live GitHub Actions error was:

```text
##[error]Cannot upload asset dmtools-v1.7.181-all.jar to an immutable release. GitHub only allows asset uploads before a release is published, but draft prereleases publish with the release.published event instead of release.prereleased. If you need prereleases with assets on an immutable-release repository, keep the release as a draft with draft: true, then publish it later from that draft and subscribe downstream workflows to release.published.
```

- The manual release page was still visible afterward at [`v2026.0506.193624-standalone`](https://github.com/epam/dm.ai/releases/tag/v2026.0506.193624-standalone), and its body showed the expected deprecated/internal-only warning text.
- `standalone-release-auto.yml` run [`25456977847`](https://github.com/epam/dm.ai/actions/runs/25456977847) succeeded in job [`auto-standalone-release`](https://github.com/epam/dm.ai/actions/runs/25456977847/job/74688954163); the visible release page [`v2026.0506.194120-standalone`](https://github.com/epam/dm.ai/releases/tag/v2026.0506.194120-standalone) and summary text matched the expected deprecated/internal-only messaging.
- Neither workflow log contained any configured `:dmtools-core:test` failure marker:
  - `Task :dmtools-core:test FAILED`
  - `Execution failed for task ':dmtools-core:test'.`
  - `There were failing tests.`

### Expected vs actual

- **Expected:** both workflows finish successfully and still publish Release body plus `GITHUB_STEP_SUMMARY` while the job log proves the `:dmtools-core:test` failure condition was exercised.
- **Actual:** the auto workflow published outputs successfully, but `standalone-release.yml` failed at `Create Release`, skipped `Summary`, and the live logs for both workflows did not contain the expected `:dmtools-core:test` failure evidence.

### Failure excerpt

```text
AssertionError: standalone-release.yml: Deprecated workflow run outputs did not match the expected live behavior:
Step 2: The Create Standalone Release with Flutter SPA workflow did not finish successfully.
Expected: A completed workflow run with conclusion 'success'.
Actual: Run https://github.com/epam/dm.ai/actions/runs/25456848628 finished with status='completed' and conclusion='failure'.

standalone-release.yml: Expected step 'Create Release' to conclude with 'success', got 'failure'.
standalone-release.yml: Expected step 'Summary' to conclude with 'success', got 'skipped'.
standalone-release.yml: Expected the live job log to include at least one configured dmtools-core test failure marker ['Task :dmtools-core:test FAILED', "Execution failed for task ':dmtools-core:test'.", 'There were failing tests.'].
```
