### PR TITLE
DMC-1030 Test: GitHub API rate limit hit with X-RateLimit-Reset header — ReportGenerator waits and successfully retries

### DIFF
--- a/testing/components/factories/report_generator_rate_limit_service_factory.py
+++ b/testing/components/factories/report_generator_rate_limit_service_factory.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from testing.components.services.report_generator_rate_limit_service import (
+    ReportGeneratorRateLimitService as ReportGeneratorRateLimitServiceImpl,
+)
+from testing.core.interfaces.report_generator_rate_limit_service import (
     ReportGeneratorRateLimitService,
 )
 from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
@@ -11,10 +14,10 @@ from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProc
 def create_report_generator_rate_limit_service(
     repository_root: Path,
     *,
-    test_class: str = ReportGeneratorRateLimitService.DEFAULT_TEST_CLASS,
-    test_methods: tuple[str, ...] = ReportGeneratorRateLimitService.DEFAULT_TEST_METHODS,
+    test_class: str = ReportGeneratorRateLimitServiceImpl.DEFAULT_TEST_CLASS,
+    test_methods: tuple[str, ...] = ReportGeneratorRateLimitServiceImpl.DEFAULT_TEST_METHODS,
 ) -> ReportGeneratorRateLimitService:
-    return ReportGeneratorRateLimitService(
+    return ReportGeneratorRateLimitServiceImpl(
         repository_root=repository_root,
         runner=SubprocessProcessRunner(),
         test_class=test_class,

--- a/testing/components/factories/report_generator_rate_limit_service_factory.py
+++ b/testing/components/factories/report_generator_rate_limit_service_factory.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.report_generator_rate_limit_service import (
+    ReportGeneratorRateLimitService,
+)
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_report_generator_rate_limit_service(
+    repository_root: Path,
+    *,
+    test_class: str = ReportGeneratorRateLimitService.DEFAULT_TEST_CLASS,
+    test_methods: tuple[str, ...] = ReportGeneratorRateLimitService.DEFAULT_TEST_METHODS,
+) -> ReportGeneratorRateLimitService:
+    return ReportGeneratorRateLimitService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+        test_class=test_class,
+        test_methods=test_methods,
+    )

--- a/testing/components/services/report_generator_rate_limit_service.py
+++ b/testing/components/services/report_generator_rate_limit_service.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import shutil
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.report_generator_rate_limit_audit import (
+    ReportGeneratorRateLimitAudit,
+    ReportGeneratorRateLimitCheck,
+    ReportGeneratorRateLimitFailure,
+)
+
+
+class ReportGeneratorRateLimitService:
+    DEFAULT_TEST_CLASS = "com.github.istin.dmtools.reporting.ReportGeneratorTest"
+    DEFAULT_TEST_METHODS = (
+        "testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric",
+        "testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap",
+    )
+
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+        *,
+        test_class: str = DEFAULT_TEST_CLASS,
+        test_methods: tuple[str, ...] = DEFAULT_TEST_METHODS,
+    ) -> None:
+        self.repository_root = repository_root
+        self.runner = runner
+        self.test_class = test_class
+        self.test_methods = test_methods
+        self.junit_report_path = (
+            repository_root / "dmtools-core" / "build" / "test-results" / "test" / f"TEST-{test_class}.xml"
+        )
+        self.gradle_command = self._build_gradle_command()
+
+    def audit(self) -> ReportGeneratorRateLimitAudit:
+        test_results_path = self.junit_report_path.parent
+        test_report_directory = self.repository_root / "dmtools-core" / "build" / "reports" / "tests" / "test"
+        if test_results_path.exists():
+            shutil.rmtree(test_results_path)
+        if test_report_directory.exists():
+            shutil.rmtree(test_report_directory)
+        execution = self.runner.run(self.gradle_command, cwd=self.repository_root)
+        observed_checks = self._load_junit_checks()
+        failures: list[ReportGeneratorRateLimitFailure] = []
+        command_display = " ".join(self.gradle_command)
+        combined_output = execution.combined_output
+
+        if execution.returncode != 0:
+            failures.append(
+                ReportGeneratorRateLimitFailure(
+                    step=1,
+                    summary="The maintainer-visible ReportGenerator regression command failed.",
+                    expected=(
+                        f"`{command_display}` should exit 0 so the live implementation can prove the "
+                        "rate-limit recovery flow still passes."
+                    ),
+                    actual=(
+                        f"`{command_display}` exited {execution.returncode}.\n"
+                        f"{combined_output or '<no Gradle output>'}"
+                    ),
+                )
+            )
+        elif "BUILD SUCCESSFUL" not in combined_output:
+            failures.append(
+                ReportGeneratorRateLimitFailure(
+                    step=1,
+                    summary="The Gradle output did not visibly confirm a successful maintainer flow.",
+                    expected=(
+                        f"`{command_display}` should show `BUILD SUCCESSFUL` after the targeted "
+                        "ReportGenerator regression checks complete."
+                    ),
+                    actual=combined_output or "<no Gradle output>",
+                )
+            )
+
+        if not self.junit_report_path.exists():
+            failures.append(
+                ReportGeneratorRateLimitFailure(
+                    step=2,
+                    summary="The JUnit report for the targeted ReportGenerator regression was not produced.",
+                    expected=(
+                        "Gradle should write the ReportGenerator test report so the ticket automation can "
+                        "confirm which retry checks passed."
+                    ),
+                    actual=(
+                        f"`{self.junit_report_path.relative_to(self.repository_root).as_posix()}` "
+                        "does not exist."
+                    ),
+                )
+            )
+        else:
+            observed_by_name = {check.name: check for check in observed_checks}
+            for method_name in self.test_methods:
+                observed = observed_by_name.get(method_name)
+                if observed is None:
+                    failures.append(
+                        ReportGeneratorRateLimitFailure(
+                            step=3,
+                            summary="A required ReportGenerator regression check was not executed.",
+                            expected=(
+                                "The targeted Gradle run should report the exact JUnit method that "
+                                "proves the ticket scenario."
+                            ),
+                            actual=f"Missing JUnit testcase `{self.test_class}.{method_name}`.",
+                        )
+                    )
+                    continue
+                if observed.status != "passed":
+                    failures.append(
+                        ReportGeneratorRateLimitFailure(
+                            step=3,
+                            summary="A required ReportGenerator regression check did not pass.",
+                            expected=(
+                                f"`{self.test_class}.{method_name}` should pass to confirm the "
+                                "rate-limit retry behavior is still correct."
+                            ),
+                            actual=observed.describe(),
+                        )
+                    )
+
+        return ReportGeneratorRateLimitAudit(
+            gradle_command=self.gradle_command,
+            execution=execution,
+            junit_report_path=self.junit_report_path,
+            observed_checks=observed_checks,
+            failures=tuple(failures),
+        )
+
+    def human_observations(self, audit: ReportGeneratorRateLimitAudit) -> list[str]:
+        observations: list[str] = []
+        build_outcome = (
+            "BUILD SUCCESSFUL"
+            if "BUILD SUCCESSFUL" in audit.execution.combined_output
+            else "BUILD FAILED"
+        )
+        observations.append(
+            "Maintainer flow: running "
+            f"`{' '.join(audit.gradle_command)}` exited {audit.execution.returncode} and showed "
+            f"`{build_outcome}`."
+        )
+
+        checks = {check.name: check for check in audit.observed_checks}
+        retry_check = checks.get(
+            "testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric"
+        )
+        if retry_check is not None:
+            observations.append(
+                "Observable report outcome: "
+                f"`{retry_check.name}` was `{retry_check.status}`, confirming the "
+                "pull-request data source recovered the interrupted GitHub metric and the same "
+                "report run still completed with both pull-request metrics populated."
+            )
+
+        delay_check = checks.get(
+            "testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap"
+        )
+        if delay_check is not None:
+            observations.append(
+                "Observable wait outcome: "
+                f"`{delay_check.name}` was `{delay_check.status}`, confirming the live "
+                "implementation honored `X-RateLimit-Reset` instead of falling back to the default "
+                "60-second cap."
+            )
+
+        if audit.junit_report_path.exists():
+            observations.append(
+                "JUnit evidence: "
+                f"`{audit.junit_report_path.relative_to(self.repository_root).as_posix()}` was "
+                "produced for the executed regression run."
+            )
+        return observations
+
+    def format_failures(self, audit: ReportGeneratorRateLimitAudit) -> str:
+        if not audit.failures:
+            return (
+                "DMC-1030 expects ReportGenerator to honor `X-RateLimit-Reset`, wait before "
+                "retrying the interrupted GitHub pull-request collection, and finish the same "
+                "report run successfully."
+            )
+
+        lines = [
+            "DMC-1030 ReportGenerator rate-limit regression failed.",
+            "",
+            *[failure.format() for failure in audit.failures],
+            "",
+            "Gradle stdout:",
+            audit.execution.stdout.rstrip() or "<empty>",
+            "",
+            "Gradle stderr:",
+            audit.execution.stderr.rstrip() or "<empty>",
+        ]
+        if audit.observed_checks:
+            lines.extend(
+                [
+                    "",
+                    "Observed JUnit checks:",
+                    *[f"- {check.describe()}" for check in audit.observed_checks],
+                ]
+            )
+        return "\n".join(lines)
+
+    def _build_gradle_command(self) -> tuple[str, ...]:
+        command = ["./gradlew", "--no-daemon", ":dmtools-core:test"]
+        for method_name in self.test_methods:
+            command.extend(["--tests", f"{self.test_class}.{method_name}"])
+        return tuple(command)
+
+    def _load_junit_checks(self) -> tuple[ReportGeneratorRateLimitCheck, ...]:
+        if not self.junit_report_path.exists():
+            return ()
+
+        root = ET.fromstring(self.junit_report_path.read_text(encoding="utf-8"))
+        checks: list[ReportGeneratorRateLimitCheck] = []
+        for testcase in root.findall("testcase"):
+            status = "passed"
+            failure_message = ""
+            if testcase.find("failure") is not None:
+                status = "failed"
+                failure = testcase.find("failure")
+                failure_message = (
+                    (failure.text or "").strip()
+                    if failure is not None
+                    else ""
+                )
+            elif testcase.find("error") is not None:
+                status = "error"
+                error = testcase.find("error")
+                failure_message = (
+                    (error.text or "").strip()
+                    if error is not None
+                    else ""
+                )
+
+            checks.append(
+                ReportGeneratorRateLimitCheck(
+                    name=str(testcase.attrib.get("name", "")).removesuffix("()"),
+                    classname=str(testcase.attrib.get("classname", "")),
+                    time_seconds=float(testcase.attrib.get("time", "0") or 0.0),
+                    status=status,
+                    failure_message=failure_message,
+                )
+            )
+        return tuple(checks)

--- a/testing/components/services/report_generator_rate_limit_service.py
+++ b/testing/components/services/report_generator_rate_limit_service.py
@@ -44,7 +44,7 @@ class ReportGeneratorRateLimitService:
         if test_report_directory.exists():
             shutil.rmtree(test_report_directory)
         execution = self.runner.run(self.gradle_command, cwd=self.repository_root)
-        observed_checks = self._load_junit_checks()
+        observed_checks, system_out, system_err = self._load_junit_report()
         failures: list[ReportGeneratorRateLimitFailure] = []
         command_display = " ".join(self.gradle_command)
         combined_output = execution.combined_output
@@ -127,6 +127,8 @@ class ReportGeneratorRateLimitService:
             execution=execution,
             junit_report_path=self.junit_report_path,
             observed_checks=observed_checks,
+            system_out=system_out,
+            system_err=system_err,
             failures=tuple(failures),
         )
 
@@ -143,27 +145,33 @@ class ReportGeneratorRateLimitService:
             f"`{build_outcome}`."
         )
 
-        checks = {check.name: check for check in audit.observed_checks}
-        retry_check = checks.get(
-            "testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric"
+        retry_warning = self._first_matching_line(
+            audit.system_out,
+            "Rate limit interrupted metric 'PullRequestsApprovalsMetricSource'",
         )
-        if retry_check is not None:
+        if retry_warning is not None:
             observations.append(
-                "Observable report outcome: "
-                f"`{retry_check.name}` was `{retry_check.status}`, confirming the "
-                "pull-request data source recovered the interrupted GitHub metric and the same "
-                "report run still completed with both pull-request metrics populated."
+                "Observable retry evidence: "
+                f"`{retry_warning}`"
             )
 
+        recovered_metric = self._first_matching_line(
+            audit.system_out,
+            "Metric 'PullRequestsApprovalsMetricSource': collected 1 items",
+        )
+        if recovered_metric is not None:
+            observations.append(
+                "Observable completion evidence: "
+                f"`{recovered_metric}`"
+            )
+        checks = {check.name: check for check in audit.observed_checks}
         delay_check = checks.get(
             "testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap"
         )
         if delay_check is not None:
             observations.append(
-                "Observable wait outcome: "
-                f"`{delay_check.name}` was `{delay_check.status}`, confirming the live "
-                "implementation honored `X-RateLimit-Reset` instead of falling back to the default "
-                "60-second cap."
+                "Reset-header regression evidence: "
+                f"`{self.test_class}.{delay_check.name}` finished with status `{delay_check.status}`."
             )
 
         if audit.junit_report_path.exists():
@@ -209,9 +217,11 @@ class ReportGeneratorRateLimitService:
             command.extend(["--tests", f"{self.test_class}.{method_name}"])
         return tuple(command)
 
-    def _load_junit_checks(self) -> tuple[ReportGeneratorRateLimitCheck, ...]:
+    def _load_junit_report(
+        self,
+    ) -> tuple[tuple[ReportGeneratorRateLimitCheck, ...], str, str]:
         if not self.junit_report_path.exists():
-            return ()
+            return (), "", ""
 
         root = ET.fromstring(self.junit_report_path.read_text(encoding="utf-8"))
         checks: list[ReportGeneratorRateLimitCheck] = []
@@ -244,4 +254,14 @@ class ReportGeneratorRateLimitService:
                     failure_message=failure_message,
                 )
             )
-        return tuple(checks)
+        system_out = (root.findtext("system-out") or "").strip()
+        system_err = (root.findtext("system-err") or "").strip()
+        return tuple(checks), system_out, system_err
+
+    @staticmethod
+    def _first_matching_line(text: str, marker: str) -> str | None:
+        for line in text.splitlines():
+            normalized = line.strip()
+            if marker in normalized:
+                return normalized
+        return None

--- a/testing/core/interfaces/report_generator_rate_limit_service.py
+++ b/testing/core/interfaces/report_generator_rate_limit_service.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.report_generator_rate_limit_audit import (
+    ReportGeneratorRateLimitAudit,
+)
+
+
+class ReportGeneratorRateLimitService(Protocol):
+    def audit(self) -> ReportGeneratorRateLimitAudit:
+        raise NotImplementedError
+
+    def human_observations(self, audit: ReportGeneratorRateLimitAudit) -> list[str]:
+        raise NotImplementedError
+
+    def format_failures(self, audit: ReportGeneratorRateLimitAudit) -> str:
+        raise NotImplementedError

--- a/testing/core/models/report_generator_rate_limit_audit.py
+++ b/testing/core/models/report_generator_rate_limit_audit.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+@dataclass(frozen=True)
+class ReportGeneratorRateLimitCheck:
+    name: str
+    classname: str
+    time_seconds: float
+    status: str
+    failure_message: str = ""
+
+    def describe(self) -> str:
+        details = f"{self.classname}.{self.name} [{self.status}]"
+        if self.time_seconds > 0:
+            details = f"{details} ({self.time_seconds:.3f}s)"
+        if self.failure_message:
+            return f"{details}: {self.failure_message}"
+        return details
+
+
+@dataclass(frozen=True)
+class ReportGeneratorRateLimitFailure:
+    step: int
+    summary: str
+    expected: str
+    actual: str
+
+    def format(self) -> str:
+        return (
+            f"Step {self.step}: {self.summary}\n"
+            f"Expected: {self.expected}\n"
+            f"Actual: {self.actual}"
+        )
+
+
+@dataclass(frozen=True)
+class ReportGeneratorRateLimitAudit:
+    gradle_command: tuple[str, ...]
+    execution: ProcessExecutionResult
+    junit_report_path: Path
+    observed_checks: tuple[ReportGeneratorRateLimitCheck, ...]
+    failures: tuple[ReportGeneratorRateLimitFailure, ...]

--- a/testing/core/models/report_generator_rate_limit_audit.py
+++ b/testing/core/models/report_generator_rate_limit_audit.py
@@ -44,4 +44,6 @@ class ReportGeneratorRateLimitAudit:
     execution: ProcessExecutionResult
     junit_report_path: Path
     observed_checks: tuple[ReportGeneratorRateLimitCheck, ...]
+    system_out: str
+    system_err: str
     failures: tuple[ReportGeneratorRateLimitFailure, ...]

--- a/testing/tests/DMC-1030/README.md
+++ b/testing/tests/DMC-1030/README.md
@@ -1,0 +1,28 @@
+# DMC-1030 automated test
+
+This ticket harness runs the live `ReportGenerator` regression checks that cover
+GitHub rate-limit recovery for pull-request data collection. It verifies two
+observable outcomes from the maintainer flow:
+
+1. the interrupted pull-request data-source request is retried and the same
+   report run continues to completion; and
+2. `X-RateLimit-Reset` is honored instead of falling back to the default retry
+   cap.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1030/test_dmc_1030.py -q
+```
+
+## Environment
+
+No external credentials are required. The test executes targeted JUnit methods
+from `com.github.istin.dmtools.reporting.ReportGeneratorTest` against the
+current repository checkout.

--- a/testing/tests/DMC-1030/config.yaml
+++ b/testing/tests/DMC-1030/config.yaml
@@ -1,0 +1,9 @@
+test_id: DMC-1030
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+test_class: com.github.istin.dmtools.reporting.ReportGeneratorTest
+test_methods:
+  - testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric
+  - testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap

--- a/testing/tests/DMC-1030/test_dmc_1030.py
+++ b/testing/tests/DMC-1030/test_dmc_1030.py
@@ -8,13 +8,13 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 if str(REPOSITORY_ROOT) not in sys.path:
     sys.path.insert(0, str(REPOSITORY_ROOT))
 
+from testing.components.factories.report_generator_rate_limit_service_factory import (  # noqa: E402
+    create_report_generator_rate_limit_service,
+)
 from testing.components.services.report_generator_rate_limit_service import (  # noqa: E402
     ReportGeneratorRateLimitService,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
-from testing.frameworks.api.rest.subprocess_process_runner import (  # noqa: E402
-    SubprocessProcessRunner,
-)
 
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
@@ -24,9 +24,8 @@ CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
 def build_service(
     repository_root: Path = REPOSITORY_ROOT,
 ) -> ReportGeneratorRateLimitService:
-    return ReportGeneratorRateLimitService(
+    return create_report_generator_rate_limit_service(
         repository_root=repository_root,
-        runner=SubprocessProcessRunner(),
         test_class=str(CONFIG["test_class"]),
         test_methods=tuple(str(value) for value in CONFIG["test_methods"]),
     )
@@ -40,11 +39,24 @@ def test_dmc_1030_report_generator_honors_github_reset_header_and_retries_pull_r
     assert audit.execution.returncode == 0, service.format_failures(audit)
     assert audit.junit_report_path.exists(), service.format_failures(audit)
     assert not audit.failures, service.format_failures(audit)
+    assert "BUILD SUCCESSFUL" in audit.execution.combined_output, service.format_failures(audit)
 
     observed_names = {check.name for check in audit.observed_checks if check.status == "passed"}
     expected_names = {str(value) for value in CONFIG["test_methods"]}
     assert expected_names.issubset(observed_names), service.format_failures(audit)
 
-    observations = service.human_observations(audit)
-    assert any("same report run still completed" in observation for observation in observations)
-    assert any("honored `X-RateLimit-Reset`" in observation for observation in observations)
+    retry_metric_index = audit.system_out.find("Metric 'PullRequestsMetricSource': collected 1 items")
+    retry_warning_index = audit.system_out.find(
+        "Rate limit interrupted metric 'PullRequestsApprovalsMetricSource' for source 'pullRequests'. "
+        "Waiting 0 ms before retry attempt 1/5."
+    )
+    recovered_metric_index = audit.system_out.find(
+        "Metric 'PullRequestsApprovalsMetricSource': collected 1 items"
+    )
+
+    assert retry_metric_index != -1, service.format_failures(audit)
+    assert retry_warning_index != -1, service.format_failures(audit)
+    assert recovered_metric_index != -1, service.format_failures(audit)
+    assert retry_metric_index < retry_warning_index < recovered_metric_index, (
+        service.format_failures(audit)
+    )

--- a/testing/tests/DMC-1030/test_dmc_1030.py
+++ b/testing/tests/DMC-1030/test_dmc_1030.py
@@ -11,7 +11,7 @@ if str(REPOSITORY_ROOT) not in sys.path:
 from testing.components.factories.report_generator_rate_limit_service_factory import (  # noqa: E402
     create_report_generator_rate_limit_service,
 )
-from testing.components.services.report_generator_rate_limit_service import (  # noqa: E402
+from testing.core.interfaces.report_generator_rate_limit_service import (  # noqa: E402
     ReportGeneratorRateLimitService,
 )
 from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402

--- a/testing/tests/DMC-1030/test_dmc_1030.py
+++ b/testing/tests/DMC-1030/test_dmc_1030.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.report_generator_rate_limit_service import (  # noqa: E402
+    ReportGeneratorRateLimitService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+from testing.frameworks.api.rest.subprocess_process_runner import (  # noqa: E402
+    SubprocessProcessRunner,
+)
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+
+
+def build_service(
+    repository_root: Path = REPOSITORY_ROOT,
+) -> ReportGeneratorRateLimitService:
+    return ReportGeneratorRateLimitService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+        test_class=str(CONFIG["test_class"]),
+        test_methods=tuple(str(value) for value in CONFIG["test_methods"]),
+    )
+
+
+def test_dmc_1030_report_generator_honors_github_reset_header_and_retries_pull_request_collection() -> None:
+    service = build_service()
+
+    audit = service.audit()
+
+    assert audit.execution.returncode == 0, service.format_failures(audit)
+    assert audit.junit_report_path.exists(), service.format_failures(audit)
+    assert not audit.failures, service.format_failures(audit)
+
+    observed_names = {check.name for check in audit.observed_checks if check.status == "passed"}
+    expected_names = {str(value) for value in CONFIG["test_methods"]}
+    assert expected_names.issubset(observed_names), service.format_failures(audit)
+
+    observations = service.human_observations(audit)
+    assert any("same report run still completed" in observation for observation in observations)
+    assert any("honored `X-RateLimit-Reset`" in observation for observation in observations)


### PR DESCRIPTION
# DMC-1030 test automation result: PASSED

## What changed

- Added `testing/tests/DMC-1030/test_dmc_1030.py`
- Added `testing/tests/DMC-1030/config.yaml`
- Added `testing/tests/DMC-1030/README.md`
- Added `testing/components/services/report_generator_rate_limit_service.py`
- Added `testing/core/models/report_generator_rate_limit_audit.py`

## What automation checked

1. Ran the ticket pytest harness, which executes the live implementation regressions from `com.github.istin.dmtools.reporting.ReportGeneratorTest`.
2. Verified `testCollectDataFromAllSources_retriesOnlyInterruptedGitHubMetric()` passed.
3. Verified `testCalculateRateLimitDelayMs_usesGitHubResetHeaderBeyondDefaultRetryCap()` passed.
4. Verified the JUnit report was produced at `dmtools-core/build/test-results/test/TEST-com.github.istin.dmtools.reporting.ReportGeneratorTest.xml`.

## Real user / human-style verification

- Checked the maintainer-visible outcome of the report run, not just the command exit code.
- Observed `BUILD SUCCESSFUL` for the targeted Gradle/JUnit flow.
- Observed this log sequence in the JUnit report:
  - `Metric 'PullRequestsMetricSource': collected 1 items`
  - `Rate limit interrupted metric 'PullRequestsApprovalsMetricSource' for source 'pullRequests'. Waiting 0 ms before retry attempt 1/5.`
  - `Metric 'PullRequestsApprovalsMetricSource': collected 1 items`
- This shows the report generation continued after the GitHub rate-limit interruption instead of aborting.
- The `X-RateLimit-Reset` delay regression also passed, confirming the implementation honors the reset header rather than falling back to the default retry cap.

## Result

- `python3 -m pytest testing/tests/DMC-1030/test_dmc_1030.py -q` → **1 passed**
- JUnit summary → **2 tests, 0 failures, 0 errors**

**Expected:** ReportGenerator catches the GitHub rate limit, waits according to reset metadata, retries the interrupted request, and completes the same report run.

**Actual:** The targeted live implementation regressions passed, and the observable report log showed the rate-limit warning followed by successful continuation of pull-request metric collection.

Result matches expected behavior.
