### PR TITLE
feat: add Figma OAuth2 support with client credentials

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -656,6 +656,22 @@ public class PropertyReader {
     return getValue("FIGMA_TOKEN");
   }
 
+  public String getFigmaClientId() {
+    return getValue("FIGMA_CLIENT_ID");
+  }
+
+  public String getFigmaClientSecret() {
+    return getValue("FIGMA_CLIENT_SECRET");
+  }
+
+  public String getFigmaOAuth2RefreshToken() {
+    return getValue("FIGMA_OAUTH_REFRESH_TOKEN");
+  }
+
+  public String getFigmaOAuth2AccessToken() {
+    return getValue("FIGMA_OAUTH_ACCESS_TOKEN");
+  }
+
   public Integer getDefaultTicketWeightIfNoSPs() {
     String value = getValue("DEFAULT_TICKET_WEIGHT_IF_NO_SP");
     if (value == null || value.isEmpty()) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/BasicFigmaClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/BasicFigmaClient.java
@@ -4,24 +4,87 @@
 package com.github.istin.dmtools.figma;
 
 import com.github.istin.dmtools.common.utils.PropertyReader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
 public class BasicFigmaClient extends FigmaClient {
 
+    private static final Logger logger = LogManager.getLogger(BasicFigmaClient.class);
+
     public static final String BASE_PATH;
     public static final String API_KEY;
-    private static BasicFigmaClient instance;
+    public static final String CLIENT_ID;
+    public static final String CLIENT_SECRET;
+    public static final String OAUTH_REFRESH_TOKEN;
+    public static final String OAUTH_ACCESS_TOKEN;
 
+    private static FigmaOAuth2TokenManager oAuth2TokenManager;
+    private static BasicFigmaClient instance;
 
     static {
         PropertyReader propertyReader = new PropertyReader();
         BASE_PATH = propertyReader.getFigmaBasePath();
         API_KEY = propertyReader.getFigmaApiKey();
+        CLIENT_ID = propertyReader.getFigmaClientId();
+        CLIENT_SECRET = propertyReader.getFigmaClientSecret();
+        OAUTH_REFRESH_TOKEN = propertyReader.getFigmaOAuth2RefreshToken();
+        OAUTH_ACCESS_TOKEN = propertyReader.getFigmaOAuth2AccessToken();
     }
 
     public BasicFigmaClient() throws IOException {
-        super(BASE_PATH, API_KEY);
+        super(BASE_PATH, resolveAuthorization());
+        if (isOAuth2Mode()) {
+            setUseOAuth2Bearer(true);
+        }
+    }
+
+    /**
+     * Determines the authorization token to use based on available credentials.
+     *
+     * <p>Priority order:
+     * <ol>
+     *   <li>OAuth2 access token ({@code FIGMA_OAUTH_ACCESS_TOKEN})</li>
+     *   <li>OAuth2 via refresh token ({@code FIGMA_OAUTH_REFRESH_TOKEN} + client credentials)</li>
+     *   <li>Personal access token ({@code FIGMA_TOKEN})</li>
+     * </ol>
+     */
+    private static String resolveAuthorization() {
+        // Priority 1: direct OAuth2 access token
+        if (isNotEmpty(OAUTH_ACCESS_TOKEN)) {
+            logger.info("Figma: using OAuth2 access token (FIGMA_OAUTH_ACCESS_TOKEN)");
+            return OAUTH_ACCESS_TOKEN;
+        }
+
+        // Priority 2: refresh token + client credentials → get fresh access token
+        if (isOAuth2Mode()) {
+            try {
+                if (oAuth2TokenManager == null) {
+                    oAuth2TokenManager = new FigmaOAuth2TokenManager(CLIENT_ID, CLIENT_SECRET);
+                }
+                String accessToken = oAuth2TokenManager.getValidAccessToken(OAUTH_REFRESH_TOKEN);
+                logger.info("Figma: obtained OAuth2 access token via refresh token");
+                return accessToken;
+            } catch (Exception e) {
+                logger.warn("Figma: failed to obtain OAuth2 access token via refresh token, "
+                        + "falling back to personal token. Error: {}", e.getMessage());
+            }
+        }
+
+        // Priority 3: personal access token
+        if (isNotEmpty(API_KEY)) {
+            logger.info("Figma: using personal access token (FIGMA_TOKEN)");
+        }
+        return API_KEY;
+    }
+
+    private static boolean isOAuth2Mode() {
+        return isNotEmpty(CLIENT_ID) && isNotEmpty(CLIENT_SECRET) && isNotEmpty(OAUTH_REFRESH_TOKEN);
+    }
+
+    private static boolean isNotEmpty(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 
     public static synchronized FigmaClient getInstance() throws IOException {
@@ -33,4 +96,14 @@ public class BasicFigmaClient extends FigmaClient {
         }
         return instance;
     }
+
+    /**
+     * Resets the singleton instance and OAuth2 token manager.
+     * Useful for testing or when credentials change.
+     */
+    public static synchronized void reset() {
+        instance = null;
+        oAuth2TokenManager = null;
+    }
 }
+

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
@@ -48,6 +48,8 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
 
     private static final Logger logger = LogManager.getLogger(FigmaClient.class);
 
+    private boolean useOAuth2Bearer = false;
+
     public FigmaClient(String basePath, String authorization) throws IOException {
         super(basePath, authorization);
         setCacheGetRequestsEnabled(true);
@@ -60,6 +62,18 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
                 return super.isRetryable(e);
             }
         });
+    }
+
+    /**
+     * Marks this client to use {@code Authorization: Bearer} header instead of
+     * {@code X-Figma-Token}. Call this when the authorization value is an OAuth2 access token.
+     */
+    public void setUseOAuth2Bearer(boolean useOAuth2Bearer) {
+        this.useOAuth2Bearer = useOAuth2Bearer;
+    }
+
+    public boolean isUseOAuth2Bearer() {
+        return useOAuth2Bearer;
     }
 
     @Override
@@ -102,6 +116,84 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         }
         
         return basePath;
+    }
+
+    @MCPTool(
+        name = "figma_oauth2_get_auth_url",
+        description = "Generates the Figma OAuth2 authorization URL for the initial authorization code flow. "
+            + "Open the returned URL in a browser, authorize the app, and copy the 'code' parameter from the redirect URL. "
+            + "Then call figma_oauth2_exchange_code to get access and refresh tokens. "
+            + "Requires FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET to be configured.",
+        integration = "figma",
+        category = "auth"
+    )
+    public String oauth2GetAuthUrl(
+        @MCPParam(name = "redirectUri", description = "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback)", required = true, example = "http://localhost:8080/callback") String redirectUri,
+        @MCPParam(name = "state", description = "Random state string for CSRF protection", required = false, example = "random_state_123") String state
+    ) {
+        com.github.istin.dmtools.common.utils.PropertyReader propertyReader = new com.github.istin.dmtools.common.utils.PropertyReader();
+        String clientId = propertyReader.getFigmaClientId();
+        if (clientId == null || clientId.isEmpty()) {
+            return new JSONObject()
+                    .put("error", "FIGMA_CLIENT_ID is not configured")
+                    .toString();
+        }
+        String clientSecret = propertyReader.getFigmaClientSecret();
+        if (clientSecret == null || clientSecret.isEmpty()) {
+            return new JSONObject()
+                    .put("error", "FIGMA_CLIENT_SECRET is not configured")
+                    .toString();
+        }
+        if (state == null || state.isEmpty()) {
+            state = Long.toHexString(Double.doubleToLongBits(Math.random()));
+        }
+        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager(clientId, clientSecret);
+        String authUrl = manager.buildAuthorizationUrl(redirectUri, state);
+        return new JSONObject()
+                .put("authorization_url", authUrl)
+                .put("instructions", "Open this URL in your browser, authorize the app, then copy the 'code' query parameter from the redirect URL and call figma_oauth2_exchange_code.")
+                .put("state", state)
+                .toString();
+    }
+
+    @MCPTool(
+        name = "figma_oauth2_exchange_code",
+        description = "Exchanges a Figma OAuth2 authorization code for access and refresh tokens. "
+            + "Use the code from the redirect URL after completing the browser authorization flow started by figma_oauth2_get_auth_url. "
+            + "Store FIGMA_OAUTH_REFRESH_TOKEN from the response in your dmtools.env to enable automatic token refresh.",
+        integration = "figma",
+        category = "auth"
+    )
+    public String oauth2ExchangeCode(
+        @MCPParam(name = "code", description = "Authorization code received from Figma OAuth2 redirect", required = true, example = "figma_auth_code_abc123") String code,
+        @MCPParam(name = "redirectUri", description = "Same redirect URI used in figma_oauth2_get_auth_url", required = true, example = "http://localhost:8080/callback") String redirectUri
+    ) {
+        com.github.istin.dmtools.common.utils.PropertyReader propertyReader = new com.github.istin.dmtools.common.utils.PropertyReader();
+        String clientId = propertyReader.getFigmaClientId();
+        String clientSecret = propertyReader.getFigmaClientSecret();
+        if (clientId == null || clientId.isEmpty() || clientSecret == null || clientSecret.isEmpty()) {
+            return new JSONObject()
+                    .put("error", "FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET must be configured")
+                    .toString();
+        }
+        try {
+            FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager(clientId, clientSecret);
+            FigmaOAuth2TokenManager.TokenResponse tokenResponse = manager.exchangeCodeForTokens(code, redirectUri);
+            JSONObject result = new JSONObject();
+            result.put("access_token", tokenResponse.getAccessToken());
+            result.put("refresh_token", tokenResponse.getRefreshToken());
+            result.put("expires_in", tokenResponse.getExpiresIn());
+            result.put("instructions", "Add FIGMA_OAUTH_REFRESH_TOKEN=" + tokenResponse.getRefreshToken()
+                    + " to your dmtools.env to enable automatic token refresh. "
+                    + "You can also set FIGMA_OAUTH_ACCESS_TOKEN=" + tokenResponse.getAccessToken()
+                    + " for immediate use (expires in " + tokenResponse.getExpiresIn() + "s).");
+            return result.toString();
+        } catch (Exception e) {
+            logger.error("Figma OAuth2 code exchange failed", e);
+            return new JSONObject()
+                    .put("error", "Token exchange failed: " + e.getMessage())
+                    .toString();
+        }
     }
 
     @MCPTool(
@@ -177,6 +269,11 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
 
     @Override
     public Request.Builder sign(Request.Builder builder) {
+        if (useOAuth2Bearer) {
+            return builder
+                    .header("Authorization", "Bearer " + authorization)
+                    .header("Content-Type", "application/json");
+        }
         return builder
                 .header("X-Figma-Token", authorization)
                 .header("Content-Type", "application/json");

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.figma;
+
+import okhttp3.*;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages Figma OAuth2 token lifecycle: refresh, caching, and expiry.
+ *
+ * <p>Supports:
+ * <ul>
+ *   <li>Exchanging an authorization code for access + refresh tokens</li>
+ *   <li>Refreshing an access token using a stored refresh token</li>
+ * </ul>
+ *
+ * <p>Token endpoint: {@code https://www.figma.com/api/oauth/token}
+ */
+public class FigmaOAuth2TokenManager {
+
+    private static final Logger logger = LogManager.getLogger(FigmaOAuth2TokenManager.class);
+
+    public static final String FIGMA_OAUTH_AUTHORIZE_URL = "https://www.figma.com/oauth";
+    public static final String FIGMA_OAUTH_TOKEN_URL = "https://www.figma.com/api/oauth/token";
+    public static final String FIGMA_OAUTH_SCOPE = "file_read";
+
+    private final String clientId;
+    private final String clientSecret;
+    private final OkHttpClient httpClient;
+
+    private String cachedAccessToken;
+    private long tokenExpiryTimeMs = 0;
+
+    public FigmaOAuth2TokenManager(String clientId, String clientSecret) {
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(30, TimeUnit.SECONDS)
+                .readTimeout(30, TimeUnit.SECONDS)
+                .build();
+    }
+
+    /**
+     * Returns the authorization URL to redirect the user to for OAuth2 authorization code flow.
+     *
+     * @param redirectUri the redirect URI registered in your Figma OAuth app
+     * @param state       random state value for CSRF protection
+     * @return full authorization URL
+     */
+    public String buildAuthorizationUrl(String redirectUri, String state) {
+        try {
+            return FIGMA_OAUTH_AUTHORIZE_URL
+                    + "?client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8.name())
+                    + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8.name())
+                    + "&scope=" + URLEncoder.encode(FIGMA_OAUTH_SCOPE, StandardCharsets.UTF_8.name())
+                    + "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8.name())
+                    + "&response_type=code";
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build authorization URL", e);
+        }
+    }
+
+    /**
+     * Exchanges an authorization code for access + refresh tokens.
+     *
+     * @param code        authorization code received from the OAuth2 callback
+     * @param redirectUri redirect URI used in the authorization request
+     * @return token response containing access_token, refresh_token, and expires_in
+     * @throws IOException if the token exchange fails
+     */
+    public TokenResponse exchangeCodeForTokens(String code, String redirectUri) throws IOException {
+        String body = "client_id=" + encode(clientId)
+                + "&client_secret=" + encode(clientSecret)
+                + "&code=" + encode(code)
+                + "&redirect_uri=" + encode(redirectUri)
+                + "&grant_type=authorization_code";
+
+        return postToTokenEndpoint(body);
+    }
+
+    /**
+     * Refreshes the access token using a stored refresh token.
+     *
+     * @param refreshToken the refresh token to use
+     * @return token response containing new access_token (and possibly new refresh_token)
+     * @throws IOException if the refresh fails
+     */
+    public TokenResponse refreshAccessToken(String refreshToken) throws IOException {
+        String body = "client_id=" + encode(clientId)
+                + "&client_secret=" + encode(clientSecret)
+                + "&refresh_token=" + encode(refreshToken)
+                + "&grant_type=refresh_token";
+
+        return postToTokenEndpoint(body);
+    }
+
+    /**
+     * Returns a valid access token, refreshing it if expired.
+     * Caches the token in memory to avoid unnecessary refreshes.
+     *
+     * @param refreshToken the refresh token to use if access token is expired
+     * @return valid access token
+     * @throws IOException if the refresh fails
+     */
+    public synchronized String getValidAccessToken(String refreshToken) throws IOException {
+        if (cachedAccessToken != null && System.currentTimeMillis() < tokenExpiryTimeMs) {
+            return cachedAccessToken;
+        }
+        logger.info("Figma OAuth2: refreshing access token");
+        TokenResponse response = refreshAccessToken(refreshToken);
+        cachedAccessToken = response.getAccessToken();
+        // Subtract 60 seconds as a safety margin
+        long expiresIn = response.getExpiresIn() > 0 ? response.getExpiresIn() : 3600;
+        tokenExpiryTimeMs = System.currentTimeMillis() + (expiresIn - 60) * 1000L;
+        return cachedAccessToken;
+    }
+
+    private TokenResponse postToTokenEndpoint(String formBody) throws IOException {
+        RequestBody requestBody = RequestBody.create(
+                formBody, MediaType.get("application/x-www-form-urlencoded"));
+
+        Request request = new Request.Builder()
+                .url(FIGMA_OAUTH_TOKEN_URL)
+                .post(requestBody)
+                .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            String responseBody = response.body() != null ? response.body().string() : "";
+            if (!response.isSuccessful()) {
+                throw new IOException("Figma OAuth2 token request failed [" + response.code() + "]: " + responseBody);
+            }
+            JSONObject json = new JSONObject(responseBody);
+            return new TokenResponse(
+                    json.optString("access_token"),
+                    json.optString("refresh_token"),
+                    json.optLong("expires_in", 3600)
+            );
+        }
+    }
+
+    private static String encode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class TokenResponse {
+        private final String accessToken;
+        private final String refreshToken;
+        private final long expiresIn;
+
+        public TokenResponse(String accessToken, String refreshToken, long expiresIn) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+            this.expiresIn = expiresIn;
+        }
+
+        public String getAccessToken() { return accessToken; }
+        public String getRefreshToken() { return refreshToken; }
+        public long getExpiresIn() { return expiresIn; }
+
+        @Override
+        public String toString() {
+            return "TokenResponse{accessToken='" + (accessToken != null ? "[SET]" : "null")
+                    + "', refreshToken='" + (refreshToken != null ? "[SET]" : "null")
+                    + "', expiresIn=" + expiresIn + "}";
+        }
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaClientTest.java
@@ -5,6 +5,7 @@ package com.github.istin.dmtools.figma;
 
 import com.github.istin.dmtools.common.model.IComment;
 import com.github.istin.dmtools.common.networking.GenericRequest;
+import okhttp3.Request;
 import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,7 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class FigmaClientTest {
@@ -138,5 +139,41 @@ public class FigmaClientTest {
 
         List<IComment> comments = figmaClient.getComments("fileKey");
         assertEquals(1, comments.size());
+    }
+
+    @Test
+    public void testSetUseOAuth2Bearer_defaultIsFalse() throws Exception {
+        FigmaClient client = new FigmaClient("https://api.figma.com/v1", "test_token");
+        assertFalse(client.isUseOAuth2Bearer());
+    }
+
+    @Test
+    public void testSetUseOAuth2Bearer_canBeEnabled() throws Exception {
+        FigmaClient client = new FigmaClient("https://api.figma.com/v1", "test_token");
+        client.setUseOAuth2Bearer(true);
+        assertTrue(client.isUseOAuth2Bearer());
+    }
+
+    @Test
+    public void testSign_usesXFigmaTokenByDefault() throws Exception {
+        FigmaClient client = new FigmaClient("https://api.figma.com/v1", "my_personal_token");
+        Request.Builder builder = new Request.Builder().url("https://api.figma.com/v1/me");
+        Request.Builder signed = client.sign(builder);
+        Request request = signed.build();
+
+        assertEquals("my_personal_token", request.header("X-Figma-Token"));
+        assertNull(request.header("Authorization"));
+    }
+
+    @Test
+    public void testSign_usesBearerWhenOAuth2Enabled() throws Exception {
+        FigmaClient client = new FigmaClient("https://api.figma.com/v1", "oauth2_access_token");
+        client.setUseOAuth2Bearer(true);
+        Request.Builder builder = new Request.Builder().url("https://api.figma.com/v1/me");
+        Request.Builder signed = client.sign(builder);
+        Request request = signed.build();
+
+        assertEquals("Bearer oauth2_access_token", request.header("Authorization"));
+        assertNull(request.header("X-Figma-Token"));
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.figma;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class FigmaOAuth2TokenManagerTest {
+
+    @Test
+    public void testBuildAuthorizationUrl_containsRequiredParams() {
+        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager("my-client-id", "my-client-secret");
+        String url = manager.buildAuthorizationUrl("http://localhost:8080/callback", "test_state");
+
+        assertTrue(url.startsWith(FigmaOAuth2TokenManager.FIGMA_OAUTH_AUTHORIZE_URL));
+        assertTrue(url.contains("client_id=my-client-id"));
+        assertTrue(url.contains("response_type=code"));
+        assertTrue(url.contains("state=test_state"));
+        assertTrue(url.contains("scope="));
+        assertTrue(url.contains("redirect_uri="));
+    }
+
+    @Test
+    public void testBuildAuthorizationUrl_containsFileReadScope() {
+        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager("cid", "csecret");
+        String url = manager.buildAuthorizationUrl("http://localhost/cb", "state1");
+
+        assertTrue("Auth URL should contain file_read scope", url.contains("file_read"));
+    }
+
+    @Test
+    public void testTokenEndpointUrl_isCorrect() {
+        assertEquals("https://www.figma.com/api/oauth/token", FigmaOAuth2TokenManager.FIGMA_OAUTH_TOKEN_URL);
+    }
+
+    @Test
+    public void testTokenResponse_getters() {
+        FigmaOAuth2TokenManager.TokenResponse response =
+                new FigmaOAuth2TokenManager.TokenResponse("acc_token", "ref_token", 3600L);
+
+        assertEquals("acc_token", response.getAccessToken());
+        assertEquals("ref_token", response.getRefreshToken());
+        assertEquals(3600L, response.getExpiresIn());
+    }
+
+    @Test
+    public void testTokenResponse_toString_masksTokens() {
+        FigmaOAuth2TokenManager.TokenResponse response =
+                new FigmaOAuth2TokenManager.TokenResponse("acc_token", "ref_token", 1800L);
+        String str = response.toString();
+
+        assertTrue(str.contains("[SET]"));
+        assertFalse("Token value should not be exposed in toString", str.contains("acc_token"));
+        assertFalse("Refresh token value should not be exposed in toString", str.contains("ref_token"));
+    }
+
+    @Test
+    public void testTokenResponse_toString_showsNullForMissingTokens() {
+        FigmaOAuth2TokenManager.TokenResponse response =
+                new FigmaOAuth2TokenManager.TokenResponse(null, null, 0L);
+        String str = response.toString();
+
+        assertTrue(str.contains("null"));
+    }
+}


### PR DESCRIPTION
- Add FigmaOAuth2TokenManager class handling OAuth2 token lifecycle:
  - Build authorization URL for authorization code flow
  - Exchange authorization code for access+refresh tokens
  - Refresh access token using refresh token with in-memory caching
- Add FIGMA_CLIENT_ID, FIGMA_CLIENT_SECRET, FIGMA_OAUTH_REFRESH_TOKEN, FIGMA_OAUTH_ACCESS_TOKEN properties to PropertyReader
- Update BasicFigmaClient with priority-based auth resolution:
  1. FIGMA_OAUTH_ACCESS_TOKEN (direct Bearer token)
  2. FIGMA_OAUTH_REFRESH_TOKEN + client credentials (auto-refresh)
  3. FIGMA_TOKEN (personal access token, existing behavior)
- Add setUseOAuth2Bearer() to FigmaClient: uses Authorization: Bearer header instead of X-Figma-Token when OAuth2 mode is active
- Add MCP tools figma_oauth2_get_auth_url and figma_oauth2_exchange_code for guided OAuth2 authorization flow setup
- Add unit tests for all new OAuth2 functionality