### PR TITLE
DMC-1007 Test: Trigger standalone-release-auto.yml — workflow completes without Gradle project resolution error

### DIFF
--- a/testing/components/services/deprecated_workflow_run_audit_service.py
+++ b/testing/components/services/deprecated_workflow_run_audit_service.py
@@ -20,7 +20,9 @@ from testing.core.models.deprecated_workflow_run_audit import (
 
 
 class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContract):
-    SUMMARY_ECHO_PATTERN = re.compile(r'echo (?P<argument>.+?) >> \$GITHUB_STEP_SUMMARY$')
+    SUMMARY_ECHO_PATTERN = re.compile(
+        r'echo (?P<argument>.+?) >> (?:"\$GITHUB_STEP_SUMMARY"|\$GITHUB_STEP_SUMMARY)$'
+    )
     ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
     TIMESTAMP_PREFIX_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}T[^ ]+\s+")
     RELEASE_URL_PATTERN = re.compile(r"/releases/tag/(?P<tag>[^)\s]+)")
@@ -422,8 +424,8 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
         if payload is None:
             return None
 
-        created_at = self._parse_github_datetime(str(payload.get("created_at", "")))
-        if created_at is not None and created_at < dispatch_started_at - timedelta(minutes=5):
+        release_timestamp = self._release_timestamp(payload)
+        if release_timestamp is not None and release_timestamp < dispatch_started_at - timedelta(minutes=5):
             return None
 
         return DeprecatedWorkflowReleaseObservation(
@@ -454,11 +456,18 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             tag_name = str(release.get("tag_name", "")).strip()
             if candidate_tags and tag_name not in candidate_tags:
                 continue
-            created_at = self._parse_github_datetime(str(release.get("created_at", "")))
-            if created_at is None or created_at < dispatch_started_at - timedelta(minutes=5):
+            release_timestamp = self._release_timestamp(release)
+            if release_timestamp is None or release_timestamp < dispatch_started_at - timedelta(minutes=5):
                 continue
             if candidate_tags or self._release_looks_like_deprecated_workflow_output(release):
                 return release
+        return None
+
+    def _release_timestamp(self, payload: dict[str, Any]) -> datetime | None:
+        for key in ("published_at", "created_at"):
+            value = self._parse_github_datetime(str(payload.get(key, "")))
+            if value is not None:
+                return value
         return None
 
     def _extract_step_summary_markdown(self, raw_log_text: str) -> str:
@@ -467,7 +476,7 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
             line = self._normalize_log_line(raw_line)
             if line.startswith("##[group]Run "):
                 continue
-            if ">> $GITHUB_STEP_SUMMARY" not in line:
+            if "$GITHUB_STEP_SUMMARY" not in line:
                 continue
             match = self.SUMMARY_ECHO_PATTERN.search(line)
             if not match:
@@ -504,10 +513,13 @@ class DeprecatedWorkflowRunAuditService(DeprecatedWorkflowRunAuditServiceContrac
 
     @classmethod
     def _release_tag_from_text(cls, text: str) -> str:
-        for pattern in (cls.RELEASE_URL_PATTERN, cls.RELEASE_TAG_OUTPUT_PATTERN, cls.USING_TAG_PATTERN):
+        for pattern in (cls.RELEASE_TAG_OUTPUT_PATTERN, cls.USING_TAG_PATTERN):
             match = pattern.search(text)
             if match:
                 return match.group("tag")
+        release_url_matches = list(cls.RELEASE_URL_PATTERN.finditer(text))
+        if release_url_matches:
+            return release_url_matches[-1].group("tag")
         return ""
 
     def _release_looks_like_deprecated_workflow_output(self, payload: dict[str, Any]) -> bool:

--- a/testing/tests/DMC-1003/test_dmc_1003_service.py
+++ b/testing/tests/DMC-1003/test_dmc_1003_service.py
@@ -298,3 +298,143 @@ def test_service_discovers_release_tag_from_logs_when_not_predicted() -> None:
     assert audit.release is not None
     assert audit.release.tag_name == "v2099.05.06-standalone-abcdef1"
     assert audit.failures == ()
+
+
+def test_service_uses_published_at_when_release_created_at_matches_older_target_commit() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 20,
+            "html_url": "https://example.test/runs/20",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-06T12:00:00Z",
+            "run_number": 20,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[20] = {
+        "id": 20,
+        "html_url": "https://example.test/runs/20",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-06T12:00:00Z",
+        "run_number": 20,
+    }
+    client.jobs_by_run_id[20] = [
+        {
+            "id": 104,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/104",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[104] = (
+        '2099-05-06T12:03:00Z echo "**Release:** [v2099.05.06-standalone-abcdef2]'
+        '(https://github.com/example/releases/tag/v2099.05.06-standalone-abcdef2)" >> $GITHUB_STEP_SUMMARY\n'
+        '2099-05-06T12:03:01Z echo "**Positioning:** Deprecated/internal-only packaging workflow" '
+        '>> $GITHUB_STEP_SUMMARY\n'
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef2"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef2",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef2",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T10:00:00Z",
+        "published_at": "2099-05-06T12:03:02Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="v2099.05.06-standalone-abcdef2",
+        require_step_summary=True,
+    ).audit()
+
+    assert client.dispatch_calls == [("standalone-release-auto.yml", "main", {})]
+    assert audit.release is not None
+    assert audit.release.tag_name == "v2099.05.06-standalone-abcdef2"
+    assert audit.failures == ()
+
+
+def test_service_prefers_quoted_step_summary_tag_over_untagged_release_url() -> None:
+    client = FakeGitHubActionsReleaseClient()
+    dispatched_run = [
+        {
+            "id": 21,
+            "html_url": "https://example.test/runs/21",
+            "event": "workflow_dispatch",
+            "status": "in_progress",
+            "conclusion": "",
+            "head_branch": "main",
+            "head_sha": client.head_sha,
+            "created_at": "2099-05-06T13:00:00Z",
+            "run_number": 21,
+        }
+    ]
+    client.workflow_runs_responses = [
+        [],
+        dispatched_run,
+    ]
+    client.run_by_id[21] = {
+        "id": 21,
+        "html_url": "https://example.test/runs/21",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": "success",
+        "head_branch": "main",
+        "head_sha": client.head_sha,
+        "created_at": "2099-05-06T13:00:00Z",
+        "run_number": 21,
+    }
+    client.jobs_by_run_id[21] = [
+        {
+            "id": 105,
+            "name": "auto-standalone-release",
+            "html_url": "https://example.test/jobs/105",
+            "status": "completed",
+            "conclusion": "success",
+        }
+    ]
+    client.logs_by_job_id[105] = (
+        "2099-05-06T13:03:00Z https://github.com/example/releases/tag/untagged-deadbeef\n"
+        '2099-05-06T13:03:01Z echo "**Release:** [v2099.05.06-standalone-abcdef3]'
+        '(https://github.com/example/releases/tag/v2099.05.06-standalone-abcdef3)" '
+        '>> "$GITHUB_STEP_SUMMARY"\n'
+        '2099-05-06T13:03:02Z echo "**Positioning:** Deprecated/internal-only packaging workflow" '
+        '>> "$GITHUB_STEP_SUMMARY"\n'
+    )
+    client.release_by_tag_payload["v2099.05.06-standalone-abcdef3"] = {
+        "tag_name": "v2099.05.06-standalone-abcdef3",
+        "html_url": "https://example.test/releases/v2099.05.06-standalone-abcdef3",
+        "body": (
+            "> **Deprecated / internal-only workflow.**\n"
+            "Do not treat this release body as installation guidance."
+        ),
+        "created_at": "2099-05-06T11:00:00Z",
+        "published_at": "2099-05-06T13:03:03Z",
+    }
+
+    audit = _build_service(
+        client,
+        release_tag="",
+        require_step_summary=True,
+    ).audit()
+
+    assert client.dispatch_calls == [("standalone-release-auto.yml", "main", {})]
+    assert audit.release is not None
+    assert audit.release.tag_name == "v2099.05.06-standalone-abcdef3"
+    assert audit.release_job is not None
+    assert "v2099.05.06-standalone-abcdef3" in audit.release_job.step_summary_markdown
+    assert audit.failures == ()

--- a/testing/tests/DMC-1007/README.md
+++ b/testing/tests/DMC-1007/README.md
@@ -3,8 +3,8 @@
 This test dispatches the live `standalone-release-auto.yml` workflow on `main`
 and verifies the run completes successfully without the removed-project Gradle
 resolution error for `:dmtools-automation:test`. It also confirms the workflow
-still publishes the release body and visible `GITHUB_STEP_SUMMARY` output that
-depend on successful completion.
+publishes the expected release body, visible `GITHUB_STEP_SUMMARY` text, and
+the deprecated compatibility JAR asset on the resulting GitHub Release.
 
 ## Install dependencies
 

--- a/testing/tests/DMC-1007/config.yaml
+++ b/testing/tests/DMC-1007/config.yaml
@@ -9,6 +9,17 @@ workflow_ref: main
 forbidden_log_fragments:
   - Cannot locate excluded tasks that match ':dmtools-automation:test'
   - project 'dmtools-automation' not found in root project
+  - Cannot upload asset
+required_release_body_fragments:
+  - Deprecated / internal-only workflow
+  - Assets produced by this workflow
+  - Deprecated compatibility CLI fat JAR
+required_step_summary_fragments:
+  - Deprecated Standalone Packaging Release Created
+  - Release:
+  - Positioning:
+  - Deprecated/internal-only packaging workflow
+  - Compatibility asset:
 dispatch_timeout_seconds: 300
 completion_timeout_seconds: 7200
 poll_interval_seconds: 20

--- a/testing/tests/DMC-1007/test_dmc_1007.py
+++ b/testing/tests/DMC-1007/test_dmc_1007.py
@@ -41,6 +41,12 @@ def _normalized_config_list(key: str) -> tuple[str, ...]:
 FORBIDDEN_LOG_FRAGMENTS = tuple(
     _normalized_config_list("forbidden_log_fragments")
 )
+REQUIRED_RELEASE_BODY_FRAGMENTS = tuple(
+    _normalized_config_list("required_release_body_fragments")
+)
+REQUIRED_STEP_SUMMARY_FRAGMENTS = tuple(
+    _normalized_config_list("required_step_summary_fragments")
+)
 
 
 def build_github_client() -> GitHubActionsReleaseClient:
@@ -79,6 +85,48 @@ def _normalize_visible_text(value: str) -> str:
     return " ".join(value.lower().split())
 
 
+def _preview_text(value: str, *, limit: int = 360) -> str:
+    normalized = " ".join(value.split())
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3] + "..."
+
+
+def _assert_contains_fragments(
+    *,
+    content: str,
+    fragments: tuple[str, ...],
+    surface_name: str,
+) -> None:
+    normalized_content = _normalize_visible_text(content)
+    missing_fragments = [fragment for fragment in fragments if fragment not in normalized_content]
+    assert not missing_fragments, (
+        f"Expected the published {surface_name} to include {missing_fragments!r}, "
+        f"but it only exposed: {_preview_text(content)!r}"
+    )
+
+
+def _release_asset_names(
+    client: GitHubActionsReleaseClient,
+    *,
+    release_tag: str,
+) -> tuple[str, ...]:
+    release_payload = client.release_by_tag(release_tag)
+    assets = release_payload.get("assets", [])
+    assert isinstance(assets, list), (
+        f"Expected the GitHub release payload for {release_tag!r} to expose an assets list, "
+        f"got {type(assets)!r}."
+    )
+    return tuple(
+        asset_name
+        for asset_name in (
+            str(asset.get("name", "")).strip() if isinstance(asset, dict) else ""
+            for asset in assets
+        )
+        if asset_name
+    )
+
+
 def test_dmc_1007_live_auto_standalone_workflow_completes_without_removed_project_gradle_errors() -> None:
     client = build_github_client()
     service = build_service()
@@ -102,3 +150,24 @@ def test_dmc_1007_live_auto_standalone_workflow_completes_without_removed_projec
     assert audit.release.html_url
     assert audit.release.body.strip()
     assert audit.release_job.step_summary_markdown.strip()
+    assert audit.release.tag_name in audit.release_job.step_summary_markdown
+
+    _assert_contains_fragments(
+        content=audit.release.body,
+        fragments=REQUIRED_RELEASE_BODY_FRAGMENTS,
+        surface_name="release body",
+    )
+    _assert_contains_fragments(
+        content=audit.release_job.step_summary_markdown,
+        fragments=REQUIRED_STEP_SUMMARY_FRAGMENTS,
+        surface_name="step summary",
+    )
+
+    release_asset_names = _release_asset_names(client, release_tag=audit.release.tag_name)
+    assert any(
+        asset_name.startswith("dmtools-v") and asset_name.endswith("-all.jar")
+        for asset_name in release_asset_names
+    ), (
+        "Expected the published GitHub release to include the deprecated compatibility JAR "
+        f"asset, but assets were {release_asset_names!r}."
+    )


### PR DESCRIPTION
## DMC-1007 Result: PASSED

**Latest rework result:** `PASSED`

---

## DMC-1007 Automation Rework

- Resolved the merge conflicts in the shared deprecated workflow audit service and its regression tests.
- Preserved both sets of intended coverage: quoted/unquoted `$GITHUB_STEP_SUMMARY` parsing, release visibility based on published timestamps, release-job step extraction, and the DMC-1007 release-output assertions.
- Re-ran the shared regression suite and the live DMC-1007 workflow test successfully.

### Test result

```text
PYTHONPATH=. python3 -m pytest testing/tests/DMC-1003/test_dmc_1003_service.py -q
8 passed in 0.07s

PYTHONPATH=. python3 -m pytest testing/tests/DMC-1007/test_dmc_1007.py -q
1 passed in 187.02s (0:03:07)
```
