### PR TITLE
DMC-1033 Test: GitHub rate limit hit — operational logs display wait time and retry details

### DIFF
--- a/testing/components/factories/report_generator_rate_limit_log_service_factory.py
+++ b/testing/components/factories/report_generator_rate_limit_log_service_factory.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.report_generator_rate_limit_log_service import (
+    ReportGeneratorRateLimitLogService,
+)
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_report_generator_rate_limit_log_service(
+    repository_root: Path,
+) -> ReportGeneratorRateLimitLogService:
+    return ReportGeneratorRateLimitLogService(
+        repository_root=repository_root,
+        runner=SubprocessProcessRunner(),
+    )

--- a/testing/components/factories/report_generator_rate_limit_log_service_factory.py
+++ b/testing/components/factories/report_generator_rate_limit_log_service_factory.py
@@ -5,6 +5,9 @@ from pathlib import Path
 from testing.components.services.report_generator_rate_limit_log_service import (
     ReportGeneratorRateLimitLogService,
 )
+from testing.frameworks.api.rest.report_generator_rate_limit_harness_factory import (
+    RestReportGeneratorRateLimitHarnessFactory,
+)
 from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
 
 
@@ -14,4 +17,5 @@ def create_report_generator_rate_limit_log_service(
     return ReportGeneratorRateLimitLogService(
         repository_root=repository_root,
         runner=SubprocessProcessRunner(),
+        harness_factory=RestReportGeneratorRateLimitHarnessFactory(),
     )

--- a/testing/components/factories/report_generator_rate_limit_log_service_factory.py
+++ b/testing/components/factories/report_generator_rate_limit_log_service_factory.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from testing.components.services.report_generator_rate_limit_log_service import (
+    ReportGeneratorRateLimitLogService as ReportGeneratorRateLimitLogServiceImpl,
+)
+from testing.core.interfaces.report_generator_rate_limit_log_service import (
     ReportGeneratorRateLimitLogService,
 )
 from testing.frameworks.api.rest.report_generator_rate_limit_harness_factory import (
@@ -14,7 +17,7 @@ from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProc
 def create_report_generator_rate_limit_log_service(
     repository_root: Path,
 ) -> ReportGeneratorRateLimitLogService:
-    return ReportGeneratorRateLimitLogService(
+    return ReportGeneratorRateLimitLogServiceImpl(
         repository_root=repository_root,
         runner=SubprocessProcessRunner(),
         harness_factory=RestReportGeneratorRateLimitHarnessFactory(),

--- a/testing/components/services/report_generator_rate_limit_log_service.py
+++ b/testing/components/services/report_generator_rate_limit_log_service.py
@@ -17,7 +17,12 @@ from testing.core.models.report_generator_rate_limit_log_audit import (
 
 class ReportGeneratorRateLimitLogService:
     ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
-    WAIT_LINE_PATTERN = re.compile(r"Waiting (?P<delay>\d+) ms before retry")
+    WAIT_DURATION_PATTERN = re.compile(r"(?P<delay>\d+)\s*ms\b", re.IGNORECASE)
+    WAIT_REFERENCE_PATTERN = re.compile(
+        r"\b(wait(?:ing)?|delay(?:ed|ing)?|pause(?:d|ing)?|sleep(?:ing)?|"
+        r"backoff|cooldown)\b",
+        re.IGNORECASE,
+    )
     RETRY_REFERENCE_PATTERN = re.compile(
         r"\b(retry(?:ing|ies|ied)?|re-try|try(?:ing)?\s+again|another\s+attempt|"
         r"second\s+attempt)\b",
@@ -188,15 +193,15 @@ class ReportGeneratorRateLimitLogService:
                     (
                         line
                         for line in output_lines
-                        if self.WAIT_LINE_PATTERN.search(line) is not None
+                        if self._extract_wait_duration_ms(line) is not None
                     ),
                     None,
                 )
-                wait_duration_ms = None
-                if wait_line is not None:
-                    wait_match = self.WAIT_LINE_PATTERN.search(wait_line)
-                    if wait_match is not None:
-                        wait_duration_ms = int(wait_match.group("delay"))
+                wait_duration_ms = (
+                    self._extract_wait_duration_ms(wait_line)
+                    if wait_line is not None
+                    else None
+                )
 
                 retry_confirmation_line = self._find_retry_confirmation_line(output_lines)
                 metric_collection_line = next(
@@ -262,3 +267,18 @@ class ReportGeneratorRateLimitLogService:
         if cls.RETRY_REFERENCE_PATTERN.search(line) is not None:
             return True
         return "again" in line.lower() and cls.RETRY_TARGET_PATTERN.search(line) is not None
+
+    @classmethod
+    def _extract_wait_duration_ms(cls, line: str | None) -> int | None:
+        if line is None:
+            return None
+        wait_match = cls.WAIT_DURATION_PATTERN.search(line)
+        if wait_match is None:
+            return None
+
+        has_wait_intent = cls.WAIT_REFERENCE_PATTERN.search(line) is not None
+        has_retry_intent = cls.RETRY_REFERENCE_PATTERN.search(line) is not None
+        if not has_wait_intent and not has_retry_intent:
+            return None
+
+        return int(wait_match.group("delay"))

--- a/testing/components/services/report_generator_rate_limit_log_service.py
+++ b/testing/components/services/report_generator_rate_limit_log_service.py
@@ -9,6 +9,7 @@ from testing.core.interfaces.process_runner import ProcessRunner
 from testing.core.interfaces.report_generator_rate_limit_harness import (
     ReportGeneratorRateLimitHarnessFactory,
 )
+from testing.core.models.process_execution_result import ProcessExecutionResult
 from testing.core.models.report_generator_rate_limit_log_audit import (
     ReportGeneratorRateLimitLogAudit,
 )
@@ -61,6 +62,21 @@ class ReportGeneratorRateLimitLogService:
                 cwd=self.repository_root,
                 env=common_env,
             )
+
+            if bootstrap_result.returncode != 0:
+                return ReportGeneratorRateLimitLogAudit(
+                    bootstrap_result=bootstrap_result,
+                    job_result=self._skipped_job_result(work_dir),
+                    recorded_requests=(),
+                    report_json_path=None,
+                    report_json_text="",
+                    rate_limit_warning_line=None,
+                    wait_line=None,
+                    wait_duration_ms=None,
+                    retry_confirmation_line=None,
+                    metric_collection_line=None,
+                    request_gap_seconds=None,
+                )
 
             workspace = "rate-limit-owner"
             repository = "rate-limit-repo"
@@ -216,6 +232,15 @@ class ReportGeneratorRateLimitLogService:
                     metric_collection_line=metric_collection_line,
                     request_gap_seconds=request_gap_seconds,
                 )
+
+    def _skipped_job_result(self, cwd: Path) -> ProcessExecutionResult:
+        return ProcessExecutionResult(
+            args=(),
+            cwd=cwd,
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
 
     @classmethod
     def _find_retry_confirmation_line(

--- a/testing/components/services/report_generator_rate_limit_log_service.py
+++ b/testing/components/services/report_generator_rate_limit_log_service.py
@@ -6,29 +6,40 @@ import tempfile
 from pathlib import Path
 
 from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.interfaces.report_generator_rate_limit_harness import (
+    ReportGeneratorRateLimitHarnessFactory,
+)
 from testing.core.models.report_generator_rate_limit_log_audit import (
     ReportGeneratorRateLimitLogAudit,
-)
-from testing.frameworks.api.rest.report_generator_rate_limit_harness import (
-    ReportGeneratorRateLimitHarness,
 )
 
 
 class ReportGeneratorRateLimitLogService:
     ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
     WAIT_LINE_PATTERN = re.compile(r"Waiting (?P<delay>\d+) ms before retry")
-    EXPLICIT_RETRY_PATTERN = re.compile(
-        r"\b(retrying|retry initiated|starting retry|retry attempt \d+)\b",
+    RETRY_REFERENCE_PATTERN = re.compile(
+        r"\b(retry(?:ing|ies|ied)?|re-try|try(?:ing)?\s+again|another\s+attempt|"
+        r"second\s+attempt)\b",
         re.IGNORECASE,
     )
+    RETRY_ACTION_PATTERN = re.compile(
+        r"\b(start(?:ed|ing)?|initiat(?:e|ed|ing)|attempt(?:ing)?|resum(?:e|ed|es|ing)|"
+        r"continu(?:e|ed|es|ing)|proceed(?:ed|ing|s)?|issu(?:e|ed|es|ing)|"
+        r"send(?:ing|s)?|perform(?:ed|ing|s)?|mak(?:e|es|ing)|"
+        r"run(?:ning|s)?|call(?:ing|s)?)\b",
+        re.IGNORECASE,
+    )
+    RETRY_TARGET_PATTERN = re.compile(r"\b(request|call|attempt)\b", re.IGNORECASE)
 
     def __init__(
         self,
         repository_root: Path,
         runner: ProcessRunner,
+        harness_factory: ReportGeneratorRateLimitHarnessFactory,
     ) -> None:
         self.repository_root = repository_root
         self.runner = runner
+        self.harness_factory = harness_factory
 
     def audit(self) -> ReportGeneratorRateLimitLogAudit:
         with tempfile.TemporaryDirectory(prefix="dmc-1033-") as temp_dir:
@@ -55,7 +66,7 @@ class ReportGeneratorRateLimitLogService:
             repository = "rate-limit-repo"
             branch = "main"
 
-            with ReportGeneratorRateLimitHarness(
+            with self.harness_factory.create(
                 workspace=workspace,
                 repository=repository,
                 branch=branch,
@@ -171,15 +182,7 @@ class ReportGeneratorRateLimitLogService:
                     if wait_match is not None:
                         wait_duration_ms = int(wait_match.group("delay"))
 
-                retry_confirmation_line = next(
-                    (
-                        line
-                        for line in output_lines
-                        if self.EXPLICIT_RETRY_PATTERN.search(line) is not None
-                        and "before retry" not in line.lower()
-                    ),
-                    None,
-                )
+                retry_confirmation_line = self._find_retry_confirmation_line(output_lines)
                 metric_collection_line = next(
                     (
                         line
@@ -213,3 +216,24 @@ class ReportGeneratorRateLimitLogService:
                     metric_collection_line=metric_collection_line,
                     request_gap_seconds=request_gap_seconds,
                 )
+
+    @classmethod
+    def _find_retry_confirmation_line(
+        cls,
+        output_lines: list[str],
+    ) -> str | None:
+        for line in output_lines:
+            lowered_line = line.lower()
+            if "before retry" in lowered_line:
+                continue
+            if cls._is_retry_confirmation_line(line):
+                return line
+        return None
+
+    @classmethod
+    def _is_retry_confirmation_line(cls, line: str) -> bool:
+        if cls.RETRY_ACTION_PATTERN.search(line) is None:
+            return False
+        if cls.RETRY_REFERENCE_PATTERN.search(line) is not None:
+            return True
+        return "again" in line.lower() and cls.RETRY_TARGET_PATTERN.search(line) is not None

--- a/testing/components/services/report_generator_rate_limit_log_service.py
+++ b/testing/components/services/report_generator_rate_limit_log_service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.report_generator_rate_limit_log_audit import (
+    ReportGeneratorRateLimitLogAudit,
+)
+from testing.frameworks.api.rest.report_generator_rate_limit_harness import (
+    ReportGeneratorRateLimitHarness,
+)
+
+
+class ReportGeneratorRateLimitLogService:
+    ANSI_ESCAPE_PATTERN = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+    WAIT_LINE_PATTERN = re.compile(r"Waiting (?P<delay>\d+) ms before retry")
+    EXPLICIT_RETRY_PATTERN = re.compile(
+        r"\b(retrying|retry initiated|starting retry|retry attempt \d+)\b",
+        re.IGNORECASE,
+    )
+
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+    ) -> None:
+        self.repository_root = repository_root
+        self.runner = runner
+
+    def audit(self) -> ReportGeneratorRateLimitLogAudit:
+        with tempfile.TemporaryDirectory(prefix="dmc-1033-") as temp_dir:
+            temp_root = Path(temp_dir)
+            home_dir = temp_root / "home"
+            work_dir = temp_root / "work"
+            home_dir.mkdir(parents=True)
+            work_dir.mkdir(parents=True)
+
+            common_env = {
+                "HOME": str(home_dir),
+                "GRADLE_USER_HOME": str(home_dir / ".gradle"),
+                "XDG_CACHE_HOME": str(home_dir / ".cache"),
+                "PYTHONUNBUFFERED": "1",
+            }
+
+            bootstrap_result = self.runner.run(
+                ["bash", "./buildInstallLocal.sh"],
+                cwd=self.repository_root,
+                env=common_env,
+            )
+
+            workspace = "rate-limit-owner"
+            repository = "rate-limit-repo"
+            branch = "main"
+
+            with ReportGeneratorRateLimitHarness(
+                workspace=workspace,
+                repository=repository,
+                branch=branch,
+            ) as harness:
+                config_path = work_dir / "report-generator-rate-limit.json"
+                config_path.write_text(
+                    json.dumps(
+                        {
+                            "name": "ReportGenerator",
+                            "params": {
+                                "reportName": "DMC-1033 Rate Limit Logging",
+                                "startDate": "2026-05-01",
+                                "endDate": "2026-05-31",
+                                "dataSources": [
+                                    {
+                                        "name": "commits",
+                                        "params": {
+                                            "sourceType": "github",
+                                            "workspace": workspace,
+                                            "repository": repository,
+                                            "branch": branch,
+                                        },
+                                        "metrics": [
+                                            {
+                                                "name": "CommitsMetricSource",
+                                                "params": {"label": "GitHub Commits"},
+                                            }
+                                        ],
+                                    }
+                                ],
+                                "timeGrouping": {
+                                    "type": "static",
+                                    "periods": [
+                                        {
+                                            "name": "May 2026",
+                                            "start": "2026-05-01",
+                                            "end": "2026-05-31",
+                                        }
+                                    ],
+                                },
+                                "aggregation": {
+                                    "formula": "${GitHub Commits}",
+                                    "label": "GitHub Commits",
+                                },
+                                "output": {
+                                    "mode": "combined",
+                                    "outputPath": str((work_dir / "reports").resolve()),
+                                    "visualizer": "none",
+                                },
+                            },
+                        },
+                        indent=2,
+                    ),
+                    encoding="utf-8",
+                )
+
+                job_env = {
+                    **common_env,
+                    "SOURCE_GITHUB_TOKEN": "test-token",
+                    "SOURCE_GITHUB_WORKSPACE": workspace,
+                    "SOURCE_GITHUB_REPOSITORY": repository,
+                    "SOURCE_GITHUB_BRANCH": branch,
+                    "SOURCE_GITHUB_BASE_PATH": harness.base_url,
+                }
+                job_result = self.runner.run(
+                    [
+                        str((self.repository_root / "dmtools.sh").resolve()),
+                        "--debug",
+                        "run",
+                        str(config_path),
+                    ],
+                    cwd=work_dir,
+                    env=job_env,
+                )
+
+                report_paths = sorted((work_dir / "reports").glob("*.json"))
+                report_json_path = report_paths[0] if report_paths else None
+                report_json_text = (
+                    report_json_path.read_text(encoding="utf-8")
+                    if report_json_path is not None
+                    else ""
+                )
+
+                sanitized_output = self.ANSI_ESCAPE_PATTERN.sub(
+                    "",
+                    job_result.combined_output,
+                )
+                output_lines = [
+                    line.strip()
+                    for line in sanitized_output.splitlines()
+                    if line.strip()
+                ]
+
+                rate_limit_warning_line = next(
+                    (
+                        line
+                        for line in output_lines
+                        if "Rate limit hit" in line or "Rate limit interrupted metric" in line
+                    ),
+                    None,
+                )
+                wait_line = next(
+                    (
+                        line
+                        for line in output_lines
+                        if self.WAIT_LINE_PATTERN.search(line) is not None
+                    ),
+                    None,
+                )
+                wait_duration_ms = None
+                if wait_line is not None:
+                    wait_match = self.WAIT_LINE_PATTERN.search(wait_line)
+                    if wait_match is not None:
+                        wait_duration_ms = int(wait_match.group("delay"))
+
+                retry_confirmation_line = next(
+                    (
+                        line
+                        for line in output_lines
+                        if self.EXPLICIT_RETRY_PATTERN.search(line) is not None
+                        and "before retry" not in line.lower()
+                    ),
+                    None,
+                )
+                metric_collection_line = next(
+                    (
+                        line
+                        for line in output_lines
+                        if "Metric 'GitHub Commits': collected" in line
+                    ),
+                    None,
+                )
+
+                page_one_requests = [
+                    request
+                    for request in harness.requests
+                    if "/commits" in request.path and "page=1" in request.path
+                ]
+                request_gap_seconds = None
+                if len(page_one_requests) >= 2:
+                    request_gap_seconds = (
+                        page_one_requests[1].timestamp - page_one_requests[0].timestamp
+                    )
+
+                return ReportGeneratorRateLimitLogAudit(
+                    bootstrap_result=bootstrap_result,
+                    job_result=job_result,
+                    recorded_requests=harness.requests,
+                    report_json_path=report_json_path,
+                    report_json_text=report_json_text,
+                    rate_limit_warning_line=rate_limit_warning_line,
+                    wait_line=wait_line,
+                    wait_duration_ms=wait_duration_ms,
+                    retry_confirmation_line=retry_confirmation_line,
+                    metric_collection_line=metric_collection_line,
+                    request_gap_seconds=request_gap_seconds,
+                )

--- a/testing/core/interfaces/report_generator_rate_limit_harness.py
+++ b/testing/core/interfaces/report_generator_rate_limit_harness.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.recorded_request import RecordedRequest
+
+
+class ReportGeneratorRateLimitHarness(Protocol):
+    @property
+    def base_url(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def requests(self) -> tuple[RecordedRequest, ...]:
+        raise NotImplementedError
+
+    def __enter__(self) -> "ReportGeneratorRateLimitHarness":
+        raise NotImplementedError
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        raise NotImplementedError
+
+
+class ReportGeneratorRateLimitHarnessFactory(Protocol):
+    def create(
+        self,
+        *,
+        workspace: str,
+        repository: str,
+        branch: str,
+    ) -> ReportGeneratorRateLimitHarness:
+        raise NotImplementedError

--- a/testing/core/interfaces/report_generator_rate_limit_log_service.py
+++ b/testing/core/interfaces/report_generator_rate_limit_log_service.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.report_generator_rate_limit_log_audit import (
+    ReportGeneratorRateLimitLogAudit,
+)
+
+
+class ReportGeneratorRateLimitLogService(Protocol):
+    def audit(self) -> ReportGeneratorRateLimitLogAudit:
+        raise NotImplementedError

--- a/testing/core/models/recorded_request.py
+++ b/testing/core/models/recorded_request.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    method: str
+    path: str
+    timestamp: float

--- a/testing/core/models/report_generator_rate_limit_log_audit.py
+++ b/testing/core/models/report_generator_rate_limit_log_audit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+from testing.frameworks.api.rest.report_generator_rate_limit_harness import (
+    RecordedRequest,
+)
+
+
+@dataclass(frozen=True)
+class ReportGeneratorRateLimitLogAudit:
+    bootstrap_result: ProcessExecutionResult
+    job_result: ProcessExecutionResult
+    recorded_requests: tuple[RecordedRequest, ...]
+    report_json_path: Path | None
+    report_json_text: str
+    rate_limit_warning_line: str | None
+    wait_line: str | None
+    wait_duration_ms: int | None
+    retry_confirmation_line: str | None
+    metric_collection_line: str | None
+    request_gap_seconds: float | None

--- a/testing/core/models/report_generator_rate_limit_log_audit.py
+++ b/testing/core/models/report_generator_rate_limit_log_audit.py
@@ -4,9 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from testing.core.models.process_execution_result import ProcessExecutionResult
-from testing.frameworks.api.rest.report_generator_rate_limit_harness import (
-    RecordedRequest,
-)
+from testing.core.models.recorded_request import RecordedRequest
 
 
 @dataclass(frozen=True)

--- a/testing/frameworks/api/rest/report_generator_rate_limit_harness.py
+++ b/testing/frameworks/api/rest/report_generator_rate_limit_harness.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import cast
+from urllib.parse import parse_qs, urlparse
+
+
+@dataclass(frozen=True)
+class RecordedRequest:
+    method: str
+    path: str
+    timestamp: float
+
+
+class _HarnessHttpServer(ThreadingHTTPServer):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        request_handler_class: type[BaseHTTPRequestHandler],
+        harness: "ReportGeneratorRateLimitHarness",
+    ) -> None:
+        super().__init__(server_address, request_handler_class)
+        self.harness = harness
+
+
+class _HarnessRequestHandler(BaseHTTPRequestHandler):
+    server: _HarnessHttpServer
+
+    def do_GET(self) -> None:  # noqa: N802
+        harness = self.server.harness
+        harness.record_request("GET", self.path)
+
+        parsed = urlparse(self.path)
+        query = parse_qs(parsed.query)
+        expected_path = (
+            f"/repos/{harness.workspace}/{harness.repository}/commits"
+        )
+        page = query.get("page", ["1"])[0]
+
+        if parsed.path != expected_path:
+            self._write_json(HTTPStatus.NOT_FOUND, {"message": "Not Found"})
+            return
+
+        if page != "1":
+            self._write_json(HTTPStatus.OK, [])
+            return
+
+        if harness.consume_rate_limit():
+            reset_epoch_seconds = int(time.time()) + harness.reset_after_seconds
+            self.send_response(HTTPStatus.TOO_MANY_REQUESTS)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Retry-After", str(harness.reset_after_seconds))
+            self.send_header("X-RateLimit-Reset", str(reset_epoch_seconds))
+            self.end_headers()
+            self.wfile.write(
+                json.dumps({"message": "API rate limit exceeded"}).encode("utf-8")
+            )
+            return
+
+        self._write_json(HTTPStatus.OK, [harness.commit_payload])
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        del format, args
+
+    def _write_json(self, status: HTTPStatus, payload: object) -> None:
+        encoded = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+
+class ReportGeneratorRateLimitHarness:
+    def __init__(
+        self,
+        *,
+        workspace: str,
+        repository: str,
+        branch: str,
+        reset_after_seconds: int = 2,
+    ) -> None:
+        self.workspace = workspace
+        self.repository = repository
+        self.branch = branch
+        self.reset_after_seconds = reset_after_seconds
+        self._rate_limit_remaining = 1
+        self._requests: list[RecordedRequest] = []
+        self._server = _HarnessHttpServer(
+            ("127.0.0.1", 0),
+            _HarnessRequestHandler,
+            self,
+        )
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="report-generator-rate-limit-harness",
+            daemon=True,
+        )
+
+        self.commit_payload = {
+            "node_id": "commit-node-1",
+            "sha": "abc123",
+            "html_url": "https://example.test/commit/abc123",
+            "author": {"id": "1", "login": "rate-limit-tester"},
+            "commit": {
+                "message": "Rate limit retry commit",
+                "committer": {"date": "2026-05-15T12:00:00Z"},
+            },
+        }
+
+    def __enter__(self) -> "ReportGeneratorRateLimitHarness":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        del exc_type, exc, tb
+        self.stop()
+
+    @property
+    def base_url(self) -> str:
+        host, port = cast(tuple[str, int], self._server.server_address)
+        return f"http://{host}:{port}"
+
+    @property
+    def requests(self) -> tuple[RecordedRequest, ...]:
+        return tuple(self._requests)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+
+    def record_request(self, method: str, path: str) -> None:
+        self._requests.append(
+            RecordedRequest(method=method, path=path, timestamp=time.monotonic())
+        )
+
+    def consume_rate_limit(self) -> bool:
+        if self._rate_limit_remaining <= 0:
+            return False
+        self._rate_limit_remaining -= 1
+        return True

--- a/testing/frameworks/api/rest/report_generator_rate_limit_harness.py
+++ b/testing/frameworks/api/rest/report_generator_rate_limit_harness.py
@@ -3,18 +3,12 @@ from __future__ import annotations
 import json
 import threading
 import time
-from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import cast
 from urllib.parse import parse_qs, urlparse
 
-
-@dataclass(frozen=True)
-class RecordedRequest:
-    method: str
-    path: str
-    timestamp: float
+from testing.core.models.recorded_request import RecordedRequest
 
 
 class _HarnessHttpServer(ThreadingHTTPServer):

--- a/testing/frameworks/api/rest/report_generator_rate_limit_harness_factory.py
+++ b/testing/frameworks/api/rest/report_generator_rate_limit_harness_factory.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from testing.core.interfaces.report_generator_rate_limit_harness import (
+    ReportGeneratorRateLimitHarness,
+    ReportGeneratorRateLimitHarnessFactory,
+)
+from testing.frameworks.api.rest.report_generator_rate_limit_harness import (
+    ReportGeneratorRateLimitHarness as RestReportGeneratorRateLimitHarness,
+)
+
+
+class RestReportGeneratorRateLimitHarnessFactory(ReportGeneratorRateLimitHarnessFactory):
+    def create(
+        self,
+        *,
+        workspace: str,
+        repository: str,
+        branch: str,
+    ) -> ReportGeneratorRateLimitHarness:
+        return RestReportGeneratorRateLimitHarness(
+            workspace=workspace,
+            repository=repository,
+            branch=branch,
+        )

--- a/testing/tests/DMC-1033/README.md
+++ b/testing/tests/DMC-1033/README.md
@@ -1,0 +1,31 @@
+# DMC-1033 automated test
+
+This test runs the real `ReportGenerator` job against a local GitHub API harness
+that returns a temporary `429 Too Many Requests` response for the first commits
+request and then succeeds on retry. It verifies the operator-visible logging
+behavior around the wait/retry flow and confirms the report still completes after
+the delayed retry.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1033/test_dmc_1033.py -q
+```
+
+## Environment
+
+The test builds the local DMTools CLI with `buildInstallLocal.sh`, runs it with a
+temporary HOME directory, and points the GitHub source-code integration at a local
+stub server. No external GitHub credentials are required.
+
+## Expected passing output
+
+```text
+1 passed
+```

--- a/testing/tests/DMC-1033/config.yaml
+++ b/testing/tests/DMC-1033/config.yaml
@@ -1,0 +1,5 @@
+test_id: DMC-1033
+type: api
+framework: pytest
+platform: linux
+dependencies: []

--- a/testing/tests/DMC-1033/test_dmc_1033.py
+++ b/testing/tests/DMC-1033/test_dmc_1033.py
@@ -12,10 +12,20 @@ if str(REPOSITORY_ROOT) not in sys.path:
 from testing.components.factories.report_generator_rate_limit_log_service_factory import (  # noqa: E402
     create_report_generator_rate_limit_log_service,
 )
+from testing.core.interfaces.report_generator_rate_limit_log_service import (  # noqa: E402
+    ReportGeneratorRateLimitLogService,
+)
+
+
+def create_service(
+    *,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> ReportGeneratorRateLimitLogService:
+    return create_report_generator_rate_limit_log_service(repository_root)
 
 
 def test_dmc_1033_rate_limit_logs_show_wait_time_and_retry_visibility() -> None:
-    service = create_report_generator_rate_limit_log_service(REPOSITORY_ROOT)
+    service = create_service()
     audit = service.audit()
 
     failures: list[str] = []

--- a/testing/tests/DMC-1033/test_dmc_1033.py
+++ b/testing/tests/DMC-1033/test_dmc_1033.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.report_generator_rate_limit_log_service_factory import (  # noqa: E402
+    create_report_generator_rate_limit_log_service,
+)
+
+
+def test_dmc_1033_rate_limit_logs_show_wait_time_and_retry_visibility() -> None:
+    service = create_report_generator_rate_limit_log_service(REPOSITORY_ROOT)
+    audit = service.audit()
+
+    failures: list[str] = []
+
+    if audit.bootstrap_result.returncode != 0:
+        failures.append(
+            "buildInstallLocal.sh failed while preparing the live DMTools runtime.\n"
+            f"{audit.bootstrap_result.combined_output}"
+        )
+
+    if audit.job_result.returncode != 0:
+        failures.append(
+            "The ReportGenerator live run did not complete successfully after the induced rate limit.\n"
+            f"{audit.job_result.combined_output}"
+        )
+
+    if audit.rate_limit_warning_line is None:
+        failures.append(
+            "The application logs did not include a warning that the GitHub rate limit was hit.\n"
+            f"Combined output:\n{audit.job_result.combined_output}"
+        )
+
+    if audit.wait_duration_ms is None:
+        failures.append(
+            "The application logs did not include the wait duration in milliseconds.\n"
+            f"Combined output:\n{audit.job_result.combined_output}"
+        )
+
+    if audit.request_gap_seconds is None or audit.request_gap_seconds < 1.5:
+        failures.append(
+            "The retried GitHub commits request was not observably delayed long enough after the "
+            "429 response. The live run should wait before retrying, not retry immediately.\n"
+            f"Observed gap: {audit.request_gap_seconds!r} seconds\n"
+            f"Recorded requests: {[request.path for request in audit.recorded_requests]}"
+        )
+
+    if audit.retry_confirmation_line is None:
+        failures.append(
+            "The application logs did not include an explicit confirmation that the retry was "
+            "initiated after the wait.\n"
+            f"Combined output:\n{audit.job_result.combined_output}"
+        )
+
+    if audit.metric_collection_line is None:
+        failures.append(
+            "The report did not log successful metric collection after the induced rate limit.\n"
+            f"Combined output:\n{audit.job_result.combined_output}"
+        )
+
+    if audit.report_json_path is None:
+        failures.append(
+            "The report JSON output was not generated after the retry.\n"
+            f"Combined output:\n{audit.job_result.combined_output}"
+        )
+    else:
+        report_payload = json.loads(audit.report_json_text)
+        assert report_payload["reportName"] == "DMC-1033 Rate Limit Logging"
+
+    assert not failures, "\n\n".join(failures)

--- a/testing/tests/DMC-1033/test_dmc_1033_service.py
+++ b/testing/tests/DMC-1033/test_dmc_1033_service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.services.report_generator_rate_limit_log_service import (  # noqa: E402
+    ReportGeneratorRateLimitLogService,
+)
+from testing.core.models.process_execution_result import ProcessExecutionResult  # noqa: E402
+from testing.core.models.recorded_request import RecordedRequest  # noqa: E402
+
+
+class FakeProcessRunner:
+    def __init__(self, job_output: str) -> None:
+        self.job_output = job_output
+        self.calls: list[tuple[tuple[str, ...], Path, dict[str, str | None] | None]] = []
+
+    def run(
+        self,
+        args: tuple[str, ...] | list[str],
+        cwd: Path,
+        env: dict[str, str | None] | None = None,
+        trace_network: bool = False,
+    ) -> ProcessExecutionResult:
+        del trace_network
+        call_args = tuple(args)
+        self.calls.append((call_args, cwd, dict(env) if env is not None else None))
+        if call_args[:2] == ("bash", "./buildInstallLocal.sh"):
+            return ProcessExecutionResult(
+                args=call_args,
+                cwd=cwd,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        reports_dir = cwd / "reports"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        (reports_dir / "report.json").write_text(
+            json.dumps({"reportName": "DMC-1033 Rate Limit Logging"}),
+            encoding="utf-8",
+        )
+        return ProcessExecutionResult(
+            args=call_args,
+            cwd=cwd,
+            returncode=0,
+            stdout=self.job_output,
+            stderr="",
+        )
+
+
+class FakeHarness:
+    def __init__(self) -> None:
+        self.base_url = "http://127.0.0.1:9999"
+        self.requests = (
+            RecordedRequest(
+                method="GET",
+                path="/repos/rate-limit-owner/rate-limit-repo/commits?page=1",
+                timestamp=100.0,
+            ),
+            RecordedRequest(
+                method="GET",
+                path="/repos/rate-limit-owner/rate-limit-repo/commits?page=1",
+                timestamp=102.1,
+            ),
+        )
+
+    def __enter__(self) -> "FakeHarness":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        del exc_type, exc, tb
+
+
+class FakeHarnessFactory:
+    def __init__(self, harness: FakeHarness) -> None:
+        self.harness = harness
+        self.calls: list[tuple[str, str, str]] = []
+
+    def create(
+        self,
+        *,
+        workspace: str,
+        repository: str,
+        branch: str,
+    ) -> FakeHarness:
+        self.calls.append((workspace, repository, branch))
+        return self.harness
+
+
+def _build_service(job_output: str) -> tuple[ReportGeneratorRateLimitLogService, FakeProcessRunner, FakeHarnessFactory]:
+    runner = FakeProcessRunner(job_output=job_output)
+    harness_factory = FakeHarnessFactory(harness=FakeHarness())
+    service = ReportGeneratorRateLimitLogService(
+        repository_root=REPOSITORY_ROOT,
+        runner=runner,
+        harness_factory=harness_factory,
+    )
+    return service, runner, harness_factory
+
+
+def test_service_uses_injected_harness_factory_for_live_audit() -> None:
+    service, runner, harness_factory = _build_service(
+        "\n".join(
+            [
+                "[WARN] AbstractRestClient - Rate limit hit for URL: http://127.0.0.1:9999/repos/rate-limit-owner/rate-limit-repo/commits?page=1 (Attempt 1/5). Error: rate limit",
+                "[INFO] AbstractRestClient - Waiting 2000 ms before retry (2.000s)",
+                "[INFO] AbstractRestClient - Starting retry request now that the wait window has elapsed",
+                "[INFO] ReportGenerator - Metric 'GitHub Commits': collected 1 items",
+            ]
+        )
+    )
+
+    audit = service.audit()
+
+    assert harness_factory.calls == [("rate-limit-owner", "rate-limit-repo", "main")]
+    assert runner.calls[1][2] is not None
+    assert runner.calls[1][2]["SOURCE_GITHUB_BASE_PATH"] == "http://127.0.0.1:9999"
+    assert audit.retry_confirmation_line == (
+        "[INFO] AbstractRestClient - Starting retry request now that the wait window has elapsed"
+    )
+    assert audit.request_gap_seconds is not None
+    assert abs(audit.request_gap_seconds - 2.1) < 1e-9
+
+
+def test_service_accepts_retry_confirmation_with_clear_operator_wording() -> None:
+    service, _, _ = _build_service(
+        "\n".join(
+            [
+                "[WARN] AbstractRestClient - Rate limit hit for URL: http://127.0.0.1:9999/repos/rate-limit-owner/rate-limit-repo/commits?page=1 (Attempt 1/5). Error: rate limit",
+                "[INFO] AbstractRestClient - Waiting 2000 ms before retry (2.000s)",
+                "[INFO] AbstractRestClient - Resuming request again after the rate-limit window",
+                "[INFO] ReportGenerator - Metric 'GitHub Commits': collected 1 items",
+            ]
+        )
+    )
+
+    audit = service.audit()
+
+    assert audit.retry_confirmation_line == (
+        "[INFO] AbstractRestClient - Resuming request again after the rate-limit window"
+    )

--- a/testing/tests/DMC-1033/test_dmc_1033_service.py
+++ b/testing/tests/DMC-1033/test_dmc_1033_service.py
@@ -17,8 +17,18 @@ from testing.core.models.recorded_request import RecordedRequest  # noqa: E402
 
 
 class FakeProcessRunner:
-    def __init__(self, job_output: str) -> None:
+    def __init__(
+        self,
+        job_output: str,
+        *,
+        bootstrap_returncode: int = 0,
+        bootstrap_stdout: str = "",
+        bootstrap_stderr: str = "",
+    ) -> None:
         self.job_output = job_output
+        self.bootstrap_returncode = bootstrap_returncode
+        self.bootstrap_stdout = bootstrap_stdout
+        self.bootstrap_stderr = bootstrap_stderr
         self.calls: list[tuple[tuple[str, ...], Path, dict[str, str | None] | None]] = []
 
     def run(
@@ -35,9 +45,9 @@ class FakeProcessRunner:
             return ProcessExecutionResult(
                 args=call_args,
                 cwd=cwd,
-                returncode=0,
-                stdout="",
-                stderr="",
+                returncode=self.bootstrap_returncode,
+                stdout=self.bootstrap_stdout,
+                stderr=self.bootstrap_stderr,
             )
 
         reports_dir = cwd / "reports"
@@ -94,8 +104,19 @@ class FakeHarnessFactory:
         return self.harness
 
 
-def _build_service(job_output: str) -> tuple[ReportGeneratorRateLimitLogService, FakeProcessRunner, FakeHarnessFactory]:
-    runner = FakeProcessRunner(job_output=job_output)
+def _build_service(
+    job_output: str,
+    *,
+    bootstrap_returncode: int = 0,
+    bootstrap_stdout: str = "",
+    bootstrap_stderr: str = "",
+) -> tuple[ReportGeneratorRateLimitLogService, FakeProcessRunner, FakeHarnessFactory]:
+    runner = FakeProcessRunner(
+        job_output=job_output,
+        bootstrap_returncode=bootstrap_returncode,
+        bootstrap_stdout=bootstrap_stdout,
+        bootstrap_stderr=bootstrap_stderr,
+    )
     harness_factory = FakeHarnessFactory(harness=FakeHarness())
     service = ReportGeneratorRateLimitLogService(
         repository_root=REPOSITORY_ROOT,
@@ -146,3 +167,21 @@ def test_service_accepts_retry_confirmation_with_clear_operator_wording() -> Non
     assert audit.retry_confirmation_line == (
         "[INFO] AbstractRestClient - Resuming request again after the rate-limit window"
     )
+
+
+def test_service_stops_before_live_run_when_bootstrap_fails() -> None:
+    service, runner, harness_factory = _build_service(
+        "",
+        bootstrap_returncode=1,
+        bootstrap_stderr="bootstrap failed",
+    )
+
+    audit = service.audit()
+
+    assert [call[0] for call in runner.calls] == [("bash", "./buildInstallLocal.sh")]
+    assert harness_factory.calls == []
+    assert audit.bootstrap_result.returncode == 1
+    assert audit.bootstrap_result.combined_output == "bootstrap failed"
+    assert audit.job_result.returncode == 0
+    assert audit.recorded_requests == ()
+    assert audit.report_json_path is None

--- a/testing/tests/DMC-1033/test_dmc_1033_service.py
+++ b/testing/tests/DMC-1033/test_dmc_1033_service.py
@@ -169,6 +169,26 @@ def test_service_accepts_retry_confirmation_with_clear_operator_wording() -> Non
     )
 
 
+def test_service_accepts_wait_duration_with_clear_operator_friendly_wording() -> None:
+    service, _, _ = _build_service(
+        "\n".join(
+            [
+                "[WARN] AbstractRestClient - Rate limit hit for URL: http://127.0.0.1:9999/repos/rate-limit-owner/rate-limit-repo/commits?page=1 (Attempt 1/5). Error: rate limit",
+                "[INFO] AbstractRestClient - Retrying in 1901 ms after rate-limit backoff",
+                "[INFO] AbstractRestClient - Starting retry request now that the wait window has elapsed",
+                "[INFO] ReportGenerator - Metric 'GitHub Commits': collected 1 items",
+            ]
+        )
+    )
+
+    audit = service.audit()
+
+    assert audit.wait_line == (
+        "[INFO] AbstractRestClient - Retrying in 1901 ms after rate-limit backoff"
+    )
+    assert audit.wait_duration_ms == 1901
+
+
 def test_service_stops_before_live_run_when_bootstrap_fails() -> None:
     service, runner, harness_factory = _build_service(
         "",


### PR DESCRIPTION
## DMC-1033 automation result: **FAILED**

The live implementation recovered from the induced GitHub rate limit and completed the report, but it did **not** emit an explicit log message confirming that the retry was initiated after the wait. That means the ticket’s expected result is not fully satisfied.

### What automation checked

1. Ran the real `ReportGenerator` path with logging enabled via `./dmtools.sh --debug run ...`.
2. Induced a real `429 Too Many Requests` response on the first GitHub commits request.
3. Verified the console output contained:
   - a visible rate-limit warning;
   - a visible wait duration in milliseconds;
   - delayed retry behavior instead of an immediate retry.
4. Verified the report still completed after the retry and generated JSON output.

### What was observed

Visible logs included:

```text
[WARN] AbstractRestClient - Rate limit hit for URL: http://127.0.0.1:37689/repos/rate-limit-owner/rate-limit-repo/commits?sha=main&since=2026-05-01T00:00:00Z&page=1&per_page=100 (Attempt 1/5). Error: rate limit
[INFO] AbstractRestClient - Waiting 1901 ms before retry (1.901s)
```

The retried page=1 request was delayed by about **1.905 seconds**, and the report then completed successfully:

```text
[INFO] ReportGenerator - Metric 'GitHub Commits': collected 1 items
[INFO] ReportGenerator - Report saved to: /tmp/dmc-1033-6738mhz6/work/reports/DMC-1033_Rate_Limit_Logging.json
[INFO] JobRunner - Job execution completed successfully
```

### Human-style verification

From a user/operator perspective, the console clearly showed that a rate limit was hit and how long the system would wait. After the wait, the report completed successfully. However, there was **no explicit, human-readable log line** stating that the retry had started. The next visible lines were opaque numeric URL timing lines:

```text
[INFO] AbstractRestClient - 1710 http://127.0.0.1:37689/repos/rate-limit-owner/rate-limit-repo/commits?sha=main&since=2026-05-01T00:00:00Z&page=1&per_page=100
[INFO] AbstractRestClient - -198 http://127.0.0.1:37689/repos/rate-limit-owner/rate-limit-repo/commits?sha=main&since=2026-05-01T00:00:00Z&page=2&per_page=100
```

That does not meet the ticket’s expected result for retry visibility.

### Result

- Automated status: **FAILED**
- User-visible expectation match: **No**
- Failure reason: missing explicit retry-initiation confirmation in logs
