### PR TITLE
feat(github): implement overwrite, list and delete release asset tools

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -372,7 +372,7 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
 
     @MCPTool(
             name = "github_upload_release_asset",
-            description = "Upload a local file as a GitHub release asset. Returns the uploaded asset metadata including browser_download_url.",
+            description = "Upload a local file as a GitHub release asset. Returns the uploaded asset metadata including browser_download_url. Set overwrite=true to automatically delete an existing asset with the same name before uploading.",
             integration = "github",
             category = "releases"
     )
@@ -390,7 +390,9 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             @MCPParam(name = "contentType", description = "Optional MIME type. Defaults to detected type or application/octet-stream.", required = false, example = "image/png")
             String contentType,
             @MCPParam(name = "label", description = "Optional display label for the uploaded asset.", required = false, example = "Screenshot")
-            String label) throws IOException {
+            String label,
+            @MCPParam(name = "overwrite", description = "If true, delete any existing asset with the same name before uploading. Defaults to false.", required = false, example = "true")
+            String overwrite) throws IOException {
         File assetFile = new File(filePath);
         if (!assetFile.exists()) {
             throw new FileNotFoundException("Release asset file not found: " + assetFile.getAbsolutePath());
@@ -399,9 +401,48 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             throw new IllegalArgumentException("Release asset path must point to a file: " + assetFile.getAbsolutePath());
         }
         String resolvedAssetName = isBlank(assetName) ? assetFile.getName() : assetName.trim();
+        if (Boolean.parseBoolean(overwrite)) {
+            deleteExistingAssetByName(workspace, repository, releaseId, resolvedAssetName);
+        }
         String resolvedContentType = resolveAssetContentType(assetFile, contentType);
         String uploadUrl = buildReleaseAssetUploadUrl(workspace, repository, releaseId, resolvedAssetName, label);
         return uploadReleaseAssetBinary(uploadUrl, assetFile, resolvedContentType);
+    }
+
+    @MCPTool(
+            name = "github_delete_release_asset",
+            description = "Delete a GitHub release asset by its asset ID. Use github_list_release_assets to find asset IDs.",
+            integration = "github",
+            category = "releases"
+    )
+    public void deleteReleaseAsset(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "assetId", description = "The numeric asset ID to delete.", required = true, example = "422721847")
+            String assetId) throws IOException {
+        String path = path(String.format("repos/%s/%s/releases/assets/%s", workspace, repository, assetId));
+        GenericRequest deleteRequest = new GenericRequest(this, path);
+        delete(deleteRequest);
+    }
+
+    @MCPTool(
+            name = "github_list_release_assets",
+            description = "List all assets attached to a GitHub release. Returns a JSON array of asset objects including id, name, size, and browser_download_url.",
+            integration = "github",
+            category = "releases"
+    )
+    public String listReleaseAssets(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "releaseId", description = "The numeric GitHub release ID.", required = true, example = "323096697")
+            String releaseId) throws IOException {
+        String path = path(String.format("repos/%s/%s/releases/%s/assets", workspace, repository, releaseId));
+        GenericRequest getRequest = new GenericRequest(this, path);
+        return execute(getRequest);
     }
 
     private String getPullRequestResponse(String workspace, String repository, String pullRequestId, boolean isDiff) throws IOException {
@@ -415,6 +456,26 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
 
     private static void addDiffHeader(GenericRequest getRequest) {
         getRequest.header("Accept", "application/vnd.github.diff");
+    }
+
+    private void deleteExistingAssetByName(String workspace, String repository, String releaseId, String assetName) throws IOException {
+        String assetsPath = path(String.format("repos/%s/%s/releases/%s/assets", workspace, repository, releaseId));
+        GenericRequest getRequest = new GenericRequest(this, assetsPath);
+        String response = execute(getRequest);
+        if (response == null || response.isEmpty()) {
+            return;
+        }
+        JSONArray assets = new JSONArray(response);
+        for (int i = 0; i < assets.length(); i++) {
+            JSONObject asset = assets.getJSONObject(i);
+            if (assetName.equals(asset.optString("name"))) {
+                String assetId = String.valueOf(asset.getLong("id"));
+                String deletePath = path(String.format("repos/%s/%s/releases/assets/%s", workspace, repository, assetId));
+                GenericRequest deleteRequest = new GenericRequest(this, deletePath);
+                delete(deleteRequest);
+                return;
+            }
+        }
     }
 
     private JSONObject findReleaseByTagOrName(String workspace, String repository, String tagName, String releaseName) throws IOException {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubReleaseTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubReleaseTest.java
@@ -121,7 +121,7 @@ public class GitHubReleaseTest {
 
         String result = gitHub.uploadReleaseAsset(
                 WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
-                "preview image.png", "image/png", "Screenshot Label");
+                "preview image.png", "image/png", "Screenshot Label", null);
 
         assertTrue(result.contains("browser_download_url"));
 
@@ -147,11 +147,107 @@ public class GitHubReleaseTest {
 
         gitHub.uploadReleaseAsset(
                 WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
-                null, "text/plain", null);
+                null, "text/plain", null, null);
 
         ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
         verify(gitHub, times(1)).uploadReleaseAssetBinary(urlCaptor.capture(), any(File.class), anyString());
         assertTrue(urlCaptor.getValue().contains("name=" + tempAsset.getName()));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteFalse_doesNotCheckExistingAssets() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("{\"browser_download_url\":\"https://github.com/download\"}")
+                .when(gitHub).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+
+        gitHub.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
+                "screenshot.png", "image/png", null, "false");
+
+        // execute() should NOT be called (no asset listing)
+        verify(gitHub, never()).execute(any(GenericRequest.class));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteTrue_deletesExistingAndUploads() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        JSONArray existingAssets = new JSONArray()
+                .put(buildAssetJson(422721847L, "screenshot.png"));
+        doReturn(existingAssets.toString()).when(gitHub).execute(any(GenericRequest.class));
+        doReturn(null).when(gitHub).delete(any(GenericRequest.class));
+        doReturn("{\"browser_download_url\":\"https://github.com/download/screenshot.png\"}")
+                .when(gitHub).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+
+        String result = gitHub.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
+                "screenshot.png", "image/png", null, "true");
+
+        assertTrue(result.contains("browser_download_url"));
+
+        // delete must have been called with the asset's ID in the path
+        ArgumentCaptor<GenericRequest> deleteCaptor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitHub).delete(deleteCaptor.capture());
+        assertTrue(deleteCaptor.getValue().url().contains("releases/assets/422721847"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteTrue_noExistingAsset_uploadsDirectly() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("[]").when(gitHub).execute(any(GenericRequest.class));
+        doReturn("{\"browser_download_url\":\"https://github.com/download/new.png\"}")
+                .when(gitHub).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+
+        gitHub.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "323096697", tempAsset.getAbsolutePath(),
+                "new.png", "image/png", null, "true");
+
+        verify(gitHub, never()).delete(any(GenericRequest.class));
+        verify(gitHub, times(1)).uploadReleaseAssetBinary(anyString(), any(File.class), anyString());
+    }
+
+    @Test
+    public void testListReleaseAssets_returnsAssetsForRelease() throws IOException {
+        JSONArray assets = new JSONArray()
+                .put(buildAssetJson(111L, "file-a.zip"))
+                .put(buildAssetJson(222L, "file-b.txt"));
+        doReturn(assets.toString()).when(gitHub).execute(any(GenericRequest.class));
+
+        String result = gitHub.listReleaseAssets(WORKSPACE, REPOSITORY, "323096697");
+
+        JSONArray resultArray = new JSONArray(result);
+        assertEquals(2, resultArray.length());
+        assertEquals("file-a.zip", resultArray.getJSONObject(0).getString("name"));
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitHub).execute(captor.capture());
+        assertTrue(captor.getValue().url().contains("repos/IstiN/dmtools/releases/323096697/assets"));
+    }
+
+    @Test
+    public void testDeleteReleaseAsset_callsDeleteWithCorrectPath() throws IOException {
+        doReturn(null).when(gitHub).delete(any(GenericRequest.class));
+
+        gitHub.deleteReleaseAsset(WORKSPACE, REPOSITORY, "422721847");
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitHub).delete(captor.capture());
+        assertTrue(captor.getValue().url().contains("repos/IstiN/dmtools/releases/assets/422721847"));
+    }
+
+    private JSONObject buildAssetJson(long id, String name) {
+        JSONObject json = new JSONObject();
+        json.put("id", id);
+        json.put("name", name);
+        json.put("size", 1024);
+        json.put("state", "uploaded");
+        json.put("browser_download_url", "https://github.com/download/" + name);
+        return json;
     }
 
     private JSONObject buildReleaseJson(long id, String tagName, String name, boolean draft) {


### PR DESCRIPTION
## Summary

Implements the actual Java code for 3 MCP tools that were previously only documented (PR #220, #221):

### Changes

- **`github_upload_release_asset`**: Added `overwrite` parameter — when `true`, automatically deletes existing asset with the same name before uploading (prevents HTTP 422 `already_exists`)
- **`github_delete_release_asset`**: New MCP tool to delete an asset by ID
- **`github_list_release_assets`**: New MCP tool to list all assets in a release

### Implementation

- `deleteExistingAssetByName()` — lists assets, finds by name, deletes if found
- `deleteReleaseAsset()` — direct DELETE by asset ID  
- `listReleaseAssets()` — GET assets array for a release
- 5 new tests in `GitHubReleaseTest` (10 total, all passing)

### Motivation

Timer-based session save and post-action artefact upload fail on re-runs because assets already exist. The `overwrite` param fixes this transparently.