### PR TITLE
DMC-1028 Test: Handle GitHub API failure in installer — actionable error message displayed

### DIFF
--- a/testing/components/factories/live_installer_github_api_failure_service_factory.py
+++ b/testing/components/factories/live_installer_github_api_failure_service_factory.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.live_installer_github_api_failure_service import (
+    LiveInstallerGitHubApiFailureService,
+)
+from testing.core.interfaces.live_installer_github_api_failure_service import (
+    LiveInstallerGitHubApiFailureService as LiveInstallerGitHubApiFailureServiceProtocol,
+)
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_live_installer_github_api_failure_service(
+    repository_root: Path,
+    *,
+    release_installer_url: str,
+    repo: str,
+    api_failure_exit_code: int,
+    api_failure_message: str,
+    git_failure_exit_code: int,
+    git_failure_message: str,
+) -> LiveInstallerGitHubApiFailureServiceProtocol:
+    return LiveInstallerGitHubApiFailureService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+        release_installer_url=release_installer_url,
+        repo=repo,
+        api_failure_exit_code=api_failure_exit_code,
+        api_failure_message=api_failure_message,
+        git_failure_exit_code=git_failure_exit_code,
+        git_failure_message=git_failure_message,
+    )

--- a/testing/components/services/live_installer_github_api_failure_service.py
+++ b/testing/components/services/live_installer_github_api_failure_service.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import os
+import tempfile
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+@dataclass(frozen=True)
+class LiveInstallerGitHubApiFailureObservation:
+    release_installer_url: str
+    resolved_installer_url: str
+    execution: ProcessExecutionResult
+
+
+class LiveInstallerGitHubApiFailureService:
+    USER_AGENT = "dm-ai-testing-dmc-1028"
+
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+        *,
+        release_installer_url: str,
+        repo: str,
+        api_failure_exit_code: int,
+        api_failure_message: str,
+        git_failure_exit_code: int,
+        git_failure_message: str,
+    ) -> None:
+        self.repository_root = repository_root
+        self.runner = runner
+        self.release_installer_url = release_installer_url
+        self.repo = repo
+        self.api_failure_exit_code = api_failure_exit_code
+        self.api_failure_message = api_failure_message
+        self.git_failure_exit_code = git_failure_exit_code
+        self.git_failure_message = git_failure_message
+
+    def simulate_github_api_failure(self) -> LiveInstallerGitHubApiFailureObservation:
+        with tempfile.TemporaryDirectory(prefix="dmc-1028-") as temp_dir:
+            temp_path = Path(temp_dir)
+            installer_script_path, resolved_installer_url = self._download_release_installer(temp_path)
+            bin_dir = temp_path / "bin"
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            self._write_executable(bin_dir / "curl", self._curl_stub_script())
+            self._write_executable(bin_dir / "git", self._git_stub_script())
+
+            command = textwrap.dedent(
+                f"""
+                set -e
+                source "{installer_script_path}"
+                check_java() {{ :; }}
+                download_dmtools() {{ :; }}
+                update_shell_config() {{ :; }}
+                verify_installation() {{ :; }}
+                print_instructions() {{ :; }}
+                main
+                """
+            ).strip()
+            execution = self.runner.run(
+                ["bash", "-lc", command],
+                cwd=self.repository_root,
+                env={"DMTOOLS_INSTALLER_TEST_MODE": "true", "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+            )
+            return LiveInstallerGitHubApiFailureObservation(
+                release_installer_url=self.release_installer_url,
+                resolved_installer_url=resolved_installer_url,
+                execution=execution,
+            )
+
+    def normalized_stdout(self, execution: ProcessExecutionResult) -> str:
+        return self._strip_ansi(execution.stdout)
+
+    def normalized_stderr(self, execution: ProcessExecutionResult) -> str:
+        return self._strip_ansi(execution.stderr)
+
+    def normalized_combined_output(self, execution: ProcessExecutionResult) -> str:
+        return self._strip_ansi(execution.combined_output)
+
+    def _download_release_installer(self, temp_path: Path) -> tuple[Path, str]:
+        request = Request(self.release_installer_url, headers={"User-Agent": self.USER_AGENT})
+        with urlopen(request, timeout=30) as response:
+            installer_script = response.read().decode("utf-8")
+            resolved_installer_url = response.geturl()
+
+        installer_script_path = temp_path / "install.sh"
+        installer_script_path.write_text(installer_script, encoding="utf-8")
+        installer_script_path.chmod(0o755)
+        return installer_script_path, resolved_installer_url
+
+    def _curl_stub_script(self) -> str:
+        return textwrap.dedent(
+            f"""\
+            #!/bin/bash
+            url="${{@: -1}}"
+            if [[ "$url" == "https://api.github.com/repos/{self.repo}/releases"* ]]; then
+                echo {self.api_failure_message!r} >&2
+                exit {self.api_failure_exit_code}
+            fi
+            echo "unexpected curl invocation: $*" >&2
+            exit 99
+            """
+        )
+
+    def _git_stub_script(self) -> str:
+        return textwrap.dedent(
+            f"""\
+            #!/bin/bash
+            if [ "$1" = "ls-remote" ] && [ "$2" = "--tags" ] && [ "$3" = "--refs" ]; then
+                echo {self.git_failure_message!r} >&2
+                exit {self.git_failure_exit_code}
+            fi
+            echo "unexpected git invocation: $*" >&2
+            exit 99
+            """
+        )
+
+    @staticmethod
+    def _write_executable(path: Path, content: str) -> None:
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    @staticmethod
+    def _strip_ansi(text: str) -> str:
+        result: list[str] = []
+        index = 0
+        while index < len(text):
+            if text[index] == "\x1b" and index + 1 < len(text) and text[index + 1] == "[":
+                index += 2
+                while index < len(text) and text[index] not in "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~":
+                    index += 1
+                if index < len(text):
+                    index += 1
+                continue
+            result.append(text[index])
+            index += 1
+        return "".join(result)

--- a/testing/core/interfaces/live_installer_github_api_failure_service.py
+++ b/testing/core/interfaces/live_installer_github_api_failure_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import Protocol
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+class LiveInstallerGitHubApiFailureService(Protocol):
+    def simulate_github_api_failure(self) -> Any:
+        raise NotImplementedError
+
+    def normalized_stdout(self, execution: ProcessExecutionResult) -> str:
+        raise NotImplementedError
+
+    def normalized_stderr(self, execution: ProcessExecutionResult) -> str:
+        raise NotImplementedError
+
+    def normalized_combined_output(self, execution: ProcessExecutionResult) -> str:
+        raise NotImplementedError

--- a/testing/tests/DMC-1028/README.md
+++ b/testing/tests/DMC-1028/README.md
@@ -1,0 +1,24 @@
+# DMC-1028 automated test
+
+This test downloads the live latest-release `install.sh` asset from
+`epam/dm.ai`, simulates GitHub API and git tag lookup failures, and verifies
+that the installer shows the actionable user-facing error details required by
+the ticket.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1028/test_dmc_1028.py -q
+```
+
+## Environment
+
+The test runs on Linux, downloads the deployed installer from the latest GitHub
+release, and uses temporary `curl`/`git` stubs to force the GitHub API failure
+path without performing a real installation on the host machine.

--- a/testing/tests/DMC-1028/config.yaml
+++ b/testing/tests/DMC-1028/config.yaml
@@ -1,0 +1,30 @@
+test_id: DMC-1028
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+release_installer_url: https://github.com/epam/dm.ai/releases/latest/download/install.sh
+repo: epam/dm.ai
+api_failure_exit_code: 22
+api_failure_message: curl: (22) The requested URL returned error: 502
+git_failure_exit_code: 1
+git_failure_message: fatal: unable to access 'https://github.com/epam/dm.ai.git/': Could not resolve host: github.com
+expected_resolved_installer_url_fragment: install.sh
+expected_output_fragments:
+  - Installing DMTools CLI...
+  - Effective skills:
+  - Effective integrations:
+  - Fetching latest CLI release information...
+  - Paginated search failed (exit code: 22) or no CLI release found, trying fallback...
+  - Failed to find latest CLI release from GitHub API.
+  - Possible causes:
+  - Network connectivity issues
+  - GitHub API rate limiting
+  - No CLI releases available (only skill/standalone releases found)
+  - curl version incompatibility
+  - Debug information:
+  - Last curl exit code: 22
+  - API response:
+  - Please check your network connection and try again.
+  - If the issue persists, you can manually download from:
+  - https://github.com/epam/dm.ai/releases/latest

--- a/testing/tests/DMC-1028/test_dmc_1028.py
+++ b/testing/tests/DMC-1028/test_dmc_1028.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.live_installer_github_api_failure_service import (  # noqa: E402
+    LiveInstallerGitHubApiFailureService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+from testing.frameworks.api.rest.subprocess_process_runner import (  # noqa: E402
+    SubprocessProcessRunner,
+)
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+EXPECTED_OUTPUT_FRAGMENTS = tuple(str(fragment) for fragment in CONFIG["expected_output_fragments"])
+
+
+def build_service() -> LiveInstallerGitHubApiFailureService:
+    return LiveInstallerGitHubApiFailureService(
+        repository_root=REPOSITORY_ROOT,
+        runner=SubprocessProcessRunner(),
+        release_installer_url=str(CONFIG["release_installer_url"]),
+        repo=str(CONFIG["repo"]),
+        api_failure_exit_code=int(str(CONFIG["api_failure_exit_code"])),
+        api_failure_message=str(CONFIG["api_failure_message"]),
+        git_failure_exit_code=int(str(CONFIG["git_failure_exit_code"])),
+        git_failure_message=str(CONFIG["git_failure_message"]),
+    )
+
+
+def test_dmc_1028_installer_reports_actionable_error_when_github_api_lookup_fails() -> None:
+    service = build_service()
+
+    observation = service.simulate_github_api_failure()
+    stdout = service.normalized_stdout(observation.execution)
+    stderr = service.normalized_stderr(observation.execution)
+    combined_output = service.normalized_combined_output(observation.execution)
+
+    assert observation.resolved_installer_url.startswith("https://"), (
+        "The test must exercise the live deployed installer downloaded from GitHub rather than "
+        "a local repository copy.\n"
+        f"Requested URL: {observation.release_installer_url}\n"
+        f"Resolved URL: {observation.resolved_installer_url}"
+    )
+    assert str(CONFIG["expected_resolved_installer_url_fragment"]) in observation.resolved_installer_url, (
+        "The latest release download should resolve to the installer shell script asset payload.\n"
+        f"Resolved URL: {observation.resolved_installer_url}"
+    )
+    assert observation.execution.returncode != 0, (
+        "The installer should stop with a non-zero exit when both GitHub API release lookups "
+        "and the git tag fallback fail.\n"
+        f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )
+
+    for fragment in EXPECTED_OUTPUT_FRAGMENTS:
+        assert fragment in combined_output, (
+            "The user-visible installer output must keep the actionable GitHub API failure details "
+            "described in the ticket.\n"
+            f"Missing fragment: {fragment!r}\n"
+            f"output:\n{combined_output}"
+        )
+
+    assert str(CONFIG["api_failure_message"]) in combined_output, (
+        "The failure output should surface the curl/API error text so a user can see the actual "
+        "GitHub API failure without rerunning the installer in debug mode.\n"
+        f"output:\n{combined_output}"
+    )

--- a/testing/tests/DMC-1028/test_dmc_1028.py
+++ b/testing/tests/DMC-1028/test_dmc_1028.py
@@ -8,13 +8,13 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from testing.components.services.live_installer_github_api_failure_service import (  # noqa: E402
+from testing.components.factories.live_installer_github_api_failure_service_factory import (  # noqa: E402
+    create_live_installer_github_api_failure_service,
+)
+from testing.core.interfaces.live_installer_github_api_failure_service import (  # noqa: E402
     LiveInstallerGitHubApiFailureService,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
-from testing.frameworks.api.rest.subprocess_process_runner import (  # noqa: E402
-    SubprocessProcessRunner,
-)
 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
@@ -23,9 +23,8 @@ EXPECTED_OUTPUT_FRAGMENTS = tuple(str(fragment) for fragment in CONFIG["expected
 
 
 def build_service() -> LiveInstallerGitHubApiFailureService:
-    return LiveInstallerGitHubApiFailureService(
+    return create_live_installer_github_api_failure_service(
         repository_root=REPOSITORY_ROOT,
-        runner=SubprocessProcessRunner(),
         release_installer_url=str(CONFIG["release_installer_url"]),
         repo=str(CONFIG["repo"]),
         api_failure_exit_code=int(str(CONFIG["api_failure_exit_code"])),


### PR DESCRIPTION
## Test Automation Result

**Status:** ✅ PASSED  
**Test Case:** DMC-1028 — Handle GitHub API failure in installer — actionable error message displayed

## What was automated

- Added a live-installer regression that downloads the latest-release `install.sh` asset from `epam/dm.ai`.
- Simulated GitHub API curl failures with exit code `22` and verified the visible installer output instead of asserting only internal helper behavior.
- Added a small reusable service under `testing/components/services/` to exercise the deployed installer safely in a temporary environment.

## Result

- `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1028/test_dmc_1028.py -q` passed.
- Human-style verification confirmed the terminal output showed the actionable error block a user would actually read after running the installer: the installer banner, the GitHub API failure message, the possible causes list, `Last curl exit code: 22`, `API response: curl: (22) The requested URL returned error: 502`, and the manual download link `https://github.com/epam/dm.ai/releases/latest`.
- Related installer regression `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1025/test_dmc_1025.py -q` also remained green.

## How to run

```bash
PYTHONPATH=. python3 -m pytest testing/tests/DMC-1028/test_dmc_1028.py -q
```
