### PR TITLE
fix: skill-install.sh doesn't run when piped via curl | bash

### DIFF
--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -146,7 +146,8 @@ NC='\033[0m'
 
 GITHUB_REPO="epam/dm.ai"
 TEMP_DIR=$(mktemp -d)
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+_script_source="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR=$(cd "$(dirname "$_script_source")" 2>/dev/null && pwd || pwd)
 REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 
 print_header() {
@@ -718,7 +719,7 @@ main() {
     echo "For more information: https://github.com/epam/dm.ai" >&2
 }
 
-if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+if [ "${BASH_SOURCE[0]}" = "$0" ] || [ -z "${BASH_SOURCE[0]}" ]; then
     case "${1:-install}" in
         install)
             main


### PR DESCRIPTION
## Problem

When running the install command via:
```
curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.184/skill-install.sh | bash
```

...nothing happened (silent exit with code 0).

## Root Cause

When a script is piped through bash (`curl | bash`), `BASH_SOURCE[0]` is **empty** and `$0` is `bash`. The guard condition at the bottom of the script:

```bash
if [ "${BASH_SOURCE[0]}" = "$0" ]; then
```

evaluates as `[ "" = "bash" ]` → **false**, so `main()` was never called.

## Fix

- Add `|| [ -z "${BASH_SOURCE[0]}" ]` to also trigger `main` when `BASH_SOURCE[0]` is empty (piped execution)
- Make `SCRIPT_DIR` computation robust for piped mode using a fallback