### PR TITLE
DMC-1040 Test: Gradle shadow JAR production — build generates expected dmtools-core artifact

### DIFF
--- a/testing/components/factories/shadow_jar_build_audit_service_factory.py
+++ b/testing/components/factories/shadow_jar_build_audit_service_factory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.shadow_jar_build_audit_service import (
+    ShadowJarBuildAuditService as ShadowJarBuildAuditServiceImpl,
+)
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.interfaces.shadow_jar_build_audit_service import (
+    ShadowJarBuildAuditService,
+)
+from testing.frameworks.api.rest.subprocess_process_runner import SubprocessProcessRunner
+
+
+def create_shadow_jar_build_audit_service(
+    repository_root: Path,
+    runner: ProcessRunner | None = None,
+    *,
+    gradle_task: str = ":dmtools-core:shadowJar",
+    expected_directory: str = "dmtools-core/build/libs",
+    fallback_directory: str = "build/libs",
+    artifact_pattern: str = "dmtools-v*-all.jar",
+) -> ShadowJarBuildAuditService:
+    return ShadowJarBuildAuditServiceImpl(
+        repository_root=repository_root,
+        runner=runner or SubprocessProcessRunner(),
+        gradle_task=gradle_task,
+        expected_directory=expected_directory,
+        fallback_directory=fallback_directory,
+        artifact_pattern=artifact_pattern,
+    )

--- a/testing/components/services/shadow_jar_build_audit_service.py
+++ b/testing/components/services/shadow_jar_build_audit_service.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.core.interfaces.process_runner import ProcessRunner
+from testing.core.models.shadow_jar_build_audit import ShadowJarBuildAudit
+
+
+class ShadowJarBuildAuditService:
+    def __init__(
+        self,
+        repository_root: Path,
+        runner: ProcessRunner,
+        *,
+        gradle_task: str = ":dmtools-core:shadowJar",
+        expected_directory: str = "dmtools-core/build/libs",
+        fallback_directory: str = "build/libs",
+        artifact_pattern: str = "dmtools-v*-all.jar",
+    ) -> None:
+        self.repository_root = repository_root
+        self.runner = runner
+        self.gradle_task = gradle_task
+        self.expected_directory = repository_root / expected_directory
+        self.fallback_directory = repository_root / fallback_directory
+        self.artifact_pattern = artifact_pattern
+
+    def audit(self) -> ShadowJarBuildAudit:
+        gradle_command = (
+            str(self.repository_root / "gradlew"),
+            "--no-daemon",
+            self.gradle_task,
+        )
+        execution = self.runner.run(
+            gradle_command,
+            cwd=self.repository_root,
+        )
+        return ShadowJarBuildAudit(
+            gradle_command=gradle_command,
+            execution=execution,
+            expected_directory=self.expected_directory,
+            fallback_directory=self.fallback_directory,
+            artifact_pattern=self.artifact_pattern,
+            expected_artifacts=self._find_artifacts(self.expected_directory),
+            fallback_artifacts=self._find_artifacts(self.fallback_directory),
+        )
+
+    def format_failure(self, audit: ShadowJarBuildAudit) -> str:
+        return (
+            "The Gradle shadow JAR build did not produce the requested compatibility artifact in the "
+            "ticket's expected directory.\n"
+            f"Command: {' '.join(audit.gradle_command)}\n"
+            f"Build return code: {audit.execution.returncode}\n"
+            f"Expected directory: {audit.expected_directory}\n"
+            f"Expected directory exists: {audit.expected_directory_exists}\n"
+            f"Expected artifact pattern: {audit.artifact_pattern}\n"
+            f"Observed expected-directory artifacts: {self._format_paths(audit.expected_artifacts)}\n"
+            f"Observed fallback directory: {audit.fallback_directory}\n"
+            f"Observed fallback-directory artifacts: {self._format_paths(audit.fallback_artifacts)}\n"
+            f"stdout:\n{audit.execution.stdout}\n\nstderr:\n{audit.execution.stderr}"
+        )
+
+    def _find_artifacts(self, directory: Path) -> tuple[Path, ...]:
+        if not directory.exists():
+            return ()
+        return tuple(
+            sorted(
+                directory.glob(self.artifact_pattern),
+                key=lambda candidate: candidate.name,
+            )
+        )
+
+    def _format_paths(self, paths: tuple[Path, ...]) -> str:
+        if not paths:
+            return "<none>"
+        return ", ".join(path.as_posix() for path in paths)

--- a/testing/components/services/shadow_jar_build_audit_service.py
+++ b/testing/components/services/shadow_jar_build_audit_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Mapping
 
 from testing.core.interfaces.process_runner import ProcessRunner
 from testing.core.models.shadow_jar_build_audit import ShadowJarBuildAudit
@@ -25,6 +26,8 @@ class ShadowJarBuildAuditService:
         self.artifact_pattern = artifact_pattern
 
     def audit(self) -> ShadowJarBuildAudit:
+        expected_before = self._snapshot_artifacts(self.expected_directory)
+        fallback_before = self._snapshot_artifacts(self.fallback_directory)
         gradle_command = (
             str(self.repository_root / "gradlew"),
             "--no-daemon",
@@ -34,14 +37,26 @@ class ShadowJarBuildAuditService:
             gradle_command,
             cwd=self.repository_root,
         )
+        expected_after = self._snapshot_artifacts(self.expected_directory)
+        fallback_after = self._snapshot_artifacts(self.fallback_directory)
         return ShadowJarBuildAudit(
             gradle_command=gradle_command,
             execution=execution,
             expected_directory=self.expected_directory,
             fallback_directory=self.fallback_directory,
             artifact_pattern=self.artifact_pattern,
-            expected_artifacts=self._find_artifacts(self.expected_directory),
-            fallback_artifacts=self._find_artifacts(self.fallback_directory),
+            expected_artifacts_before_build=self._paths_from_snapshot(expected_before),
+            expected_artifacts=self._paths_from_snapshot(expected_after),
+            expected_artifacts_from_current_build=self._find_changed_artifacts(
+                before=expected_before,
+                after=expected_after,
+            ),
+            fallback_artifacts_before_build=self._paths_from_snapshot(fallback_before),
+            fallback_artifacts=self._paths_from_snapshot(fallback_after),
+            fallback_artifacts_from_current_build=self._find_changed_artifacts(
+                before=fallback_before,
+                after=fallback_after,
+            ),
         )
 
     def format_failure(self, audit: ShadowJarBuildAudit) -> str:
@@ -53,21 +68,48 @@ class ShadowJarBuildAuditService:
             f"Expected directory: {audit.expected_directory}\n"
             f"Expected directory exists: {audit.expected_directory_exists}\n"
             f"Expected artifact pattern: {audit.artifact_pattern}\n"
-            f"Observed expected-directory artifacts: {self._format_paths(audit.expected_artifacts)}\n"
+            "Observed expected-directory artifacts before build: "
+            f"{self._format_paths(audit.expected_artifacts_before_build)}\n"
+            f"Observed expected-directory artifacts after build: {self._format_paths(audit.expected_artifacts)}\n"
+            "Observed expected-directory artifacts created or updated by this build: "
+            f"{self._format_paths(audit.expected_artifacts_from_current_build)}\n"
             f"Observed fallback directory: {audit.fallback_directory}\n"
-            f"Observed fallback-directory artifacts: {self._format_paths(audit.fallback_artifacts)}\n"
+            "Observed fallback-directory artifacts before build: "
+            f"{self._format_paths(audit.fallback_artifacts_before_build)}\n"
+            f"Observed fallback-directory artifacts after build: {self._format_paths(audit.fallback_artifacts)}\n"
+            "Observed fallback-directory artifacts created or updated by this build: "
+            f"{self._format_paths(audit.fallback_artifacts_from_current_build)}\n"
             f"stdout:\n{audit.execution.stdout}\n\nstderr:\n{audit.execution.stderr}"
         )
 
-    def _find_artifacts(self, directory: Path) -> tuple[Path, ...]:
+    def _snapshot_artifacts(self, directory: Path) -> dict[Path, tuple[int, int, int]]:
         if not directory.exists():
-            return ()
-        return tuple(
-            sorted(
-                directory.glob(self.artifact_pattern),
-                key=lambda candidate: candidate.name,
+            return {}
+        snapshots: dict[Path, tuple[int, int, int]] = {}
+        for candidate in sorted(directory.glob(self.artifact_pattern), key=lambda item: item.name):
+            stat_result = candidate.stat()
+            snapshots[candidate] = (
+                stat_result.st_size,
+                stat_result.st_mtime_ns,
+                stat_result.st_ino,
             )
-        )
+        return snapshots
+
+    def _paths_from_snapshot(self, snapshot: Mapping[Path, tuple[int, int, int]]) -> tuple[Path, ...]:
+        return tuple(snapshot.keys())
+
+    def _find_changed_artifacts(
+        self,
+        *,
+        before: Mapping[Path, tuple[int, int, int]],
+        after: Mapping[Path, tuple[int, int, int]],
+    ) -> tuple[Path, ...]:
+        changed_paths = [
+            path
+            for path, fingerprint in after.items()
+            if before.get(path) != fingerprint
+        ]
+        return tuple(sorted(changed_paths, key=lambda candidate: candidate.name))
 
     def _format_paths(self, paths: tuple[Path, ...]) -> str:
         if not paths:

--- a/testing/core/interfaces/shadow_jar_build_audit_service.py
+++ b/testing/core/interfaces/shadow_jar_build_audit_service.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from testing.core.models.shadow_jar_build_audit import ShadowJarBuildAudit
+
+
+class ShadowJarBuildAuditService(Protocol):
+    def audit(self) -> ShadowJarBuildAudit:
+        raise NotImplementedError
+
+    def format_failure(self, audit: ShadowJarBuildAudit) -> str:
+        raise NotImplementedError

--- a/testing/core/models/shadow_jar_build_audit.py
+++ b/testing/core/models/shadow_jar_build_audit.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+@dataclass(frozen=True)
+class ShadowJarBuildAudit:
+    gradle_command: tuple[str, ...]
+    execution: ProcessExecutionResult
+    expected_directory: Path
+    fallback_directory: Path
+    artifact_pattern: str
+    expected_artifacts: tuple[Path, ...]
+    fallback_artifacts: tuple[Path, ...]
+
+    @property
+    def expected_directory_exists(self) -> bool:
+        return self.expected_directory.exists()
+
+    @property
+    def fallback_directory_exists(self) -> bool:
+        return self.fallback_directory.exists()
+
+    @property
+    def expected_artifact_present(self) -> bool:
+        return bool(self.expected_artifacts)
+
+    @property
+    def fallback_artifact_present(self) -> bool:
+        return bool(self.fallback_artifacts)

--- a/testing/core/models/shadow_jar_build_audit.py
+++ b/testing/core/models/shadow_jar_build_audit.py
@@ -13,8 +13,12 @@ class ShadowJarBuildAudit:
     expected_directory: Path
     fallback_directory: Path
     artifact_pattern: str
+    expected_artifacts_before_build: tuple[Path, ...]
     expected_artifacts: tuple[Path, ...]
+    expected_artifacts_from_current_build: tuple[Path, ...]
+    fallback_artifacts_before_build: tuple[Path, ...]
     fallback_artifacts: tuple[Path, ...]
+    fallback_artifacts_from_current_build: tuple[Path, ...]
 
     @property
     def expected_directory_exists(self) -> bool:
@@ -29,5 +33,13 @@ class ShadowJarBuildAudit:
         return bool(self.expected_artifacts)
 
     @property
+    def expected_artifact_built_this_run(self) -> bool:
+        return bool(self.expected_artifacts_from_current_build)
+
+    @property
     def fallback_artifact_present(self) -> bool:
         return bool(self.fallback_artifacts)
+
+    @property
+    def fallback_artifact_built_this_run(self) -> bool:
+        return bool(self.fallback_artifacts_from_current_build)

--- a/testing/tests/DMC-1040/README.md
+++ b/testing/tests/DMC-1040/README.md
@@ -3,7 +3,8 @@
 This test reproduces the ticket flow exactly: it runs
 `./gradlew :dmtools-core:shadowJar` and then inspects the ticket's expected
 artifact directory, `dmtools-core/build/libs/`, for a `dmtools-v*-all.jar`
-shadow JAR.
+shadow JAR. It also compares the artifact state before and after the build so
+leftover workspace output cannot create a false-positive pass.
 
 ## Install dependencies
 

--- a/testing/tests/DMC-1040/README.md
+++ b/testing/tests/DMC-1040/README.md
@@ -1,0 +1,27 @@
+# DMC-1040 automated test
+
+This test reproduces the ticket flow exactly: it runs
+`./gradlew :dmtools-core:shadowJar` and then inspects the ticket's expected
+artifact directory, `dmtools-core/build/libs/`, for a `dmtools-v*-all.jar`
+shadow JAR.
+
+## Install dependencies
+
+```bash
+python3 -m pip install -r testing/requirements.txt
+```
+
+## Run this test
+
+```bash
+PYTHONPATH=. python3 -m pytest testing/tests/DMC-1040/test_dmc_1040.py -q
+```
+
+## Human-style verification
+
+The automated scenario mirrors a user verifying the build output manually after
+running the documented Gradle command:
+
+1. Run `./gradlew :dmtools-core:shadowJar`.
+2. Open `dmtools-core/build/libs/`.
+3. Confirm whether a `dmtools-v*-all.jar` file is visibly present there.

--- a/testing/tests/DMC-1040/config.yaml
+++ b/testing/tests/DMC-1040/config.yaml
@@ -1,0 +1,9 @@
+test_id: DMC-1040
+type: api
+framework: pytest
+platform: linux
+dependencies: []
+gradle_task: :dmtools-core:shadowJar
+expected_directory: dmtools-core/build/libs
+fallback_directory: build/libs
+artifact_pattern: dmtools-v*-all.jar

--- a/testing/tests/DMC-1040/test_dmc_1040.py
+++ b/testing/tests/DMC-1040/test_dmc_1040.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from testing.components.factories.shadow_jar_build_audit_service_factory import (  # noqa: E402
+    create_shadow_jar_build_audit_service,
+)
+from testing.core.interfaces.shadow_jar_build_audit_service import (  # noqa: E402
+    ShadowJarBuildAuditService,
+)
+from testing.core.utils.ticket_config_loader import load_ticket_config  # noqa: E402
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+CONFIG = load_ticket_config(TEST_DIRECTORY / "config.yaml")
+
+
+def build_service() -> ShadowJarBuildAuditService:
+    return create_shadow_jar_build_audit_service(
+        repository_root=REPOSITORY_ROOT,
+        gradle_task=str(CONFIG["gradle_task"]),
+        expected_directory=str(CONFIG["expected_directory"]),
+        fallback_directory=str(CONFIG["fallback_directory"]),
+        artifact_pattern=str(CONFIG["artifact_pattern"]),
+    )
+
+
+def test_dmc_1040_shadowjar_build_generates_expected_dmtools_core_artifact() -> None:
+    service = build_service()
+    audit = service.audit()
+
+    print(
+        "DMC1040_OBSERVATION="
+        + json.dumps(
+            {
+                "returncode": audit.execution.returncode,
+                "expected_directory": audit.expected_directory.as_posix(),
+                "expected_directory_exists": audit.expected_directory_exists,
+                "expected_artifacts": [path.name for path in audit.expected_artifacts],
+                "fallback_directory": audit.fallback_directory.as_posix(),
+                "fallback_artifacts": [path.name for path in audit.fallback_artifacts],
+            },
+            sort_keys=True,
+        )
+    )
+
+    assert audit.execution.returncode == 0, service.format_failure(audit)
+    assert audit.expected_directory_exists, service.format_failure(audit)
+    assert audit.expected_artifact_present, service.format_failure(audit)

--- a/testing/tests/DMC-1040/test_dmc_1040.py
+++ b/testing/tests/DMC-1040/test_dmc_1040.py
@@ -43,9 +43,21 @@ def test_dmc_1040_shadowjar_build_generates_expected_dmtools_core_artifact() -> 
                 "returncode": audit.execution.returncode,
                 "expected_directory": audit.expected_directory.as_posix(),
                 "expected_directory_exists": audit.expected_directory_exists,
+                "expected_artifacts_before_build": [
+                    path.name for path in audit.expected_artifacts_before_build
+                ],
                 "expected_artifacts": [path.name for path in audit.expected_artifacts],
+                "expected_artifacts_from_current_build": [
+                    path.name for path in audit.expected_artifacts_from_current_build
+                ],
                 "fallback_directory": audit.fallback_directory.as_posix(),
+                "fallback_artifacts_before_build": [
+                    path.name for path in audit.fallback_artifacts_before_build
+                ],
                 "fallback_artifacts": [path.name for path in audit.fallback_artifacts],
+                "fallback_artifacts_from_current_build": [
+                    path.name for path in audit.fallback_artifacts_from_current_build
+                ],
             },
             sort_keys=True,
         )
@@ -54,3 +66,4 @@ def test_dmc_1040_shadowjar_build_generates_expected_dmtools_core_artifact() -> 
     assert audit.execution.returncode == 0, service.format_failure(audit)
     assert audit.expected_directory_exists, service.format_failure(audit)
     assert audit.expected_artifact_present, service.format_failure(audit)
+    assert audit.expected_artifact_built_this_run, service.format_failure(audit)

--- a/testing/tests/DMC-1040/test_dmc_1040_service.py
+++ b/testing/tests/DMC-1040/test_dmc_1040_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from testing.components.services.shadow_jar_build_audit_service import (
+    ShadowJarBuildAuditService,
+)
+from testing.core.models.process_execution_result import ProcessExecutionResult
+
+
+class FakeProcessRunner:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = "build ok",
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.calls: list[tuple[tuple[str, ...], Path]] = []
+
+    def run(
+        self,
+        args: tuple[str, ...] | list[str],
+        cwd: Path,
+        env: dict[str, str | None] | None = None,
+        trace_network: bool = False,
+    ) -> ProcessExecutionResult:
+        del env, trace_network
+        call_args = tuple(args)
+        self.calls.append((call_args, cwd))
+        return ProcessExecutionResult(
+            args=call_args,
+            cwd=cwd,
+            returncode=self.returncode,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+def test_audit_reports_expected_directory_artifact_when_present(tmp_path: Path) -> None:
+    expected_directory = tmp_path / "dmtools-core" / "build" / "libs"
+    expected_directory.mkdir(parents=True)
+    artifact_path = expected_directory / "dmtools-v1.0.0-all.jar"
+    artifact_path.write_text("jar", encoding="utf-8")
+
+    runner = FakeProcessRunner()
+    service = ShadowJarBuildAuditService(
+        repository_root=tmp_path,
+        runner=runner,
+    )
+
+    audit = service.audit()
+
+    assert runner.calls == [((str(tmp_path / "gradlew"), "--no-daemon", ":dmtools-core:shadowJar"), tmp_path)]
+    assert audit.expected_directory_exists
+    assert audit.expected_artifact_present
+    assert audit.expected_artifacts == (artifact_path,)
+    assert not audit.fallback_artifact_present
+
+
+def test_audit_captures_fallback_artifact_when_ticket_expected_directory_is_missing(tmp_path: Path) -> None:
+    fallback_directory = tmp_path / "build" / "libs"
+    fallback_directory.mkdir(parents=True)
+    fallback_artifact = fallback_directory / "dmtools-v1.0.0-all.jar"
+    fallback_artifact.write_text("jar", encoding="utf-8")
+
+    service = ShadowJarBuildAuditService(
+        repository_root=tmp_path,
+        runner=FakeProcessRunner(),
+    )
+
+    audit = service.audit()
+
+    assert not audit.expected_directory_exists
+    assert not audit.expected_artifact_present
+    assert audit.fallback_directory_exists
+    assert audit.fallback_artifact_present
+    assert audit.fallback_artifacts == (fallback_artifact,)
+    failure_message = service.format_failure(audit)
+    assert "Expected directory exists: False" in failure_message
+    assert fallback_artifact.as_posix() in failure_message

--- a/testing/tests/DMC-1040/test_dmc_1040_service.py
+++ b/testing/tests/DMC-1040/test_dmc_1040_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
 from testing.components.services.shadow_jar_build_audit_service import (
     ShadowJarBuildAuditService,
@@ -15,10 +16,12 @@ class FakeProcessRunner:
         returncode: int = 0,
         stdout: str = "build ok",
         stderr: str = "",
+        on_run: Callable[[Path], None] | None = None,
     ) -> None:
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+        self.on_run = on_run
         self.calls: list[tuple[tuple[str, ...], Path]] = []
 
     def run(
@@ -31,6 +34,8 @@ class FakeProcessRunner:
         del env, trace_network
         call_args = tuple(args)
         self.calls.append((call_args, cwd))
+        if self.on_run is not None:
+            self.on_run(cwd)
         return ProcessExecutionResult(
             args=call_args,
             cwd=cwd,
@@ -41,12 +46,11 @@ class FakeProcessRunner:
 
 
 def test_audit_reports_expected_directory_artifact_when_present(tmp_path: Path) -> None:
-    expected_directory = tmp_path / "dmtools-core" / "build" / "libs"
-    expected_directory.mkdir(parents=True)
-    artifact_path = expected_directory / "dmtools-v1.0.0-all.jar"
-    artifact_path.write_text("jar", encoding="utf-8")
+    artifact_path = tmp_path / "dmtools-core" / "build" / "libs" / "dmtools-v1.0.0-all.jar"
 
-    runner = FakeProcessRunner()
+    runner = FakeProcessRunner(
+        on_run=lambda _: _write_artifact(artifact_path),
+    )
     service = ShadowJarBuildAuditService(
         repository_root=tmp_path,
         runner=runner,
@@ -57,19 +61,20 @@ def test_audit_reports_expected_directory_artifact_when_present(tmp_path: Path) 
     assert runner.calls == [((str(tmp_path / "gradlew"), "--no-daemon", ":dmtools-core:shadowJar"), tmp_path)]
     assert audit.expected_directory_exists
     assert audit.expected_artifact_present
+    assert audit.expected_artifacts_before_build == ()
     assert audit.expected_artifacts == (artifact_path,)
+    assert audit.expected_artifacts_from_current_build == (artifact_path,)
     assert not audit.fallback_artifact_present
 
 
 def test_audit_captures_fallback_artifact_when_ticket_expected_directory_is_missing(tmp_path: Path) -> None:
-    fallback_directory = tmp_path / "build" / "libs"
-    fallback_directory.mkdir(parents=True)
-    fallback_artifact = fallback_directory / "dmtools-v1.0.0-all.jar"
-    fallback_artifact.write_text("jar", encoding="utf-8")
+    fallback_artifact = tmp_path / "build" / "libs" / "dmtools-v1.0.0-all.jar"
 
     service = ShadowJarBuildAuditService(
         repository_root=tmp_path,
-        runner=FakeProcessRunner(),
+        runner=FakeProcessRunner(
+            on_run=lambda _: _write_artifact(fallback_artifact),
+        ),
     )
 
     audit = service.audit()
@@ -78,7 +83,35 @@ def test_audit_captures_fallback_artifact_when_ticket_expected_directory_is_miss
     assert not audit.expected_artifact_present
     assert audit.fallback_directory_exists
     assert audit.fallback_artifact_present
+    assert audit.fallback_artifacts_before_build == ()
     assert audit.fallback_artifacts == (fallback_artifact,)
+    assert audit.fallback_artifacts_from_current_build == (fallback_artifact,)
     failure_message = service.format_failure(audit)
     assert "Expected directory exists: False" in failure_message
     assert fallback_artifact.as_posix() in failure_message
+
+
+def test_audit_does_not_treat_stale_expected_artifact_as_current_build_output(tmp_path: Path) -> None:
+    expected_artifact = tmp_path / "dmtools-core" / "build" / "libs" / "dmtools-v1.0.0-all.jar"
+    _write_artifact(expected_artifact)
+
+    service = ShadowJarBuildAuditService(
+        repository_root=tmp_path,
+        runner=FakeProcessRunner(),
+    )
+
+    audit = service.audit()
+
+    assert audit.expected_directory_exists
+    assert audit.expected_artifact_present
+    assert audit.expected_artifacts_before_build == (expected_artifact,)
+    assert audit.expected_artifacts == (expected_artifact,)
+    assert not audit.expected_artifact_built_this_run
+    failure_message = service.format_failure(audit)
+    assert "Observed expected-directory artifacts before build" in failure_message
+    assert "Observed expected-directory artifacts created or updated by this build: <none>" in failure_message
+
+
+def _write_artifact(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("jar", encoding="utf-8")


### PR DESCRIPTION
## DMC-1040 Result: FAILED

**Latest rework result:** `FAILED`

---

# DMC-1040 rework result: failed

## What changed
- Fixed the review issue that could false-pass on leftover build output.
- The audit now snapshots expected and fallback artifact state before and after `./gradlew --no-daemon :dmtools-core:shadowJar`.
- The test only treats artifacts created or updated by the current build as valid output.
- Added unit coverage for current-build artifact detection and stale-artifact rejection.

## New execution result
- `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1040/test_dmc_1040_service.py -q` → `3 passed`
- `PYTHONPATH=. python3 -m pytest testing/tests/DMC-1040/test_dmc_1040.py -q` → `1 failed`

## Observed product behavior
- `./gradlew --no-daemon :dmtools-core:shadowJar` succeeded.
- `dmtools-core/build/libs/` was still missing after the build.
- The current build created `build/libs/dmtools-v1.7.197-all.jar` instead.

## Conclusion
The review feedback is addressed, and the test now proves causality for the current run. The ticket still fails because the production build does not expose the expected `dmtools-core/build/libs/dmtools-v*-all.jar` artifact.
