### PR TITLE
DMC-1027 Test: Filter CLI releases from GitHub API — only vX.Y.Z tags selected

### DIFF
--- a/testing/components/factories/installer_version_resolution_service_factory.py
+++ b/testing/components/factories/installer_version_resolution_service_factory.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.installer_version_resolution_service import (
+    InstallerVersionResolutionService,
+)
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_installer_version_resolution_service(
+    repository_root: Path,
+    install_script_relative_path: str | Path = "install.sh",
+) -> InstallerVersionResolutionService:
+    return InstallerVersionResolutionService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+        install_script_relative_path=install_script_relative_path,
+    )
+

--- a/testing/components/services/installer_version_resolution_service.py
+++ b/testing/components/services/installer_version_resolution_service.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import textwrap
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.installer_version_resolution_observation import (
+    InstallerVersionResolutionObservation,
+)
+
+
+class InstallerVersionResolutionService:
+    _ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+    _RELEASES_URL_TEMPLATE = "https://api.github.com/repos/epam/dm.ai/releases?per_page=100&page={page}"
+    _LATEST_URL = "https://api.github.com/repos/epam/dm.ai/releases/latest"
+
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+        install_script_relative_path: str | Path = "install.sh",
+    ) -> None:
+        self.repository_root = repository_root
+        self.runner = runner
+        self.install_script_path = repository_root / Path(install_script_relative_path)
+
+    def observe_latest_release_resolution(
+        self,
+        *,
+        release_pages: Sequence[str],
+        latest_release_response: str | None = None,
+        extra_env: Mapping[str, str | None] | None = None,
+    ) -> InstallerVersionResolutionObservation:
+        if not release_pages:
+            raise ValueError("At least one paginated GitHub releases response must be provided.")
+
+        with tempfile.TemporaryDirectory(prefix="dmtools-installer-version-") as temp_dir:
+            temp_root = Path(temp_dir)
+            stub_bin_dir = temp_root / "stub-bin"
+            install_dir = temp_root / "install"
+            bin_dir = install_dir / "bin"
+            installer_env_path = bin_dir / "dmtools-installer.env"
+            curl_log_path = temp_root / "curl-calls.log"
+
+            stub_bin_dir.mkdir(parents=True, exist_ok=True)
+            self._write_executable(
+                stub_bin_dir / "curl",
+                self._curl_stub_script(
+                    release_pages=release_pages,
+                    curl_log_path=curl_log_path,
+                    latest_release_response=latest_release_response,
+                ),
+            )
+            self._write_executable(
+                stub_bin_dir / "git",
+                """
+                #!/bin/bash
+                echo "git fallback should not be used when the paginated releases API already contains a stable CLI tag" >&2
+                exit 1
+                """,
+            )
+
+            env: dict[str, str | None] = {
+                "DMTOOLS_INSTALLER_TEST_MODE": "true",
+                "DMTOOLS_INSTALL_DIR": str(install_dir),
+                "DMTOOLS_BIN_DIR": str(bin_dir),
+                "DMTOOLS_INSTALLER_ENV_PATH": str(installer_env_path),
+                "DMTOOLS_SKILLS": None,
+                "PATH": f"{stub_bin_dir}:{os.environ['PATH']}",
+            }
+            if extra_env:
+                env.update(extra_env)
+
+            execution = self.runner.run(
+                ["bash", "-lc", self._installer_command()],
+                cwd=self.repository_root,
+                env=env,
+            )
+
+            return InstallerVersionResolutionObservation(
+                execution=execution,
+                stdout=self._strip_ansi(execution.stdout).strip(),
+                stderr=self._strip_ansi(execution.stderr).strip(),
+                curl_calls=tuple(
+                    curl_log_path.read_text(encoding="utf-8").splitlines()
+                    if curl_log_path.exists()
+                    else ()
+                ),
+            )
+
+    def _installer_command(self) -> str:
+        return textwrap.dedent(
+            f"""
+            set -e
+            source "{self.install_script_path}"
+
+            check_java() {{
+                info "stubbed check_java"
+            }}
+
+            download_dmtools() {{
+                local version="$1"
+                info "stubbed download_dmtools $version"
+                mkdir -p "$(dirname "$JAR_PATH")" "$BIN_DIR"
+                printf 'stub jar for %s\\n' "$version" > "$JAR_PATH"
+                cat > "$SCRIPT_PATH" <<'EOF'
+            #!/bin/bash
+            echo "dmtools stub"
+            EOF
+                chmod +x "$SCRIPT_PATH"
+            }}
+
+            update_shell_config() {{
+                info "stubbed update_shell_config"
+            }}
+
+            verify_installation() {{
+                info "stubbed verify_installation"
+            }}
+
+            print_instructions() {{
+                info "stubbed print_instructions"
+            }}
+
+            main
+            """
+        ).strip()
+
+    def _curl_stub_script(
+        self,
+        *,
+        release_pages: Sequence[str],
+        curl_log_path: Path,
+        latest_release_response: str | None,
+    ) -> str:
+        cases: list[str] = []
+        for page, response in enumerate(release_pages, start=1):
+            url = self._RELEASES_URL_TEMPLATE.format(page=page)
+            cases.append(
+                f'"{url}")\n'
+                f"cat <<'EOF_RELEASES_PAGE_{page}'\n"
+                f"{response}\n"
+                f"EOF_RELEASES_PAGE_{page}\n"
+                ";;"
+            )
+
+        if latest_release_response is not None:
+            cases.append(
+                f'"{self._LATEST_URL}")\n'
+                "cat <<'EOF_LATEST_RELEASE'\n"
+                f"{latest_release_response}\n"
+                "EOF_LATEST_RELEASE\n"
+                ";;"
+            )
+
+        cases_block = "\n".join(cases)
+        return (
+            "#!/bin/bash\n"
+            "set -e\n"
+            f"printf '%s\\n' \"$*\" >> \"{curl_log_path}\"\n"
+            "url=\"${@: -1}\"\n"
+            "case \"$url\" in\n"
+            f"{cases_block}\n"
+            "*)\n"
+            "    echo \"unexpected curl invocation: $*\" >&2\n"
+            "    exit 1\n"
+            "    ;;\n"
+            "esac\n"
+        ).strip()
+
+    @staticmethod
+    def _write_executable(path: Path, content: str) -> None:
+        path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+        path.chmod(0o755)
+
+    @classmethod
+    def _strip_ansi(cls, text: str) -> str:
+        return cls._ANSI_ESCAPE_PATTERN.sub("", text)

--- a/testing/core/models/installer_version_resolution_observation.py
+++ b/testing/core/models/installer_version_resolution_observation.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+@dataclass(frozen=True)
+class InstallerVersionResolutionObservation:
+    execution: ProcessExecutionResult
+    stdout: str
+    stderr: str
+    curl_calls: tuple[str, ...]
+

--- a/testing/tests/DMC-1027/README.md
+++ b/testing/tests/DMC-1027/README.md
@@ -1,0 +1,28 @@
+# DMC-1027 automated test
+
+This regression test executes the real installer `main()` flow for both
+`install.sh` and `install` while stubbing external side effects. It verifies the
+installer resolves the newest stable CLI release from the paginated GitHub
+releases API, reports that version in the installer logs, and never falls back
+to `/releases/latest` or git tag lookup when a valid `vX.Y.Z` release is already
+present.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+python3 -m pytest testing/tests/DMC-1027/test_dmc_1027.py -q
+```
+
+## Environment
+
+No credentials are required. The test runs the repository installers locally in
+`DMTOOLS_INSTALLER_TEST_MODE=true`, injects mocked GitHub API responses through a
+shared testing service, and validates the user-visible stdout/stderr emitted by
+the installer flow.
+

--- a/testing/tests/DMC-1027/config.yaml
+++ b/testing/tests/DMC-1027/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-1027
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-1027/test_dmc_1027.py
+++ b/testing/tests/DMC-1027/test_dmc_1027.py
@@ -1,104 +1,81 @@
 from __future__ import annotations
 
-import os
-import subprocess
-import tempfile
-import textwrap
+import sys
 from pathlib import Path
+
+import pytest
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
-INSTALL_ENTRYPOINTS = (REPOSITORY_ROOT / "install.sh", REPOSITORY_ROOT / "install")
-EXPECTED_VERSION = "v1.7.184"
-EXPECTED_RELEASES_URL = (
-    "https://api.github.com/repos/epam/dm.ai/releases?per_page=100&page=1"
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.installer_version_resolution_service_factory import (  # noqa: E402
+    create_installer_version_resolution_service,
 )
 
 
-def run_installer_functions(
-    commands: str,
-    *,
-    installer_script: Path,
-    extra_env: dict[str, str] | None = None,
-) -> subprocess.CompletedProcess[str]:
-    env = os.environ.copy()
-    env["DMTOOLS_INSTALLER_TEST_MODE"] = "true"
-    if extra_env:
-        env.update(extra_env)
+EXPECTED_VERSION = "v1.7.184"
+EXPECTED_RELEASES_URL = "https://api.github.com/repos/epam/dm.ai/releases?per_page=100&page=1"
+RELEASES_PAGE = f"""[
+  {{ "tag_name": "v2026.0507.195911-standalone" }},
+  {{ "tag_name": "skill-v1.0.19" }},
+  {{ "tag_name": "v1.7.184-beta.55.1" }},
+  {{ "tag_name": "{EXPECTED_VERSION}" }},
+  {{ "tag_name": "v1.7.183" }}
+]"""
 
-    script = f"""
-set -e
-source "{installer_script}"
-{commands}
-"""
-    return subprocess.run(
-        ["bash", "-lc", script],
-        cwd=REPOSITORY_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
+
+@pytest.mark.parametrize(
+    "installer_script_relative_path",
+    ["install.sh", "install"],
+    ids=["install.sh", "install"],
+)
+def test_dmc_1027_installer_filters_non_cli_releases_from_github_api(
+    installer_script_relative_path: str,
+) -> None:
+    service = create_installer_version_resolution_service(
+        REPOSITORY_ROOT,
+        install_script_relative_path=installer_script_relative_path,
     )
 
+    observation = service.observe_latest_release_resolution(release_pages=[RELEASES_PAGE])
 
-def _write_executable(path: Path, content: str) -> None:
-    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
-    path.chmod(0o755)
-
-
-def test_dmc_1027_installer_filters_non_cli_releases_from_github_api() -> None:
-    for installer_script in INSTALL_ENTRYPOINTS:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            bin_dir = Path(temp_dir) / "bin"
-            curl_calls_log = Path(temp_dir) / "curl-calls.log"
-            bin_dir.mkdir(parents=True)
-
-            _write_executable(
-                bin_dir / "curl",
-                f"""
-                #!/bin/bash
-                set -e
-                printf '%s\\n' "$*" >> "{curl_calls_log}"
-                url="${{@: -1}}"
-                if [ "$url" = "{EXPECTED_RELEASES_URL}" ]; then
-                    cat <<'EOF'
-                [
-                  {{ "tag_name": "v2026.0507.195911-standalone" }},
-                  {{ "tag_name": "skill-v1.0.19" }},
-                  {{ "tag_name": "v1.7.184-beta.55.1" }},
-                  {{ "tag_name": "{EXPECTED_VERSION}" }},
-                  {{ "tag_name": "v1.7.183" }}
-                ]
-                EOF
-                else
-                    echo "unexpected curl invocation: $*" >&2
-                    exit 1
-                fi
-                """,
-            )
-            _write_executable(
-                bin_dir / "git",
-                """
-                #!/bin/bash
-                echo "git fallback should not be used when the releases API already contains a stable CLI tag" >&2
-                exit 1
-                """,
-            )
-
-            result = run_installer_functions(
-                """
-                version=$(get_latest_version)
-                printf 'version=%s\\n' "$version"
-                """,
-                installer_script=installer_script,
-                extra_env={"PATH": f"{bin_dir}:{os.environ['PATH']}"},
-            )
-
-            assert result.returncode == 0, result.stderr
-            assert f"version={EXPECTED_VERSION}" in result.stdout
-            assert f"Found latest CLI release: {EXPECTED_VERSION}" in result.stderr
-            assert "trying fallback" not in result.stderr
-
-            curl_calls = curl_calls_log.read_text(encoding="utf-8").splitlines()
-            assert curl_calls == [
-                f"-s --connect-timeout 10 --max-time 30 --fail {EXPECTED_RELEASES_URL}"
-            ]
+    assert observation.execution.returncode == 0, (
+        "The installer flow should complete successfully when the paginated GitHub "
+        "releases API already includes a stable CLI release.\n"
+        f"stdout:\n{observation.stdout}\n\nstderr:\n{observation.stderr}"
+    )
+    assert "Installing DMTools CLI..." in observation.stdout, (
+        "The real installer path should emit the standard installation banner.\n"
+        f"stdout:\n{observation.stdout}"
+    )
+    assert f"Latest version: {EXPECTED_VERSION}" in observation.stdout, (
+        "The installer logs should report the resolved stable CLI version.\n"
+        f"stdout:\n{observation.stdout}"
+    )
+    assert f"stubbed download_dmtools {EXPECTED_VERSION}" in observation.stdout, (
+        "The installer should pass the resolved version through the normal download step.\n"
+        f"stdout:\n{observation.stdout}"
+    )
+    assert f"Found latest CLI release: {EXPECTED_VERSION}" in observation.stderr, (
+        "The installer should report the selected stable CLI release in its progress logs.\n"
+        f"stderr:\n{observation.stderr}"
+    )
+    assert "Paginated search failed" not in observation.stderr, (
+        "The installer should not fall back when the paginated releases API already "
+        "contains a matching stable CLI release.\n"
+        f"stderr:\n{observation.stderr}"
+    )
+    assert "Falling back to git tag lookup" not in observation.stderr, (
+        "Git tag fallback must stay unused when the paginated releases API already "
+        "returned a stable CLI release.\n"
+        f"stderr:\n{observation.stderr}"
+    )
+    assert observation.curl_calls == (
+        f"-s --connect-timeout 10 --max-time 30 --fail {EXPECTED_RELEASES_URL}",
+    ), (
+        "The installer should stop after the first paginated releases request once it "
+        "finds the newest stable CLI release.\n"
+        f"curl calls:\n{observation.curl_calls}"
+    )

--- a/testing/tests/DMC-1027/test_dmc_1027.py
+++ b/testing/tests/DMC-1027/test_dmc_1027.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+INSTALL_ENTRYPOINTS = (REPOSITORY_ROOT / "install.sh", REPOSITORY_ROOT / "install")
+EXPECTED_VERSION = "v1.7.184"
+EXPECTED_RELEASES_URL = (
+    "https://api.github.com/repos/epam/dm.ai/releases?per_page=100&page=1"
+)
+
+
+def run_installer_functions(
+    commands: str,
+    *,
+    installer_script: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["DMTOOLS_INSTALLER_TEST_MODE"] = "true"
+    if extra_env:
+        env.update(extra_env)
+
+    script = f"""
+set -e
+source "{installer_script}"
+{commands}
+"""
+    return subprocess.run(
+        ["bash", "-lc", script],
+        cwd=REPOSITORY_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_dmc_1027_installer_filters_non_cli_releases_from_github_api() -> None:
+    for installer_script in INSTALL_ENTRYPOINTS:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = Path(temp_dir) / "bin"
+            curl_calls_log = Path(temp_dir) / "curl-calls.log"
+            bin_dir.mkdir(parents=True)
+
+            _write_executable(
+                bin_dir / "curl",
+                f"""
+                #!/bin/bash
+                set -e
+                printf '%s\\n' "$*" >> "{curl_calls_log}"
+                url="${{@: -1}}"
+                if [ "$url" = "{EXPECTED_RELEASES_URL}" ]; then
+                    cat <<'EOF'
+                [
+                  {{ "tag_name": "v2026.0507.195911-standalone" }},
+                  {{ "tag_name": "skill-v1.0.19" }},
+                  {{ "tag_name": "v1.7.184-beta.55.1" }},
+                  {{ "tag_name": "{EXPECTED_VERSION}" }},
+                  {{ "tag_name": "v1.7.183" }}
+                ]
+                EOF
+                else
+                    echo "unexpected curl invocation: $*" >&2
+                    exit 1
+                fi
+                """,
+            )
+            _write_executable(
+                bin_dir / "git",
+                """
+                #!/bin/bash
+                echo "git fallback should not be used when the releases API already contains a stable CLI tag" >&2
+                exit 1
+                """,
+            )
+
+            result = run_installer_functions(
+                """
+                version=$(get_latest_version)
+                printf 'version=%s\\n' "$version"
+                """,
+                installer_script=installer_script,
+                extra_env={"PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            )
+
+            assert result.returncode == 0, result.stderr
+            assert f"version={EXPECTED_VERSION}" in result.stdout
+            assert f"Found latest CLI release: {EXPECTED_VERSION}" in result.stderr
+            assert "trying fallback" not in result.stderr
+
+            curl_calls = curl_calls_log.read_text(encoding="utf-8").splitlines()
+            assert curl_calls == [
+                f"-s --connect-timeout 10 --max-time 30 --fail {EXPECTED_RELEASES_URL}"
+            ]


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-1027 — Filter CLI releases from GitHub API — only vX.Y.Z tags selected

## What was automated
- Added `testing/tests/DMC-1027/test_dmc_1027.py` to exercise the live installer version-resolution logic with a mocked GitHub releases API response that mixes standalone, skill, beta, and stable CLI tags.
- Verified both `install.sh` and `install` select `v1.7.184` from the paginated releases API response and avoid fallback paths when a stable CLI tag is already present.
- Performed a user-style verification by observing the installer’s stdout/stderr for the same scenario.

## Result
- The automated test passed.
- Human-style observation matched the expected user-visible outcome: stdout reported `version=v1.7.184` and stderr logged `Found latest CLI release: v1.7.184`.
- This confirms the installer ignores non-CLI release types and resolves the newest stable `vX.Y.Z` tag.

## How to run
```bash
python3 -m pytest -q testing/tests/DMC-1027/test_dmc_1027.py
```
