### PR TITLE
DMC-1026 Test: Install DMTools CLI on Windows via Git Bash — latest release resolved and installation successful

### DIFF
--- a/testing/components/factories/windows_installer_workflow_audit_service_factory.py
+++ b/testing/components/factories/windows_installer_workflow_audit_service_factory.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from testing.components.factories.github_actions_release_client_factory import (
+    create_github_actions_release_client,
+)
+from testing.components.services.windows_installer_workflow_audit_service import (
+    WindowsInstallerWorkflowAuditService as WindowsInstallerWorkflowAuditServiceImpl,
+)
+from testing.core.interfaces.windows_installer_workflow_audit_service import (
+    WindowsInstallerWorkflowAuditService,
+)
+
+
+def create_windows_installer_workflow_audit_service(
+    *,
+    owner: str,
+    repo: str,
+    workflow_file: str,
+    workflow_ref: str,
+    workflow_name: str,
+    workflow_job_name: str,
+    dispatch_timeout_seconds: int,
+    completion_timeout_seconds: int,
+    poll_interval_seconds: int,
+    token: str | None = None,
+) -> WindowsInstallerWorkflowAuditService:
+    return WindowsInstallerWorkflowAuditServiceImpl(
+        github_client=create_github_actions_release_client(
+            owner=owner,
+            repo=repo,
+            token=token,
+        ),
+        workflow_file=workflow_file,
+        workflow_ref=workflow_ref,
+        workflow_name=workflow_name,
+        workflow_job_name=workflow_job_name,
+        dispatch_timeout_seconds=dispatch_timeout_seconds,
+        completion_timeout_seconds=completion_timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+    )

--- a/testing/components/services/windows_installer_workflow_audit_service.py
+++ b/testing/components/services/windows_installer_workflow_audit_service.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from threading import Event
+from typing import Any
+
+from testing.core.interfaces.github_actions_release_client import GitHubActionsReleaseClient
+from testing.core.interfaces.windows_installer_workflow_audit_service import (
+    WindowsInstallerWorkflowAuditService as WindowsInstallerWorkflowAuditServiceContract,
+)
+from testing.core.models.windows_installer_workflow_audit import (
+    WindowsInstallerWorkflowAudit,
+    WindowsInstallerWorkflowAuditFailure,
+    WindowsInstallerWorkflowJobObservation,
+    WindowsInstallerWorkflowRunObservation,
+)
+
+
+class WindowsInstallerWorkflowAuditService(WindowsInstallerWorkflowAuditServiceContract):
+    ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+    TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
+
+    def __init__(
+        self,
+        github_client: GitHubActionsReleaseClient,
+        *,
+        workflow_file: str,
+        workflow_ref: str,
+        workflow_name: str,
+        workflow_job_name: str,
+        dispatch_timeout_seconds: int,
+        completion_timeout_seconds: int,
+        poll_interval_seconds: int,
+    ) -> None:
+        self.github_client = github_client
+        self.workflow_file = workflow_file
+        self.workflow_ref = workflow_ref
+        self.workflow_name = workflow_name
+        self.workflow_job_name = workflow_job_name
+        self.dispatch_timeout_seconds = dispatch_timeout_seconds
+        self.completion_timeout_seconds = completion_timeout_seconds
+        self.poll_interval_seconds = poll_interval_seconds
+        self._waiter = Event()
+
+    def audit(self) -> WindowsInstallerWorkflowAudit:
+        failures: list[WindowsInstallerWorkflowAuditFailure] = []
+        dispatch_started_at = datetime.now(timezone.utc)
+        target_head_sha = self.github_client.branch_head_sha(self.workflow_ref)
+        existing_run_ids = {
+            int(run["id"])
+            for run in self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                per_page=20,
+            )
+            if run.get("id") is not None
+        }
+
+        self.github_client.dispatch_workflow(self.workflow_file, ref=self.workflow_ref)
+        workflow_run = self._wait_for_dispatched_run(
+            existing_run_ids=existing_run_ids,
+            target_head_sha=target_head_sha,
+            dispatch_started_at=dispatch_started_at,
+        )
+        if workflow_run is None:
+            failures.append(
+                WindowsInstallerWorkflowAuditFailure(
+                    step=1,
+                    summary=f"The {self.workflow_name} workflow did not appear after dispatch.",
+                    expected=(
+                        f"A new {self.workflow_name!r} run triggered by workflow_dispatch on "
+                        f"{self.workflow_ref!r}."
+                    ),
+                    actual=(
+                        f"No new workflow_dispatch run was listed for {self.workflow_file!r} "
+                        f"within {self.dispatch_timeout_seconds} seconds."
+                    ),
+                )
+            )
+            return WindowsInstallerWorkflowAudit(
+                workflow_run=None,
+                workflow_job=None,
+                failures=tuple(failures),
+            )
+
+        completed_run = self._wait_for_completion(workflow_run.run_id)
+        workflow_job_payload = self._find_workflow_job_payload(completed_run.run_id)
+        workflow_job = (
+            self._build_workflow_job_observation(workflow_job_payload)
+            if workflow_job_payload is not None
+            else None
+        )
+
+        if completed_run.status != "completed" or completed_run.conclusion != "success":
+            failures.append(
+                WindowsInstallerWorkflowAuditFailure(
+                    step=2,
+                    summary=f"The {self.workflow_name} workflow did not finish successfully.",
+                    expected="A completed workflow run with conclusion 'success'.",
+                    actual=(
+                        f"Run {completed_run.html_url} finished with status={completed_run.status!r} "
+                        f"and conclusion={completed_run.conclusion!r}. "
+                        + (
+                            f"Job excerpt: {workflow_job.log_excerpt}"
+                            if workflow_job is not None and workflow_job.log_excerpt
+                            else "No workflow job log was available."
+                        )
+                    ),
+                )
+            )
+            return WindowsInstallerWorkflowAudit(
+                workflow_run=completed_run,
+                workflow_job=workflow_job,
+                failures=tuple(failures),
+            )
+
+        if workflow_job is None:
+            failures.append(
+                WindowsInstallerWorkflowAuditFailure(
+                    step=3,
+                    summary="The completed workflow run does not expose the expected job.",
+                    expected=f"A job named {self.workflow_job_name!r} in the completed workflow run.",
+                    actual=(
+                        f"No job matched {self.workflow_job_name!r} in run {completed_run.html_url}."
+                    ),
+                )
+            )
+            return WindowsInstallerWorkflowAudit(
+                workflow_run=completed_run,
+                workflow_job=None,
+                failures=tuple(failures),
+            )
+
+        if workflow_job.status != "completed" or workflow_job.conclusion != "success":
+            failures.append(
+                WindowsInstallerWorkflowAuditFailure(
+                    step=4,
+                    summary="The expected workflow job did not finish successfully.",
+                    expected=f"A completed {self.workflow_job_name!r} job with conclusion 'success'.",
+                    actual=(
+                        f"Job {workflow_job.html_url} finished with status={workflow_job.status!r} "
+                        f"and conclusion={workflow_job.conclusion!r}. "
+                        f"Step conclusions: {workflow_job.step_conclusions}. "
+                        f"Job excerpt: {workflow_job.log_excerpt}"
+                    ),
+                )
+            )
+
+        return WindowsInstallerWorkflowAudit(
+            workflow_run=completed_run,
+            workflow_job=workflow_job,
+            failures=tuple(failures),
+        )
+
+    @staticmethod
+    def format_failures(
+        failures: tuple[WindowsInstallerWorkflowAuditFailure, ...]
+        | list[WindowsInstallerWorkflowAuditFailure],
+    ) -> str:
+        lines = ["Windows installer workflow outputs did not match the expected live behavior:"]
+        for failure in failures:
+            lines.append(failure.format())
+        return "\n".join(lines)
+
+    def _wait_for_dispatched_run(
+        self,
+        *,
+        existing_run_ids: set[int],
+        target_head_sha: str,
+        dispatch_started_at: datetime,
+    ) -> WindowsInstallerWorkflowRunObservation | None:
+        deadline = self._deadline(self.dispatch_timeout_seconds)
+        earliest_created_at = dispatch_started_at - timedelta(seconds=self.poll_interval_seconds)
+
+        while datetime.now(timezone.utc) < deadline:
+            runs = self.github_client.workflow_runs_for_workflow(
+                self.workflow_file,
+                branch=self.workflow_ref,
+                event="workflow_dispatch",
+                per_page=20,
+            )
+            for run in runs:
+                run_id = run.get("id")
+                if run_id is None or int(run_id) in existing_run_ids:
+                    continue
+                if str(run.get("head_sha", "")) != target_head_sha:
+                    continue
+                created_at = self._parse_github_datetime(str(run.get("created_at", "")))
+                if created_at is None or created_at < earliest_created_at:
+                    continue
+                return self._build_run_observation(run)
+            self._waiter.wait(self.poll_interval_seconds)
+        return None
+
+    def _wait_for_completion(self, run_id: int) -> WindowsInstallerWorkflowRunObservation:
+        deadline = self._deadline(self.completion_timeout_seconds)
+        last_seen = self._build_run_observation(self.github_client.workflow_run(run_id))
+
+        while datetime.now(timezone.utc) < deadline:
+            current = self._build_run_observation(self.github_client.workflow_run(run_id))
+            last_seen = current
+            if current.status == "completed":
+                return current
+            self._waiter.wait(self.poll_interval_seconds)
+        return last_seen
+
+    def _find_workflow_job_payload(self, run_id: int) -> dict[str, Any] | None:
+        for job in self.github_client.workflow_jobs(run_id):
+            if str(job.get("name", "")) == self.workflow_job_name:
+                return job
+        return None
+
+    def _build_workflow_job_observation(
+        self,
+        payload: dict[str, Any],
+    ) -> WindowsInstallerWorkflowJobObservation:
+        job_id = int(payload["id"])
+        raw_log_text = self.github_client.workflow_job_logs(job_id)
+        normalized_log_text = self._normalize_log_text(raw_log_text)
+        return WindowsInstallerWorkflowJobObservation(
+            job_id=job_id,
+            name=str(payload.get("name", "")),
+            html_url=str(payload.get("html_url", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            step_conclusions=self._extract_step_conclusions(payload),
+            normalized_log_text=normalized_log_text,
+            log_excerpt=self._log_excerpt(normalized_log_text),
+            raw_log_text=raw_log_text,
+        )
+
+    @staticmethod
+    def _extract_step_conclusions(job_payload: dict[str, Any]) -> dict[str, str]:
+        steps = job_payload.get("steps", [])
+        if not isinstance(steps, list):
+            return {}
+        return {
+            str(step.get("name", "")).strip(): str(step.get("conclusion", "")).strip()
+            for step in steps
+            if isinstance(step, dict) and str(step.get("name", "")).strip()
+        }
+
+    @classmethod
+    def _normalize_log_text(cls, raw_log_text: str) -> str:
+        normalized_lines: list[str] = []
+        for raw_line in raw_log_text.splitlines():
+            line = raw_line.lstrip("\ufeff")
+            parts = line.split("\t", 2)
+            if len(parts) == 3:
+                line = parts[2]
+            line = cls.ANSI_PATTERN.sub("", line)
+            line = cls.TIMESTAMP_PREFIX_PATTERN.sub("", line)
+            normalized_lines.append(line)
+        return "\n".join(normalized_lines)
+
+    @staticmethod
+    def _log_excerpt(normalized_log_text: str, limit: int = 4000) -> str:
+        stripped = normalized_log_text.strip()
+        if len(stripped) <= limit:
+            return stripped
+        return f"...{stripped[-limit:]}"
+
+    @staticmethod
+    def _build_run_observation(payload: dict[str, Any]) -> WindowsInstallerWorkflowRunObservation:
+        return WindowsInstallerWorkflowRunObservation(
+            run_id=int(payload["id"]),
+            html_url=str(payload.get("html_url", "")),
+            event=str(payload.get("event", "")),
+            status=str(payload.get("status", "")),
+            conclusion=str(payload.get("conclusion", "")),
+            head_branch=str(payload.get("head_branch", "")),
+            head_sha=str(payload.get("head_sha", "")),
+            created_at=str(payload.get("created_at", "")),
+            run_number=int(payload.get("run_number", 0)),
+        )
+
+    @staticmethod
+    def _parse_github_datetime(value: str) -> datetime | None:
+        if not value.strip():
+            return None
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+    @staticmethod
+    def _deadline(timeout_seconds: int) -> datetime:
+        return datetime.now(timezone.utc) + timedelta(seconds=timeout_seconds)

--- a/testing/core/interfaces/windows_installer_workflow_audit_service.py
+++ b/testing/core/interfaces/windows_installer_workflow_audit_service.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.windows_installer_workflow_audit import (
+    WindowsInstallerWorkflowAudit,
+    WindowsInstallerWorkflowAuditFailure,
+)
+
+
+class WindowsInstallerWorkflowAuditService(Protocol):
+    def audit(self) -> WindowsInstallerWorkflowAudit:
+        raise NotImplementedError
+
+    def format_failures(
+        self,
+        failures: tuple[WindowsInstallerWorkflowAuditFailure, ...]
+        | list[WindowsInstallerWorkflowAuditFailure],
+    ) -> str:
+        raise NotImplementedError

--- a/testing/core/models/windows_installer_workflow_audit.py
+++ b/testing/core/models/windows_installer_workflow_audit.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class WindowsInstallerWorkflowAuditFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class WindowsInstallerWorkflowRunObservation:
+    run_id: int
+    html_url: str
+    event: str
+    status: str
+    conclusion: str
+    head_branch: str
+    head_sha: str
+    created_at: str
+    run_number: int
+
+
+@dataclass(frozen=True)
+class WindowsInstallerWorkflowJobObservation:
+    job_id: int
+    name: str
+    html_url: str
+    status: str
+    conclusion: str
+    step_conclusions: dict[str, str] = field(default_factory=dict)
+    normalized_log_text: str = ""
+    log_excerpt: str = ""
+    raw_log_text: str = ""
+
+
+@dataclass(frozen=True)
+class WindowsInstallerWorkflowAudit:
+    workflow_run: WindowsInstallerWorkflowRunObservation | None
+    workflow_job: WindowsInstallerWorkflowJobObservation | None
+    failures: tuple[WindowsInstallerWorkflowAuditFailure, ...]

--- a/testing/tests/DMC-1026/README.md
+++ b/testing/tests/DMC-1026/README.md
@@ -1,0 +1,26 @@
+# DMC-1026 automated test
+
+This test dispatches the live `windows-git-bash-installer-check.yml` workflow on
+`main` and verifies the documented Git Bash installer path on a real Windows
+runner. It checks the visible installer output for latest-release resolution,
+ensures the historical GitHub API lookup failure does not appear, and requires
+the post-install wrapper validation step to succeed for a user-observable
+"installation successful" outcome.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1026/test_dmc_1026.py -q
+```
+
+## Environment
+
+GitHub credentials are required. The test dispatches a real workflow run in
+`epam/dm.ai`, waits for completion through the GitHub Actions API, and inspects
+the resulting Windows Git Bash job log.

--- a/testing/tests/DMC-1026/config.yaml
+++ b/testing/tests/DMC-1026/config.yaml
@@ -1,0 +1,14 @@
+test_id: DMC-1026
+type: api
+framework: pytest
+platform: windows-github-actions
+dependencies: []
+owner: epam
+repo: dm.ai
+workflow_ref: main
+workflow_file: windows-git-bash-installer-check.yml
+workflow_name: Windows Git Bash Installer Check
+workflow_job_name: validate-latest-installer
+dispatch_timeout_seconds: 300
+completion_timeout_seconds: 900
+poll_interval_seconds: 10

--- a/testing/tests/DMC-1026/test_dmc_1026.py
+++ b/testing/tests/DMC-1026/test_dmc_1026.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import os
+import re
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
+    create_github_actions_release_client,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+VISIBLE_VERSION_PATTERN = re.compile(r"v\d+\.\d+\.\d+")
+ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
+TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
+
+
+def _config_int(key: str) -> int:
+    return int(str(CONFIG[key]))
+
+
+OWNER = str(CONFIG["owner"])
+REPO = str(CONFIG["repo"])
+WORKFLOW_REF = str(CONFIG["workflow_ref"])
+WORKFLOW_FILE = str(CONFIG["workflow_file"])
+WORKFLOW_NAME = str(CONFIG["workflow_name"])
+WORKFLOW_JOB_NAME = str(CONFIG["workflow_job_name"])
+DISPATCH_TIMEOUT_SECONDS = _config_int("dispatch_timeout_seconds")
+COMPLETION_TIMEOUT_SECONDS = _config_int("completion_timeout_seconds")
+POLL_INTERVAL_SECONDS = _config_int("poll_interval_seconds")
+
+
+def build_github_client() -> GitHubActionsReleaseClient:
+    return create_github_actions_release_client(
+        owner=OWNER,
+        repo=REPO,
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
+    )
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _normalize_log_text(raw_log: str) -> str:
+    normalized_lines: list[str] = []
+    for raw_line in raw_log.splitlines():
+        line = raw_line.lstrip("\ufeff")
+        parts = line.split("\t", 2)
+        if len(parts) == 3:
+            line = parts[2]
+        line = ANSI_PATTERN.sub("", line)
+        line = TIMESTAMP_PREFIX_PATTERN.sub("", line)
+        normalized_lines.append(line)
+    return "\n".join(normalized_lines)
+
+
+def _log_excerpt(text: str, limit: int = 4000) -> str:
+    stripped = text.strip()
+    if len(stripped) <= limit:
+        return stripped
+    return f"...{stripped[-limit:]}"
+
+
+def _format_run(run: dict[str, Any]) -> str:
+    return (
+        f"id={run.get('id')} status={run.get('status')} conclusion={run.get('conclusion')} "
+        f"url={run.get('html_url')}"
+    )
+
+
+def _wait_for_dispatched_run(
+    client: GitHubActionsReleaseClient,
+    *,
+    existing_run_ids: set[int],
+    target_head_sha: str,
+    dispatch_started_at: datetime,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + DISPATCH_TIMEOUT_SECONDS
+    earliest_created_at = dispatch_started_at - timedelta(seconds=POLL_INTERVAL_SECONDS)
+    last_seen_runs: list[dict[str, Any]] = []
+
+    while time.monotonic() < deadline:
+        last_seen_runs = client.workflow_runs_for_workflow(
+            WORKFLOW_FILE,
+            branch=WORKFLOW_REF,
+            event="workflow_dispatch",
+            per_page=20,
+        )
+        matching_runs = [
+            run
+            for run in last_seen_runs
+            if int(run.get("id", 0)) not in existing_run_ids
+            and str(run.get("head_sha", "")) == target_head_sha
+            and _parse_timestamp(str(run.get("created_at", ""))) >= earliest_created_at
+        ]
+        if matching_runs:
+            return max(matching_runs, key=lambda run: int(run["id"]))
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    observed_runs = "\n".join(_format_run(run) for run in last_seen_runs) or "No runs returned."
+    raise AssertionError(
+        f"The {WORKFLOW_NAME!r} workflow did not appear after dispatch on {WORKFLOW_REF!r} within "
+        f"{DISPATCH_TIMEOUT_SECONDS} seconds.\nObserved runs:\n{observed_runs}"
+    )
+
+
+def _wait_for_completion(
+    client: GitHubActionsReleaseClient,
+    *,
+    run_id: int,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + COMPLETION_TIMEOUT_SECONDS
+    last_seen_run = client.workflow_run(run_id)
+
+    while time.monotonic() < deadline:
+        last_seen_run = client.workflow_run(run_id)
+        if str(last_seen_run.get("status")) == "completed":
+            return last_seen_run
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    raise AssertionError(
+        f"Workflow run {run_id} did not complete within {COMPLETION_TIMEOUT_SECONDS} seconds.\n"
+        f"Last observed run: {_format_run(last_seen_run)}"
+    )
+
+
+def _find_job(
+    client: GitHubActionsReleaseClient,
+    *,
+    run_id: int,
+) -> dict[str, Any]:
+    jobs = client.workflow_jobs(run_id)
+    for job in jobs:
+        if str(job.get("name")) == WORKFLOW_JOB_NAME:
+            return job
+
+    observed_jobs = ", ".join(str(job.get("name")) for job in jobs) or "No jobs returned."
+    raise AssertionError(
+        f"Workflow run {run_id} did not expose the expected job {WORKFLOW_JOB_NAME!r}.\n"
+        f"Observed jobs: {observed_jobs}"
+    )
+
+
+def _step_conclusions(job: dict[str, Any]) -> dict[str, str]:
+    step_conclusions: dict[str, str] = {}
+    for step in job.get("steps") or []:
+        step_name = str(step.get("name", "")).strip()
+        if step_name:
+            step_conclusions[step_name] = str(step.get("conclusion", "")).strip()
+    return step_conclusions
+
+
+def _assert_visible_installer_behavior(normalized_log: str) -> None:
+    assert (
+        "curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash"
+        in normalized_log
+    ), (
+        "The Windows workflow must exercise the documented Git Bash installer command.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert (
+        "shell: C:\\Program Files\\Git\\bin\\bash.EXE" in normalized_log
+    ), (
+        "The installer run must execute under Git Bash on a Windows runner.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert "Fetching latest CLI release information..." in normalized_log, (
+        "A user should see the latest-release lookup stage in the Git Bash installer output.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+
+    found_release_match = re.search(
+        r"Found latest CLI release:\s*(?P<version>v\d+\.\d+\.\d+)",
+        normalized_log,
+    )
+    latest_version_match = re.search(
+        r"Latest version:\s*(?P<version>v\d+\.\d+\.\d+)",
+        normalized_log,
+    )
+    assert found_release_match is not None, (
+        "The installer output should show the resolved stable CLI release tag.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert latest_version_match is not None, (
+        "The installer output should print the selected latest version after lookup.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert found_release_match.group("version") == latest_version_match.group("version"), (
+        "The visible release resolution and selected latest version must match.\n"
+        f"Resolved: {found_release_match.group('version')}\n"
+        f"Selected: {latest_version_match.group('version')}\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert VISIBLE_VERSION_PATTERN.fullmatch(found_release_match.group("version")), (
+        "The resolved version must remain on a stable vX.Y.Z tag.\n"
+        f"Resolved version: {found_release_match.group('version')}"
+    )
+
+    forbidden_fragments = (
+        "GitHub API failed (exit code: 22)",
+        "Failed to find latest CLI release from GitHub API.",
+        "Warning: Installation completed but dmtools command test failed.",
+        "Error: DMTools JAR file not found. Please install DMTools first:",
+    )
+    for forbidden_fragment in forbidden_fragments:
+        assert forbidden_fragment not in normalized_log, (
+            "The Windows Git Bash install path must finish without the historical release-lookup "
+            f"failure or a broken wrapper validation message {forbidden_fragment!r}.\n"
+            f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+        )
+
+    assert "DMTools CLI installation completed!" in normalized_log, (
+        "The installer output should end with the success completion message.\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+
+
+def test_dmc_1026_windows_git_bash_latest_installer_path_resolves_and_installs_successfully() -> None:
+    client = build_github_client()
+
+    dispatch_started_at = datetime.now(timezone.utc)
+    target_head_sha = client.branch_head_sha(WORKFLOW_REF)
+    existing_run_ids = {
+        int(run["id"])
+        for run in client.workflow_runs_for_workflow(
+            WORKFLOW_FILE,
+            branch=WORKFLOW_REF,
+            per_page=20,
+        )
+        if run.get("id") is not None
+    }
+
+    client.dispatch_workflow(WORKFLOW_FILE, ref=WORKFLOW_REF)
+    workflow_run = _wait_for_dispatched_run(
+        client,
+        existing_run_ids=existing_run_ids,
+        target_head_sha=target_head_sha,
+        dispatch_started_at=dispatch_started_at,
+    )
+    completed_run = _wait_for_completion(client, run_id=int(workflow_run["id"]))
+    job = _find_job(client, run_id=int(completed_run["id"]))
+    normalized_log = _normalize_log_text(client.workflow_job_logs(int(job["id"])))
+    step_conclusions = _step_conclusions(job)
+
+    assert str(completed_run.get("conclusion")) == "success", (
+        f"The live {WORKFLOW_NAME!r} workflow should complete successfully after dispatch.\n"
+        f"Observed run: {_format_run(completed_run)}\n"
+        f"Observed job conclusion: {job.get('conclusion')}\n"
+        f"Step conclusions: {step_conclusions}\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert str(job.get("conclusion")) == "success", (
+        f"The workflow job {WORKFLOW_JOB_NAME!r} should complete successfully.\n"
+        f"Observed job id={job.get('id')} conclusion={job.get('conclusion')} url={job.get('html_url')}\n"
+        f"Step conclusions: {step_conclusions}\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert step_conclusions.get("Install DMTools CLI from latest release") == "success", (
+        "The installer step itself should succeed on Windows Git Bash.\n"
+        f"Step conclusions: {step_conclusions}\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+    assert step_conclusions.get("Validate installed wrapper and metadata") == "success", (
+        "The installed wrapper and metadata validation must succeed so the user can actually use "
+        "the installed CLI after the documented Git Bash flow.\n"
+        f"Step conclusions: {step_conclusions}\n"
+        f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
+    )
+
+    _assert_visible_installer_behavior(normalized_log)

--- a/testing/tests/DMC-1026/test_dmc_1026.py
+++ b/testing/tests/DMC-1026/test_dmc_1026.py
@@ -3,21 +3,18 @@ from __future__ import annotations
 import os
 import re
 import sys
-import time
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
-from testing.components.factories.github_actions_release_client_factory import (  # noqa: E402
-    create_github_actions_release_client,
+from testing.components.factories.windows_installer_workflow_audit_service_factory import (  # noqa: E402
+    create_windows_installer_workflow_audit_service,
 )
-from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
-    GitHubActionsReleaseClient,
+from testing.core.interfaces.windows_installer_workflow_audit_service import (  # noqa: E402
+    WindowsInstallerWorkflowAuditService,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
 
@@ -25,8 +22,6 @@ from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
 VISIBLE_VERSION_PATTERN = re.compile(r"v\d+\.\d+\.\d+")
-ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
-TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
 
 
 def _config_int(key: str) -> int:
@@ -44,31 +39,6 @@ COMPLETION_TIMEOUT_SECONDS = _config_int("completion_timeout_seconds")
 POLL_INTERVAL_SECONDS = _config_int("poll_interval_seconds")
 
 
-def build_github_client() -> GitHubActionsReleaseClient:
-    return create_github_actions_release_client(
-        owner=OWNER,
-        repo=REPO,
-        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
-    )
-
-
-def _parse_timestamp(value: str) -> datetime:
-    return datetime.fromisoformat(value.replace("Z", "+00:00"))
-
-
-def _normalize_log_text(raw_log: str) -> str:
-    normalized_lines: list[str] = []
-    for raw_line in raw_log.splitlines():
-        line = raw_line.lstrip("\ufeff")
-        parts = line.split("\t", 2)
-        if len(parts) == 3:
-            line = parts[2]
-        line = ANSI_PATTERN.sub("", line)
-        line = TIMESTAMP_PREFIX_PATTERN.sub("", line)
-        normalized_lines.append(line)
-    return "\n".join(normalized_lines)
-
-
 def _log_excerpt(text: str, limit: int = 4000) -> str:
     stripped = text.strip()
     if len(stripped) <= limit:
@@ -76,93 +46,19 @@ def _log_excerpt(text: str, limit: int = 4000) -> str:
     return f"...{stripped[-limit:]}"
 
 
-def _format_run(run: dict[str, Any]) -> str:
-    return (
-        f"id={run.get('id')} status={run.get('status')} conclusion={run.get('conclusion')} "
-        f"url={run.get('html_url')}"
+def build_workflow_audit_service() -> WindowsInstallerWorkflowAuditService:
+    return create_windows_installer_workflow_audit_service(
+        owner=OWNER,
+        repo=REPO,
+        workflow_file=WORKFLOW_FILE,
+        workflow_ref=WORKFLOW_REF,
+        workflow_name=WORKFLOW_NAME,
+        workflow_job_name=WORKFLOW_JOB_NAME,
+        dispatch_timeout_seconds=DISPATCH_TIMEOUT_SECONDS,
+        completion_timeout_seconds=COMPLETION_TIMEOUT_SECONDS,
+        poll_interval_seconds=POLL_INTERVAL_SECONDS,
+        token=os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN"),
     )
-
-
-def _wait_for_dispatched_run(
-    client: GitHubActionsReleaseClient,
-    *,
-    existing_run_ids: set[int],
-    target_head_sha: str,
-    dispatch_started_at: datetime,
-) -> dict[str, Any]:
-    deadline = time.monotonic() + DISPATCH_TIMEOUT_SECONDS
-    earliest_created_at = dispatch_started_at - timedelta(seconds=POLL_INTERVAL_SECONDS)
-    last_seen_runs: list[dict[str, Any]] = []
-
-    while time.monotonic() < deadline:
-        last_seen_runs = client.workflow_runs_for_workflow(
-            WORKFLOW_FILE,
-            branch=WORKFLOW_REF,
-            event="workflow_dispatch",
-            per_page=20,
-        )
-        matching_runs = [
-            run
-            for run in last_seen_runs
-            if int(run.get("id", 0)) not in existing_run_ids
-            and str(run.get("head_sha", "")) == target_head_sha
-            and _parse_timestamp(str(run.get("created_at", ""))) >= earliest_created_at
-        ]
-        if matching_runs:
-            return max(matching_runs, key=lambda run: int(run["id"]))
-        time.sleep(POLL_INTERVAL_SECONDS)
-
-    observed_runs = "\n".join(_format_run(run) for run in last_seen_runs) or "No runs returned."
-    raise AssertionError(
-        f"The {WORKFLOW_NAME!r} workflow did not appear after dispatch on {WORKFLOW_REF!r} within "
-        f"{DISPATCH_TIMEOUT_SECONDS} seconds.\nObserved runs:\n{observed_runs}"
-    )
-
-
-def _wait_for_completion(
-    client: GitHubActionsReleaseClient,
-    *,
-    run_id: int,
-) -> dict[str, Any]:
-    deadline = time.monotonic() + COMPLETION_TIMEOUT_SECONDS
-    last_seen_run = client.workflow_run(run_id)
-
-    while time.monotonic() < deadline:
-        last_seen_run = client.workflow_run(run_id)
-        if str(last_seen_run.get("status")) == "completed":
-            return last_seen_run
-        time.sleep(POLL_INTERVAL_SECONDS)
-
-    raise AssertionError(
-        f"Workflow run {run_id} did not complete within {COMPLETION_TIMEOUT_SECONDS} seconds.\n"
-        f"Last observed run: {_format_run(last_seen_run)}"
-    )
-
-
-def _find_job(
-    client: GitHubActionsReleaseClient,
-    *,
-    run_id: int,
-) -> dict[str, Any]:
-    jobs = client.workflow_jobs(run_id)
-    for job in jobs:
-        if str(job.get("name")) == WORKFLOW_JOB_NAME:
-            return job
-
-    observed_jobs = ", ".join(str(job.get("name")) for job in jobs) or "No jobs returned."
-    raise AssertionError(
-        f"Workflow run {run_id} did not expose the expected job {WORKFLOW_JOB_NAME!r}.\n"
-        f"Observed jobs: {observed_jobs}"
-    )
-
-
-def _step_conclusions(job: dict[str, Any]) -> dict[str, str]:
-    step_conclusions: dict[str, str] = {}
-    for step in job.get("steps") or []:
-        step_name = str(step.get("name", "")).strip()
-        if step_name:
-            step_conclusions[step_name] = str(step.get("conclusion", "")).strip()
-    return step_conclusions
 
 
 def _assert_visible_installer_behavior(normalized_log: str) -> None:
@@ -231,42 +127,30 @@ def _assert_visible_installer_behavior(normalized_log: str) -> None:
 
 
 def test_dmc_1026_windows_git_bash_latest_installer_path_resolves_and_installs_successfully() -> None:
-    client = build_github_client()
+    service = build_workflow_audit_service()
+    audit = service.audit()
 
-    dispatch_started_at = datetime.now(timezone.utc)
-    target_head_sha = client.branch_head_sha(WORKFLOW_REF)
-    existing_run_ids = {
-        int(run["id"])
-        for run in client.workflow_runs_for_workflow(
-            WORKFLOW_FILE,
-            branch=WORKFLOW_REF,
-            per_page=20,
-        )
-        if run.get("id") is not None
-    }
+    if audit.failures:
+        raise AssertionError(service.format_failures(audit.failures))
 
-    client.dispatch_workflow(WORKFLOW_FILE, ref=WORKFLOW_REF)
-    workflow_run = _wait_for_dispatched_run(
-        client,
-        existing_run_ids=existing_run_ids,
-        target_head_sha=target_head_sha,
-        dispatch_started_at=dispatch_started_at,
-    )
-    completed_run = _wait_for_completion(client, run_id=int(workflow_run["id"]))
-    job = _find_job(client, run_id=int(completed_run["id"]))
-    normalized_log = _normalize_log_text(client.workflow_job_logs(int(job["id"])))
-    step_conclusions = _step_conclusions(job)
+    assert audit.workflow_run is not None, "Expected a workflow run observation."
+    assert audit.workflow_job is not None, "Expected a workflow job observation."
 
-    assert str(completed_run.get("conclusion")) == "success", (
+    normalized_log = audit.workflow_job.normalized_log_text
+    step_conclusions = audit.workflow_job.step_conclusions
+
+    assert audit.workflow_run.conclusion == "success", (
         f"The live {WORKFLOW_NAME!r} workflow should complete successfully after dispatch.\n"
-        f"Observed run: {_format_run(completed_run)}\n"
-        f"Observed job conclusion: {job.get('conclusion')}\n"
+        f"Observed run: id={audit.workflow_run.run_id} status={audit.workflow_run.status} "
+        f"conclusion={audit.workflow_run.conclusion} url={audit.workflow_run.html_url}\n"
+        f"Observed job conclusion: {audit.workflow_job.conclusion}\n"
         f"Step conclusions: {step_conclusions}\n"
         f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
     )
-    assert str(job.get("conclusion")) == "success", (
+    assert audit.workflow_job.conclusion == "success", (
         f"The workflow job {WORKFLOW_JOB_NAME!r} should complete successfully.\n"
-        f"Observed job id={job.get('id')} conclusion={job.get('conclusion')} url={job.get('html_url')}\n"
+        f"Observed job id={audit.workflow_job.job_id} conclusion={audit.workflow_job.conclusion} "
+        f"url={audit.workflow_job.html_url}\n"
         f"Step conclusions: {step_conclusions}\n"
         f"Visible log excerpt:\n{_log_excerpt(normalized_log)}"
     )

--- a/testing/tests/DMC-1026/test_dmc_1026_service.py
+++ b/testing/tests/DMC-1026/test_dmc_1026_service.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.windows_installer_workflow_audit_service import (  # noqa: E402
+    WindowsInstallerWorkflowAuditService,
+)
+from testing.core.interfaces.github_actions_release_client import (  # noqa: E402
+    GitHubActionsReleaseClient,
+)
+
+
+class FakeGitHubActionsReleaseClient(GitHubActionsReleaseClient):
+    def __init__(self) -> None:
+        self.dispatch_calls: list[tuple[str, str, dict[str, object]]] = []
+        self.head_sha = "abcdef1234567890"
+        self.runs_by_workflow: list[dict[str, Any]] = []
+        self.workflow_runs_responses: list[list[dict[str, Any]]] = []
+        self.run_responses_by_id: dict[int, list[dict[str, Any]]] = {}
+        self.jobs_by_run_id: dict[int, list[dict[str, Any]]] = {}
+        self.logs_by_job_id: dict[int, str] = {}
+
+    def dispatch_workflow(
+        self,
+        workflow_id: str,
+        *,
+        ref: str,
+        inputs: dict[str, object] | None = None,
+    ) -> None:
+        self.dispatch_calls.append((workflow_id, ref, dict(inputs or {})))
+
+    def branch_head_sha(self, branch: str) -> str:
+        del branch
+        return self.head_sha
+
+    def workflow_runs_for_workflow(
+        self,
+        workflow_id: str,
+        *,
+        branch: str | None = None,
+        event: str | None = None,
+        per_page: int = 20,
+    ) -> list[dict[str, Any]]:
+        del workflow_id, branch, event, per_page
+        if self.workflow_runs_responses:
+            return list(self.workflow_runs_responses.pop(0))
+        return list(self.runs_by_workflow)
+
+    def workflow_run(self, run_id: int) -> dict[str, Any]:
+        responses = self.run_responses_by_id.get(run_id)
+        if not responses:
+            raise AssertionError(f"No workflow_run response configured for run_id={run_id}.")
+        if len(responses) > 1:
+            return dict(responses.pop(0))
+        return dict(responses[0])
+
+    def list_releases(self, per_page: int = 20) -> list[dict[str, Any]]:
+        del per_page
+        return []
+
+    def release_by_tag(self, tag: str) -> dict[str, Any]:
+        raise AssertionError(f"Unexpected release_by_tag call for {tag!r}.")
+
+    def list_recent_pull_requests(self, limit: int = 20) -> list[dict[str, Any]]:
+        del limit
+        return []
+
+    def pull_request_files(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_reviews(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request_issue_comments(self, number: int) -> list[dict[str, Any]]:
+        del number
+        return []
+
+    def pull_request(self, number: int) -> dict[str, Any]:
+        del number
+        return {}
+
+    def workflow_runs_for_head_sha(self, head_sha: str) -> list[dict[str, Any]]:
+        del head_sha
+        return []
+
+    def workflow_jobs(self, run_id: int) -> list[dict[str, Any]]:
+        return list(self.jobs_by_run_id.get(run_id, []))
+
+    def workflow_job_logs(self, job_id: int) -> str:
+        return self.logs_by_job_id[job_id]
+
+
+def _build_service(
+    client: GitHubActionsReleaseClient,
+) -> WindowsInstallerWorkflowAuditService:
+    return WindowsInstallerWorkflowAuditService(
+        github_client=client,
+        workflow_file="windows-git-bash-installer-check.yml",
+        workflow_ref="main",
+        workflow_name="Windows Git Bash Installer Check",
+        workflow_job_name="validate-latest-installer",
+        dispatch_timeout_seconds=1,
+        completion_timeout_seconds=1,
+        poll_interval_seconds=1,
+    )
+
+
+def test_service_dispatches_workflow_waits_for_completion_and_normalizes_logs() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    workflow_run = {
+        "id": 42,
+        "html_url": "https://example.test/runs/42",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-15T13:00:05Z",
+        "run_number": 42,
+    }
+    client.workflow_runs_responses = [
+        [],
+        [workflow_run],
+    ]
+    client.run_responses_by_id[42] = [workflow_run]
+    client.jobs_by_run_id[42] = [
+        {
+            "id": 501,
+            "name": "validate-latest-installer",
+            "html_url": "https://example.test/jobs/501",
+            "status": "completed",
+            "conclusion": "success",
+            "steps": [
+                {"name": "Install DMTools CLI from latest release", "conclusion": "success"},
+                {"name": "Validate installed wrapper and metadata", "conclusion": "success"},
+            ],
+        }
+    ]
+    client.logs_by_job_id[501] = (
+        "\ufeff2026-05-15T13:00:10Z\tvalidate\t"
+        "\x1b[32mFound latest CLI release: v1.7.184\x1b[0m\n"
+        "2026-05-15T13:00:11Z\tvalidate\tDMTools CLI installation completed!"
+    )
+
+    audit = _build_service(client).audit()
+
+    assert client.dispatch_calls == [("windows-git-bash-installer-check.yml", "main", {})]
+    assert audit.failures == ()
+    assert audit.workflow_run is not None
+    assert audit.workflow_run.run_id == 42
+    assert audit.workflow_job is not None
+    assert audit.workflow_job.step_conclusions == {
+        "Install DMTools CLI from latest release": "success",
+        "Validate installed wrapper and metadata": "success",
+    }
+    assert "Found latest CLI release: v1.7.184" in audit.workflow_job.normalized_log_text
+    assert "\x1b[32m" not in audit.workflow_job.normalized_log_text
+    assert "2026-05-15T13:00:10Z" not in audit.workflow_job.normalized_log_text
+
+
+def test_service_reports_failed_job_with_step_conclusions_and_excerpt() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    discovered_run = {
+        "id": 43,
+        "html_url": "https://example.test/runs/43",
+        "event": "workflow_dispatch",
+        "status": "in_progress",
+        "conclusion": "",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-15T13:01:00Z",
+        "run_number": 43,
+    }
+    completed_run = dict(discovered_run)
+    completed_run["status"] = "completed"
+    completed_run["conclusion"] = "failure"
+    client.workflow_runs_responses = [
+        [],
+        [discovered_run],
+    ]
+    client.run_responses_by_id[43] = [completed_run]
+    client.jobs_by_run_id[43] = [
+        {
+            "id": 502,
+            "name": "validate-latest-installer",
+            "html_url": "https://example.test/jobs/502",
+            "status": "completed",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Install DMTools CLI from latest release", "conclusion": "success"},
+                {"name": "Validate installed wrapper and metadata", "conclusion": "failure"},
+            ],
+        }
+    ]
+    client.logs_by_job_id[502] = (
+        "2026-05-15T13:01:05Z\tvalidate\tError: DMTools JAR file not found. Please install DMTools first:"
+    )
+
+    audit = _build_service(client).audit()
+
+    assert len(audit.failures) == 1
+    failure = audit.failures[0]
+    assert failure.step == 2
+    assert "conclusion='failure'" in failure.actual
+    assert "Error: DMTools JAR file not found" in failure.actual
+    assert audit.workflow_job is not None
+    assert audit.workflow_job.conclusion == "failure"


### PR DESCRIPTION
# Test Result: FAILED

The new live regression test for **DMC-1026** reproduces a real Windows Git Bash failure in the deployed installer flow.

## What automation checked

- Added `testing/tests/DMC-1026/test_dmc_1026.py`.
- Ran `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1025/test_dmc_1025.py testing/tests/DMC-1026/test_dmc_1026.py -q`.
- Confirmed the documented command `curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash` runs on a real Windows runner under Git Bash (`C:\Program Files\Git\bin\bash.EXE`).
- Verified the installer reaches `Fetching latest CLI release information...`, resolves `v1.7.184`, and does **not** show `GitHub API failed (exit code: 22)`.
- Required the post-install wrapper validation to succeed as part of a real successful installation outcome.

## Real user / human-style verification

- **Open Git Bash** — passed; the workflow ran in Git Bash on Windows Server 2025.
- **Run the documented installer command** — partially passed; the installer banner, Java detection, latest release lookup, and completion banner were visible.
- **Observe latest-release resolution** — passed; `Found latest CLI release: v1.7.184` appeared and the old API lookup error did not.
- **Use the installed CLI after install** — failed; the validation step ran `"$DMTOOLS_BIN_DIR/dmtools" --help >/dev/null` and the wrapper exited with:

```text
Error: DMTools JAR file not found. Please install DMTools first:
  curl -fsSL https://github.com/epam/dm.ai/releases/latest/download/install.sh | bash

Or if you're developing locally, build the project first:
  ./gradlew build

Note: Java 17+ is required for DMTools to run.
```

## Observed vs expected

- **Expected:** the latest CLI release resolves on Windows Git Bash and the installation completes successfully with a usable installed wrapper.
- **Actual:** latest-release resolution now works, but the installed wrapper cannot find the DMTools JAR during immediate post-install validation, so the workflow fails.

## Evidence

- Workflow run: https://github.com/epam/dm.ai/actions/runs/25917723416
- Failing job: https://github.com/epam/dm.ai/actions/runs/25917723416/job/76178451829

## Test runner failure

```text
E       AssertionError: The live 'Windows Git Bash Installer Check' workflow should complete successfully after dispatch.
E         Observed run: id=25917723416 status=completed conclusion=failure url=https://github.com/epam/dm.ai/actions/runs/25917723416
E         Observed job conclusion: failure
E         Step conclusions: {'Set up job': 'success', 'Set up Java 17': 'success', 'Install DMTools CLI from latest release': 'success', 'Validate installed wrapper and metadata': 'failure', 'Post Set up Java 17': 'success', 'Complete job': 'success'}
E         assert 'failure' == 'success'
E
E         - success
E         + failure
```
