### PR TITLE
DMC-1029 Test: Trigger manual Windows validation workflow — installer passes in CI environment

### DIFF
--- a/testing/components/factories/workflow_dispatch_validation_service_factory.py
+++ b/testing/components/factories/workflow_dispatch_validation_service_factory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from testing.components.factories.github_actions_release_client_factory import (
+    create_github_actions_release_client,
+)
+from testing.components.services.workflow_dispatch_validation_service import (
+    WorkflowDispatchValidationService as WorkflowDispatchValidationServiceImpl,
+)
+from testing.core.interfaces.workflow_dispatch_validation_service import (
+    WorkflowDispatchValidationService,
+)
+
+
+def create_workflow_dispatch_validation_service(
+    *,
+    owner: str,
+    repo: str,
+    workflow_file: str,
+    workflow_ref: str,
+    workflow_name: str,
+    workflow_job_name: str,
+    dispatch_timeout_seconds: int,
+    completion_timeout_seconds: int,
+    poll_interval_seconds: int,
+    required_step_names: tuple[str, ...],
+    required_log_fragments: tuple[str, ...],
+    token: str | None = None,
+) -> WorkflowDispatchValidationService:
+    return WorkflowDispatchValidationServiceImpl(
+        github_client=create_github_actions_release_client(
+            owner=owner,
+            repo=repo,
+            token=token,
+        ),
+        workflow_file=workflow_file,
+        workflow_ref=workflow_ref,
+        workflow_name=workflow_name,
+        workflow_job_name=workflow_job_name,
+        dispatch_timeout_seconds=dispatch_timeout_seconds,
+        completion_timeout_seconds=completion_timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        required_step_names=required_step_names,
+        required_log_fragments=required_log_fragments,
+    )

--- a/testing/components/services/workflow_dispatch_validation_service.py
+++ b/testing/components/services/workflow_dispatch_validation_service.py
@@ -85,8 +85,8 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
             )
 
         workflow_run = self._wait_for_completion(workflow_run.run_id)
+        workflow_job = self._job_observation_or_none(workflow_run.run_id)
         if workflow_run.status != "completed" or workflow_run.conclusion != "success":
-            workflow_job = self._job_observation_or_none(workflow_run.run_id)
             failures.append(
                 WorkflowDispatchAuditFailure(
                     step=2,
@@ -103,13 +103,6 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
                     ),
                 )
             )
-            return WorkflowDispatchValidationAudit(
-                workflow_run=workflow_run,
-                workflow_job=workflow_job,
-                failures=tuple(failures),
-            )
-
-        workflow_job = self._job_observation_or_none(workflow_run.run_id)
         if workflow_job is None:
             failures.append(
                 WorkflowDispatchAuditFailure(
@@ -143,11 +136,6 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
                         f"Job excerpt: {workflow_job.log_excerpt or 'no log excerpt available'}"
                     ),
                 )
-            )
-            return WorkflowDispatchValidationAudit(
-                workflow_run=workflow_run,
-                workflow_job=workflow_job,
-                failures=tuple(failures),
             )
 
         missing_steps = [

--- a/testing/components/services/workflow_dispatch_validation_service.py
+++ b/testing/components/services/workflow_dispatch_validation_service.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from threading import Event
+from typing import Any
+
+from testing.core.interfaces.github_actions_release_client import GitHubActionsReleaseClient
+from testing.core.interfaces.workflow_dispatch_validation_service import (
+    WorkflowDispatchValidationService as WorkflowDispatchValidationServiceContract,
+)
+from testing.core.models.workflow_dispatch_validation import (
+    WorkflowDispatchAuditFailure,
+    WorkflowDispatchJobObservation,
+    WorkflowDispatchRunObservation,
+    WorkflowDispatchValidationAudit,
+)
+
+
+class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContract):
+    def __init__(
+        self,
+        github_client: GitHubActionsReleaseClient,
+        *,
+        workflow_file: str,
+        workflow_ref: str,
+        workflow_name: str,
+        workflow_job_name: str,
+        dispatch_timeout_seconds: int,
+        completion_timeout_seconds: int,
+        poll_interval_seconds: int,
+        required_step_names: tuple[str, ...],
+        required_log_fragments: tuple[str, ...],
+    ) -> None:
+        self.github_client = github_client
+        self.workflow_file = workflow_file
+        self.workflow_ref = workflow_ref
+        self.workflow_name = workflow_name
+        self.workflow_job_name = workflow_job_name
+        self.dispatch_timeout_seconds = dispatch_timeout_seconds
+        self.completion_timeout_seconds = completion_timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self.required_step_names = required_step_names
+        self.required_log_fragments = required_log_fragments
+        self._waiter = Event()
+
+    def audit(self) -> WorkflowDispatchValidationAudit:
+        failures: list[WorkflowDispatchAuditFailure] = []
+        dispatch_started_at = datetime.now(timezone.utc)
+        target_head_sha = self.github_client.branch_head_sha(self.workflow_ref)
+        existing_run_ids = {
+            int(run["id"])
+            for run in self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                per_page=20,
+            )
+            if run.get("id") is not None
+        }
+
+        self.github_client.dispatch_workflow(self.workflow_file, ref=self.workflow_ref)
+        workflow_run = self._wait_for_dispatched_run(
+            existing_run_ids=existing_run_ids,
+            target_head_sha=target_head_sha,
+            dispatch_started_at=dispatch_started_at,
+        )
+        if workflow_run is None:
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=1,
+                    summary=f"The {self.workflow_name} workflow did not appear after dispatch.",
+                    expected=(
+                        f"A new {self.workflow_name!r} run triggered by workflow_dispatch on "
+                        f"{self.workflow_ref!r}."
+                    ),
+                    actual=(
+                        f"No new workflow_dispatch run was listed for {self.workflow_file!r} "
+                        f"within {self.dispatch_timeout_seconds} seconds."
+                    ),
+                )
+            )
+            return WorkflowDispatchValidationAudit(
+                workflow_run=None,
+                workflow_job=None,
+                failures=tuple(failures),
+            )
+
+        workflow_run = self._wait_for_completion(workflow_run.run_id)
+        if workflow_run.status != "completed" or workflow_run.conclusion != "success":
+            workflow_job = self._job_observation_or_none(workflow_run.run_id)
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=2,
+                    summary=f"The {self.workflow_name} workflow did not finish successfully.",
+                    expected="A completed workflow run with conclusion 'success'.",
+                    actual=(
+                        f"Run {workflow_run.html_url} finished with status={workflow_run.status!r} "
+                        f"and conclusion={workflow_run.conclusion!r}. "
+                        + (
+                            f"Job excerpt: {workflow_job.log_excerpt}"
+                            if workflow_job is not None and workflow_job.log_excerpt
+                            else "No workflow job log excerpt was available."
+                        )
+                    ),
+                )
+            )
+            return WorkflowDispatchValidationAudit(
+                workflow_run=workflow_run,
+                workflow_job=workflow_job,
+                failures=tuple(failures),
+            )
+
+        workflow_job = self._job_observation_or_none(workflow_run.run_id)
+        if workflow_job is None:
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=3,
+                    summary="The completed workflow run did not expose the validation job.",
+                    expected=(
+                        f"A job named {self.workflow_job_name!r} in the completed workflow run."
+                    ),
+                    actual=(
+                        f"No job matched {self.workflow_job_name!r} in run {workflow_run.html_url}."
+                    ),
+                )
+            )
+            return WorkflowDispatchValidationAudit(
+                workflow_run=workflow_run,
+                workflow_job=None,
+                failures=tuple(failures),
+            )
+
+        if workflow_job.status != "completed" or workflow_job.conclusion != "success":
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=4,
+                    summary="The validation job did not finish successfully.",
+                    expected=(
+                        f"A completed {self.workflow_job_name!r} job with conclusion 'success'."
+                    ),
+                    actual=(
+                        f"Job {workflow_job.html_url} finished with status={workflow_job.status!r} "
+                        f"and conclusion={workflow_job.conclusion!r}. "
+                        f"Job excerpt: {workflow_job.log_excerpt or 'no log excerpt available'}"
+                    ),
+                )
+            )
+            return WorkflowDispatchValidationAudit(
+                workflow_run=workflow_run,
+                workflow_job=workflow_job,
+                failures=tuple(failures),
+            )
+
+        missing_steps = [
+            step_name
+            for step_name in self.required_step_names
+            if step_name not in workflow_job.step_conclusions
+        ]
+        if missing_steps:
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=5,
+                    summary="The validation job did not expose all expected user-visible steps.",
+                    expected=(
+                        "Step names visible in the run should include "
+                        + ", ".join(repr(step_name) for step_name in self.required_step_names)
+                        + "."
+                    ),
+                    actual=(
+                        f"Missing steps: {missing_steps}. Visible steps: "
+                        f"{list(workflow_job.step_conclusions.keys()) or ['none']}."
+                    ),
+                )
+            )
+
+        failed_steps = [
+            step_name
+            for step_name in self.required_step_names
+            if workflow_job.step_conclusions.get(step_name) != "success"
+        ]
+        if failed_steps:
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=6,
+                    summary="One or more expected validation steps did not complete successfully.",
+                    expected="Each user-visible validation step should conclude with 'success'.",
+                    actual=(
+                        "Observed step conclusions: "
+                        + ", ".join(
+                            f"{step_name}={workflow_job.step_conclusions.get(step_name, 'missing')!r}"
+                            for step_name in self.required_step_names
+                        )
+                    ),
+                )
+            )
+
+        normalized_log_text = self._normalize_visible_text(workflow_job.raw_log_text)
+        missing_log_fragments = [
+            fragment
+            for fragment in self.required_log_fragments
+            if self._normalize_visible_text(fragment) not in normalized_log_text
+        ]
+        if missing_log_fragments:
+            failures.append(
+                WorkflowDispatchAuditFailure(
+                    step=7,
+                    summary="The validation job log did not show the expected installer verification flow.",
+                    expected=(
+                        "The user-visible job log should show the latest-release install command and "
+                        "wrapper validation commands."
+                    ),
+                    actual=(
+                        f"Missing log fragments: {missing_log_fragments}. "
+                        f"Job excerpt: {workflow_job.log_excerpt or 'no log excerpt available'}"
+                    ),
+                )
+            )
+
+        return WorkflowDispatchValidationAudit(
+            workflow_run=workflow_run,
+            workflow_job=workflow_job,
+            failures=tuple(failures),
+        )
+
+    @staticmethod
+    def format_failures(
+        failures: tuple[WorkflowDispatchAuditFailure, ...] | list[WorkflowDispatchAuditFailure],
+    ) -> str:
+        lines = ["Workflow-dispatch validation did not match the expected live behavior:"]
+        for failure in failures:
+            lines.append(failure.format())
+        return "\n".join(lines)
+
+    def _wait_for_dispatched_run(
+        self,
+        *,
+        existing_run_ids: set[int],
+        target_head_sha: str,
+        dispatch_started_at: datetime,
+    ) -> WorkflowDispatchRunObservation | None:
+        deadline = self._deadline(self.dispatch_timeout_seconds)
+        while datetime.now(timezone.utc) < deadline:
+            runs = self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                event="workflow_dispatch",
+                per_page=20,
+            )
+            for run in runs:
+                run_id = run.get("id")
+                if run_id is None or int(run_id) in existing_run_ids:
+                    continue
+                if str(run.get("head_sha", "")) != target_head_sha:
+                    continue
+                created_at = self._parse_github_datetime(str(run.get("created_at", "")))
+                if created_at is None or created_at < dispatch_started_at - timedelta(minutes=1):
+                    continue
+                return self._build_run_observation(run)
+            self._waiter.wait(self.poll_interval_seconds)
+        return None
+
+    def _wait_for_completion(self, run_id: int) -> WorkflowDispatchRunObservation:
+        deadline = self._deadline(self.completion_timeout_seconds)
+        last_seen = self._build_run_observation(self.github_client.workflow_run(run_id))
+        while datetime.now(timezone.utc) < deadline:
+            current = self._build_run_observation(self.github_client.workflow_run(run_id))
+            last_seen = current
+            if current.status == "completed":
+                return current
+            self._waiter.wait(self.poll_interval_seconds)
+        return last_seen
+
+    def _job_observation_or_none(self, run_id: int) -> WorkflowDispatchJobObservation | None:
+        for job in self.github_client.workflow_jobs(run_id):
+            if str(job.get("name", "")) == self.workflow_job_name:
+                return self._build_job_observation(job)
+        return None
+
+    def _build_job_observation(self, payload: dict[str, Any]) -> WorkflowDispatchJobObservation:
+        job_id = int(payload["id"])
+        raw_log_text = self.github_client.workflow_job_logs(job_id)
+        return WorkflowDispatchJobObservation(
+            job_id=job_id,
+            name=str(payload.get("name", "")),
+            html_url=str(payload.get("html_url", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            step_conclusions=self._extract_step_conclusions(payload),
+            raw_log_text=raw_log_text,
+            log_excerpt=self._log_excerpt(raw_log_text),
+        )
+
+    @staticmethod
+    def _extract_step_conclusions(job_payload: dict[str, Any]) -> dict[str, str]:
+        steps = job_payload.get("steps", [])
+        if not isinstance(steps, list):
+            return {}
+        return {
+            str(step.get("name", "")): str(step.get("conclusion", ""))
+            for step in steps
+            if isinstance(step, dict) and str(step.get("name", ""))
+        }
+
+    @staticmethod
+    def _parse_github_datetime(value: str) -> datetime | None:
+        if not value:
+            return None
+        try:
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _normalize_visible_text(value: str) -> str:
+        return " ".join(value.lower().split())
+
+    @classmethod
+    def _log_excerpt(cls, raw_log_text: str, limit: int = 6000) -> str:
+        normalized = "\n".join(line.rstrip() for line in raw_log_text.splitlines())
+        if len(normalized) <= limit:
+            return normalized
+        return "..." + normalized[-(limit - 3) :]
+
+    @staticmethod
+    def _deadline(timeout_seconds: int) -> datetime:
+        return datetime.now(timezone.utc) + timedelta(seconds=timeout_seconds)
+
+    @staticmethod
+    def _build_run_observation(payload: dict[str, Any]) -> WorkflowDispatchRunObservation:
+        return WorkflowDispatchRunObservation(
+            run_id=int(payload["id"]),
+            html_url=str(payload.get("html_url", "")),
+            event=str(payload.get("event", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            head_branch=str(payload.get("head_branch", "")),
+            head_sha=str(payload.get("head_sha", "")),
+            created_at=str(payload.get("created_at", "")),
+            run_number=int(payload.get("run_number", 0) or 0),
+        )

--- a/testing/components/services/workflow_dispatch_validation_service.py
+++ b/testing/components/services/workflow_dispatch_validation_service.py
@@ -46,7 +46,6 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
     def audit(self) -> WorkflowDispatchValidationAudit:
         failures: list[WorkflowDispatchAuditFailure] = []
         dispatch_started_at = datetime.now(timezone.utc)
-        target_head_sha = self.github_client.branch_head_sha(self.workflow_ref)
         existing_run_ids = {
             int(run["id"])
             for run in self.github_client.workflow_runs_for_workflow(
@@ -60,7 +59,6 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
         self.github_client.dispatch_workflow(self.workflow_file, ref=self.workflow_ref)
         workflow_run = self._wait_for_dispatched_run(
             existing_run_ids=existing_run_ids,
-            target_head_sha=target_head_sha,
             dispatch_started_at=dispatch_started_at,
         )
         if workflow_run is None:
@@ -222,10 +220,10 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
         self,
         *,
         existing_run_ids: set[int],
-        target_head_sha: str,
         dispatch_started_at: datetime,
     ) -> WorkflowDispatchRunObservation | None:
         deadline = self._deadline(self.dispatch_timeout_seconds)
+        earliest_created_at = dispatch_started_at - timedelta(seconds=self.poll_interval_seconds)
         while datetime.now(timezone.utc) < deadline:
             runs = self.github_client.workflow_runs_for_workflow(
                 self.workflow_file,
@@ -233,16 +231,18 @@ class WorkflowDispatchValidationService(WorkflowDispatchValidationServiceContrac
                 event="workflow_dispatch",
                 per_page=20,
             )
+            candidates: list[tuple[datetime, int, dict[str, Any]]] = []
             for run in runs:
                 run_id = run.get("id")
                 if run_id is None or int(run_id) in existing_run_ids:
                     continue
-                if str(run.get("head_sha", "")) != target_head_sha:
-                    continue
                 created_at = self._parse_github_datetime(str(run.get("created_at", "")))
-                if created_at is None or created_at < dispatch_started_at - timedelta(minutes=1):
+                if created_at is None or created_at < earliest_created_at:
                     continue
-                return self._build_run_observation(run)
+                candidates.append((created_at, int(run_id), run))
+            if candidates:
+                _, _, earliest_run = min(candidates, key=lambda candidate: (candidate[0], candidate[1]))
+                return self._build_run_observation(earliest_run)
             self._waiter.wait(self.poll_interval_seconds)
         return None
 

--- a/testing/core/interfaces/workflow_dispatch_validation_service.py
+++ b/testing/core/interfaces/workflow_dispatch_validation_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.workflow_dispatch_validation import (
+    WorkflowDispatchAuditFailure,
+    WorkflowDispatchValidationAudit,
+)
+
+
+class WorkflowDispatchValidationService(Protocol):
+    def audit(self) -> WorkflowDispatchValidationAudit:
+        raise NotImplementedError
+
+    def format_failures(
+        self,
+        failures: tuple[WorkflowDispatchAuditFailure, ...] | list[WorkflowDispatchAuditFailure],
+    ) -> str:
+        raise NotImplementedError

--- a/testing/core/models/workflow_dispatch_validation.py
+++ b/testing/core/models/workflow_dispatch_validation.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class WorkflowDispatchAuditFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowDispatchRunObservation:
+    run_id: int
+    html_url: str
+    event: str
+    status: str
+    conclusion: str
+    head_branch: str
+    head_sha: str
+    created_at: str
+    run_number: int
+
+
+@dataclass(frozen=True)
+class WorkflowDispatchJobObservation:
+    job_id: int
+    name: str
+    html_url: str
+    status: str
+    conclusion: str
+    step_conclusions: dict[str, str] = field(default_factory=dict)
+    raw_log_text: str = ""
+    log_excerpt: str = ""
+
+
+@dataclass(frozen=True)
+class WorkflowDispatchValidationAudit:
+    workflow_run: WorkflowDispatchRunObservation | None
+    workflow_job: WorkflowDispatchJobObservation | None
+    failures: tuple[WorkflowDispatchAuditFailure, ...]

--- a/testing/tests/DMC-1029/README.md
+++ b/testing/tests/DMC-1029/README.md
@@ -1,0 +1,31 @@
+# DMC-1029 automated test
+
+This test validates the live `windows-git-bash-installer-check.yml` workflow on
+`main`. It confirms that the manually dispatchable Windows Git Bash validation
+workflow exists, runs on a Windows runner with Bash, installs the CLI from the
+latest GitHub release, and finishes successfully.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1029/test_dmc_1029.py -q
+```
+
+## Environment
+
+The live workflow dispatch requires repository access through `GH_TOKEN` or
+`GITHUB_TOKEN`. In CI those credentials are injected automatically; when
+running locally, use a token that can dispatch workflows and read Actions logs
+for `epam/dm.ai`.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-1029/config.yaml
+++ b/testing/tests/DMC-1029/config.yaml
@@ -1,0 +1,22 @@
+test_id: DMC-1029
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_file: windows-git-bash-installer-check.yml
+workflow_ref: main
+workflow_name: Windows Git Bash Installer Check
+workflow_job_name: validate-latest-installer
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 1800
+poll_interval_seconds: 20
+required_step_names:
+  - Set up Java 17
+  - Install DMTools CLI from latest release
+  - Validate installed wrapper and metadata
+required_log_fragments:
+  - releases/latest/download/install.sh | bash
+  - DMTOOLS_INSTALL_DIR/dmtools.jar
+  - DMTOOLS_BIN_DIR/dmtools

--- a/testing/tests/DMC-1029/test_dmc_1029.py
+++ b/testing/tests/DMC-1029/test_dmc_1029.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.workflow_dispatch_validation_service_factory import (  # noqa: E402
+    create_workflow_dispatch_validation_service,
+)
+from testing.core.interfaces.workflow_dispatch_validation_service import (  # noqa: E402
+    WorkflowDispatchValidationService,
+)
+from testing.core.models.workflow_dispatch_validation import (  # noqa: E402
+    WorkflowDispatchValidationAudit,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / str(CONFIG["workflow_file"])
+
+
+def _normalized_config_list(key: str) -> tuple[str, ...]:
+    values = CONFIG.get(key, [])
+    if not isinstance(values, list):
+        raise TypeError(f"Expected {key!r} to be a list in {TEST_DIRECTORY / 'config.yaml'}.")
+    return tuple(str(value) for value in values)
+
+
+def build_service() -> WorkflowDispatchValidationService:
+    return create_workflow_dispatch_validation_service(
+        owner=str(CONFIG["owner"]),
+        repo=str(CONFIG["repo"]),
+        workflow_file=str(CONFIG["workflow_file"]),
+        workflow_ref=str(CONFIG["workflow_ref"]),
+        workflow_name=str(CONFIG["workflow_name"]),
+        workflow_job_name=str(CONFIG["workflow_job_name"]),
+        dispatch_timeout_seconds=int(str(CONFIG["dispatch_timeout_seconds"])),
+        completion_timeout_seconds=int(str(CONFIG["completion_timeout_seconds"])),
+        poll_interval_seconds=int(str(CONFIG["poll_interval_seconds"])),
+        required_step_names=_normalized_config_list("required_step_names"),
+        required_log_fragments=_normalized_config_list("required_log_fragments"),
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def _assert_successful_audit(audit: WorkflowDispatchValidationAudit) -> None:
+    assert audit.workflow_run is not None
+    assert audit.workflow_job is not None
+
+
+def test_dmc_1029_manual_windows_validation_workflow_passes_in_ci_environment() -> None:
+    workflow_text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "name: Windows Git Bash Installer Check" in workflow_text
+    assert "workflow_dispatch:" in workflow_text
+    assert "runs-on: windows-latest" in workflow_text
+    assert "shell: bash" in workflow_text
+    assert "releases/latest/download/install.sh | bash" in workflow_text
+    assert 'test -f "$DMTOOLS_INSTALL_DIR/dmtools.jar"' in workflow_text
+    assert '"$DMTOOLS_BIN_DIR/dmtools" --help >/dev/null' in workflow_text
+
+    service = build_service()
+    audit = service.audit()
+
+    assert not audit.failures, service.format_failures(audit.failures)
+    _assert_successful_audit(audit)
+
+    assert audit.workflow_run.event == "workflow_dispatch"
+    assert audit.workflow_run.head_branch == str(CONFIG["workflow_ref"])
+    assert audit.workflow_run.conclusion == "success"
+    assert audit.workflow_job.name == str(CONFIG["workflow_job_name"])
+    assert audit.workflow_job.conclusion == "success"
+
+    required_steps = _normalized_config_list("required_step_names")
+    observed_steps = audit.workflow_job.step_conclusions
+    assert tuple(observed_steps.keys())[: len(required_steps)] or observed_steps
+    for step_name in required_steps:
+        assert observed_steps.get(step_name) == "success"
+
+    print(f"Workflow run URL: {audit.workflow_run.html_url}")
+    print(f"Workflow job URL: {audit.workflow_job.html_url}")
+    print(f"Observed steps: {observed_steps}")

--- a/testing/tests/DMC-1029/test_dmc_1029_service.py
+++ b/testing/tests/DMC-1029/test_dmc_1029_service.py
@@ -178,3 +178,70 @@ def test_service_keeps_collecting_failed_run_step_and_log_evidence() -> None:
     assert all(failure.step != 5 for failure in audit.failures)
     assert all(failure.step != 7 for failure in audit.failures)
     assert "releases/latest/download/install.sh | bash" in audit.workflow_job.raw_log_text
+
+
+def test_service_selects_the_earliest_new_run_after_dispatch_even_when_head_sha_changes() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    client.head_sha = "before-dispatch-sha"
+
+    dispatched_run = {
+        "id": 701,
+        "html_url": "https://example.test/actions/runs/701",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": "after-dispatch-sha",
+        "created_at": "2099-05-15T12:00:00Z",
+        "run_number": 70,
+    }
+    later_run = {
+        "id": 702,
+        "html_url": "https://example.test/actions/runs/702",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": "even-later-sha",
+        "created_at": "2099-05-15T12:00:02Z",
+        "run_number": 71,
+    }
+    client.workflow_runs_responses = [
+        [],
+        [later_run, dispatched_run],
+    ]
+    client.run_by_id[701] = dict(dispatched_run)
+    client.jobs_by_run_id[701] = [
+        {
+            "id": 801,
+            "name": "validate-latest-installer",
+            "html_url": "https://example.test/actions/runs/701/job/801",
+            "status": "completed",
+            "conclusion": "success",
+            "steps": [
+                {"name": "Set up Java 17", "conclusion": "success"},
+                {
+                    "name": "Install DMTools CLI from latest release",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "Validate installed wrapper and metadata",
+                    "conclusion": "success",
+                },
+            ],
+        }
+    ]
+    client.logs_by_job_id[801] = (
+        "Run curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash\n"
+        'Run test -f "$DMTOOLS_INSTALL_DIR/dmtools.jar"\n'
+        'Run "$DMTOOLS_BIN_DIR/dmtools" --help >/dev/null\n'
+    )
+
+    audit = _build_service(client).audit()
+
+    assert audit.failures == ()
+    assert audit.workflow_run is not None
+    assert audit.workflow_job is not None
+    assert audit.workflow_run.run_id == 701
+    assert audit.workflow_run.head_sha == "after-dispatch-sha"
+    assert audit.workflow_job.conclusion == "success"

--- a/testing/tests/DMC-1029/test_dmc_1029_service.py
+++ b/testing/tests/DMC-1029/test_dmc_1029_service.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.workflow_dispatch_validation_service import (  # noqa: E402
+    WorkflowDispatchValidationService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+
+
+class FakeGitHubActionsReleaseClient(GitHubActionsReleaseClient):
+    def __init__(self) -> None:
+        self.dispatch_calls: list[tuple[str, str, dict[str, object]]] = []
+        self.head_sha = "abcdef1234567890"
+        self.workflow_runs_responses: list[list[dict[str, Any]]] = []
+        self.run_by_id: dict[int, dict[str, Any]] = {}
+        self.jobs_by_run_id: dict[int, list[dict[str, Any]]] = {}
+        self.logs_by_job_id: dict[int, str] = {}
+
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
+        self.dispatch_calls.append((workflow_id, ref, dict(inputs or {})))
+
+    def branch_head_sha(self, branch: str) -> str:
+        del branch
+        return self.head_sha
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, Any]]:
+        del workflow_id, branch, event, per_page
+        if self.workflow_runs_responses:
+            return list(self.workflow_runs_responses.pop(0))
+        return []
+
+    def workflow_run(self, run_id: int) -> dict[str, Any]:
+        return dict(self.run_by_id[run_id])
+
+    def list_recent_pull_requests(self, limit: int = 20) -> list[dict[str, Any]]:
+        del limit
+        return []
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_issue_comments(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        del number
+        return {}
+
+    def workflow_runs_for_head_sha(self, head_sha: str) -> list[dict[str, Any]]:
+        del head_sha
+        return []
+
+    def workflow_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        return list(self.jobs_by_run_id[run_id])
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        return self.logs_by_job_id[job_id]
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, Any]]:
+        del per_page
+        return []
+
+    def release_by_tag(self, tag: str) -> dict[str, Any]:
+        raise AssertionError(f"Unexpected release lookup for {tag!r}")
+
+
+def _build_service(client: GitHubActionsReleaseClient) -> WorkflowDispatchValidationService:
+    return WorkflowDispatchValidationService(
+        github_client=client,
+        workflow_file="windows-git-bash-installer-check.yml",
+        workflow_ref="main",
+        workflow_name="Windows Git Bash Installer Check",
+        workflow_job_name="validate-latest-installer",
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+        required_step_names=(
+            "Set up Java 17",
+            "Install DMTools CLI from latest release",
+            "Validate installed wrapper and metadata",
+        ),
+        required_log_fragments=(
+            "releases/latest/download/install.sh | bash",
+            "DMTOOLS_INSTALL_DIR/dmtools.jar",
+            "DMTOOLS_BIN_DIR/dmtools",
+        ),
+    )
+
+
+def test_service_keeps_collecting_failed_run_step_and_log_evidence() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = {
+        "id": 501,
+        "html_url": "https://example.test/actions/runs/501",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "failure",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-15T12:00:00Z",
+        "run_number": 44,
+    }
+    client.workflow_runs_responses = [
+        [],
+        [dispatched_run],
+    ]
+    client.run_by_id[501] = dict(dispatched_run)
+    client.jobs_by_run_id[501] = [
+        {
+            "id": 601,
+            "name": "validate-latest-installer",
+            "html_url": "https://example.test/actions/runs/501/job/601",
+            "status": "completed",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Set up Java 17", "conclusion": "success"},
+                {
+                    "name": "Install DMTools CLI from latest release",
+                    "conclusion": "success",
+                },
+                {
+                    "name": "Validate installed wrapper and metadata",
+                    "conclusion": "failure",
+                },
+            ],
+        }
+    ]
+    client.logs_by_job_id[601] = (
+        "Run curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash\n"
+        'Run test -f "$DMTOOLS_INSTALL_DIR/dmtools.jar"\n'
+        'Run "$DMTOOLS_BIN_DIR/dmtools" --help >/dev/null\n'
+    )
+
+    audit = _build_service(client).audit()
+
+    assert client.dispatch_calls == [
+        ("windows-git-bash-installer-check.yml", "main", {}),
+    ]
+    assert audit.workflow_run is not None
+    assert audit.workflow_job is not None
+    assert audit.workflow_job.step_conclusions == {
+        "Set up Java 17": "success",
+        "Install DMTools CLI from latest release": "success",
+        "Validate installed wrapper and metadata": "failure",
+    }
+
+    failure_steps = [failure.step for failure in audit.failures]
+    assert failure_steps == [2, 4, 6]
+    assert all(failure.step != 5 for failure in audit.failures)
+    assert all(failure.step != 7 for failure in audit.failures)
+    assert "releases/latest/download/install.sh | bash" in audit.workflow_job.raw_log_text


### PR DESCRIPTION
# DMC-1029 automation result: **FAILED**

## What changed

- Added the live workflow-dispatch test in `testing/tests/DMC-1029/test_dmc_1029.py`
- Added reusable GitHub Actions workflow audit support in:
  - `testing/components/services/workflow_dispatch_validation_service.py`
  - `testing/components/factories/workflow_dispatch_validation_service_factory.py`
  - `testing/core/interfaces/workflow_dispatch_validation_service.py`
  - `testing/core/models/workflow_dispatch_validation.py`
- Added `testing/tests/DMC-1029/config.yaml` and `testing/tests/DMC-1029/README.md`

## What automation checked

- `.github/workflows/windows-git-bash-installer-check.yml` exists and is manually triggerable with `workflow_dispatch`
- the workflow is configured for `windows-latest` with Bash
- the installer step uses `https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash`
- a real live `workflow_dispatch` run on `main` appears
- the live job exposes the expected visible steps:
  - `Set up Java 17`
  - `Install DMTools CLI from latest release`
  - `Validate installed wrapper and metadata`
- the live job log shows the installer command and wrapper-validation commands

## Related bug context checked first

- linked bug `DMC-1025` is marked **Done**
- the linked local regression test `testing/tests/DMC-1025/test_dmc_1025.py` passed
- the deployed live workflow still fails in the final validation step

## Real user-style verification

- Triggered the live workflow and checked the GitHub Actions run page: [Run #25917625900](https://github.com/epam/dm.ai/actions/runs/25917625900)
- Observed the workflow result as **Failure**
- Observed job [validate-latest-installer](https://github.com/epam/dm.ai/actions/runs/25917625900/job/76178128959) with these visible step results:
  - `Set up Java 17` — **PASS**
  - `Install DMTools CLI from latest release` — **PASS**
  - `Validate installed wrapper and metadata` — **FAIL**
- Observed the failing message:

```text
Error: DMTools JAR file not found. Please install DMTools first:
  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash

Or if you're developing locally, build the project first:
  ./gradlew build

Note: Java 17+ is required for DMTools to run.
##[error]Process completed with exit code 1.
```

## Expected vs actual

- **Expected:** the workflow finishes with **Success**, proving that the documented Git Bash install path works on a Windows runner.
- **Actual:** the workflow finished with **Failure**. The install step reported success, but the next step could not find `$DMTOOLS_INSTALL_DIR/dmtools.jar`.

## Reproduction from the ticket

1. Navigate to the GitHub Actions tab in the repository. ✅ The workflow is present as **Windows Git Bash Installer Check**.
2. Locate and manually trigger the workflow specifically configured to test the Windows Git Bash installation path. ✅ Triggered via `workflow_dispatch` on `main`.
3. Wait for the workflow to complete. ❌ Run [#25917625900](https://github.com/epam/dm.ai/actions/runs/25917625900) completed with **Failure** because step **Validate installed wrapper and metadata** failed in job [validate-latest-installer](https://github.com/epam/dm.ai/actions/runs/25917625900/job/76178128959).

## Environment

- Repository: `epam/dm.ai`
- Workflow file: `.github/workflows/windows-git-bash-installer-check.yml`
- Runner OS: Windows Server 2025 (`windows-latest`)
- Shell: `C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}`
- Java: `17.0.19`

## Artifacts

- Full job log: `outputs/dmc_1029_run_25917625900_job_76178128959.log`
- Run and job metadata: `outputs/dmc_1029_live_run_debug.txt`
