### PR TITLE
Fix false-positive errorMessages detection in jira_get_ticket

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -775,12 +775,36 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
                           @MCPParam(name = "fields", description = "Optional array of fields to include in the response", required = false) String[] fields) throws IOException {
         GenericRequest jiraRequest = createPerformTicketRequest(ticketKey, fields);
         String response = jiraRequest.execute();
-        if (response.contains("errorMessages")) {
+        if (isErrorResponse(response)) {
             return null;
         }
         String projectKey = extractProjectKeyFromTicketKey(ticketKey);
         response = transformResponse(response, projectKey);
         return createTicket(response);
+    }
+
+    /**
+     * Checks whether a Jira API response is an error response by parsing the JSON
+     * and looking for a non-empty {@code errorMessages} array at the root level.
+     * <p>
+     * Unlike a naive {@code response.contains("errorMessages")} check, this method
+     * avoids false positives when ticket field values happen to contain the literal
+     * text "errorMessages".
+     */
+    protected boolean isErrorResponse(String response) {
+        if (response == null || response.isEmpty()) {
+            return false;
+        }
+        if (!response.contains("errorMessages")) {
+            return false;
+        }
+        try {
+            JSONObject json = new JSONObject(response);
+            JSONArray errorMessages = json.optJSONArray("errorMessages");
+            return errorMessages != null && !errorMessages.isEmpty();
+        } catch (JSONException e) {
+            return false;
+        }
     }
 
     protected GenericRequest createPerformTicketRequest(String ticketKey, String[] fields) {


### PR DESCRIPTION
## Problem

`JiraClient.performTicket()` used `response.contains("errorMessages")` to detect Jira API errors. This is a **substring check on the raw JSON response**, causing `jira_get_ticket` to return `null` when any field value in a valid ticket contains the literal text `"errorMessages"`.

## Root cause

```java
// Before (line 778):
if (response.contains("errorMessages")) {
    return null;  // false positive when ticket content contains this string
}
```

A valid Jira response like `{"key":"TS-966","fields":{"description":"...validate errorMessages..."}}` matches this substring check and is treated as a Jira API error.

## Fix

Added `isErrorResponse()` method that:
1. Quick `contains()` pre-check to skip JSON parsing on the 99% happy path
2. Parses JSON and checks for a non-empty `"errorMessages"` array **at the root level**
3. Returns `false` on any parse exception

This matches the pattern already used in `executePost()` and `executeDelete()` which properly parse JSON before acting on error keys.