### PR TITLE
fix: pass shared liveCliOutput to CliExecutionHelper for timer JS

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -379,7 +379,27 @@ public class CliExecutionHelper {
     public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
                                                            String envVariablesFile,
                                                            Runnable timerAction, int timerIntervalSeconds) {
-        AtomicReference<String> liveOutput = timerAction != null ? new AtomicReference<>("") : null;
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction, timerIntervalSeconds, null);
+    }
+
+    /**
+     * Executes CLI commands with an optional background timer and shared live output reference.
+     *
+     * @param cliCommands          Array of CLI commands to execute
+     * @param workingDirectory     Working directory for command execution (optional)
+     * @param envVariablesFile     Path to environment file (null → auto-resolve)
+     * @param timerAction          Optional runnable executed on the timer thread
+     * @param timerIntervalSeconds Interval between timer firings in seconds; timer is disabled if &lt;= 0
+     * @param liveCliOutput        Optional shared AtomicReference updated with accumulated CLI output;
+     *                             if null, an internal reference is created when timerAction is non-null
+     * @return CliExecutionResult containing command responses and output response
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile,
+                                                           Runnable timerAction, int timerIntervalSeconds,
+                                                           AtomicReference<String> liveCliOutput) {
+        AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
+                : (timerAction != null ? new AtomicReference<>("") : null);
 
         ScheduledExecutorService scheduler = null;
         if (timerAction != null && timerIntervalSeconds > 0) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -516,7 +516,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     }
 
                     cliResult = cliHelper.executeCliCommandsWithResult(finalCliCommands, projectRoot, null,
-                            timerRunnable, timerIntervalSeconds);
+                            timerRunnable, timerIntervalSeconds, liveCliOutput);
                     
                     // Append CLI responses to knownInfo if not empty
                     StringBuilder cliResponses = cliResult.getCommandResponses();


### PR DESCRIPTION
## Problem

The `timerJSAction` feature (v1.7.191) has a bug where `params.currentCliOutput` is always empty (`""`) in the timer JS context.

**Root cause**: `Teammate.java` creates an `AtomicReference<String> liveCliOutput` (line 499) that the timer Runnable reads via `.get()`. However, `CliExecutionHelper.executeCliCommandsWithResult` creates its own **separate** `AtomicReference<String> liveOutput` (line 382) that actually receives the accumulated CLI stdout. The two references are never connected.

## Fix

- Added new overload: `executeCliCommandsWithResult(..., AtomicReference<String> liveCliOutput)`
- When non-null, the helper uses the provided reference instead of creating its own
- Old signature delegates to the new one with `null` (backward compatible)
- `Teammate.java` now passes its `liveCliOutput` to the new overload

## Testing

- `TeammateTimerJSActionTest` — ✅ (6 tests)
- `CliExecutionHelperTest` — ✅
- `TeammatePreCliJSActionTest` — ✅
- `TeammateCliIntegrationTest` — ✅

## Impact

Timer JS actions will now receive the real accumulated CLI stdout on each tick. This enables features like saving CLI session output to GitHub Releases as artefacts.