### PR TITLE
DMC-1018 Fix release guidance for skill install, Java baseline, and inheritance discoverability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -458,7 +458,7 @@ jobs:
           
           ## 📋 System Requirements
           
-          - **Java 23+** (required)
+          - **Java 17+** (required)
           - **2GB RAM** minimum, 4GB recommended
           - **1GB disk space** for application and data
           
@@ -475,7 +475,7 @@ jobs:
           
           ### Common Issues
           
-          1. **Java version:** Ensure Java 23+ is installed (\`java -version\`)
+          1. **Java version:** Ensure Java 17+ is installed (\`java -version\`)
           2. **Memory issues:** Increase heap size with \`-Xmx4g\`
           
           ### Getting Help

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | b
 irm https://github.com/epam/dm.ai/releases/latest/download/install.ps1 | iex
 ```
 
+**Java baseline:** Java 17+ for the DMTools CLI and Agent Skill installer flow.
+
+### Agent Skill
+
+Run the Agent Skill installer from your project root so it can detect project-level skill directories:
+
+```bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira,github
+```
+
+For shared base configs and child-agent overrides, use the existing [`parent` config inheritance pattern](dmtools-ai-docs/references/configuration/json-config-rules.md#config-inheritance-via-parent).
+
 **Verify installation:**
 
 ```bash
@@ -108,6 +121,7 @@ Keep the latest-release installer flow introduced in DMC-858 when refreshing exi
 3. Preserve or merge your existing `dmtools.env`, `dmtools-local.env`, and local configuration instead of overwriting them.
 4. Remove stale aliases, wrapper scripts, and PATH entries that resolve outside `~/.dmtools/bin`.
 5. Verify the migrated install with `dmtools --version` and `dmtools list`.
+6. If anything fails, roll back by restoring the backup copy of `~/.dmtools` and reactivating the previous wrapper or PATH configuration.
 
 Tagged reinstall example for rollback or migration validation:
 

--- a/dmtools-ai-docs/README.md
+++ b/dmtools-ai-docs/README.md
@@ -33,22 +33,22 @@ Non-interactive mode detected, installing to all detected locations
 ### Advanced Installation Options
 
 ```bash
-# Interactive mode: choose specific location
-bash install.sh
+# Interactive mode: choose specific location after downloading skill-install.sh
+bash skill-install.sh
 
 # Install to specific location only
-INSTALL_LOCATION=1 bash install.sh    # First location (.cursor)
-INSTALL_LOCATION=2 bash install.sh    # Second location (.claude)
+INSTALL_LOCATION=1 bash skill-install.sh    # First location (.cursor)
+INSTALL_LOCATION=2 bash skill-install.sh    # Second location (.claude)
 
 # Install to all locations (explicit)
-bash install.sh --all
+bash skill-install.sh --all
 
 # Install only selected focused skills
-DMTOOLS_SKILLS=jira,github bash install.sh
-bash install.sh --skills jira,github
+DMTOOLS_SKILLS=jira,github bash skill-install.sh
+bash skill-install.sh --skills jira,github
 
 # Show help
-bash install.sh --help
+bash skill-install.sh --help
 ```
 
 ## Install Only the Skills You Need
@@ -72,8 +72,9 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 # Install Jira + GitHub together
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills jira,github
 
-# Local installer usage
-bash install.sh --skills ado,testrail
+# Download the installer first, then reuse it locally
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh -o skill-install.sh
+bash skill-install.sh --skills ado,testrail
 ```
 
 ```powershell
@@ -94,6 +95,10 @@ irm https://github.com/epam/dm.ai/releases/latest/download/skill-install.ps1 | i
 | `.codex/skills/` | Codex | Project-specific skill for Codex |
 
 **Note**: The installer no longer supports global (user-level) installation. Each project should have its own skill installation to ensure version compatibility.
+
+## 🧬 Child Agent Config Inheritance
+
+When you need a base Agent Skill config plus specialized child configs, use the existing root-level `parent` block and deep-merge rules documented in [Config inheritance via `parent`](references/configuration/json-config-rules.md#config-inheritance-via-parent).
 
 ## 🎯 What's Included
 

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -40,6 +40,8 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | b
 
 **Focused skill packages:** install only the integrations you need with `DMTOOLS_SKILLS=jira,github` and the skill installer described in [references/installation/README.md#install-only-the-skills-you-need](references/installation/README.md#install-only-the-skills-you-need).
 
+**Child agent configs:** define a shared base config and extend it with the existing [`parent` inheritance pattern](references/configuration/json-config-rules.md#config-inheritance-via-parent).
+
 ### Step 1: Check if DMtools is installed
 ```bash
 # Check if dmtools command is available

--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -9,15 +9,15 @@
 #   curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash
 #   # When piped (non-interactive): installs to ALL detected locations automatically
 #
-#   DMTOOLS_SKILLS=jira,github bash install.sh      # Install focused skills only
-#   INSTALL_LOCATION=1 bash install.sh              # Install to first detected location only
-#   bash install.sh --all                           # Install to all detected locations
-#   bash install.sh --skill jira                    # Select one package explicitly
-#   bash install.sh --skills=jira,github            # Allowed alias for multi-skill selection
-#   bash install.sh --all-skills                    # Select every supported package
-#   bash install.sh --skills=jira,unknown           # Fails and lists invalid names
-#   bash install.sh --skills=jira,unknown --skip-unknown  # Warns and keeps valid skills
-#   bash install.sh                             # Interactive mode: ask user to choose
+#   DMTOOLS_SKILLS=jira,github bash skill-install.sh      # Install focused skills only
+#   INSTALL_LOCATION=1 bash skill-install.sh              # Install to first detected location only
+#   bash skill-install.sh --all                           # Install to all detected locations
+#   bash skill-install.sh --skill jira                    # Select one package explicitly
+#   bash skill-install.sh --skills=jira,github            # Allowed alias for multi-skill selection
+#   bash skill-install.sh --all-skills                    # Select every supported package
+#   bash skill-install.sh --skills=jira,unknown           # Fails and lists invalid names
+#   bash skill-install.sh --skills=jira,unknown --skip-unknown  # Warns and keeps valid skills
+#   bash skill-install.sh                                 # Interactive mode: ask user to choose
 
 set -e
 
@@ -107,22 +107,22 @@ while [ $# -gt 0 ]; do
             echo "  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --skills=jira,github"
             echo "    → Install only /dmtools-jira and /dmtools-github"
             echo ""
-            echo "  bash install.sh"
+            echo "  bash skill-install.sh"
             echo "    → Interactive mode: shows menu to choose location"
             echo ""
-            echo "  INSTALL_LOCATION=1 bash install.sh"
+            echo "  INSTALL_LOCATION=1 bash skill-install.sh"
             echo "    → Install to first location only"
             echo ""
-            echo "  bash install.sh --all"
+            echo "  bash skill-install.sh --all"
             echo "    → Install to all locations"
             echo ""
-            echo "  bash install.sh --all-skills"
+            echo "  bash skill-install.sh --all-skills"
             echo "    → Select every supported skill package"
             echo ""
-            echo "  bash install.sh --skills=jira,unknown"
+            echo "  bash skill-install.sh --skills=jira,unknown"
             echo "    → Fails with a non-zero exit and lists the invalid names"
             echo ""
-            echo "  bash install.sh --skills=jira,unknown --skip-unknown"
+            echo "  bash skill-install.sh --skills=jira,unknown --skip-unknown"
             echo "    → Downgrades invalid skill names to warnings and installs Jira"
             echo ""
             echo "Note: Installs to project-level and global (~/.claude/skills) directories"

--- a/dmtools-ai-docs/per-skill-packages/dmtools-ado.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-ado.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills ado
+bash skill-install.sh --skills ado
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools ado_get_work_item 12345
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills confluence
+bash skill-install.sh --skills confluence
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools confluence_content_by_title_and_space "Onboarding" "TEAM"
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-figma.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-figma.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills figma
+bash skill-install.sh --skills figma
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools figma_get_layers "https://www.figma.com/file/abc123/Product?node-id=1%3A
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-github.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-github.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills github
+bash skill-install.sh --skills github
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools github_get_pr workspace=epam repository=dm.ai pullRequestId=42
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-gitlab.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-gitlab.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills gitlab
+bash skill-install.sh --skills gitlab
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools gitlab_get_mr workspace=mygroup repository=myrepo pullRequestId=42
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-jira.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-jira.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills jira
+bash skill-install.sh --skills jira
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools jira_get_ticket PROJ-123
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-report.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-report.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills report
+bash skill-install.sh --skills report
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools run dmtools-ai-docs/references/examples/report-generator-job.json
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-teams.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-teams.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills teams
+bash skill-install.sh --skills teams
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools teams_messages_since "Release Coordination" "2026-05-01T00:00:00Z"
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/per-skill-packages/dmtools-testrail.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-testrail.md
@@ -17,7 +17,7 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 ```
 
 ```bash
-bash install.sh --skills testrail
+bash skill-install.sh --skills testrail
 ```
 
 ## Endpoints / Config keys
@@ -58,4 +58,3 @@ dmtools testrail_get_cases_by_refs PROJ-123 "Regression"
 
 - Maintainer: DMtools Team
 - Support: [github.com/epam/dm.ai/issues](https://github.com/epam/dm.ai/issues)
-

--- a/dmtools-ai-docs/references/installation/README.md
+++ b/dmtools-ai-docs/references/installation/README.md
@@ -58,11 +58,15 @@ curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.
 # Install every supported skill package
 curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh | bash -s -- --all-skills
 
+# Download the installer first when you want to reuse it locally
+curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/skill-install.sh -o skill-install.sh
+bash skill-install.sh --skills=jira,github
+
 # Invalid skill names cause a non-zero exit and list the invalid names
-bash install.sh --skills=jira,unknown
+bash skill-install.sh --skills=jira,unknown
 
 # Use --skip-unknown to downgrade invalid skill names to warnings
-bash install.sh --skills=jira,unknown --skip-unknown
+bash skill-install.sh --skills=jira,unknown --skip-unknown
 ```
 
 ```powershell
@@ -78,6 +82,10 @@ When `--skip-unknown` is provided, invalid skill names are downgraded to warning
 1. Download the ZIP or TAR for the skill you need.
 2. Extract it into `.cursor/skills/`, `.claude/skills/`, or `.codex/skills/`.
 3. The extracted folder name becomes the slash command, for example `dmtools-jira` → `/dmtools-jira`.
+
+### Child agent configs and shared defaults
+
+If you maintain a base config plus child agent variants, DMtools already supports root-level `parent` inheritance. See [Config inheritance via `parent`](../configuration/json-config-rules.md#config-inheritance-via-parent) for the merge and override rules.
 
 ### Upgrading from legacy installs
 

--- a/dmtools.sh
+++ b/dmtools.sh
@@ -39,7 +39,7 @@ find_java_command() {
 
 # Get Java command or error
 JAVA_CMD=$(find_java_command 2>/dev/null) || {
-    echo "Error: Java 23 is required but not found." >&2
+    echo "Error: Java 17+ is required but not found." >&2
     echo "Please install DMTools first:" >&2
     echo "  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash" >&2
     exit 1
@@ -199,7 +199,7 @@ usage() {
 Or if you're developing locally, build the project first:
   ./gradlew build
 
-Note: Java 23 is required for DMTools to run."
+Note: Java 17+ is required for DMTools to run."
     fi
     execute_java_command "$JAVA_CMD" -Dlog4j2.configurationFile=classpath:log4j2-cli.xml -Dlog4j.configuration=log4j2-cli.xml -Dlog4j2.disable.jmx=true -Djava.net.preferIPv4Stack=true -Djava.rmi.server.hostname=127.0.0.1 --add-opens java.base/java.lang=ALL-UNNAMED -XX:-PrintWarnings -Dpolyglot.engine.WarnInterpreterOnly=false -cp "$JAR_FILE" com.github.istin.dmtools.job.JobRunner
     exit 0
@@ -325,7 +325,7 @@ if [ -z "$JAR_FILE" ] || [ ! -f "$JAR_FILE" ]; then
 Or if you're developing locally, build the project first:
   ./gradlew build
 
-Note: Java 23 is required for DMTools to run."
+Note: Java 17+ is required for DMTools to run."
 fi
 
 # Check if command starts with - or --, then proxy directly to JobRunner

--- a/install.sh
+++ b/install.sh
@@ -1035,7 +1035,7 @@ is_windows() {
     return 1
 }
 
-# Download and install Java 23 locally
+# Download and install Java 17 locally
 install_local_java() {
     local platform="$1"
     local jre_dir="$INSTALL_DIR/jre"
@@ -1251,7 +1251,7 @@ check_java() {
     if ! command -v java >/dev/null 2>&1; then
         # First check if we're on Windows - don't try to install Java automatically
         if is_windows; then
-            error "Java 17+ is required but not installed. Please install Java 23 manually on Windows:
+            error "Java 17+ is required but not installed. Please install Java 17 manually on Windows:
   - Download from: https://adoptium.net/
   - Or use Chocolatey: choco install temurin17jdk
   - Or use Windows installer: https://adoptium.net/temurin/releases/?version=17
@@ -1273,11 +1273,11 @@ steps:
         elif [[ "$OSTYPE" == "darwin"* ]]; then
             warn "Java not found. Attempting to install via Homebrew..."
             if command -v brew >/dev/null 2>&1; then
-                progress "Installing OpenJDK 23 via Homebrew..."
+                progress "Installing OpenJDK 17 via Homebrew..."
                 brew install openjdk@17 || error "Failed to install Java via Homebrew"
                 info "Java installed successfully via Homebrew"
             else
-                error "Java 17+ is required but not installed. Please install Java 23:
+                error "Java 17+ is required but not installed. Please install Java 17:
   - Via Homebrew: brew install openjdk@17
   - Via Oracle: https://www.oracle.com/java/technologies/downloads/
   - Via Eclipse Temurin: https://adoptium.net/"
@@ -1286,25 +1286,25 @@ steps:
             # This is real Linux (not Windows/WSL)
             if command -v apt-get >/dev/null 2>&1; then
                 warn "Java not found. Attempting to install via apt..."
-                progress "Installing OpenJDK 23..."
-                sudo apt-get update && sudo apt-get install -y openjdk-17-jdk || error "Failed to install Java 23 via apt. Please install manually."
+                progress "Installing OpenJDK 17..."
+                sudo apt-get update && sudo apt-get install -y openjdk-17-jdk || error "Failed to install Java 17 via apt. Please install manually."
                 info "Java installed successfully"
             elif command -v yum >/dev/null 2>&1; then
                 warn "Java not found. Attempting to install via yum..."
-                sudo yum install -y java-17-openjdk-devel || error "Failed to install Java 23 via yum. Please install manually."
+                sudo yum install -y java-17-openjdk-devel || error "Failed to install Java 17 via yum. Please install manually."
                 info "Java installed successfully"
             elif command -v dnf >/dev/null 2>&1; then
                 warn "Java not found. Attempting to install via dnf..."
-                sudo dnf install -y java-17-openjdk-devel || error "Failed to install Java 23 via dnf. Please install manually."
+                sudo dnf install -y java-17-openjdk-devel || error "Failed to install Java 17 via dnf. Please install manually."
                 info "Java installed successfully"
             else
-                error "Java 17+ is required but not installed. Please install Java 23:
+                error "Java 17+ is required but not installed. Please install Java 17:
   - Ubuntu/Debian: sudo apt-get install openjdk-17-jdk
   - RHEL/CentOS: sudo yum install java-17-openjdk-devel
   - Fedora: sudo dnf install java-17-openjdk-devel"
             fi
         else
-            error "Java 17+ is required but not installed. Please install Java 23."
+            error "Java 17+ is required but not installed. Please install Java 17."
         fi
     fi
 
@@ -1321,7 +1321,7 @@ steps:
             error "Java $java_version is too old. DMTools requires Java 17+."
         fi
     else
-        error "Java installation failed. Please install Java 23 manually."
+        error "Java installation failed. Please install Java 17 manually."
     fi
 }
 

--- a/testing/tests/DMC-1018/test_dmc_1018.py
+++ b/testing/tests/DMC-1018/test_dmc_1018.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _read(relative_path: str) -> str:
+    return (REPOSITORY_ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_dmc_1018_release_guidance_matches_skill_assets_java_baseline_and_parent_docs() -> None:
+    root_readme = _read("README.md")
+    skill_readme = _read("dmtools-ai-docs/README.md")
+    skill_manifest = _read("dmtools-ai-docs/SKILL.md")
+    install_readme = _read("dmtools-ai-docs/references/installation/README.md")
+    install_script = _read("install.sh")
+    wrapper_script = _read("dmtools.sh")
+    release_workflow = _read(".github/workflows/release.yml")
+
+    guidance_surfaces = {
+        "README.md": root_readme,
+        "dmtools-ai-docs/README.md": skill_readme,
+        "dmtools-ai-docs/references/installation/README.md": install_readme,
+        ".github/workflows/release.yml": release_workflow,
+    }
+
+    missing_skill_installer_guidance = [
+        path
+        for path, text in guidance_surfaces.items()
+        if "skill-install.sh" not in text
+    ]
+    assert not missing_skill_installer_guidance, (
+        "Agent Skill guidance must point users to the published skill-install.sh asset; "
+        f"missing from {', '.join(missing_skill_installer_guidance)}"
+    )
+
+    misleading_local_skill_installer_paths = [
+        path
+        for path, text in {
+            "dmtools-ai-docs/README.md": skill_readme,
+            "dmtools-ai-docs/references/installation/README.md": install_readme,
+        }.items()
+        if "bash install.sh" in text
+    ]
+    assert not misleading_local_skill_installer_paths, (
+        "Agent Skill docs must not tell first-time users to run a bare install.sh script when "
+        "the published installer asset is skill-install.sh; found in "
+        + ", ".join(misleading_local_skill_installer_paths)
+    )
+
+    stale_java_23_surfaces = [
+        path
+        for path, text in {
+            ".github/workflows/release.yml": release_workflow,
+            "install.sh": install_script,
+            "dmtools.sh": wrapper_script,
+        }.items()
+        if "Java 23" in text
+    ]
+    assert not stale_java_23_surfaces, (
+        "User-facing install/runtime guidance must align to the Java 17 baseline; stale Java 23 "
+        "references remain in " + ", ".join(stale_java_23_surfaces)
+    )
+
+    assert "Java 17+" in release_workflow, "release.yml must publish the Java 17+ baseline."
+    assert "Java 17+" in root_readme, "README.md must expose the Java 17+ baseline."
+
+    inheritance_link = "references/configuration/json-config-rules.md#config-inheritance-via-parent"
+    discoverable_inheritance_surfaces = [
+        path
+        for path, text in {
+            "README.md": root_readme,
+            "dmtools-ai-docs/README.md": skill_readme,
+            "dmtools-ai-docs/SKILL.md": skill_manifest,
+            "dmtools-ai-docs/references/installation/README.md": install_readme,
+        }.items()
+        if inheritance_link in text or "Config inheritance via `parent`" in text
+    ]
+    assert discoverable_inheritance_surfaces, (
+        "Agent Skill docs must expose the existing parent-based config inheritance path in a "
+        "discoverable location."
+    )


### PR DESCRIPTION
## Issues/Notes

- Repo-root `instruction.md` was not present, so I used the ticket context plus the in-repo install/release/docs constraints that were available.
- Copied the reporter screenshot to `outputs/attachments/release-author-badge.png`.

## Approach

The root cause was documentation and messaging drift: the release flow publishes `skill-install.sh` as the Agent Skill installer asset, but several user-facing docs still told users to run `install.sh`; release notes and runtime/install messages also still said Java 23 even though the supported baseline is Java 17; and the existing `parent` inheritance docs were buried in the JSON config rules reference instead of being surfaced from the main skill/install guidance.

I fixed the release notes template, root README, skill README, installation guide, per-skill package docs, and installer/help text so the public guidance consistently points to `skill-install.sh`, states Java 17+, and links users to the existing `parent` inheritance documentation for shared base configs and child agents. I also aligned CLI/runtime installer messages with Java 17+.

## Files Modified

- `.github/workflows/release.yml`
- `README.md`
- `dmtools-ai-docs/README.md`
- `dmtools-ai-docs/SKILL.md`
- `dmtools-ai-docs/install.sh`
- `dmtools-ai-docs/references/installation/README.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-ado.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-confluence.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-figma.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-github.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-gitlab.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-jira.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-report.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-teams.md`
- `dmtools-ai-docs/per-skill-packages/dmtools-testrail.md`
- `install.sh`
- `dmtools.sh`
- `testing/tests/DMC-1018/test_dmc_1018.py`
- `outputs/rca.md`

## Test Coverage

- Reproduction test added: `testing/tests/DMC-1018/test_dmc_1018.py` — `test_dmc_1018_release_guidance_matches_skill_assets_java_baseline_and_parent_docs`
- Local installer/docs regression tests: `python3 -m pytest testing/tests/DMC-906/test_dmc_906.py testing/tests/DMC-915/test_dmc_915.py testing/tests/DMC-1018/test_dmc_1018.py testing/tests/DMC-995/test_dmc_995.py -k 'not live' -q`
- Core suite: `./gradlew :dmtools-core:test`
