### PR TITLE
DMC-1035 Windows Git Bash install wrapper cannot find DMTools JAR after successful latest-release install

### DIFF
--- a/dmtools.sh
+++ b/dmtools.sh
@@ -7,25 +7,46 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+get_install_dir_candidates() {
+    local script_parent_dir=""
+    script_parent_dir="$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd)"
+
+    if [ -n "${DMTOOLS_INSTALL_DIR:-}" ]; then
+        printf '%s\n' "$DMTOOLS_INSTALL_DIR"
+    fi
+
+    if [ -n "$script_parent_dir" ] && [ "$script_parent_dir" != "${DMTOOLS_INSTALL_DIR:-}" ]; then
+        printf '%s\n' "$script_parent_dir"
+    fi
+
+    if [ "$HOME/.dmtools" != "${DMTOOLS_INSTALL_DIR:-}" ] && [ "$HOME/.dmtools" != "$script_parent_dir" ]; then
+        printf '%s\n' "$HOME/.dmtools"
+    fi
+}
+
 # Find Java command (bundled or system)
 find_java_command() {
-    # Check for bundled Java first (installed with dmtools)
-    # macOS has different JRE structure: Contents/Home/bin/java
-    local bundled_java_macos="$HOME/.dmtools/jre/Contents/Home/bin/java"
-    local bundled_java="$HOME/.dmtools/jre/bin/java"
-    local bundled_java_exe="$HOME/.dmtools/jre/bin/java.exe"
+    local install_dir=""
+    while IFS= read -r install_dir; do
+        [ -n "$install_dir" ] || continue
 
-    # Check for bundled Java (order matters: macOS, Windows, Linux)
-    if [ -x "$bundled_java_macos" ]; then
-        echo "$bundled_java_macos"
-        return 0
-    elif [ -x "$bundled_java_exe" ]; then
-        echo "$bundled_java_exe"
-        return 0
-    elif [ -x "$bundled_java" ]; then
-        echo "$bundled_java"
-        return 0
-    fi
+        # macOS has different JRE structure: Contents/Home/bin/java
+        local bundled_java_macos="$install_dir/jre/Contents/Home/bin/java"
+        local bundled_java="$install_dir/jre/bin/java"
+        local bundled_java_exe="$install_dir/jre/bin/java.exe"
+
+        # Check for bundled Java (order matters: macOS, Windows, Linux)
+        if [ -x "$bundled_java_macos" ]; then
+            echo "$bundled_java_macos"
+            return 0
+        elif [ -x "$bundled_java_exe" ]; then
+            echo "$bundled_java_exe"
+            return 0
+        elif [ -x "$bundled_java" ]; then
+            echo "$bundled_java"
+            return 0
+        fi
+    done < <(get_install_dir_candidates)
 
     # Fall back to system Java
     if command -v java >/dev/null 2>&1; then
@@ -150,17 +171,23 @@ load_env_files quiet
 # Try to find JAR file in multiple locations
 find_jar_file() {
     local jar_file=""
-    
-    # 1. Check if installed via installer (user's home directory)
-    if [ -f "$HOME/.dmtools/dmtools.jar" ]; then
-        jar_file="$HOME/.dmtools/dmtools.jar"
-    # 2. Check local build directory (development)
-    elif ls "$SCRIPT_DIR/build/libs"/*.jar >/dev/null 2>&1; then
+
+    local install_dir=""
+    while IFS= read -r install_dir; do
+        [ -n "$install_dir" ] || continue
+        if [ -f "$install_dir/dmtools.jar" ]; then
+            echo "$install_dir/dmtools.jar"
+            return 0
+        fi
+    done < <(get_install_dir_candidates)
+
+    # Check local build directory (development)
+    if ls "$SCRIPT_DIR/build/libs"/*.jar >/dev/null 2>&1; then
         jar_file=$(find "$SCRIPT_DIR/build/libs" -name "*-all.jar" | head -1)
-    # 3. Check for any JAR file in the script directory
+    # Check for any JAR file in the script directory
     elif ls "$SCRIPT_DIR"/*.jar >/dev/null 2>&1; then
         jar_file=$(find "$SCRIPT_DIR" -maxdepth 1 \( -name "dmtools*.jar" -o -name "*-all.jar" \) | head -1)
-    # 4. Check parent directory build folder (if script is in subdirectory)
+    # Check parent directory build folder (if script is in subdirectory)
     elif ls "$SCRIPT_DIR/../build/libs"/*.jar >/dev/null 2>&1; then
         jar_file=$(find "$SCRIPT_DIR/../build/libs" -name "*-all.jar" | head -1)
     fi

--- a/testing/tests/DMC-1035/test_dmc_1035.py
+++ b/testing/tests/DMC-1035/test_dmc_1035.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+WRAPPER_SOURCE = REPOSITORY_ROOT / "dmtools.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
+
+
+class TestDmc1035(unittest.TestCase):
+    def test_installed_wrapper_uses_custom_install_dir_for_jar_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_root = Path(temp_dir)
+            install_dir = temp_root / "custom-install"
+            bin_dir = install_dir / "bin"
+            wrapper_path = bin_dir / "dmtools"
+            fake_java_dir = temp_root / "fake-java"
+            home_dir = temp_root / "home"
+
+            bin_dir.mkdir(parents=True)
+            fake_java_dir.mkdir()
+            home_dir.mkdir()
+
+            shutil.copy2(WRAPPER_SOURCE, wrapper_path)
+            wrapper_path.chmod(0o755)
+            (install_dir / "dmtools.jar").write_text("stub jar", encoding="utf-8")
+
+            _write_executable(
+                fake_java_dir / "java",
+                """
+                #!/bin/bash
+                exit 0
+                """,
+            )
+
+            result = subprocess.run(
+                ["bash", str(wrapper_path), "--help"],
+                cwd=REPOSITORY_ROOT,
+                env={
+                    **os.environ,
+                    "HOME": str(home_dir),
+                    "DMTOOLS_INSTALL_DIR": str(install_dir),
+                    "DMTOOLS_BIN_DIR": str(bin_dir),
+                    "PATH": f"{fake_java_dir}:{os.environ['PATH']}",
+                },
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(
+                0,
+                result.returncode,
+                "The installed wrapper should find dmtools.jar in the custom installer directory "
+                "used by the latest-release workflow.\n"
+                f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Issues/Notes
No blockers. `instruction.md` was not present at the repository root, so implementation proceeded from the ticket inputs and the repository state.

## Approach
The failure was in the installed shell wrapper, not the installer's latest-release resolution. `install.sh` correctly writes the CLI into the custom workflow install directory, but `dmtools.sh` only looked for `dmtools.jar` and bundled Java under `$HOME/.dmtools` or local development build folders. I updated the wrapper to resolve install roots from `DMTOOLS_INSTALL_DIR`, then from the wrapper's own parent install directory, and finally from the legacy home install path so custom installer layouts work during post-install validation and normal use.

## Files Modified
- `dmtools.sh` - aligned wrapper JAR/JRE discovery with installer-managed custom install directories.
- `testing/tests/DMC-1035/test_dmc_1035.py` - added a regression test that reproduces the broken custom-install wrapper layout and verifies `--help` succeeds.

## Test Coverage
- Reproduction test added: `testing/tests/DMC-1035/test_dmc_1035.py` - `TestDmc1035.test_installed_wrapper_uses_custom_install_dir_for_jar_discovery`
- Related installer regression tests: `python3 -m pytest -q testing/tests/DMC-1035/test_dmc_1035.py testing/tests/DMC-1025/test_dmc_1025.py testing/tests/DMC-1026/test_dmc_1026_service.py`
- Full core suite: `./gradlew :dmtools-core:test`
