### PR TITLE
chore: add codegraph support, bump dmtools to v1.7.196 in ai-teammate

### DIFF
--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -64,7 +64,6 @@ jobs:
           node-version: '20'
 
       - name: Configure npm global prefix
-        if: vars.AI_AGENT_PROVIDER == 'copilot'
         run: |
           npm config set prefix ~/.npm-global
           echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
@@ -111,15 +110,37 @@ jobs:
           fi
           echo "Using Copilot model: ${COPILOT_MODEL}"
 
-      - name: Install DMTools CLI v1.7.180
+      - name: Export tool cache keys
+        run: bash agents/setup/cache.sh keys dmtools:v1.7.196
+
+      - name: Cache DMTools
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DMTOOLS_CACHE_PATH }}
+          key: ${{ env.DMTOOLS_CACHE_KEY }}
+          restore-keys: |
+            dmtools-
+
+      - name: Cache CodeGraph
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: ${{ runner.os }}-npm-global-codegraph-latest
+          restore-keys: |
+            ${{ runner.os }}-npm-global-codegraph-
+            ${{ runner.os }}-npm-global-
+
+      - name: Install DMTools v1.7.196
+        run: bash agents/setup/install.sh dmtools:v1.7.196
+
+      - name: Install CodeGraph
         run: |
-          curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.180/install.sh | bash -s -- v1.7.180
-
-      - name: Add DMTools to PATH
-        run: echo "$HOME/.dmtools/bin" >> $GITHUB_PATH
-
-      - name: Verify DMTools Installation
-        run: dmtools -v || echo "dmtools version check failed"
+          if ! command -v codegraph &>/dev/null; then
+            echo "📦 Installing CodeGraph..."
+            npm install -g @colbymchenry/codegraph
+          else
+            echo "✅ CodeGraph already installed (cache hit): $(codegraph --version 2>/dev/null)"
+          fi
 
       - name: Configure Git Author
         run: |
@@ -129,7 +150,7 @@ jobs:
 
       - name: Run AI Teammate
         env:
-          PATH: "/home/runner/.local/bin:/home/runner/.dmtools/bin:/bin:/usr/bin:$PATH"
+          PATH: "/home/runner/.local/bin:/home/runner/.dmtools/bin:/home/runner/.npm-global/bin:/bin:/usr/bin:$PATH"
 
           # Jira Configuration
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -775,12 +775,36 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
                           @MCPParam(name = "fields", description = "Optional array of fields to include in the response", required = false) String[] fields) throws IOException {
         GenericRequest jiraRequest = createPerformTicketRequest(ticketKey, fields);
         String response = jiraRequest.execute();
-        if (response.contains("errorMessages")) {
+        if (isErrorResponse(response)) {
             return null;
         }
         String projectKey = extractProjectKeyFromTicketKey(ticketKey);
         response = transformResponse(response, projectKey);
         return createTicket(response);
+    }
+
+    /**
+     * Checks whether a Jira API response is an error response by parsing the JSON
+     * and looking for a non-empty {@code errorMessages} array at the root level.
+     * <p>
+     * Unlike a naive {@code response.contains("errorMessages")} check, this method
+     * avoids false positives when ticket field values happen to contain the literal
+     * text "errorMessages".
+     */
+    protected boolean isErrorResponse(String response) {
+        if (response == null || response.isEmpty()) {
+            return false;
+        }
+        if (!response.contains("errorMessages")) {
+            return false;
+        }
+        try {
+            JSONObject json = new JSONObject(response);
+            JSONArray errorMessages = json.optJSONArray("errorMessages");
+            return errorMessages != null && !errorMessages.isEmpty();
+        } catch (JSONException e) {
+            return false;
+        }
     }
 
     protected GenericRequest createPerformTicketRequest(String ticketKey, String[] fields) {


### PR DESCRIPTION
## Changes

### ai-teammate.yml
- **dmtools**: replaced direct `curl` install with `agents/setup/install.sh dmtools:v1.7.196` (uses submodule setup script)
- **dmtools cache**: added `agents/setup/cache.sh keys dmtools:v1.7.196` step to export `DMTOOLS_CACHE_PATH` / `DMTOOLS_CACHE_KEY` → used by `actions/cache@v4`
- **codegraph**: added Cache CodeGraph step (`~/.npm-global`, key: `npm-global-codegraph-latest`)
- **codegraph**: added Install CodeGraph step (`npm install -g @colbymchenry/codegraph`, skips on cache hit)
- **Node.js / npm prefix**: now always enabled (previously copilot-only) — required for codegraph
- **PATH** in Run step: added `~/.npm-global/bin` for codegraph binary
- **dmtools version**: bumped **v1.7.180 → v1.7.196**

### IstiN/dmtools-agents (separate commit, already pushed to main)
- `setup/codegraph.sh` — npm installer for `@colbymchenry/codegraph`
- `setup/install.sh` — codegraph added to ALL_TOOLS
- `setup/cache.sh` — `_cache_codegraph()` added
- `setup/dmtools.sh` — default version bumped to v1.7.196
- `common/codegraph_usage.md` — full CLI interface reference

## Why codegraph?
CodeGraph builds a semantic knowledge graph for fast call-graph traversal and AI context generation. Available in JS agents via `cli_execute_command('codegraph context ...')`.