### PR TITLE
chore: add codegraph support, bump dmtools to v1.7.196 in ai-teammate

### DIFF
--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -34,38 +34,28 @@ module.exports = {
     cliPrompts: {
         story_development: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/development_focus.md',
-            './agents/instructions/common/codegraph_tools.md'
+            './.dmtools/prompts/development_focus.md'
         ],
         bug_development: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/development_focus.md',
-            './agents/instructions/common/codegraph_tools.md'
+            './.dmtools/prompts/development_focus.md'
         ],
         bug_rca: [
-            './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './agents/instructions/common/codegraph_tools.md'
+            './.dmtools/instructions/architecture/dmtools_core_scope.md'
         ],
         pr_review: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/review_focus.md',
-            './agents/instructions/common/codegraph_tools.md'
+            './.dmtools/prompts/review_focus.md'
         ],
         pr_rework: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/rework_focus.md',
-            './agents/instructions/common/codegraph_tools.md'
-        ],
-        pr_test_automation_review: [
-            './agents/instructions/common/codegraph_tools.md'
-        ],
-        pr_test_automation_rework: [
-            './agents/instructions/common/codegraph_tools.md'
-        ],
-        test_case_automation: [
-            './agents/instructions/common/codegraph_tools.md'
+            './.dmtools/prompts/rework_focus.md'
         ]
     },
+
+    globalCliPrompts: [
+        './agents/instructions/common/codegraph_tools.md'
+    ],
 
     additionalInstructions: {
         po_refinement: [

--- a/.dmtools/config.js
+++ b/.dmtools/config.js
@@ -34,22 +34,36 @@ module.exports = {
     cliPrompts: {
         story_development: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/development_focus.md'
+            './.dmtools/prompts/development_focus.md',
+            './agents/instructions/common/codegraph_tools.md'
         ],
         bug_development: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/development_focus.md'
+            './.dmtools/prompts/development_focus.md',
+            './agents/instructions/common/codegraph_tools.md'
         ],
         bug_rca: [
-            './.dmtools/instructions/architecture/dmtools_core_scope.md'
+            './.dmtools/instructions/architecture/dmtools_core_scope.md',
+            './agents/instructions/common/codegraph_tools.md'
         ],
         pr_review: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/review_focus.md'
+            './.dmtools/prompts/review_focus.md',
+            './agents/instructions/common/codegraph_tools.md'
         ],
         pr_rework: [
             './.dmtools/instructions/architecture/dmtools_core_scope.md',
-            './.dmtools/prompts/rework_focus.md'
+            './.dmtools/prompts/rework_focus.md',
+            './agents/instructions/common/codegraph_tools.md'
+        ],
+        pr_test_automation_review: [
+            './agents/instructions/common/codegraph_tools.md'
+        ],
+        pr_test_automation_rework: [
+            './agents/instructions/common/codegraph_tools.md'
+        ],
+        test_case_automation: [
+            './agents/instructions/common/codegraph_tools.md'
         ]
     },
 

--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -121,7 +121,7 @@ jobs:
           restore-keys: |
             dmtools-
 
-      - name: Cache CodeGraph
+      - name: Cache CodeGraph binary
         uses: actions/cache@v4
         with:
           path: ~/.npm-global
@@ -130,17 +130,20 @@ jobs:
             ${{ runner.os }}-npm-global-codegraph-
             ${{ runner.os }}-npm-global-
 
+      - name: Cache CodeGraph index
+        uses: actions/cache@v4
+        with:
+          path: .codegraph
+          key: ${{ runner.os }}-codegraph-index-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-codegraph-index-${{ github.ref_name }}-
+            ${{ runner.os }}-codegraph-index-
+
       - name: Install DMTools v1.7.196
         run: bash agents/setup/install.sh dmtools:v1.7.196
 
-      - name: Install CodeGraph
-        run: |
-          if ! command -v codegraph &>/dev/null; then
-            echo "📦 Installing CodeGraph..."
-            npm install -g @colbymchenry/codegraph
-          else
-            echo "✅ CodeGraph already installed (cache hit): $(codegraph --version 2>/dev/null)"
-          fi
+      - name: Install and init CodeGraph
+        run: bash agents/setup/codegraph.sh
 
       - name: Configure Git Author
         run: |

--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -64,7 +64,6 @@ jobs:
           node-version: '20'
 
       - name: Configure npm global prefix
-        if: vars.AI_AGENT_PROVIDER == 'copilot'
         run: |
           npm config set prefix ~/.npm-global
           echo "$HOME/.npm-global/bin" >> $GITHUB_PATH
@@ -111,15 +110,37 @@ jobs:
           fi
           echo "Using Copilot model: ${COPILOT_MODEL}"
 
-      - name: Install DMTools CLI v1.7.180
+      - name: Export tool cache keys
+        run: bash agents/setup/cache.sh keys dmtools:v1.7.196
+
+      - name: Cache DMTools
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.DMTOOLS_CACHE_PATH }}
+          key: ${{ env.DMTOOLS_CACHE_KEY }}
+          restore-keys: |
+            dmtools-
+
+      - name: Cache CodeGraph
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm-global
+          key: ${{ runner.os }}-npm-global-codegraph-latest
+          restore-keys: |
+            ${{ runner.os }}-npm-global-codegraph-
+            ${{ runner.os }}-npm-global-
+
+      - name: Install DMTools v1.7.196
+        run: bash agents/setup/install.sh dmtools:v1.7.196
+
+      - name: Install CodeGraph
         run: |
-          curl -fsSL https://github.com/epam/dm.ai/releases/download/v1.7.180/install.sh | bash -s -- v1.7.180
-
-      - name: Add DMTools to PATH
-        run: echo "$HOME/.dmtools/bin" >> $GITHUB_PATH
-
-      - name: Verify DMTools Installation
-        run: dmtools -v || echo "dmtools version check failed"
+          if ! command -v codegraph &>/dev/null; then
+            echo "📦 Installing CodeGraph..."
+            npm install -g @colbymchenry/codegraph
+          else
+            echo "✅ CodeGraph already installed (cache hit): $(codegraph --version 2>/dev/null)"
+          fi
 
       - name: Configure Git Author
         run: |
@@ -129,7 +150,7 @@ jobs:
 
       - name: Run AI Teammate
         env:
-          PATH: "/home/runner/.local/bin:/home/runner/.dmtools/bin:/bin:/usr/bin:$PATH"
+          PATH: "/home/runner/.local/bin:/home/runner/.dmtools/bin:/home/runner/.npm-global/bin:/bin:/usr/bin:$PATH"
 
           # Jira Configuration
           JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}

--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -111,7 +111,7 @@ jobs:
           echo "Using Copilot model: ${COPILOT_MODEL}"
 
       - name: Export tool cache keys
-        run: bash agents/setup/cache.sh keys dmtools:v1.7.196
+        run: bash agents/setup/cache.sh keys dmtools:v1.7.196 codegraph
 
       - name: Cache DMTools
         uses: actions/cache@v4
@@ -124,8 +124,8 @@ jobs:
       - name: Cache CodeGraph binary
         uses: actions/cache@v4
         with:
-          path: ~/.npm-global
-          key: ${{ runner.os }}-npm-global-codegraph-latest
+          path: ${{ env.CODEGRAPH_CACHE_PATH }}
+          key: ${{ env.CODEGRAPH_CACHE_KEY }}
           restore-keys: |
             ${{ runner.os }}-npm-global-codegraph-
             ${{ runner.os }}-npm-global-
@@ -133,11 +133,11 @@ jobs:
       - name: Cache CodeGraph index
         uses: actions/cache@v4
         with:
-          path: .codegraph
-          key: ${{ runner.os }}-codegraph-index-${{ github.sha }}
+          path: ${{ env.CODEGRAPH_INDEX_CACHE_PATH }}
+          key: ${{ env.CODEGRAPH_INDEX_CACHE_KEY }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-codegraph-index-${{ github.ref_name }}-
-            ${{ runner.os }}-codegraph-index-
+            ${{ env.CODEGRAPH_INDEX_CACHE_KEY }}-${{ github.ref_name }}-
+            ${{ env.CODEGRAPH_INDEX_CACHE_KEY }}-
 
       - name: Install DMTools v1.7.196
         run: bash agents/setup/install.sh dmtools:v1.7.196


### PR DESCRIPTION
## Changes

### ai-teammate.yml
- **dmtools**: replaced direct `curl` install with `agents/setup/install.sh dmtools:v1.7.196` (uses submodule setup script)
- **dmtools cache**: added `agents/setup/cache.sh keys dmtools:v1.7.196` step — exports `DMTOOLS_CACHE_PATH` / `DMTOOLS_CACHE_KEY` → used by `actions/cache@v4`
- **codegraph**: added Cache CodeGraph step (`~/.npm-global`, key: `npm-global-codegraph-latest`)
- **codegraph**: added Install CodeGraph step (`npm install -g @colbymchenry/codegraph`, skips on cache hit)
- **Node.js / npm prefix**: now always enabled (previously copilot-only) — required for codegraph
- **PATH** in Run step: added `~/.npm-global/bin` for codegraph binary
- **dmtools version**: bumped **v1.7.180 → v1.7.196**

### IstiN/dmtools-agents (pushed to main separately)
- `setup/codegraph.sh` — npm installer for `@colbymchenry/codegraph`
- `setup/install.sh` — codegraph added to ALL_TOOLS
- `setup/cache.sh` — `_cache_codegraph()` added
- `setup/dmtools.sh` — default version bumped to v1.7.196
- `common/codegraph_usage.md` — full CLI interface reference

## Why codegraph?
CodeGraph builds a semantic knowledge graph for fast call-graph traversal and AI context generation. Available in JS agents via `cli_execute_command('codegraph context ...')`.