### PR TITLE
DMC-1016 Deprecated standalone workflows fail in Create Release on immutable release asset upload

### DIFF
--- a/.github/workflows/standalone-release-auto.yml
+++ b/.github/workflows/standalone-release-auto.yml
@@ -114,6 +114,15 @@ jobs:
             --notes-file release_notes.md \
             --target "${GITHUB_SHA}" \
             --latest=false \
+            --draft
+
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit \
+            "${{ steps.extract_tag.outputs.tag_name }}" \
+            --draft=false \
             --prerelease
 
       - name: Upload Test Results

--- a/.github/workflows/standalone-release.yml
+++ b/.github/workflows/standalone-release.yml
@@ -151,13 +151,25 @@ jobs:
             --notes-file release_notes.md
             --target "${GITHUB_SHA}"
             --latest=false
+            --draft
+          )
+
+          gh release create "${release_args[@]}"
+
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          publish_args=(
+            "${{ github.event.inputs.release_tag }}"
+            --draft=false
           )
 
           if [ "${{ github.event.inputs.prerelease }}" = "true" ]; then
-            release_args+=(--prerelease)
+            publish_args+=(--prerelease)
           fi
 
-          gh release create "${release_args[@]}"
+          gh release edit "${publish_args[@]}"
 
       - name: Upload Test Results
         if: always()

--- a/testing/tests/DMC-1016/test_dmc_1016.py
+++ b/testing/tests/DMC-1016/test_dmc_1016.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_dmc_1016_standalone_workflows_publish_immutable_safe_draft_releases() -> None:
+    for workflow_path in (
+        ".github/workflows/standalone-release.yml",
+        ".github/workflows/standalone-release-auto.yml",
+    ):
+        workflow_text = _read(workflow_path)
+
+        assert "gh release create" in workflow_text
+        assert "--draft" in workflow_text
+        assert "gh release edit" in workflow_text
+        assert "--draft=false" in workflow_text
+        assert "--prerelease" in workflow_text


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
Both deprecated standalone workflows were creating a published GitHub prerelease and uploading the compatibility JAR in the same `gh release create` call. With immutable releases enabled, GitHub rejects that asset upload, so `Create Release` fails and the later `Summary` step never runs.

### Previous Attempt
PR #193 added DMC-1014 live regression coverage and improved step-summary parsing in the Python audit service, but it did not change the actual release publication flow in the standalone workflows. The bug therefore remained reproducible on `main`.

### Fix
Updated `.github/workflows/standalone-release.yml` and `.github/workflows/standalone-release-auto.yml` to use an immutable-safe release flow:
- `Create Release` now creates the release as a draft while attaching the compatibility JAR.
- A new `Publish Release` step explicitly publishes the draft with `gh release edit --draft=false`, preserving prerelease behavior where required.

Added `testing/tests/DMC-1016/test_dmc_1016.py` to lock this behavior in with a repository-level regression that requires the draft-create plus explicit publish flow in both standalone workflows.

### Test Coverage
- Reproduction test added: `testing/tests/DMC-1016/test_dmc_1016.py` — `test_dmc_1016_standalone_workflows_publish_immutable_safe_draft_releases`
- Regression suite: `python -m pytest -q testing/tests/DMC-1005/test_dmc_1005.py testing/tests/DMC-1013/test_dmc_1013.py testing/tests/DMC-1015/test_dmc_1015.py testing/tests/DMC-1016/test_dmc_1016.py` — PASSED
- Workflow build path: `./gradlew clean :dmtools-core:test :dmtools-core:shadowJar --continue -x integrationTest --no-daemon` — PASSED

### Notes
The linked DMC-1014 test dispatches GitHub-hosted workflows from remote `main`, so it cannot validate this unpushed local change directly from the working tree. The fix was instead verified with a new repository regression test plus the same Gradle build path used by the standalone workflows.
