### PR TITLE
DMC-1009 Test: Trigger standalone workflows with dmtools-core test failures — workflows complete and publish outputs

### DIFF
--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -426,8 +426,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         if payload is None:
             return None
 
-        created_at = self._parse_github_datetime(str(payload.get("created_at", "")))
-        if created_at is not None and created_at < dispatch_started_at - timedelta(minutes=5):
+        published_at = self._release_published_at(payload)
+        if published_at is not None and published_at < dispatch_started_at - timedelta(minutes=5):
             return None
 
         return DeprecatedWorkflowReleaseObservation(
@@ -458,8 +458,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             tag_name = str(release.get("tag_name", "")).strip()
             if candidate_tags and tag_name not in candidate_tags:
                 continue
-            created_at = self._parse_github_datetime(str(release.get("created_at", "")))
-            if created_at is None or created_at < dispatch_started_at - timedelta(minutes=5):
+            published_at = self._release_published_at(release)
+            if published_at is None or published_at < dispatch_started_at - timedelta(minutes=5):
                 continue
             if candidate_tags or self._release_looks_like_deprecated_workflow_output(release):
                 return release
@@ -530,6 +530,13 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         if not body:
             return False
         return all(marker in body for marker in self.required_notice_markers)
+
+    def _release_published_at(self, payload: dict[str, Any]) -> datetime | None:
+        for key in ("published_at", "created_at"):
+            parsed = self._parse_github_datetime(str(payload.get(key, "")))
+            if parsed is not None:
+                return parsed
+        return None
 
     @staticmethod
     def _preview_text(value: str, *, limit: int) -> str:

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -436,3 +436,68 @@ def test_service_extracts_step_summary_lines_when_github_summary_path_is_quoted(
         "Deprecated/internal-only packaging workflow\n"
         "> Do not reuse this workflow summary as customer-facing installation guidance."
     )
+
+
+def test_service_accepts_release_published_after_dispatch_even_when_created_at_is_older() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 22,
+            "html_url": "https://example.test/runs/22",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-06T12:00:00Z",
+            "run_number": 22,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[22] = {
+        "id": 22,
+        "html_url": "https://example.test/runs/22",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-06T12:00:00Z",
+        "run_number": 22,
+    }
+    client.jobs_by_run_id[22] = [
+        {
+            "id": 106,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/106",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[106] = (
+        '2099-05-06T12:00:01Z echo "Deprecated/internal-only packaging workflow" >> $GITHUB_STEP_SUMMARY\n'
+        "2099-05-06T12:00:02Z tag_name=v2099.05.06-standalone-abcdef4\n"
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef4"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef4",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef4",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T11:00:00Z",
+        "published_at": "2099-05-06T12:00:03Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="v2099.05.06-standalone-abcdef4",
+        require_step_summary=True,
+    ).audit()
+
+    assert audit.release is not None
+    assert audit.release.tag_name == "v2099.05.06-standalone-abcdef4"
+    assert audit.failures == ()


### PR DESCRIPTION
## Test result: PASSED

- **Automated test file:** `testing/tests/DMC-1009/test_dmc_1009.py`
- **Supporting shared test code updated:** `testing/components/services/deprecated_workflow_run_audit_service.py`, `testing/tests/DMC-1003/test_dmc_1003_service.py`
- **Automated command:** `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q && PYTHONPATH=. python3 -m pytest testing/tests/DMC-1009/test_dmc_1009.py -q -s`
- **Result:** `6 passed` for shared service coverage, `1 passed` for DMC-1009 live validation

## What automation checked

- Triggered live `workflow_dispatch` runs for `standalone-release.yml` and `standalone-release-auto.yml` on `main`.
- Verified the downstream release job completed successfully after `Build deprecated compatibility artifact`.
- Verified the live job logs still exercised the failure-tolerant path by containing:
  - `Task :dmtools-core:test FAILED`
  - `Execution failed for task ':dmtools-core:test'.`
  - `There were failing tests.`
- Verified the user-visible outputs were actually published:
  - non-empty Release body
  - visible `GITHUB_STEP_SUMMARY` content
  - deprecated/internal-only wording in both surfaces

## Human-style verification

- I inspected the published outputs as a user would consume them:
  - `standalone-release.yml` run [25514634135](https://github.com/epam/dm.ai/actions/runs/25514634135) published release [v2026.0507.183052-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183052-standalone)
  - `standalone-release-auto.yml` run [25514810301](https://github.com/epam/dm.ai/actions/runs/25514810301) published release [v2026.0507.183647-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183647-standalone)
- Observed visible release-body wording on both releases:

```text
Deprecated / internal-only workflow.
Do not treat this release body as installation guidance or public product documentation.
```

- Observed visible step-summary wording on both workflow runs:

```text
Deprecated Standalone Packaging Release Created
Positioning: Deprecated/internal-only packaging workflow
Do not reuse this workflow summary as customer-facing installation guidance.
```

- This matched the expected result from the ticket.

## Run details

| Workflow | Run | Job | Release | Key step results |
| --- | --- | --- | --- | --- |
| `standalone-release.yml` | [25514634135](https://github.com/epam/dm.ai/actions/runs/25514634135) | [create-standalone-release](https://github.com/epam/dm.ai/actions/runs/25514634135/job/74882342874) | [v2026.0507.183052-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183052-standalone) | Build deprecated compatibility artifact = success; Capture compatibility artifact metadata = success; Generate Release Notes = success; Create Release = success; Summary = success |
| `standalone-release-auto.yml` | [25514810301](https://github.com/epam/dm.ai/actions/runs/25514810301) | [auto-standalone-release](https://github.com/epam/dm.ai/actions/runs/25514810301/job/74882950587) | [v2026.0507.183647-standalone](https://github.com/epam/dm.ai/releases/tag/v2026.0507.183647-standalone) | Build deprecated compatibility artifact = success; Capture compatibility artifact metadata = success; Generate Release Notes = success; Create Release = success; Summary = success |

## Notes

- The fix was in shared test support, not product code: GitHub release validation now uses the release publication timestamp instead of the older `created_at` field, which had been causing a false negative even though the live releases were published correctly.
