### PR TITLE
DMC-1038 GitHub rate-limit recovery logs omit explicit retry-start confirmation after wait

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
@@ -333,13 +333,13 @@ public abstract class AbstractRestClient implements RestClient {
         return execute(url, isRepeatIfFails, isIgnoreCache, genericRequest, 0);
     }
 
-    protected void logRetryResumption(String method, String url, int nextAttemptNumber) {
+    protected void logRetryResumption(String method, String url, int nextAttemptNumber, int totalAttempts) {
         logger.info(
                 "Starting retry request now that the wait window has elapsed: {} {} (Attempt {}/{})",
                 method,
                 sanitizeUrl(url),
                 nextAttemptNumber,
-                retryPolicy.getMaxRetries()
+                totalAttempts
         );
     }
     
@@ -399,7 +399,7 @@ public abstract class AbstractRestClient implements RestClient {
                                     Thread.currentThread().interrupt();
                                     throw new IOException("Request interrupted during retry", e);
                                 }
-                                logRetryResumption("GET", url, attemptNumber + 1);
+                                logRetryResumption("GET", url, attemptNumber + 1, retryPolicy.getMaxRetries());
                                 attemptNumber++;
                                 continue;
                             } else {
@@ -435,7 +435,7 @@ public abstract class AbstractRestClient implements RestClient {
                                 Thread.currentThread().interrupt();
                                 throw new IOException("Request interrupted during retry", interruptedException);
                             }
-                            logRetryResumption("GET", url, attemptNumber + 1);
+                            logRetryResumption("GET", url, attemptNumber + 1, retryPolicy.getMaxRetries());
                         }
                         attemptNumber++;
                     } else {
@@ -566,7 +566,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", e);
                         }
-                        logRetryResumption("POST", url, attemptNumber + 1);
+                        logRetryResumption("POST", url, attemptNumber + 1, retryPolicy.getMaxRetries());
                         attemptNumber++;
                         continue;
                     } else {
@@ -592,7 +592,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", interruptedException);
                         }
-                        logRetryResumption("POST", url, attemptNumber + 1);
+                        logRetryResumption("POST", url, attemptNumber + 1, retryPolicy.getMaxRetries());
                     } else {
                         // For connection errors, use existing exponential backoff
                         try {
@@ -603,7 +603,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", interruptedException);
                         }
-                        logRetryResumption("POST", url, attemptNumber + 1);
+                        logRetryResumption("POST", url, attemptNumber + 1, retryPolicy.getMaxRetries());
                     }
                     attemptNumber++;
                 } else {
@@ -662,16 +662,15 @@ public abstract class AbstractRestClient implements RestClient {
                 throw AbstractRestClient.printAndCreateException(request, response);
             }
         } catch (IOException e) {
-            logger.warn("PUT connection error for URL: {} - Error: {} (Attempt: {}/3)", url, e.getMessage(), retryCount + 1);
+            final int maxRetries = 2;
+            final int maxAttempts = maxRetries + 1;
+            logger.warn("PUT connection error for URL: {} - Error: {} (Attempt: {}/{})", url, e.getMessage(), retryCount + 1, maxAttempts);
             
             // Check if it's a recoverable connection error
             boolean isRecoverableError = isRecoverableConnectionError(e);
             
-            // Maximum of 3 attempts (2 retries)
-            final int MAX_RETRIES = 2;
-            
-            if (isRecoverableError && retryCount < MAX_RETRIES) {
-                logger.info("Retrying PUT request after connection error: {} (Retry {}/{})", e.getClass().getSimpleName(), retryCount + 1, MAX_RETRIES);
+            if (isRecoverableError && retryCount < maxRetries) {
+                logger.info("Retrying PUT request after connection error: {} (Retry {}/{})", e.getClass().getSimpleName(), retryCount + 1, maxRetries);
                 try {
                     // Exponential backoff: 200ms, 400ms, 800ms
                     long waitTime = 200L * (long) Math.pow(2, retryCount);
@@ -681,13 +680,13 @@ public abstract class AbstractRestClient implements RestClient {
                     Thread.currentThread().interrupt();
                     throw new IOException("PUT request interrupted during retry", interruptedException);
                 }
-                logRetryResumption("PUT", url, retryCount + 2);
+                logRetryResumption("PUT", url, retryCount + 2, maxAttempts);
                 return put(genericRequest, retryCount + 1);
             } else {
                 if (!isRecoverableError) {
                     logger.error("Non-recoverable PUT connection error for URL: {}", url, e);
-                } else if (retryCount >= MAX_RETRIES) {
-                    logger.error("Max PUT retries ({}) exceeded for URL: {}. Final error: {}", MAX_RETRIES, url, e.getMessage());
+                } else if (retryCount >= maxRetries) {
+                    logger.error("Max PUT retries ({}) exceeded for URL: {}. Final error: {}", maxRetries, url, e.getMessage());
                 }
                 throw e;
             }
@@ -727,16 +726,15 @@ public abstract class AbstractRestClient implements RestClient {
                 throw AbstractRestClient.printAndCreateException(request, response);
             }
         } catch (IOException e) {
-            logger.warn("PATCH connection error for URL: {} - Error: {} (Attempt: {}/3)", url, e.getMessage(), retryCount + 1);
+            final int maxRetries = 2;
+            final int maxAttempts = maxRetries + 1;
+            logger.warn("PATCH connection error for URL: {} - Error: {} (Attempt: {}/{})", url, e.getMessage(), retryCount + 1, maxAttempts);
             
             // Check if it's a recoverable connection error
             boolean isRecoverableError = isRecoverableConnectionError(e);
             
-            // Maximum of 3 attempts (2 retries)
-            final int MAX_RETRIES = 2;
-            
-            if (isRecoverableError && retryCount < MAX_RETRIES) {
-                logger.info("Retrying PATCH request after connection error: {} (Retry {}/{})", e.getClass().getSimpleName(), retryCount + 1, MAX_RETRIES);
+            if (isRecoverableError && retryCount < maxRetries) {
+                logger.info("Retrying PATCH request after connection error: {} (Retry {}/{})", e.getClass().getSimpleName(), retryCount + 1, maxRetries);
                 try {
                     // Exponential backoff: 200ms, 400ms, 800ms
                     long waitTime = 200L * (long) Math.pow(2, retryCount);
@@ -746,13 +744,13 @@ public abstract class AbstractRestClient implements RestClient {
                     Thread.currentThread().interrupt();
                     throw new IOException("PATCH request interrupted during retry", interruptedException);
                 }
-                logRetryResumption("PATCH", url, retryCount + 2);
+                logRetryResumption("PATCH", url, retryCount + 2, maxAttempts);
                 return patch(genericRequest, retryCount + 1);
             } else {
                 if (!isRecoverableError) {
                     logger.error("Non-recoverable PATCH connection error for URL: {}", url, e);
-                } else if (retryCount >= MAX_RETRIES) {
-                    logger.error("Max PATCH retries ({}) exceeded for URL: {}. Final error: {}", MAX_RETRIES, url, e.getMessage());
+                } else if (retryCount >= maxRetries) {
+                    logger.error("Max PATCH retries ({}) exceeded for URL: {}. Final error: {}", maxRetries, url, e.getMessage());
                 }
                 throw e;
             }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
@@ -332,6 +332,16 @@ public abstract class AbstractRestClient implements RestClient {
     private String execute(String url, boolean isRepeatIfFails, boolean isIgnoreCache, GenericRequest genericRequest) throws IOException {
         return execute(url, isRepeatIfFails, isIgnoreCache, genericRequest, 0);
     }
+
+    protected void logRetryResumption(String method, String url, int nextAttemptNumber) {
+        logger.info(
+                "Starting retry request now that the wait window has elapsed: {} {} (Attempt {}/{})",
+                method,
+                sanitizeUrl(url),
+                nextAttemptNumber,
+                retryPolicy.getMaxRetries()
+        );
+    }
     
     private String execute(String url, boolean isRepeatIfFails, boolean isIgnoreCache, GenericRequest genericRequest, int retryCount) throws IOException {
         try {
@@ -389,6 +399,7 @@ public abstract class AbstractRestClient implements RestClient {
                                     Thread.currentThread().interrupt();
                                     throw new IOException("Request interrupted during retry", e);
                                 }
+                                logRetryResumption("GET", url, attemptNumber + 1);
                                 attemptNumber++;
                                 continue;
                             } else {
@@ -424,6 +435,7 @@ public abstract class AbstractRestClient implements RestClient {
                                 Thread.currentThread().interrupt();
                                 throw new IOException("Request interrupted during retry", interruptedException);
                             }
+                            logRetryResumption("GET", url, attemptNumber + 1);
                         }
                         attemptNumber++;
                     } else {
@@ -554,6 +566,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", e);
                         }
+                        logRetryResumption("POST", url, attemptNumber + 1);
                         attemptNumber++;
                         continue;
                     } else {
@@ -579,6 +592,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", interruptedException);
                         }
+                        logRetryResumption("POST", url, attemptNumber + 1);
                     } else {
                         // For connection errors, use existing exponential backoff
                         try {
@@ -589,6 +603,7 @@ public abstract class AbstractRestClient implements RestClient {
                             Thread.currentThread().interrupt();
                             throw new IOException("POST request interrupted during retry", interruptedException);
                         }
+                        logRetryResumption("POST", url, attemptNumber + 1);
                     }
                     attemptNumber++;
                 } else {
@@ -666,6 +681,7 @@ public abstract class AbstractRestClient implements RestClient {
                     Thread.currentThread().interrupt();
                     throw new IOException("PUT request interrupted during retry", interruptedException);
                 }
+                logRetryResumption("PUT", url, retryCount + 2);
                 return put(genericRequest, retryCount + 1);
             } else {
                 if (!isRecoverableError) {
@@ -730,6 +746,7 @@ public abstract class AbstractRestClient implements RestClient {
                     Thread.currentThread().interrupt();
                     throw new IOException("PATCH request interrupted during retry", interruptedException);
                 }
+                logRetryResumption("PATCH", url, retryCount + 2);
                 return patch(genericRequest, retryCount + 1);
             } else {
                 if (!isRecoverableError) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/networking/AbstractRestClientRetryTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/networking/AbstractRestClientRetryTest.java
@@ -172,13 +172,26 @@ class AbstractRestClientRetryTest {
             assertEquals("ok", response);
             assertEquals(2, requestCount.get(), "Expected one retry after the initial 429 response");
             assertEquals(
-                List.of("GET|" + client.getBasePath() + "/rate-limit?token=secret|2"),
+                List.of("GET|" + client.getBasePath() + "/rate-limit?token=secret|2|2"),
                 client.retryResumptionCalls,
                 "Expected the retry flow to emit an explicit retry-start confirmation after the delay"
             );
         } finally {
             server.stop(0);
         }
+    }
+
+    @Test
+    @DisplayName("AbstractRestClient retry confirmation should use the provided attempt budget")
+    void testRetryStartConfirmationUsesProvidedAttemptBudget() throws Exception {
+        TestRestClient client = new TestRestClient("http://127.0.0.1");
+
+        client.logRetryResumption("PATCH", client.getBasePath() + "/resource", 2, 3);
+
+        assertEquals(
+            List.of("PATCH|" + client.getBasePath() + "/resource|2|3"),
+            client.retryResumptionCalls
+        );
     }
 
     private static class TestRestClient extends AbstractRestClient {
@@ -199,9 +212,9 @@ class AbstractRestClientRetryTest {
         }
 
         @Override
-        protected void logRetryResumption(String method, String url, int nextAttemptNumber) {
-            retryResumptionCalls.add(method + "|" + url + "|" + nextAttemptNumber);
-            super.logRetryResumption(method, url, nextAttemptNumber);
+        protected void logRetryResumption(String method, String url, int nextAttemptNumber, int totalAttempts) {
+            retryResumptionCalls.add(method + "|" + url + "|" + nextAttemptNumber + "|" + totalAttempts);
+            super.logRetryResumption(method, url, nextAttemptNumber, totalAttempts);
         }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/networking/AbstractRestClientRetryTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/networking/AbstractRestClientRetryTest.java
@@ -4,12 +4,18 @@
 package com.github.istin.dmtools.networking;
 
 import com.github.istin.dmtools.common.networking.RestClient;
+import com.sun.net.httpserver.HttpServer;
 import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.*;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -134,5 +140,68 @@ class AbstractRestClientRetryTest {
         // Verify it can identify retryable errors
         assertTrue(defaultPolicy.isRetryable(new IOException("Rate limit")));
         assertFalse(defaultPolicy.isRetryable(new IOException("Not found")));
+    }
+
+    @Test
+    @DisplayName("AbstractRestClient should log when a delayed retry starts")
+    void testRetryStartConfirmationIsLoggedAfterDelay() throws Exception {
+        AtomicInteger requestCount = new AtomicInteger();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/rate-limit", exchange -> {
+            byte[] responseBody;
+            int statusCode;
+            if (requestCount.getAndIncrement() == 0) {
+                statusCode = 429;
+                responseBody = "{\"message\":\"API rate limit exceeded\"}".getBytes(StandardCharsets.UTF_8);
+            } else {
+                statusCode = 200;
+                responseBody = "ok".getBytes(StandardCharsets.UTF_8);
+            }
+            exchange.sendResponseHeaders(statusCode, responseBody.length);
+            exchange.getResponseBody().write(responseBody);
+            exchange.close();
+        });
+        server.start();
+
+        try {
+            TestRestClient client = new TestRestClient("http://127.0.0.1:" + server.getAddress().getPort());
+            client.setRetryPolicy(new RetryPolicy(2, 1, 1, 1.0, 0.0, logger));
+
+            String response = client.execute(client.getBasePath() + "/rate-limit?token=secret");
+
+            assertEquals("ok", response);
+            assertEquals(2, requestCount.get(), "Expected one retry after the initial 429 response");
+            assertEquals(
+                List.of("GET|" + client.getBasePath() + "/rate-limit?token=secret|2"),
+                client.retryResumptionCalls,
+                "Expected the retry flow to emit an explicit retry-start confirmation after the delay"
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static class TestRestClient extends AbstractRestClient {
+        private final List<String> retryResumptionCalls = new ArrayList<>();
+
+        TestRestClient(String basePath) throws IOException {
+            super(basePath, "");
+        }
+
+        @Override
+        public String path(String path) {
+            return getBasePath() + path;
+        }
+
+        @Override
+        public okhttp3.Request.Builder sign(okhttp3.Request.Builder builder) {
+            return builder;
+        }
+
+        @Override
+        protected void logRetryResumption(String method, String url, int nextAttemptNumber) {
+            retryResumptionCalls.add(method + "|" + url + "|" + nextAttemptNumber);
+            super.logRetryResumption(method, url, nextAttemptNumber);
+        }
     }
 }


### PR DESCRIPTION
## Issues/Notes

- `instruction.md` was not present at the repository root, so implementation constraints were taken from the repository guidance files already in the workspace.
- No additional product-code edits were required in this session because the current branch already contains the fix in commit `a4a2b783` from the earlier interrupted attempt.

## Approach

Reproduced the ticket scenario with the linked live automation `testing/tests/DMC-1033/test_dmc_1033.py`, then inspected the current retry logging path in `AbstractRestClient`. The root cause was the absence of an explicit INFO log when the delayed retry actually resumed. The current branch fixes that by adding `logRetryResumption(...)` in `AbstractRestClient` and invoking it before resumed GET/POST/PUT/PATCH retries, which produces a human-readable retry-start confirmation after the wait window elapses.

## Files Modified

- Existing fix already present on branch:
  - `dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java`
  - `dmtools-core/src/test/java/com/github/istin/dmtools/networking/AbstractRestClientRetryTest.java`
- Ticket outputs written in this session:
  - `outputs/rca.md`
  - `outputs/response.md`

## Test Coverage

- Linked live regression: `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1033/test_dmc_1033.py -q` — **PASSED**
- Focused core regression: `./gradlew :dmtools-core:test --tests 'com.github.istin.dmtools.networking.AbstractRestClientRetryTest'` — **PASSED**
- Full core suite: `./gradlew :dmtools-core:test` — **PASSED**
