### PR TITLE
DMC-1025 Fix Windows Git Bash failure when install.sh resolves latest CLI release

### DIFF
--- a/.github/workflows/windows-git-bash-installer-check.yml
+++ b/.github/workflows/windows-git-bash-installer-check.yml
@@ -1,0 +1,35 @@
+name: Windows Git Bash Installer Check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  validate-latest-installer:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      DMTOOLS_INSTALL_DIR: ${{ github.workspace }}/.dmtools-install
+      DMTOOLS_BIN_DIR: ${{ github.workspace }}/.dmtools-install/bin
+
+    steps:
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install DMTools CLI from latest release
+        run: |
+          set -euo pipefail
+          curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash
+
+      - name: Validate installed wrapper and metadata
+        run: |
+          set -euo pipefail
+          test -f "$DMTOOLS_INSTALL_DIR/dmtools.jar"
+          test -x "$DMTOOLS_BIN_DIR/dmtools"
+          "$DMTOOLS_BIN_DIR/dmtools" --help >/dev/null

--- a/install
+++ b/install
@@ -779,21 +779,65 @@ detect_version() {
     return 1
 }
 
-# Get latest CLI release version (filters out skill releases)
+# Resolve the latest stable CLI tag without relying on the Releases API.
+get_latest_version_from_git_tags() {
+    local git_output
+    local git_exit_code
+    local version
+
+    if ! command -v git >/dev/null 2>&1; then
+        warn "Git is not available for tag-based fallback lookup." >&2
+        return 1
+    fi
+
+    progress "Falling back to git tag lookup..." >&2
+    git_output=$(git ls-remote --tags --refs "https://github.com/${REPO}.git" 'v*' 2>&1)
+    git_exit_code=$?
+
+    if [ $git_exit_code -ne 0 ] || [ -z "$git_output" ]; then
+        warn "Git tag lookup failed (exit code: $git_exit_code)." >&2
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$git_output" | sed -nE 's#^[[:xdigit:]]+[[:space:]]+refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$#\1#p' | LC_ALL=C sort -V | tail -1)
+
+    if [ -z "$version" ]; then
+        warn "Git tag lookup did not return any stable CLI release tags." >&2
+        return 1
+    fi
+
+    progress "Found latest CLI release via git tags: $version" >&2
+    echo "$version"
+}
+
+# Get latest CLI release version (filters out skill/standalone releases, paginates if needed)
 get_latest_version() {
     progress "Fetching latest CLI release information..." >&2
     local version
     local api_response
     local curl_exit_code
+    local page=1
+    local releases_lookup_exit_code=0
+    local releases_lookup_response=""
+    local latest_lookup_exit_code=0
+    local latest_lookup_response=""
+    local git_lookup_status="not attempted"
 
-    # Get all releases (not just latest) to filter CLI releases
-    api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases" 2>&1)
-    curl_exit_code=$?
+    # Paginate through releases until a CLI release (^vX.Y.Z$) is found or no more pages
+    while true; do
+        api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}" 2>&1)
+        curl_exit_code=$?
+        releases_lookup_exit_code=$curl_exit_code
+        releases_lookup_response="$api_response"
 
-    if [ $curl_exit_code -eq 0 ] && [ -n "$api_response" ]; then
-        # Extract all tag names and filter only CLI releases (vX.Y.Z pattern, excluding skill- prefix)
-        # CLI releases have format: v1.7.126, v1.7.125, etc.
-        # Skill releases have format: skill-vskill-v1.0.19, etc.
+        if [ $curl_exit_code -ne 0 ] || [ -z "$api_response" ]; then
+            break
+        fi
+
+        if echo "$api_response" | grep -qE '^\[\s*\]$'; then
+            break
+        fi
+
         version=$(echo "$api_response" | grep '"tag_name":' | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 
         if [ -n "$version" ]; then
@@ -801,14 +845,20 @@ get_latest_version() {
             echo "$version"
             return 0
         fi
-    fi
 
-    # If GitHub API failed or no CLI release found, try alternative approach
-    progress "GitHub API failed (exit code: $curl_exit_code) or no CLI release found, trying fallback..." >&2
+        page=$((page + 1))
+        if [ "$page" -gt 10 ]; then
+            break
+        fi
+    done
+
+    progress "Paginated search failed (exit code: $curl_exit_code) or no CLI release found, trying fallback..." >&2
 
     # Try to get /releases/latest and check if it's a CLI release
     api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases/latest" 2>&1)
     curl_exit_code=$?
+    latest_lookup_exit_code=$curl_exit_code
+    latest_lookup_response="$api_response"
 
     if [ $curl_exit_code -eq 0 ] && [ -n "$api_response" ]; then
         version=$(echo "$api_response" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
@@ -819,25 +869,35 @@ get_latest_version() {
             echo "$version"
             return 0
         else
-            warn "Latest release ($version) is not a CLI release, it might be a skill release." >&2
+            warn "Latest release ($version) is not a CLI release, it might be a skill or standalone release." >&2
         fi
     fi
 
-    # Both methods failed - provide detailed error information
+    if version=$(get_latest_version_from_git_tags); then
+        echo "$version"
+        return 0
+    fi
+    git_lookup_status="failed"
+
+    # All methods failed - provide detailed error information
     error "Failed to find latest CLI release from GitHub API.
 
 Possible causes:
   - Network connectivity issues
   - GitHub API rate limiting
-  - No CLI releases available (only skill releases found)
+  - No CLI releases available (only skill/standalone releases found)
   - curl version incompatibility
+  - git tag fallback unavailable or returned no stable CLI tags
 
 Debug information:
-  - Last curl exit code: $curl_exit_code
-  - API response: ${api_response:-'(empty)'}
+  - /releases exit code: $releases_lookup_exit_code
+  - /releases response: ${releases_lookup_response:-'(empty)'}
+  - /releases/latest exit code: $latest_lookup_exit_code
+  - /releases/latest response: ${latest_lookup_response:-'(empty)'}
+  - git tag lookup: $git_lookup_status
 
 Please check your network connection and try again.
-If the issue persists, you can manually download from:
+If the issue persists, you can manually specify a version with DMTOOLS_VERSION or download from:
 https://github.com/${REPO}/releases/latest"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -779,6 +779,37 @@ detect_version() {
     return 1
 }
 
+# Resolve the latest stable CLI tag without relying on the Releases API.
+get_latest_version_from_git_tags() {
+    local git_output
+    local git_exit_code
+    local version
+
+    if ! command -v git >/dev/null 2>&1; then
+        warn "Git is not available for tag-based fallback lookup." >&2
+        return 1
+    fi
+
+    progress "Falling back to git tag lookup..." >&2
+    git_output=$(git ls-remote --tags --refs "https://github.com/${REPO}.git" 'v*' 2>&1)
+    git_exit_code=$?
+
+    if [ $git_exit_code -ne 0 ] || [ -z "$git_output" ]; then
+        warn "Git tag lookup failed (exit code: $git_exit_code)." >&2
+        return 1
+    fi
+
+    version=$(printf '%s\n' "$git_output" | sed -nE 's#^[[:xdigit:]]+[[:space:]]+refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$#\1#p' | LC_ALL=C sort -V | tail -1)
+
+    if [ -z "$version" ]; then
+        warn "Git tag lookup did not return any stable CLI release tags." >&2
+        return 1
+    fi
+
+    progress "Found latest CLI release via git tags: $version" >&2
+    echo "$version"
+}
+
 # Get latest CLI release version (filters out skill/standalone releases, paginates if needed)
 get_latest_version() {
     progress "Fetching latest CLI release information..." >&2
@@ -786,11 +817,18 @@ get_latest_version() {
     local api_response
     local curl_exit_code
     local page=1
+    local releases_lookup_exit_code=0
+    local releases_lookup_response=""
+    local latest_lookup_exit_code=0
+    local latest_lookup_response=""
+    local git_lookup_status="not attempted"
 
     # Paginate through releases until a CLI release (^vX.Y.Z$) is found or no more pages
     while true; do
         api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}" 2>&1)
         curl_exit_code=$?
+        releases_lookup_exit_code=$curl_exit_code
+        releases_lookup_response="$api_response"
 
         if [ $curl_exit_code -ne 0 ] || [ -z "$api_response" ]; then
             break
@@ -826,6 +864,8 @@ get_latest_version() {
     # Try to get /releases/latest and check if it's a CLI release
     api_response=$(curl -s --connect-timeout 10 --max-time 30 --fail "https://api.github.com/repos/${REPO}/releases/latest" 2>&1)
     curl_exit_code=$?
+    latest_lookup_exit_code=$curl_exit_code
+    latest_lookup_response="$api_response"
 
     if [ $curl_exit_code -eq 0 ] && [ -n "$api_response" ]; then
         version=$(echo "$api_response" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/' | head -1)
@@ -840,7 +880,13 @@ get_latest_version() {
         fi
     fi
 
-    # Both methods failed - provide detailed error information
+    if version=$(get_latest_version_from_git_tags); then
+        echo "$version"
+        return 0
+    fi
+    git_lookup_status="failed"
+
+    # All methods failed - provide detailed error information
     error "Failed to find latest CLI release from GitHub API.
 
 Possible causes:
@@ -848,13 +894,17 @@ Possible causes:
   - GitHub API rate limiting
   - No CLI releases available (only skill/standalone releases found)
   - curl version incompatibility
+  - git tag fallback unavailable or returned no stable CLI tags
 
 Debug information:
-  - Last curl exit code: $curl_exit_code
-  - API response: ${api_response:-'(empty)'}
+  - /releases exit code: $releases_lookup_exit_code
+  - /releases response: ${releases_lookup_response:-'(empty)'}
+  - /releases/latest exit code: $latest_lookup_exit_code
+  - /releases/latest response: ${latest_lookup_response:-'(empty)'}
+  - git tag lookup: $git_lookup_status
 
 Please check your network connection and try again.
-If the issue persists, you can manually download from:
+If the issue persists, you can manually specify a version with DMTOOLS_VERSION or download from:
 https://github.com/${REPO}/releases/latest"
 }
 

--- a/testing/tests/DMC-1025/test_dmc_1025.py
+++ b/testing/tests/DMC-1025/test_dmc_1025.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_ENTRYPOINTS = (REPOSITORY_ROOT / "install.sh", REPOSITORY_ROOT / "install")
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "windows-git-bash-installer-check.yml"
+
+
+def run_installer_functions(
+    commands: str,
+    *,
+    installer_script: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DMTOOLS_INSTALLER_TEST_MODE"] = "true"
+    if extra_env:
+        env.update(extra_env)
+
+    script = f"""
+set -e
+source "{installer_script}"
+{commands}
+"""
+    return subprocess.run(
+        ["bash", "-lc", script],
+        cwd=REPOSITORY_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
+
+
+class TestDmc1025(unittest.TestCase):
+    def test_installer_falls_back_to_git_tags_when_github_api_lookup_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = Path(temp_dir) / "bin"
+            bin_dir.mkdir(parents=True)
+
+            _write_executable(
+                bin_dir / "curl",
+                """
+                #!/bin/bash
+                echo "curl: (22) The requested URL returned error: 404" >&2
+                exit 22
+                """,
+            )
+            _write_executable(
+                bin_dir / "git",
+                """
+                #!/bin/bash
+                if [ "$1" = "ls-remote" ] && [ "$2" = "--tags" ] && [ "$3" = "--refs" ]; then
+                    cat <<'EOF'
+                deadbeef	refs/tags/v1.7.183
+                deadbeef	refs/tags/v1.7.184-beta.55.1
+                deadbeef	refs/tags/v2026.0507.195911-standalone
+                deadbeef	refs/tags/skill-v1.0.19
+                deadbeef	refs/tags/v1.7.184
+                EOF
+                    exit 0
+                fi
+                echo "unexpected git invocation: $*" >&2
+                exit 1
+                """,
+            )
+
+            for installer_script in INSTALL_ENTRYPOINTS:
+                with self.subTest(installer_script=installer_script.name):
+                    result = run_installer_functions(
+                        """
+                        version=$(get_latest_version)
+                        printf 'version=%s\\n' "$version"
+                        """,
+                        installer_script=installer_script,
+                        extra_env={"PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                    )
+
+                    self.assertEqual(0, result.returncode, result.stderr)
+                    self.assertIn("version=v1.7.184", result.stdout)
+                    self.assertIn("Falling back to git tag lookup", result.stderr)
+
+    def test_windows_git_bash_workflow_validates_documented_latest_installer_path(self) -> None:
+        workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow_text)
+        self.assertIn("runs-on: windows-latest", workflow_text)
+        self.assertIn("shell: bash", workflow_text)
+        self.assertIn("releases/latest/download/install.sh | bash", workflow_text)
+        self.assertIn("DMTOOLS_INSTALL_DIR", workflow_text)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Issues/Notes

- Exact Windows Git Bash reproduction was not possible in this Linux runner, so the failure was reproduced with a shell-level regression test that forces the GitHub API lookup to fail with exit code `22` and verifies the installer still resolves the latest stable CLI tag.

## Approach

The root cause was that `install.sh` relied on unauthenticated GitHub Releases API calls to discover the latest stable CLI version and had no independent recovery path when those calls failed or when `/releases/latest` pointed at a non-CLI release stream. I updated both `install.sh` and `install` to keep the existing `vX.Y.Z` CLI filtering, add a `git ls-remote --tags --refs` fallback for stable CLI tags, and expand the terminal error details to show which lookup paths were attempted.

I also added a manually triggerable GitHub Actions workflow for `windows-latest` that runs the documented `curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh | bash` command under Git Bash and validates the installed wrapper and JAR.

## Files Modified

- `install.sh` — added git-tag fallback and clearer failure diagnostics for latest CLI resolution
- `install` — mirrored the same latest-version fallback/error-handling changes
- `.github/workflows/windows-git-bash-installer-check.yml` — new manual Windows Git Bash installer validation workflow
- `testing/tests/DMC-1025/test_dmc_1025.py` — regression test for API-failure fallback and workflow coverage
- `outputs/rca.md` — recorded the confirmed root cause and final fix approach

## Test Coverage

- Reproduction regression: `python -m unittest discover -s testing/tests/DMC-1025 -p 'test_*.py'`
- Existing installer coverage: `python -m unittest discover -s testing/tests/DMC-859 -p 'test_*.py'`
- Core unit suite: `./gradlew :dmtools-core:test --no-daemon -x integrationTest`
- Shell syntax: `bash -n install.sh install`
