### PR TITLE
fix: add pagination to github_get_pr_activities

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -656,26 +656,47 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             String repository,
             @MCPParam(name = "pullRequestId", description = "The pull request number", required = true, example = "74")
             String pullRequestId) throws IOException {
-        // Fetch review-level activities (approvals, review comments, change requests)
-        String reviewsPath = path(String.format("repos/%s/%s/pulls/%s/reviews", workspace, repository, pullRequestId));
-        GenericRequest reviewsRequest = new GenericRequest(this, reviewsPath);
-        String reviewsResponse = execute(reviewsRequest);
+        // Fetch review-level activities (approvals, review comments, change requests) with pagination
         List<IActivity> activities = new ArrayList<>();
-        if (reviewsResponse != null) {
-            activities.addAll(JSONModel.convertToModels(GitHubActivity.class, new JSONArray(reviewsResponse)));
+        int perPage = 100;
+        int currentPage = 1;
+        while (true) {
+            String reviewsPath = path(String.format("repos/%s/%s/pulls/%s/reviews?per_page=%d&page=%d",
+                    workspace, repository, pullRequestId, perPage, currentPage));
+            GenericRequest reviewsRequest = new GenericRequest(this, reviewsPath);
+            String reviewsResponse = execute(reviewsRequest);
+            if (reviewsResponse == null || reviewsResponse.isEmpty()) {
+                break;
+            }
+            JSONArray pageArray = new JSONArray(reviewsResponse);
+            activities.addAll(JSONModel.convertToModels(GitHubActivity.class, pageArray));
+            if (pageArray.length() < perPage) {
+                break;
+            }
+            currentPage++;
         }
 
-        // Also fetch inline review comments (/pulls/{id}/comments)
+        // Also fetch inline review comments (/pulls/{id}/comments) with pagination
         // These are code-level comments left during reviews
         try {
-            String commentsPath = path(String.format("repos/%s/%s/pulls/%s/comments", workspace, repository, pullRequestId));
-            GenericRequest commentsRequest = new GenericRequest(this, commentsPath);
-            String commentsResponse = execute(commentsRequest);
-            if (commentsResponse != null) {
-                List<GitHubComment> inlineComments = JSONModel.convertToModels(GitHubComment.class, new JSONArray(commentsResponse));
+            currentPage = 1;
+            while (true) {
+                String commentsPath = path(String.format("repos/%s/%s/pulls/%s/comments?per_page=%d&page=%d",
+                        workspace, repository, pullRequestId, perPage, currentPage));
+                GenericRequest commentsRequest = new GenericRequest(this, commentsPath);
+                String commentsResponse = execute(commentsRequest);
+                if (commentsResponse == null || commentsResponse.isEmpty()) {
+                    break;
+                }
+                JSONArray pageArray = new JSONArray(commentsResponse);
+                List<GitHubComment> inlineComments = JSONModel.convertToModels(GitHubComment.class, pageArray);
                 for (GitHubComment comment : inlineComments) {
                     activities.add(new GitHubCommentActivity(comment));
                 }
+                if (pageArray.length() < perPage) {
+                    break;
+                }
+                currentPage++;
             }
         } catch (Exception e) {
             logger.debug("Failed to fetch inline PR comments for PR {}: {}", pullRequestId, e.getMessage());

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
@@ -229,7 +229,7 @@ public class GitHubPRTest {
         doAnswer(invocation -> {
             GenericRequest req = invocation.getArgument(0);
             String url = req.url();
-            if (url.endsWith("/reviews")) {
+            if (url.contains("/reviews")) {
                 return reviews.toString();
             } else if (url.contains("/pulls/") && url.contains("/comments")) {
                 return inlineComments.toString();
@@ -256,7 +256,7 @@ public class GitHubPRTest {
         doAnswer(invocation -> {
             GenericRequest req = invocation.getArgument(0);
             String url = req.url();
-            if (url.endsWith("/reviews")) {
+            if (url.contains("/reviews")) {
                 return null;
             } else if (url.contains("/pulls/") && url.contains("/comments")) {
                 return inlineComments.toString();
@@ -271,6 +271,62 @@ public class GitHubPRTest {
         assertNotNull(activities);
         assertEquals(1, activities.size());
         assertEquals("COMMENTED", activities.get(0).getAction());
+    }
+
+    @Test
+    public void testGetPRActivities_paginatesReviewsAndInlineComments() throws IOException {
+        // Build page 1 arrays as raw JSON strings to avoid 100+ JSONObject allocations
+        String reviewsPage1 = buildRawReviewsJson(100, "APPROVED");
+        String reviewsPage2 = new JSONArray().put(buildReviewJson(6000L, "CHANGES_REQUESTED")).toString();
+        String commentsPage1 = buildRawCommentsJson(100);
+        String commentsPage2 = new JSONArray().put(buildCommentJson(2000L, "Last", "2024-01-01T11:00:00Z", null)).toString();
+
+        doAnswer(invocation -> {
+            GenericRequest req = invocation.getArgument(0);
+            String url = req.url();
+            if (url.contains("/reviews")) {
+                return url.contains("page=2") ? reviewsPage2 : reviewsPage1;
+            } else if (url.contains("/pulls/") && url.contains("/comments")) {
+                return url.contains("page=2") ? commentsPage2 : commentsPage1;
+            } else if (url.contains("/issues/")) {
+                return new JSONArray().toString();
+            }
+            return null;
+        }).when(gitHub).execute(any(GenericRequest.class));
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+
+        List<IActivity> activities = gitHub.pullRequestActivities(WORKSPACE, REPOSITORY, PR_ID);
+
+        verify(gitHub, atLeast(4)).execute(captor.capture());
+        List<String> urls = captor.getAllValues().stream().map(r -> r.url()).collect(java.util.stream.Collectors.toList());
+        assertTrue("page=2 for reviews not requested", urls.stream().anyMatch(u -> u.contains("/reviews") && u.contains("page=2")));
+        assertTrue("page=2 for comments not requested", urls.stream().anyMatch(u -> u.contains("/comments") && u.contains("page=2")));
+
+        // 100 reviews page1 + 1 review page2 + 100 inline comments page1 + 1 inline comment page2 = 202
+        assertEquals(202, activities.size());
+    }
+
+    private String buildRawReviewsJson(int count, String state) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append(",");
+            sb.append("{\"id\":").append(5000 + i)
+              .append(",\"state\":\"").append(state)
+              .append("\",\"body\":\"\",\"submitted_at\":\"2024-01-01T10:00:00Z\",\"user\":{\"login\":\"reviewer\"}}");
+        }
+        return sb.append("]").toString();
+    }
+
+    private String buildRawCommentsJson(int count) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) sb.append(",");
+            sb.append("{\"id\":").append(1000 + i)
+              .append(",\"body\":\"comment ").append(i)
+              .append("\",\"created_at\":\"2024-01-01T10:00:00Z\",\"user\":{\"login\":\"reviewer\"}}");
+        }
+        return sb.append("]").toString();
     }
 
     // ---- Serialization / JSON view ----


### PR DESCRIPTION
## Problem

`github_get_pr_activities` (aka `source_code_get_pr_activities`) internally called `execute()` once for both the `/reviews` and `/pulls/{id}/comments` endpoints without pagination. GitHub paginates at 30 items by default, so any PR with more than one page of reviews or inline comments silently dropped data beyond the first page.

## Fix

Both loops now use the same paginated `while(true)` pattern already established by `pullRequestComments()` and `getPRConversations()`:
- `per_page=100` (GitHub's maximum)
- increments `page` until a partial page is returned

The issue-level comments (`/issues/{id}/comments`) were already paginated via `pullRequestCommentsFromIssue()` — no change needed there.

## Tests

- Updated existing mock URL matchers from `endsWith("/reviews")` → `contains("/reviews")` (query params broke the old matcher)
- Added `testGetPRActivities_paginatesReviewsAndInlineComments`: verifies that when page 1 returns a full 100-item page, page 2 is requested for both reviews and inline comments, and all items are included in the result