### PR TITLE
fix: filter GitHub PR report data during pagination

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/code/SourceCode.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/code/SourceCode.java
@@ -15,10 +15,26 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public interface SourceCode {
 
     List<IPullRequest> pullRequests(String workspace, String repository, String state, boolean checkAllRequests, Calendar startDate) throws IOException;
+
+    default List<IPullRequest> pullRequests(String workspace, String repository, String state, boolean checkAllRequests, Calendar startDate, Pattern titlePattern) throws IOException {
+        List<IPullRequest> pullRequests = pullRequests(workspace, repository, state, checkAllRequests, startDate);
+        if (titlePattern == null) {
+            return pullRequests;
+        }
+        return pullRequests.stream()
+                .filter(pr -> titlePattern.matcher(pr.getTitle() != null ? pr.getTitle() : "").find())
+                .collect(Collectors.toList());
+    }
+
+    default boolean supportsPullRequestTitleFiltering() {
+        return false;
+    }
 
     IPullRequest pullRequest(String workspace, String repository, String pullRequestId) throws IOException;
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -120,6 +120,22 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             String state,
             boolean checkAllRequests,
             Calendar startDate) throws IOException {
+        return pullRequests(workspace, repository, state, checkAllRequests, startDate, null);
+    }
+
+    @Override
+    public boolean supportsPullRequestTitleFiltering() {
+        return true;
+    }
+
+    @Override
+    public List<IPullRequest> pullRequests(
+            String workspace,
+            String repository,
+            String state,
+            boolean checkAllRequests,
+            Calendar startDate,
+            Pattern titlePattern) throws IOException {
         boolean isMerged = state.equalsIgnoreCase(IPullRequest.PullRequestState.STATE_MERGED);
         boolean isDeclined = state.equalsIgnoreCase(IPullRequest.PullRequestState.STATE_DECLINED);
         if (isMerged || isDeclined) {
@@ -132,7 +148,7 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
         int currentPage = 1;
 
         while (true) {
-            String path = path(String.format("repos/%s/%s/pulls?state=%s&per_page=%d&page=%d",
+            String path = path(String.format("repos/%s/%s/pulls?state=%s&sort=updated&direction=desc&per_page=%d&page=%d",
                     workspace, repository, state, perPage, currentPage));
             GenericRequest getRequest = new GenericRequest(this, path);
             String response = execute(getRequest);
@@ -146,10 +162,10 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
 
             // Date-based stop: check the UNFILTERED page so that pages consisting entirely
             // of declined (non-merged) PRs still advance the date cursor correctly.
-            // GitHub returns PRs newest-first, so the last item on the page is the oldest.
+            // The request is sorted by updated date descending, so the last item on the page is the oldest.
             boolean pastStartDate = false;
             if (startDate != null && !allOnPage.isEmpty()) {
-                long oldestOnPage = allOnPage.get(allOnPage.size() - 1).getCreatedDate();
+                long oldestOnPage = getPaginationBoundaryDate(allOnPage.get(allOnPage.size() - 1));
                 if (oldestOnPage < startDate.getTimeInMillis()) {
                     pastStartDate = true;
                 }
@@ -170,7 +186,13 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             if (startDate != null) {
                 long startMillis = startDate.getTimeInMillis();
                 pullRequests = pullRequests.stream()
-                        .filter(pr -> pr.getCreatedDate() >= startMillis)
+                        .filter(pr -> getMetricDate(pr) >= startMillis)
+                        .collect(Collectors.toList());
+            }
+
+            if (titlePattern != null) {
+                pullRequests = pullRequests.stream()
+                        .filter(pr -> titlePattern.matcher(pr.getTitle() != null ? pr.getTitle() : "").find())
                         .collect(Collectors.toList());
             }
 
@@ -188,6 +210,26 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
         }
 
         return allPullRequests;
+    }
+
+    private long getPaginationBoundaryDate(GitHubPullRequest pullRequest) {
+        Long updatedDate = pullRequest.getUpdatedDate();
+        if (updatedDate != null) {
+            return updatedDate;
+        }
+        return pullRequest.getCreatedDate();
+    }
+
+    private long getMetricDate(GitHubPullRequest pullRequest) {
+        Long closedDate = pullRequest.getClosedDate();
+        if (closedDate != null) {
+            return closedDate;
+        }
+        Long updatedDate = pullRequest.getUpdatedDate();
+        if (updatedDate != null) {
+            return updatedDate;
+        }
+        return pullRequest.getCreatedDate();
     }
 
     @MCPTool(

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/metrics/source/PullRequestsBaseMetricSource.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/metrics/source/PullRequestsBaseMetricSource.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Abstract base for all PR-based metric sources.
@@ -81,7 +82,17 @@ public abstract class PullRequestsBaseMetricSource extends CommonSourceCollector
     protected List<IPullRequest> getPullRequests() throws Exception {
         List<IPullRequest> cached = sharedPrList.get();
         if (cached == null) {
-            List<IPullRequest> fetched = sourceCode.pullRequests(workspace, repo, state, true, startDate);
+            List<IPullRequest> fetched;
+            if (titlePattern != null && sourceCode.supportsPullRequestTitleFiltering()) {
+                fetched = sourceCode.pullRequests(workspace, repo, state, true, startDate, titlePattern);
+            } else {
+                fetched = sourceCode.pullRequests(workspace, repo, state, true, startDate);
+                if (titlePattern != null) {
+                    fetched = fetched.stream()
+                            .filter(pr -> titlePattern.matcher(pr.getTitle() != null ? pr.getTitle() : "").find())
+                            .collect(Collectors.toList());
+                }
+            }
             sharedPrList.compareAndSet(null, fetched);
             cached = sharedPrList.get();
         }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/metrics/MetricFactory.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/metrics/MetricFactory.java
@@ -253,7 +253,7 @@ public class MetricFactory {
             case "PullRequestsMetricSource": {
                 Calendar sd = parseDateParam(startDateStr);
                 return new PullRequestsMetricSource(workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr));
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr, titleRegex));
             }
 
             case "CommitsMetricSource":
@@ -267,34 +267,34 @@ public class MetricFactory {
                 }
                 Calendar sd = parseDateParam(startDateStr);
                 return new PullRequestsChangesMetricSource(workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr));
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr, titleRegex));
             }
 
             case "PullRequestsCommentsMetricSource": {
                 Calendar sd = parseDateParam(startDateStr);
                 boolean isPositive = (boolean) params.getOrDefault("isPositive", true);
                 return new PullRequestsCommentsMetricSource(isPositive, workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr),
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr, titleRegex),
                         sharedActivitiesMap(workspace, repository));
             }
 
             case "PullRequestsApprovalsMetricSource": {
                 Calendar sd = parseDateParam(startDateStr);
                 return new PullRequestsApprovalsMetricSource(workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr),
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr, titleRegex),
                         sharedActivitiesMap(workspace, repository));
             }
 
             case "PullRequestsMergedByMetricSource": {
                 Calendar sd = parseDateParam(startDateStr);
                 return new PullRequestsMergedByMetricSource(workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr));
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_MERGED, startDateStr, titleRegex));
             }
 
             case "PullRequestsDeclinedMetricSource": {
                 Calendar sd = parseDateParam(startDateStr);
                 return new PullRequestsDeclinedMetricSource(workspace, repository, sourceCode, employees, sd, titleRegex,
-                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_DECLINED, startDateStr));
+                        sharedPrRef(workspace, repository, IPullRequest.PullRequestState.STATE_DECLINED, startDateStr, titleRegex));
             }
 
             default:
@@ -303,13 +303,13 @@ public class MetricFactory {
     }
 
     /**
-     * Returns the shared {@link AtomicReference} for the given (workspace, repo, state, startDate) tuple.
+     * Returns the shared {@link AtomicReference} for the given (workspace, repo, state, startDate, titleRegex) tuple.
      * All metric sources that use the same tuple will share the same reference and therefore
      * the same PR list — avoiding redundant API calls.
      */
     private AtomicReference<List<IPullRequest>> sharedPrRef(
-            String workspace, String repo, String state, String startDateStr) {
-        String key = workspace + "|" + repo + "|" + state + "|" + startDateStr;
+            String workspace, String repo, String state, String startDateStr, String titleRegex) {
+        String key = workspace + "|" + repo + "|" + state + "|" + startDateStr + "|" + titleRegex;
         return prListCache.computeIfAbsent(key, k -> new AtomicReference<>(null));
     }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubPRTest.java
@@ -20,6 +20,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.Calendar;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.mockito.ArgumentCaptor;
 import static org.junit.Assert.*;
@@ -593,14 +594,55 @@ public class GitHubPRTest {
         assertEquals(Integer.valueOf(10), result.get(0).getId());
     }
 
+    @Test
+    public void testPullRequests_appliesTitleRegexBeforeAccumulatingPageResults() throws Exception {
+        Calendar startDate = Calendar.getInstance();
+        startDate.set(2024, Calendar.JANUARY, 1, 0, 0, 0);
+        startDate.set(Calendar.MILLISECOND, 0);
+
+        JSONArray page1 = new JSONArray();
+        page1.put(prWithDateAndTitle("10", true, "SFLN-123 Implement feature", "2024-08-01T10:00:00Z"));
+        for (int i = 1; i < 100; i++) {
+            page1.put(prWithDateAndTitle(String.valueOf(1000 + i), true, "OTHER-" + i + " unrelated", "2024-08-01T10:00:00Z"));
+        }
+
+        JSONArray page2 = new JSONArray();
+        page2.put(prWithDateAndTitle("20", true, "SFLN-456 Older feature", "2023-12-01T10:00:00Z"));
+
+        doAnswer(inv -> {
+            GenericRequest req = inv.getArgument(0);
+            String url = req.url();
+            if (url.endsWith("page=1")) return page1.toString();
+            if (url.endsWith("page=2")) return page2.toString();
+            return "[]";
+        }).when(gitHub).execute(any(GenericRequest.class));
+
+        List<IPullRequest> result = gitHub.pullRequests(
+                WORKSPACE,
+                REPOSITORY,
+                "merged",
+                true,
+                startDate,
+                Pattern.compile("SFLN-\\d+"));
+
+        assertEquals("Only matching PRs inside date range should be accumulated", 1, result.size());
+        assertEquals(Integer.valueOf(10), result.get(0).getId());
+    }
+
     private JSONObject prWithDate(String number, boolean merged, String createdAt) {
+        return prWithDateAndTitle(number, merged, "PR #" + number, createdAt);
+    }
+
+    private JSONObject prWithDateAndTitle(String number, boolean merged, String title, String createdAt) {
         JSONObject json = new JSONObject();
         json.put("number", Integer.parseInt(number));
-        json.put("title", "PR #" + number);
+        json.put("title", title);
         json.put("state", "closed");
         json.put("merged", merged);
         json.put("body", "");
         json.put("created_at", createdAt);
+        json.put("updated_at", createdAt);
+        json.put("closed_at", createdAt);
         if (merged) {
             json.put("merged_at", createdAt);
         }


### PR DESCRIPTION
Problem: the report still OOMs on big repo because pull request report sources fetched every closed PR and applied titleRegex only after materializing the full list. The log reached page 256 before failing in ResponseBody.string with Java heap space.

Fix: pass titleRegex into PR loading, let GitHub filter matching titles per page before accumulating results, keep non-GitHub behavior unchanged, include titleRegex in the shared PR cache key, and sort GitHub PR pages by updated date for a better startDate boundary.

Validation: dmtools-core GitHubPRTest, RegexFilterMetricSourceTest, and full dmtools-core test suite pass.