### PR TITLE
DMC-1006 Test: Trigger standalone-release.yml — workflow completes without test-reporter failure

### DIFF
--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -426,8 +426,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         if payload is None:
             return None
 
-        created_at = self._parse_github_datetime(str(payload.get("created_at", "")))
-        if created_at is not None and created_at < dispatch_started_at - timedelta(minutes=5):
+        visible_at = self._release_visibility_datetime(payload)
+        if visible_at is not None and visible_at < dispatch_started_at - timedelta(minutes=5):
             return None
 
         return DeprecatedWorkflowReleaseObservation(
@@ -458,8 +458,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             tag_name = str(release.get("tag_name", "")).strip()
             if candidate_tags and tag_name not in candidate_tags:
                 continue
-            created_at = self._parse_github_datetime(str(release.get("created_at", "")))
-            if created_at is None or created_at < dispatch_started_at - timedelta(minutes=5):
+            visible_at = self._release_visibility_datetime(release)
+            if visible_at is None or visible_at < dispatch_started_at - timedelta(minutes=5):
                 continue
             if candidate_tags or self._release_looks_like_deprecated_workflow_output(release):
                 return release
@@ -530,6 +530,13 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         if not body:
             return False
         return all(marker in body for marker in self.required_notice_markers)
+
+    def _release_visibility_datetime(self, payload: dict[str, Any]) -> datetime | None:
+        for field in ("published_at", "created_at", "updated_at"):
+            parsed = self._parse_github_datetime(str(payload.get(field, "")))
+            if parsed is not None:
+                return parsed
+        return None
 
     @staticmethod
     def _preview_text(value: str, *, limit: int) -> str:

--- a/testing/tests/DMC-1006/test_dmc_1006_service.py
+++ b/testing/tests/DMC-1006/test_dmc_1006_service.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.deprecated_workflow_run_audit_service import (  # noqa: E402
+    DeprecatedWorkflowRunAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+
+
+class FakeGitHubActionsReleaseClient(GitHubActionsReleaseClient):
+    def __init__(self) -> None:
+        self.dispatch_calls: list[tuple[str, str, dict[str, object]]] = []
+        self.head_sha = "f625f3df36fb0f632e12d9231da356ab719462b3"
+        self.workflow_runs_responses: list[list[dict[str, Any]]] = []
+        self.run_by_id: dict[int, dict[str, Any]] = {}
+        self.jobs_by_run_id: dict[int, list[dict[str, Any]]] = {}
+        self.logs_by_job_id: dict[int, str] = {}
+        self.release_by_tag_payload: dict[str, dict[str, Any]] = {}
+
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
+        self.dispatch_calls.append((workflow_id, ref, dict(inputs or {})))
+
+    def branch_head_sha(self, branch: str) -> str:
+        del branch
+        return self.head_sha
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, Any]]:
+        del workflow_id, branch, event, per_page
+        if self.workflow_runs_responses:
+            return list(self.workflow_runs_responses.pop(0))
+        return []
+
+    def workflow_run(self, run_id: int) -> dict[str, Any]:
+        return dict(self.run_by_id[run_id])
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, Any]]:
+        del per_page
+        return []
+
+    def release_by_tag(self, tag: str) -> dict[str, Any]:
+        return dict(self.release_by_tag_payload[tag])
+
+    def list_recent_pull_requests(self, limit: int = 20) -> list[dict[str, Any]]:
+        del limit
+        return []
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_issue_comments(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        del number
+        return {}
+
+    def workflow_runs_for_head_sha(self, head_sha: str) -> list[dict[str, Any]]:
+        del head_sha
+        return []
+
+    def workflow_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        return list(self.jobs_by_run_id[run_id])
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        return self.logs_by_job_id[job_id]
+
+
+def _build_service(
+    client: GitHubActionsReleaseClient,
+    *,
+    release_tag: str,
+) -> DeprecatedWorkflowRunAuditService:
+    return DeprecatedWorkflowRunAuditService(
+        github_client=client,
+        workflow_file="standalone-release.yml",
+        workflow_ref="main",
+        workflow_name="Create Standalone Release with Flutter SPA",
+        release_job_name="create-standalone-release",
+        release_tag=release_tag,
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+        required_notice_markers=("deprecated", "internal-only"),
+        forbidden_strings=(),
+        require_step_summary=True,
+        dispatch_inputs={"release_tag": release_tag, "flutter_release_tag": "latest"},
+        reuse_existing_release=False,
+    )
+
+
+def test_service_accepts_release_published_after_dispatch_when_draft_was_created_earlier() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    release_tag = "v2026.0507.182304-standalone"
+    dispatched_run = [
+        {
+            "id": 31,
+            "html_url": "https://example.test/runs/31",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-07T18:23:39Z",
+            "run_number": 31,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[31] = {
+        "id": 31,
+        "html_url": "https://example.test/runs/31",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-07T18:23:39Z",
+        "run_number": 31,
+    }
+    client.jobs_by_run_id[31] = [
+        {
+            "id": 131,
+            "name": "create-standalone-release",
+            "html_url": "https://example.test/jobs/131",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[131] = (
+        f"2099-05-07T18:25:37Z tag_name={release_tag}\n"
+        '2099-05-07T18:26:07Z echo "Deprecated / internal-only workflow." >> $GITHUB_STEP_SUMMARY\n'
+    )
+    client.release_by_tag_payload[release_tag] = {
+        "tag_name": release_tag,
+        "html_url": f"https://example.test/releases/{release_tag}",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-07T17:05:10Z",
+        "published_at": "2099-05-07T18:25:37Z",
+    }
+
+    audit = _build_service(client, release_tag=release_tag).audit()
+
+    assert client.dispatch_calls == [
+        (
+            "standalone-release.yml",
+            "main",
+            {"release_tag": release_tag, "flutter_release_tag": "latest"},
+        )
+    ]
+    assert audit.release is not None
+    assert audit.release.tag_name == release_tag
+    assert audit.failures == ()


### PR DESCRIPTION
# DMC-1006 test automation result

**Status:** PASSED  
**Run command:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1006/test_dmc_1006_service.py testing/tests/DMC-1006/test_dmc_1006.py -q`  
**Pytest result:** `2 passed in 173.47s`  
**Workflow run:** [25514634135](https://github.com/epam/dm.ai/actions/runs/25514634135)  
**Job:** [create-standalone-release](https://github.com/epam/dm.ai/actions/runs/25514634135/job/74882342874)  
**Release:** [v2026.0507.183052-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183052-standalone)

## Automation update

- Reused the existing live automation in `testing/tests/DMC-1006/test_dmc_1006.py`.
- Fixed shared release discovery in `testing/components/services/deprecated_workflow_run_audit_service.py` so deprecated standalone releases are validated by visible publication time (`published_at`) instead of being rejected when the draft release existed before the workflow published it.
- Added `testing/tests/DMC-1006/test_dmc_1006_service.py` to lock the draft-to-published release behavior with a focused regression test.

## What automation checked

- Triggered `standalone-release.yml` on `main`.
- Waited for `create-standalone-release` to complete.
- Inspected the live job log and confirmed the historical `dorny/test-reporter` / `No test report files were found` failure did not recur.
- Verified the workflow completed successfully and published both the release body and `GITHUB_STEP_SUMMARY`.

## Human-style verification

- Viewed the GitHub Actions run as a user and confirmed the run result is **Success**.
- Confirmed the visible steps `Build deprecated compatibility artifact`, `Create Release`, `Upload Test Results`, and `Summary` all show **Success**.
- Opened the release page and confirmed the published body shows the deprecated/internal-only warning, the compatibility asset `dmtools-v1.7.183-all.jar`, and the expected standalone tag.
- Confirmed the published summary content includes the release link, deprecated/internal-only positioning, Flutter SPA source tag, compatibility asset, and internal-only warning.
- Observed behavior matched the expected result.

## Observed release body

```text
# 🚧 DMTools Deprecated Standalone Compatibility Release v2026.0507.183052-standalone
> **Deprecated / internal-only workflow.**
> This release exists only for internal validation of deprecated standalone automation paths.
> Do not treat this release body as installation guidance or public product documentation.
- Deprecated compatibility CLI fat JAR: dmtools-v1.7.183-all.jar
```

## Observed summary lines

```text
## 🚧 Deprecated Standalone Packaging Release Created
**Release:** [v2026.0507.183052-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183052-standalone)
**Positioning:** Deprecated/internal-only packaging workflow
**Flutter SPA source tag:** v2026.02.07-ce14be0
**Compatibility asset:** dmtools-v1.7.183-all.jar (87M)
> Internal-only note: compatibility artifacts are published here for validation and deprecated workflow coverage only.
> Do not reuse this workflow summary as customer-facing installation guidance.
```
