### PR TITLE
fix: stop GitHub PR pagination on date boundary even when page is all declined (OOM fix)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -142,7 +142,20 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             }
 
             JSONArray pullRequestsInResponse = new JSONArray(response);
-            List<GitHubPullRequest> pullRequests = JSONModel.convertToModels(GitHubPullRequest.class, pullRequestsInResponse);
+            List<GitHubPullRequest> allOnPage = JSONModel.convertToModels(GitHubPullRequest.class, pullRequestsInResponse);
+
+            // Date-based stop: check the UNFILTERED page so that pages consisting entirely
+            // of declined (non-merged) PRs still advance the date cursor correctly.
+            // GitHub returns PRs newest-first, so the last item on the page is the oldest.
+            boolean pastStartDate = false;
+            if (startDate != null && !allOnPage.isEmpty()) {
+                long oldestOnPage = allOnPage.get(allOnPage.size() - 1).getCreatedDate();
+                if (oldestOnPage < startDate.getTimeInMillis()) {
+                    pastStartDate = true;
+                }
+            }
+
+            List<GitHubPullRequest> pullRequests = allOnPage;
             if (isMerged) {
                 pullRequests = pullRequests.stream()
                         .filter(GitHubPullRequest::isMerged)
@@ -152,9 +165,18 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
                         .filter(pr -> !pr.isMerged())
                         .collect(Collectors.toList());
             }
+
+            // Only keep PRs within the requested date window to bound memory usage
+            if (startDate != null) {
+                long startMillis = startDate.getTimeInMillis();
+                pullRequests = pullRequests.stream()
+                        .filter(pr -> pr.getCreatedDate() >= startMillis)
+                        .collect(Collectors.toList());
+            }
+
             allPullRequests.addAll(pullRequests);
 
-            if (startDate != null && !pullRequests.isEmpty() && pullRequests.get(pullRequests.size() - 1).getCreatedDate() < startDate.getTimeInMillis()) {
+            if (pastStartDate) {
                 break;
             }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.Calendar;
 import java.util.List;
 
 import org.mockito.ArgumentCaptor;
@@ -512,6 +513,108 @@ public class GitHubPRTest {
         assertTrue(requestBody.getString("query").contains(threadId));
         JSONObject parsed = new JSONObject(result);
         assertTrue(parsed.getJSONObject("data").getJSONObject("resolveReviewThread").getJSONObject("thread").getBoolean("isResolved"));
+    }
+
+    // ---- pullRequests() date-based stop condition ----
+
+    /**
+     * Verifies the OOM fix: when fetching merged PRs, pages consisting entirely of
+     * declined (non-merged) PRs should still advance the date cursor.
+     * Before the fix, pullRequests.isEmpty() after declined-filtering caused the
+     * date check to be skipped, resulting in infinite pagination.
+     *
+     * We fill each page to 100 items (the per-page limit) so pagination only
+     * stops due to the date boundary, not the "page not full" guard.
+     */
+    @Test
+    public void testPullRequests_stopsAtStartDateEvenWhenPageIsAllDeclined() throws Exception {
+        // startDate = 2024-06-01
+        Calendar startDate = Calendar.getInstance();
+        startDate.set(2024, Calendar.JUNE, 1, 0, 0, 0);
+        startDate.set(Calendar.MILLISECOND, 0);
+
+        // Page 1: 100 declined PRs with dates AFTER startDate — should not trigger stop
+        JSONArray page1 = buildFullPageOfDeclinedPRs(1000, "2024-07-01T10:00:00Z");
+
+        // Page 2: 100 declined PRs with dates BEFORE startDate — should trigger stop
+        JSONArray page2 = buildFullPageOfDeclinedPRs(2000, "2024-01-01T10:00:00Z");
+
+        doAnswer(inv -> {
+            GenericRequest req = inv.getArgument(0);
+            String url = req.url();
+            if (url.endsWith("page=1")) return page1.toString();
+            if (url.endsWith("page=2")) return page2.toString();
+            return "[]";
+        }).when(gitHub).execute(any(GenericRequest.class));
+
+        List<IPullRequest> result = gitHub.pullRequests(WORKSPACE, REPOSITORY, "merged", true, startDate);
+
+        // No merged PRs on either page — result must be empty
+        assertTrue("Expected empty result since no PRs are merged", result.isEmpty());
+
+        // Must have stopped after page 2 (not fetched page 3)
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitHub, atMost(2)).execute(captor.capture());
+        List<GenericRequest> reqs = captor.getAllValues();
+        assertTrue("Should have fetched page 1", reqs.stream().anyMatch(r -> r.url().endsWith("page=1")));
+        assertTrue("Should have fetched page 2", reqs.stream().anyMatch(r -> r.url().endsWith("page=2")));
+        assertFalse("Should NOT have fetched page 3", reqs.stream().anyMatch(r -> r.url().endsWith("page=3")));
+    }
+
+    /** Builds a JSONArray of {@code count} declined (non-merged) PRs all having the given date. */
+    private JSONArray buildFullPageOfDeclinedPRs(int startId, String date) {
+        JSONArray arr = new JSONArray();
+        for (int i = 0; i < 100; i++) {
+            arr.put(prWithDate(String.valueOf(startId + i), false, date));
+        }
+        return arr;
+    }
+
+    @Test
+    public void testPullRequests_returnsOnlyPRsWithinDateRange() throws Exception {
+        Calendar startDate = Calendar.getInstance();
+        startDate.set(2024, Calendar.JUNE, 1, 0, 0, 0);
+        startDate.set(Calendar.MILLISECOND, 0);
+
+        // Page with a merged PR inside range and a merged PR before range (plus padding to avoid premature stop)
+        JSONArray page1 = new JSONArray();
+        page1.put(prWithDate("10", true, "2024-08-01T10:00:00Z"));
+        page1.put(prWithDate("11", true, "2024-01-01T10:00:00Z"));
+        // Pad to make the last element clearly before startDate so loop stops
+        for (int i = 100; i < 100; i++) {
+            page1.put(prWithDate(String.valueOf(100 + i), false, "2024-01-01T10:00:00Z"));
+        }
+
+        doReturn(page1.toString()).when(gitHub).execute(any(GenericRequest.class));
+
+        List<IPullRequest> result = gitHub.pullRequests(WORKSPACE, REPOSITORY, "merged", true, startDate);
+
+        assertEquals("Only PR within date range should be returned", 1, result.size());
+        assertEquals(Integer.valueOf(10), result.get(0).getId());
+    }
+
+    private JSONObject prWithDate(String number, boolean merged, String createdAt) {
+        JSONObject json = new JSONObject();
+        json.put("number", Integer.parseInt(number));
+        json.put("title", "PR #" + number);
+        json.put("state", "closed");
+        json.put("merged", merged);
+        json.put("body", "");
+        json.put("created_at", createdAt);
+        if (merged) {
+            json.put("merged_at", createdAt);
+        }
+        JSONObject head = new JSONObject();
+        head.put("ref", "feature");
+        head.put("sha", "abc");
+        json.put("head", head);
+        JSONObject base = new JSONObject();
+        base.put("ref", "main");
+        json.put("base", base);
+        JSONObject user = new JSONObject();
+        user.put("login", "user");
+        json.put("user", user);
+        return json;
     }
 
     // ---- Helper builders ----


### PR DESCRIPTION
## Problem

`GitHub.pullRequests()` was fetching 256+ pages of PRs → OutOfMemoryError.

**Root cause**: The date stop-condition was checked on the **post-filter** list. When fetching merged PRs, if an entire page contained only declined (non-merged) PRs, the filtered list was empty →

## Fix

- Parse the full unfiltered page (`allOnPage`) first
- Check the date boundary on `allOnPage` (oldest entry on the page) — works regardless of merge status
- Then apply merged/declined filter for accumulation  
- Also trim PRs older than `startDate` from the accumulated list to bound memory

## Tests Added

- `testPullRequests_stopsAtStartDateEvenWhenPageIsAllDeclined`: two full 100-item pages of declined PRs; verifies loop stops after page 2 when all items on page 2 are before `startDate`
- `testPullRequests_returnsOnlyPRsWithinDateRange`: verifies PRs older than `startDate` are excluded from the returned list