### PR TITLE
feat(github): add release asset MCP tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,8 +302,8 @@ jobs:
         with:
           name: skill-package
           path: |
-            dist/dmtools-skill-*.zip
-            dist/dmtools-skill-*.tar.gz
+            dist/dmtools-skill*.zip
+            dist/dmtools-skill*.tar.gz
             dist/dmtools-jira-skill*.zip
             dist/dmtools-jira-skill*.tar.gz
             dist/dmtools-github-skill*.zip

--- a/dmtools-ai-docs/install.sh
+++ b/dmtools-ai-docs/install.sh
@@ -510,13 +510,22 @@ download_skill() {
         skill_source="$extract_dir"
     elif [ -f "$extract_dir/dmtools-main/dmtools-ai-docs/SKILL.md" ]; then
         skill_source="$extract_dir/dmtools-main/dmtools-ai-docs"
+    elif [ -f "$extract_dir/dm.ai-main/dmtools-ai-docs/SKILL.md" ]; then
+        skill_source="$extract_dir/dm.ai-main/dmtools-ai-docs"
     elif [ -f "$extract_dir/dmtools-ai-docs/SKILL.md" ]; then
         skill_source="$extract_dir/dmtools-ai-docs"
     else
-        print_error "SKILL.md not found in $asset_name"
-        print_info "Contents of extract dir:"
-        ls -la "$extract_dir" >&2 | head -10
-        return 1
+        # Try to find SKILL.md anywhere one level deep
+        local found
+        found=$(find "$extract_dir" -maxdepth 3 -name "SKILL.md" 2>/dev/null | head -1)
+        if [ -n "$found" ]; then
+            skill_source=$(dirname "$found")
+        else
+            print_error "SKILL.md not found in $asset_name"
+            print_info "Contents of extract dir:"
+            ls -la "$extract_dir" >&2 | head -10
+            return 1
+        fi
     fi
 
     echo "$skill_source"

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -23,12 +23,15 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.*;
+import java.net.URLConnection;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -275,6 +278,70 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
         return "Workflow '" + workflowId + "' triggered successfully on " + workspace + "/" + repository;
     }
 
+    @MCPTool(
+            name = "github_get_or_create_draft_release",
+            description = "Find an existing draft release by tag or name, or create one if it does not exist. Useful for a stable PR attachment storage release.",
+            integration = "github",
+            category = "releases"
+    )
+    public String getOrCreateDraftRelease(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "tagName", description = "The Git tag name for the release. Reused to find an existing draft release.", required = true, example = "pr-attachments-storage")
+            String tagName,
+            @MCPParam(name = "releaseName", description = "The human-readable release name. If empty, tagName is used.", required = false, example = "PR Attachments Storage")
+            String releaseName,
+            @MCPParam(name = "targetCommitish", description = "Optional branch or commit SHA the release should point to when created.", required = false, example = "main")
+            String targetCommitish,
+            @MCPParam(name = "body", description = "Optional Markdown release notes/body.", required = false, example = "Internal storage release for PR attachments.")
+            String body) throws IOException {
+        String normalizedReleaseName = isBlank(releaseName) ? tagName : releaseName.trim();
+        JSONObject existingRelease = findReleaseByTagOrName(workspace, repository, tagName, normalizedReleaseName);
+        if (existingRelease != null) {
+            if (!existingRelease.optBoolean("draft")) {
+                throw new IllegalStateException("Release '" + normalizedReleaseName + "' (" + tagName + ") already exists but is not a draft release.");
+            }
+            return existingRelease.toString();
+        }
+        return createRelease(workspace, repository, tagName, normalizedReleaseName, targetCommitish, body, true);
+    }
+
+    @MCPTool(
+            name = "github_upload_release_asset",
+            description = "Upload a local file as a GitHub release asset. Returns the uploaded asset metadata including browser_download_url.",
+            integration = "github",
+            category = "releases"
+    )
+    public String uploadReleaseAsset(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "releaseId", description = "The numeric GitHub release ID returned by github_get_or_create_draft_release.", required = true, example = "323096697")
+            String releaseId,
+            @MCPParam(name = "filePath", description = "Absolute or relative path to the local file to upload.", required = true, example = "/tmp/preview.png")
+            String filePath,
+            @MCPParam(name = "assetName", description = "Optional asset filename shown in GitHub. Defaults to the local filename.", required = false, example = "clip_123.png")
+            String assetName,
+            @MCPParam(name = "contentType", description = "Optional MIME type. Defaults to detected type or application/octet-stream.", required = false, example = "image/png")
+            String contentType,
+            @MCPParam(name = "label", description = "Optional display label for the uploaded asset.", required = false, example = "Screenshot")
+            String label) throws IOException {
+        File assetFile = new File(filePath);
+        if (!assetFile.exists()) {
+            throw new FileNotFoundException("Release asset file not found: " + assetFile.getAbsolutePath());
+        }
+        if (!assetFile.isFile()) {
+            throw new IllegalArgumentException("Release asset path must point to a file: " + assetFile.getAbsolutePath());
+        }
+        String resolvedAssetName = isBlank(assetName) ? assetFile.getName() : assetName.trim();
+        String resolvedContentType = resolveAssetContentType(assetFile, contentType);
+        String uploadUrl = buildReleaseAssetUploadUrl(workspace, repository, releaseId, resolvedAssetName, label);
+        return uploadReleaseAssetBinary(uploadUrl, assetFile, resolvedContentType);
+    }
+
     private String getPullRequestResponse(String workspace, String repository, String pullRequestId, boolean isDiff) throws IOException {
         String path = path(String.format("repos/%s/%s/pulls/%s", workspace, repository, pullRequestId));
         GenericRequest getRequest = new GenericRequest(this, path);
@@ -286,6 +353,102 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
 
     private static void addDiffHeader(GenericRequest getRequest) {
         getRequest.header("Accept", "application/vnd.github.diff");
+    }
+
+    private JSONObject findReleaseByTagOrName(String workspace, String repository, String tagName, String releaseName) throws IOException {
+        int perPage = 100;
+        int page = 1;
+        JSONObject releaseNameMatch = null;
+        while (true) {
+            String releasesPath = path(String.format("repos/%s/%s/releases?per_page=%d&page=%d",
+                    workspace, repository, perPage, page));
+            GenericRequest getRequest = new GenericRequest(this, releasesPath);
+            String response = execute(getRequest);
+            if (response == null || response.isEmpty()) {
+                return null;
+            }
+            JSONArray releases = new JSONArray(response);
+            for (int i = 0; i < releases.length(); i++) {
+                JSONObject release = releases.getJSONObject(i);
+                String existingTagName = release.optString("tag_name");
+                String existingReleaseName = release.optString("name");
+                if (tagName.equals(existingTagName)) {
+                    return release;
+                }
+                if (releaseNameMatch == null && releaseName.equals(existingReleaseName)) {
+                    releaseNameMatch = release;
+                }
+            }
+            if (releases.length() < perPage) {
+                return releaseNameMatch;
+            }
+            page++;
+        }
+    }
+
+    private String createRelease(String workspace, String repository, String tagName, String releaseName,
+                                 String targetCommitish, String body, boolean draft) throws IOException {
+        String releasesPath = path(String.format("repos/%s/%s/releases", workspace, repository));
+        GenericRequest postRequest = new GenericRequest(this, releasesPath);
+        JSONObject releaseBody = new JSONObject();
+        releaseBody.put("tag_name", tagName);
+        releaseBody.put("name", releaseName);
+        releaseBody.put("draft", draft);
+        if (!isBlank(targetCommitish)) {
+            releaseBody.put("target_commitish", targetCommitish.trim());
+        }
+        if (!isBlank(body)) {
+            releaseBody.put("body", body);
+        }
+        postRequest.setBody(releaseBody.toString());
+        return post(postRequest);
+    }
+
+    private String buildReleaseAssetUploadUrl(String workspace, String repository, String releaseId, String assetName, String label) {
+        okhttp3.HttpUrl.Builder builder = Objects.requireNonNull(okhttp3.HttpUrl.parse(
+                String.format("https://uploads.github.com/repos/%s/%s/releases/%s/assets", workspace, repository, releaseId)))
+                .newBuilder()
+                .addQueryParameter("name", assetName);
+        if (!isBlank(label)) {
+            builder.addQueryParameter("label", label.trim());
+        }
+        return builder.build().toString();
+    }
+
+    private String resolveAssetContentType(File assetFile, String explicitContentType) throws IOException {
+        if (!isBlank(explicitContentType)) {
+            return explicitContentType.trim();
+        }
+        String detected = Files.probeContentType(assetFile.toPath());
+        if (isBlank(detected)) {
+            detected = URLConnection.guessContentTypeFromName(assetFile.getName());
+        }
+        return isBlank(detected) ? "application/octet-stream" : detected;
+    }
+
+    protected String uploadReleaseAssetBinary(String uploadUrl, File assetFile, String contentType) throws IOException {
+        okhttp3.MediaType mediaType = okhttp3.MediaType.parse(contentType);
+        if (mediaType == null) {
+            throw new IllegalArgumentException("Invalid content type for release asset upload: " + contentType);
+        }
+        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(assetFile, mediaType);
+        okhttp3.Request request = sign(new okhttp3.Request.Builder())
+                .url(uploadUrl)
+                .header("Content-Type", contentType)
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .post(requestBody)
+                .build();
+        try (okhttp3.Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw AbstractRestClient.printAndCreateException(request, response);
+            }
+            return response.body() != null ? response.body().string() : "";
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     @Override

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubReleaseTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubReleaseTest.java
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.github;
+
+import com.github.istin.dmtools.common.code.model.SourceCodeConfig;
+import com.github.istin.dmtools.common.networking.GenericRequest;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+import static org.mockito.Mockito.mock;
+
+public class GitHubReleaseTest {
+
+    private static final String BASE_PATH = "https://api.github.com";
+    private static final String WORKSPACE = "IstiN";
+    private static final String REPOSITORY = "dmtools";
+
+    private GitHub gitHub;
+    private File tempAsset;
+
+    @Before
+    public void setUp() throws IOException {
+        SourceCodeConfig config = SourceCodeConfig.builder()
+                .path(BASE_PATH)
+                .auth("test-token")
+                .workspaceName(WORKSPACE)
+                .repoName(REPOSITORY)
+                .branchName("main")
+                .type(SourceCodeConfig.Type.GITHUB)
+                .build();
+        gitHub = mock(BasicGithub.class, withSettings().useConstructor(config).defaultAnswer(CALLS_REAL_METHODS));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (tempAsset != null) {
+            Files.deleteIfExists(tempAsset.toPath());
+        }
+    }
+
+    @Test
+    public void testGetOrCreateDraftRelease_returnsExistingDraftWithoutCreate() throws IOException {
+        JSONArray releases = new JSONArray()
+                .put(buildReleaseJson(321L, "pr-attachments-storage", "PR Attachments Storage", true));
+        doReturn(releases.toString()).when(gitHub).execute(any(GenericRequest.class));
+
+        String result = gitHub.getOrCreateDraftRelease(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", "PR Attachments Storage", "main", "storage");
+
+        JSONObject release = new JSONObject(result);
+        assertEquals(321L, release.getLong("id"));
+        assertTrue(release.getBoolean("draft"));
+        verify(gitHub, never()).post(any(GenericRequest.class));
+    }
+
+    @Test
+    public void testGetOrCreateDraftRelease_createsReleaseWhenMissing() throws IOException {
+        doReturn("[]").when(gitHub).execute(any(GenericRequest.class));
+        doReturn(buildReleaseJson(555L, "pr-attachments-storage", "PR Attachments Storage", true).toString())
+                .when(gitHub).post(any(GenericRequest.class));
+
+        String result = gitHub.getOrCreateDraftRelease(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", "PR Attachments Storage", "main", "storage");
+
+        JSONObject release = new JSONObject(result);
+        assertEquals(555L, release.getLong("id"));
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitHub).post(captor.capture());
+        GenericRequest request = captor.getValue();
+        assertTrue(request.url().contains("repos/IstiN/dmtools/releases"));
+
+        JSONObject requestBody = new JSONObject(request.getBody());
+        assertEquals("pr-attachments-storage", requestBody.getString("tag_name"));
+        assertEquals("PR Attachments Storage", requestBody.getString("name"));
+        assertEquals("main", requestBody.getString("target_commitish"));
+        assertEquals("storage", requestBody.getString("body"));
+        assertTrue(requestBody.getBoolean("draft"));
+    }
+
+    @Test
+    public void testGetOrCreateDraftRelease_throwsWhenMatchingPublishedReleaseExists() throws IOException {
+        JSONArray releases = new JSONArray()
+                .put(buildReleaseJson(999L, "pr-attachments-storage", "PR Attachments Storage", false));
+        doReturn(releases.toString()).when(gitHub).execute(any(GenericRequest.class));
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () ->
+                gitHub.getOrCreateDraftRelease(
+                        WORKSPACE, REPOSITORY, "pr-attachments-storage", "PR Attachments Storage", null, null));
+
+        assertTrue(exception.getMessage().contains("not a draft"));
+        verify(gitHub, never()).post(any(GenericRequest.class));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_buildsUploadUrlAndPassesResolvedMetadata() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("{\"browser_download_url\":\"https://github.com/download\"}")
+                .when(gitHub).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+
+        String result = gitHub.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
+                "preview image.png", "image/png", "Screenshot Label");
+
+        assertTrue(result.contains("browser_download_url"));
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<File> fileCaptor = ArgumentCaptor.forClass(File.class);
+        ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHub).uploadReleaseAssetBinary(urlCaptor.capture(), fileCaptor.capture(), typeCaptor.capture());
+
+        assertEquals(tempAsset.getAbsolutePath(), fileCaptor.getValue().getAbsolutePath());
+        assertEquals("image/png", typeCaptor.getValue());
+        assertTrue(urlCaptor.getValue().contains("/repos/IstiN/dmtools/releases/323096697/assets"));
+        assertTrue(urlCaptor.getValue().contains("name=preview%20image.png"));
+        assertTrue(urlCaptor.getValue().contains("label=Screenshot%20Label"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_defaultsAssetNameToLocalFileName() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".txt");
+        Files.writeString(tempAsset.toPath(), "hello");
+
+        doAnswer(invocation -> "{\"state\":\"uploaded\"}")
+                .when(gitHub).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+
+        gitHub.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
+                null, "text/plain", null);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitHub, times(1)).uploadReleaseAssetBinary(urlCaptor.capture(), any(File.class), anyString());
+        assertTrue(urlCaptor.getValue().contains("name=" + tempAsset.getName()));
+    }
+
+    private JSONObject buildReleaseJson(long id, String tagName, String name, boolean draft) {
+        JSONObject json = new JSONObject();
+        json.put("id", id);
+        json.put("tag_name", tagName);
+        json.put("name", name);
+        json.put("draft", draft);
+        json.put("upload_url", "https://uploads.github.com/repos/IstiN/dmtools/releases/" + id + "/assets{?name,label}");
+        return json;
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub MCP tools to find/create draft releases and upload release assets
- keep binary upload logic inside the existing GitHub client with focused helpers
- cover release lookup/create and asset upload request construction with unit tests

## Validation
- run GitHub client unit tests
- buildInstallLocal and smoke-test release asset upload against IstiN/dmtools-agents