### PR TITLE
DMC-1024 ReportGenerator crashes instead of retrying after GitHub API rate limits

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/ReportGenerator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/ReportGenerator.java
@@ -5,9 +5,11 @@ package com.github.istin.dmtools.reporting;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.istin.dmtools.common.code.SourceCode;
+import com.github.istin.dmtools.common.networking.RestClient;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.figma.FigmaClient;
 import com.github.istin.dmtools.metrics.Metric;
+import com.github.istin.dmtools.networking.RetryPolicy;
 import com.github.istin.dmtools.report.model.KeyTime;
 import com.github.istin.dmtools.reporting.datasource.*;
 import com.github.istin.dmtools.reporting.formula.ComputedMetricsApplier;
@@ -18,8 +20,10 @@ import com.github.istin.dmtools.team.IEmployees;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
+import okhttp3.Response;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -35,10 +39,12 @@ import java.util.stream.Collectors;
  */
 public class ReportGenerator {
     private static final Logger logger = LogManager.getLogger(ReportGenerator.class);
+    private static final long RATE_LIMIT_FALLBACK_DELAY_MS = 60000L;
 
     private final TrackerClient trackerClient;
     private final SourceCode sourceCode;
     private final FigmaClient figmaClient;
+    private final RetryPolicy retryPolicy = new RetryPolicy(logger);
     private final Set<String> weightMetricLabels = new HashSet<>();
     private final Map<String, Double> metricDividers = new HashMap<>();
     private final Map<String, String> metricLinkTemplates = new HashMap<>();
@@ -245,16 +251,8 @@ public class ReportGenerator {
                     sourceConfig.getParams()
                 );
 
-                DataSourceResult result = new DataSourceResult();
-
-                // Collect KeyTimes
-                dataSource.performMetricCollection(metric, (keyTimes, rawMetadata, itemKey) -> {
-                    result.addKeyTimes(itemKey, keyTimes);
-                    result.addMetadata(itemKey, rawMetadata);
-                    logger.debug("Collected {} KeyTimes for item: {}", keyTimes.size(), itemKey);
-                });
-
                 String metricLabel = (String) metricConfig.getParams().getOrDefault("label", metricConfig.getName());
+                DataSourceResult result = collectMetricDataWithRetry(sourceConfig, metricLabel, dataSource, metric);
                 logger.info("Metric '{}': collected {} items", metricLabel, result.getAllKeyTimes().size());
                 sourceResults.put(metricLabel, result);
 
@@ -292,6 +290,129 @@ public class ReportGenerator {
         }
 
         return results;
+    }
+
+    private DataSourceResult collectMetricDataWithRetry(
+        DataSourceConfig sourceConfig,
+        String metricLabel,
+        DataSource dataSource,
+        Metric metric
+    ) throws Exception {
+        int attemptNumber = 1;
+        while (true) {
+            DataSourceResult result = new DataSourceResult();
+            try {
+                dataSource.performMetricCollection(metric, (keyTimes, rawMetadata, itemKey) -> {
+                    result.addKeyTimes(itemKey, keyTimes);
+                    result.addMetadata(itemKey, rawMetadata);
+                    logger.debug("Collected {} KeyTimes for item: {}", keyTimes.size(), itemKey);
+                });
+                return result;
+            } catch (IOException exception) {
+                if (!retryPolicy.isRetryable(exception) || attemptNumber >= retryPolicy.getMaxRetries()) {
+                    throw exception;
+                }
+
+                long delayMs = calculateRateLimitDelayMs(exception, attemptNumber);
+                logger.warn(
+                    "Rate limit interrupted metric '{}' for source '{}'. Waiting {} ms before retry attempt {}/{}.",
+                    metricLabel,
+                    sourceConfig.getName(),
+                    delayMs,
+                    attemptNumber,
+                    retryPolicy.getMaxRetries()
+                );
+                sleepBeforeRetry(delayMs);
+                attemptNumber++;
+            }
+        }
+    }
+
+    protected long calculateRateLimitDelayMs(IOException exception, int attemptNumber) {
+        Response response = exception instanceof RestClient.RateLimitException
+            ? ((RestClient.RateLimitException) exception).getResponse()
+            : null;
+        if (response != null) {
+            Long retryAfterDelay = parseRetryAfterDelay(response.header("Retry-After"));
+            if (retryAfterDelay != null) {
+                return retryAfterDelay;
+            }
+
+            Long rateLimitResetDelay = parseRateLimitResetDelay(response.header("X-RateLimit-Reset"));
+            if (rateLimitResetDelay != null) {
+                return rateLimitResetDelay;
+            }
+        }
+
+        if (isRateLimitError(exception)) {
+            logger.warn("Rate limit metadata unavailable or invalid. Falling back to {} ms before retry.", RATE_LIMIT_FALLBACK_DELAY_MS);
+            return RATE_LIMIT_FALLBACK_DELAY_MS;
+        }
+
+        try {
+            return retryPolicy.calculateDelayMs(attemptNumber, response);
+        } catch (IOException delayedException) {
+            logger.warn(
+                "Failed to calculate retry delay from rate limit metadata: {}. Falling back to {} ms.",
+                delayedException.getMessage(),
+                RATE_LIMIT_FALLBACK_DELAY_MS
+            );
+            return RATE_LIMIT_FALLBACK_DELAY_MS;
+        }
+    }
+
+    private boolean isRateLimitError(IOException exception) {
+        if (exception instanceof RestClient.RateLimitException) {
+            return true;
+        }
+        String message = exception.getMessage();
+        if (message == null) {
+            return false;
+        }
+        String lowerMessage = message.toLowerCase(Locale.ROOT);
+        return lowerMessage.contains("rate limit")
+            || lowerMessage.contains("too many requests")
+            || lowerMessage.contains("throttl")
+            || lowerMessage.contains("429");
+    }
+
+    protected void sleepBeforeRetry(long delayMs) throws InterruptedException {
+        retryPolicy.executeDelay(delayMs);
+    }
+
+    private Long parseRetryAfterDelay(String retryAfterHeader) {
+        if (retryAfterHeader == null || retryAfterHeader.isBlank()) {
+            return null;
+        }
+        try {
+            long retryAfterSeconds = Long.parseLong(retryAfterHeader.trim());
+            if (retryAfterSeconds > 0) {
+                return retryAfterSeconds * 1000L;
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("Could not parse Retry-After header '{}', falling back to another retry strategy.", retryAfterHeader);
+        }
+        return null;
+    }
+
+    private Long parseRateLimitResetDelay(String rateLimitResetHeader) {
+        if (rateLimitResetHeader == null || rateLimitResetHeader.isBlank()) {
+            return null;
+        }
+        try {
+            long resetTimeMs = Long.parseLong(rateLimitResetHeader.trim()) * 1000L;
+            long currentTimeMs = System.currentTimeMillis();
+            if (resetTimeMs <= currentTimeMs) {
+                return 0L;
+            }
+            return (resetTimeMs - currentTimeMs) + 1000L;
+        } catch (NumberFormatException e) {
+            logger.warn(
+                "Could not parse X-RateLimit-Reset header '{}', falling back to another retry strategy.",
+                rateLimitResetHeader
+            );
+            return null;
+        }
     }
 
     private TimePeriodResult buildPeriodResult(

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/reporting/ReportGeneratorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/reporting/ReportGeneratorTest.java
@@ -3,17 +3,30 @@
 
 package com.github.istin.dmtools.reporting;
 
+import com.github.istin.dmtools.common.code.SourceCode;
+import com.github.istin.dmtools.common.model.IActivity;
+import com.github.istin.dmtools.common.model.ICommit;
+import com.github.istin.dmtools.common.model.IPullRequest;
+import com.github.istin.dmtools.common.model.IUser;
+import com.github.istin.dmtools.common.networking.RestClient;
 import com.github.istin.dmtools.report.model.KeyTime;
+import com.github.istin.dmtools.reporting.datasource.DataSourceFactory;
+import com.github.istin.dmtools.reporting.metrics.MetricFactory;
 import com.github.istin.dmtools.reporting.model.*;
+import okhttp3.Response;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for ReportGenerator
@@ -545,6 +558,102 @@ class ReportGeneratorTest {
         assertTrue(weightLabels.contains("Input"));
     }
 
+    @Test
+    void testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric() throws Exception {
+        SourceCode sourceCode = mock(SourceCode.class);
+        IPullRequest pullRequest = mockPullRequest("123", "PR title");
+        IActivity approvalActivity = mock(IActivity.class);
+        IUser approver = mock(IUser.class);
+        when(approver.getFullName()).thenReturn("Reviewer");
+        when(approvalActivity.getApproval()).thenReturn(approver);
+
+        Response rateLimitResponse = mock(Response.class);
+        when(rateLimitResponse.header("Retry-After")).thenReturn(null);
+        when(rateLimitResponse.header("X-RateLimit-Reset"))
+            .thenReturn(String.valueOf(System.currentTimeMillis() / 1000L));
+
+        when(sourceCode.getDefaultWorkspace()).thenReturn("workspace");
+        when(sourceCode.getDefaultRepository()).thenReturn("repo");
+        when(sourceCode.getDefaultBranch()).thenReturn("main");
+        when(sourceCode.pullRequests(eq("workspace"), eq("repo"), eq(IPullRequest.PullRequestState.STATE_MERGED), eq(true), any(Calendar.class)))
+            .thenReturn(List.of(pullRequest))
+            .thenThrow(new RestClient.RateLimitException("rate limit", "rate limit", rateLimitResponse, 429))
+            .thenReturn(List.of(pullRequest));
+        when(sourceCode.pullRequestActivities("workspace", "repo", "123"))
+            .thenReturn(List.of(approvalActivity));
+
+        ReportGenerator generator = new TestableReportGenerator(sourceCode);
+
+        Map<String, Map<String, ReportGenerator.DataSourceResult>> results =
+            invokeCollectDataFromAllSources(generator, sourceCode, createPullRequestReportConfig());
+
+        assertEquals(1, results.size());
+        assertTrue(results.containsKey("pullRequests"));
+        assertEquals(2, results.get("pullRequests").size());
+        assertTrue(results.get("pullRequests").containsKey("PullRequestsMetricSource"));
+        assertTrue(results.get("pullRequests").containsKey("PullRequestsApprovalsMetricSource"));
+        verify(sourceCode, times(3))
+            .pullRequests(eq("workspace"), eq("repo"), eq(IPullRequest.PullRequestState.STATE_MERGED), eq(true), any(Calendar.class));
+        verify(sourceCode, times(1)).pullRequestActivities("workspace", "repo", "123");
+    }
+
+    @Test
+    void testCollectDataFromAllSources_usesFallbackDelayWhenRateLimitMetadataMissing() throws Exception {
+        SourceCode sourceCode = mock(SourceCode.class);
+        ICommit commit = mock(ICommit.class);
+        IUser author = mock(IUser.class);
+        Calendar commitDate = Calendar.getInstance();
+        commitDate.set(2025, Calendar.JANUARY, 15, 10, 0, 0);
+        commitDate.set(Calendar.MILLISECOND, 0);
+
+        when(author.getFullName()).thenReturn("Author");
+        when(commit.getAuthor()).thenReturn(author);
+        when(commit.getHash()).thenReturn("abc123");
+        when(commit.getCommitterDate()).thenReturn(commitDate);
+        when(commit.getMessage()).thenReturn("Commit message");
+        when(commit.getUrl()).thenReturn("https://github.test/commit/abc123");
+
+        Response rateLimitResponse = mock(Response.class);
+        when(rateLimitResponse.header("Retry-After")).thenReturn("invalid");
+        when(rateLimitResponse.header("X-RateLimit-Reset")).thenReturn("invalid");
+
+        when(sourceCode.getDefaultWorkspace()).thenReturn("workspace");
+        when(sourceCode.getDefaultRepository()).thenReturn("repo");
+        when(sourceCode.getDefaultBranch()).thenReturn("main");
+        when(sourceCode.getCommitsFromBranch("workspace", "repo", "main", "2025-01-01", null))
+            .thenThrow(new RestClient.RateLimitException("rate limit", "rate limit", rateLimitResponse, 429))
+            .thenReturn(List.of(commit));
+
+        TestableReportGenerator generator = new TestableReportGenerator(sourceCode);
+
+        Map<String, Map<String, ReportGenerator.DataSourceResult>> results =
+            invokeCollectDataFromAllSources(generator, sourceCode, createCommitsReportConfig());
+
+        assertEquals(1, results.size());
+        assertTrue(results.containsKey("commits"));
+        assertTrue(results.get("commits").containsKey("CommitsMetricSource"));
+        assertEquals(List.of(60000L), generator.getObservedDelays());
+        verify(sourceCode, times(2)).getCommitsFromBranch("workspace", "repo", "main", "2025-01-01", null);
+    }
+
+    @Test
+    void testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap() {
+        TestableReportGenerator generator = new TestableReportGenerator(mock(SourceCode.class));
+        Response rateLimitResponse = mock(Response.class);
+        long resetTimeSeconds = (System.currentTimeMillis() / 1000L) + 120L;
+
+        when(rateLimitResponse.header("Retry-After")).thenReturn(null);
+        when(rateLimitResponse.header("X-RateLimit-Reset")).thenReturn(String.valueOf(resetTimeSeconds));
+
+        long delayMs = generator.calculateRateLimitDelayMs(
+            new RestClient.RateLimitException("rate limit", "rate limit", rateLimitResponse, 429),
+            1
+        );
+
+        assertTrue(delayMs >= 119000L, "Delay should honor the reset timestamp rather than fall back to 60s");
+        assertTrue(delayMs <= 122000L, "Delay should stay close to the reset timestamp plus buffer");
+    }
+
     /**
      * Helper method to create a KeyTime for testing
      */
@@ -552,5 +661,103 @@ class ReportGeneratorTest {
         KeyTime kt = new KeyTime(key, when, who);
         kt.setWeight(1.0);
         return kt;
+    }
+
+    private IPullRequest mockPullRequest(String id, String title) {
+        IPullRequest pullRequest = mock(IPullRequest.class);
+        IUser author = mock(IUser.class);
+        when(author.getFullName()).thenReturn("Author");
+        when(pullRequest.getAuthor()).thenReturn(author);
+        when(pullRequest.getId()).thenReturn(Integer.valueOf(id));
+        when(pullRequest.getTitle()).thenReturn(title);
+        when(pullRequest.getClosedDate()).thenReturn(System.currentTimeMillis());
+        return pullRequest;
+    }
+
+    private ReportConfig createPullRequestReportConfig() {
+        MetricConfig pullRequestsMetric = new MetricConfig();
+        pullRequestsMetric.setName("PullRequestsMetricSource");
+        pullRequestsMetric.setParams(new HashMap<>());
+
+        MetricConfig approvalsMetric = new MetricConfig();
+        approvalsMetric.setName("PullRequestsApprovalsMetricSource");
+        approvalsMetric.setParams(new HashMap<>());
+
+        DataSourceConfig dataSourceConfig = new DataSourceConfig();
+        dataSourceConfig.setName("pullRequests");
+        dataSourceConfig.setParams(new HashMap<>(Map.of(
+            "workspace", "workspace",
+            "repository", "repo"
+        )));
+        dataSourceConfig.setMetrics(List.of(pullRequestsMetric, approvalsMetric));
+
+        ReportConfig config = new ReportConfig();
+        config.setStartDate("2025-01-01");
+        config.setDataSources(List.of(dataSourceConfig));
+        config.setTimeGroupings(Collections.singletonList(new TimeGroupingConfig()));
+        return config;
+    }
+
+    private ReportConfig createCommitsReportConfig() {
+        MetricConfig commitsMetric = new MetricConfig();
+        commitsMetric.setName("CommitsMetricSource");
+        commitsMetric.setParams(new HashMap<>());
+
+        DataSourceConfig dataSourceConfig = new DataSourceConfig();
+        dataSourceConfig.setName("commits");
+        dataSourceConfig.setParams(new HashMap<>(Map.of(
+            "workspace", "workspace",
+            "repository", "repo",
+            "branch", "main"
+        )));
+        dataSourceConfig.setMetrics(List.of(commitsMetric));
+
+        ReportConfig config = new ReportConfig();
+        config.setStartDate("2025-01-01");
+        config.setDataSources(List.of(dataSourceConfig));
+        config.setTimeGroupings(Collections.singletonList(new TimeGroupingConfig()));
+        return config;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Map<String, ReportGenerator.DataSourceResult>> invokeCollectDataFromAllSources(
+        ReportGenerator generator,
+        SourceCode sourceCode,
+        ReportConfig config
+    ) throws Exception {
+        Method method = ReportGenerator.class.getDeclaredMethod(
+            "collectDataFromAllSources",
+            ReportConfig.class,
+            com.github.istin.dmtools.common.tracker.TrackerClient.class,
+            SourceCode.class,
+            DataSourceFactory.class,
+            MetricFactory.class
+        );
+        method.setAccessible(true);
+        return (Map<String, Map<String, ReportGenerator.DataSourceResult>>) method.invoke(
+            generator,
+            config,
+            null,
+            sourceCode,
+            new DataSourceFactory(),
+            new MetricFactory(null, sourceCode, null, null, config.getStartDate())
+        );
+    }
+
+    private static class TestableReportGenerator extends ReportGenerator {
+        private final List<Long> observedDelays = new ArrayList<>();
+
+        private TestableReportGenerator(SourceCode sourceCode) {
+            super(null, sourceCode);
+        }
+
+        @Override
+        protected void sleepBeforeRetry(long delayMs) {
+            observedDelays.add(delayMs);
+        }
+
+        private List<Long> getObservedDelays() {
+            return observedDelays;
+        }
     }
 }


### PR DESCRIPTION
## Bug Fix Summary

### Root Cause
`ReportGenerator.collectDataFromAllSources` let GitHub rate-limit failures escape from individual metric collection steps after the lower-level HTTP retries were exhausted. That aborted the whole report run, and the generic retry policy's 60-second cap on `X-RateLimit-Reset` waits meant long GitHub reset windows were not honored.

### Fix
`ReportGenerator` now retries the interrupted metric collection step at the report layer instead of failing the full run. It uses `Retry-After` and `X-RateLimit-Reset` directly for GitHub-backed waits, falls back to a safe 60-second delay when rate-limit metadata is missing or invalid, logs the wait/retry behavior, and preserves data already collected for earlier metrics in the same source.

### Test Coverage
- Reproduction test added: `dmtools-core/src/test/java/com/github/istin/dmtools/reporting/ReportGeneratorTest.java` — `testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric`
- Additional coverage: `testCollectDataFromAllSources_usesFallbackDelayWhenRateLimitMetadataMissing`
- Additional coverage: `testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap`
- Full test suite: `./gradlew :dmtools-core:test`

## Issues/Notes
None.

## Approach
- Added report-level retry handling around per-metric collection in `ReportGenerator`.
- Parsed GitHub reset metadata directly so waits can extend beyond the generic 60-second retry cap.
- Applied a 60-second fallback delay when rate-limit headers are unavailable or invalid.
- Retried only the interrupted metric so previously collected report data remains intact.

## Files Modified
- `dmtools-core/src/main/java/com/github/istin/dmtools/reporting/ReportGenerator.java`
- `dmtools-core/src/test/java/com/github/istin/dmtools/reporting/ReportGeneratorTest.java`
- `outputs/rca.md`
- `outputs/response.md`

## Test Coverage
- `./gradlew :dmtools-core:test --tests 'com.github.istin.dmtools.reporting.ReportGeneratorTest.testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric' --tests 'com.github.istin.dmtools.reporting.ReportGeneratorTest.testCollectDataFromAllSources_usesFallbackDelayWhenRateLimitMetadataMissing' --tests 'com.github.istin.dmtools.reporting.ReportGeneratorTest.testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap'`
- `./gradlew :dmtools-core:test`
