### PR TITLE
fix: prevent standalone releases from overriding latest CLI release

### DIFF
--- a/.github/workflows/standalone-release-auto.yml
+++ b/.github/workflows/standalone-release-auto.yml
@@ -109,7 +109,8 @@ jobs:
           name: "DMTools Standalone (Deprecated/Internal) ${{ steps.extract_tag.outputs.tag_name }}"
           body_path: release_notes.md
           draft: false
-          prerelease: false
+          prerelease: true
+          make_latest: false
           files: |
             ${{ steps.compatibility_artifact.outputs.jar_path }}
 

--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -44,9 +44,9 @@ jobs:
           echo "Release tag: ${RELEASE_TAG}"
           echo "Flutter tag: ${FLUTTER_TAG}"
 
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-standalone$ ]]; then
             echo "ERROR: Invalid release tag format: ${RELEASE_TAG}"
-            echo "Expected format: v1.0.0 or v1.0.0-standalone"
+            echo "Expected format: v1.0.0-standalone (the -standalone suffix is required)"
             exit 1
           fi
 

--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -19,9 +19,9 @@ on:
         default: ''
         type: string
       prerelease:
-        description: 'Mark as pre-release'
+        description: 'Mark as pre-release (defaults to true for standalone releases)'
         required: false
-        default: false
+        default: true
         type: boolean
 
 permissions:
@@ -147,6 +147,7 @@ jobs:
           body_path: release_notes.md
           draft: false
           prerelease: ${{ github.event.inputs.prerelease }}
+          make_latest: false
           files: |
             ${{ steps.compatibility_artifact.outputs.jar_path }}
 

--- a/install.sh
+++ b/install.sh
@@ -779,21 +779,32 @@ detect_version() {
     return 1
 }
 
-# Get latest CLI release version (filters out skill releases)
+# Get latest CLI release version (filters out skill/standalone releases, paginates if needed)
 get_latest_version() {
     progress "Fetching latest CLI release information..." >&2
     local version
     local api_response
     local curl_exit_code
+    local page=1
 
-    # Get all releases (not just latest) to filter CLI releases
-    api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>&1)
-    curl_exit_code=$?
+    # Paginate through releases until a CLI release (^vX.Y.Z$) is found or no more pages
+    while true; do
+        api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}" 2>&1)
+        curl_exit_code=$?
 
-    if [ $curl_exit_code -eq 0 ] && [ -n "$api_response" ]; then
-        # Extract all tag names and filter only CLI releases (vX.Y.Z pattern, excluding skill- prefix)
+        if [ $curl_exit_code -ne 0 ] || [ -z "$api_response" ]; then
+            break
+        fi
+
+        # Stop if the page is an empty array (no more releases)
+        if echo "$api_response" | grep -qE '^\[\s*\]$'; then
+            break
+        fi
+
+        # Extract all tag names and filter only CLI releases (vX.Y.Z pattern)
         # CLI releases have format: v1.7.126, v1.7.125, etc.
         # Skill releases have format: skill-vskill-v1.0.19, etc.
+        # Standalone releases have format: v1.7.181-standalone, etc.
         version=$(echo "$api_response" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
         if [ -n "$version" ]; then
@@ -801,10 +812,16 @@ get_latest_version() {
             echo "$version"
             return 0
         fi
-    fi
 
-    # If GitHub API failed or no CLI release found, try alternative approach
-    progress "GitHub API failed (exit code: $curl_exit_code) or no CLI release found, trying fallback..." >&2
+        page=$((page + 1))
+        # Safety cap to avoid infinite loops
+        if [ "$page" -gt 10 ]; then
+            break
+        fi
+    done
+
+    # If pagination failed or no CLI release found, try /releases/latest as fallback
+    progress "Paginated search failed (exit code: $curl_exit_code) or no CLI release found, trying fallback..." >&2
 
     # Try to get /releases/latest and check if it's a CLI release
     api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases/latest" 2>&1)
@@ -819,7 +836,7 @@ get_latest_version() {
             echo "$version"
             return 0
         else
-            warn "Latest release ($version) is not a CLI release, it might be a skill release." >&2
+            warn "Latest release ($version) is not a CLI release, it might be a skill or standalone release." >&2
         fi
     fi
 
@@ -829,7 +846,7 @@ get_latest_version() {
 Possible causes:
   - Network connectivity issues
   - GitHub API rate limiting
-  - No CLI releases available (only skill releases found)
+  - No CLI releases available (only skill/standalone releases found)
   - curl version incompatibility
 
 Debug information:

--- a/install.sh
+++ b/install.sh
@@ -787,7 +787,7 @@ get_latest_version() {
     local curl_exit_code
 
     # Get all releases (not just latest) to filter CLI releases
-    api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases" 2>&1)
+    api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases?per_page=100" 2>&1)
     curl_exit_code=$?
 
     if [ $curl_exit_code -eq 0 ] && [ -n "$api_response" ]; then


### PR DESCRIPTION
## Problem

Standalone releases (`vX.Y.Z-standalone`) were published with `prerelease: false`, making them GitHub's **latest** release. This caused `install.sh` to fail because:

1. Fetches `/releases` and filters for `^v[0-9]+\.[0-9]+\.[0-9]+$` — standalone tags don't match
2. Fallback to `/releases/latest` — gets the standalone release, which also doesn't match
3. Both fail → installation error → **SM Agent broken**

## Fix

| File | Change |
|---|---|
| `standalone-release-auto.yml` | `prerelease: true` + `make_latest: false` |
| `standalone-release.yml` | Default `prerelease` to `true`, add `make_latest: false` |
| `install.sh` | Use `per_page=100` for more resilient release scanning |

Standalone releases are already documented as deprecated/internal-only, so marking them as pre-releases is semantically correct and prevents them from displacing CLI releases as "latest".