### PR TITLE
feat: paginate GitHub workflow runs by created filter

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/github-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/github-tools.md
@@ -615,6 +615,8 @@ List GitHub Actions workflow runs for a repository, optionally filtered by statu
 | `status` | String | ❌ | Filter by status: `failure`, `success`, `in_progress`, `queued`, `cancelled`, `timed_out`, `action_required`, `neutral`, `skipped`, `stale`, `completed` |
 | `workflowId` | String | ❌ | Workflow filename to filter runs (e.g. `rework.yml`). If omitted, returns runs for all workflows. |
 | `perPage` | Integer | ❌ | Number of results per page (max 100, default 30) |
+| `page` | Integer | ❌ | Page number for pagination (default 1) |
+| `created` | String | ❌ | Filter by created date/range using GitHub search syntax, e.g. `2026-05-01..2026-05-31` or `>=2026-05-01` |
 
 ```bash
 # All failed runs across all workflows
@@ -622,6 +624,12 @@ dmtools github_list_workflow_runs workspace=IstiN repository=dmtools status=fail
 
 # Failed runs for a specific workflow
 dmtools github_list_workflow_runs workspace=IstiN repository=dmtools status=failure workflowId=rework.yml perPage=50
+
+# Page through historical completed runs
+dmtools github_list_workflow_runs workspace=IstiN repository=dmtools status=completed workflowId=ai-teammate.yml perPage=100 page=2
+
+# Page within a created-date window to bypass GitHub's 1000-result search cap
+dmtools github_list_workflow_runs workspace=IstiN repository=dmtools status=completed workflowId=ai-teammate.yml perPage=100 page=1 created=2026-05-01..2026-05-31
 
 # All currently running workflows
 dmtools github_list_workflow_runs workspace=IstiN repository=dmtools status=in_progress

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -29,6 +29,8 @@ import java.util.Map;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
 import java.net.URLConnection;
@@ -1316,7 +1318,11 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
             @MCPParam(name = "workflowId", description = "Optional workflow filename to filter runs (e.g. rework.yml). If omitted, returns runs for all workflows.", required = false, example = "rework.yml")
             String workflowId,
             @MCPParam(name = "perPage", description = "Number of results per page (max 100, default 30)", required = false, example = "50")
-            Integer perPage) throws IOException {
+            Integer perPage,
+            @MCPParam(name = "page", description = "Page number for pagination (default 1)", required = false, example = "2")
+            Integer page,
+            @MCPParam(name = "created", description = "Filter by created date/range using GitHub search syntax, e.g. 2026-05-01..2026-05-31 or >=2026-05-01", required = false, example = "2026-05-01..2026-05-31")
+            String created) throws IOException {
         String basePath;
         if (workflowId != null && !workflowId.trim().isEmpty()) {
             basePath = String.format("repos/%s/%s/actions/workflows/%s/runs", workspace, repository, workflowId);
@@ -1330,6 +1336,14 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
         if (perPage != null) {
             if (query.length() > 0) query.append("&");
             query.append("per_page=").append(perPage);
+        }
+        if (page != null) {
+            if (query.length() > 0) query.append("&");
+            query.append("page=").append(page);
+        }
+        if (created != null && !created.trim().isEmpty()) {
+            if (query.length() > 0) query.append("&");
+            query.append("created=").append(URLEncoder.encode(created, StandardCharsets.UTF_8));
         }
         String fullPath = query.length() > 0
                 ? path(basePath + "?" + query)

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/github/GitHubTest.java
@@ -4,14 +4,18 @@
 package com.github.istin.dmtools.github;
 
 import com.github.istin.dmtools.common.code.model.SourceCodeConfig;
+import com.github.istin.dmtools.common.networking.GenericRequest;
 import okhttp3.Request;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 import java.util.Set;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for GitHub class that test functionality without external API calls.
@@ -78,6 +82,54 @@ public class GitHubTest {
     public void testGetDefaultWorkspace() {
         String workspace = gitHub.getDefaultWorkspace();
         assertEquals("testWorkspace", workspace);
+    }
+
+    @Test
+    public void testListWorkflowRunsAddsPageParameter() throws Exception {
+        GitHub spyGitHub = spy(gitHub);
+        doReturn("{\"workflow_runs\":[]}").when(spyGitHub).execute(any(GenericRequest.class));
+
+        spyGitHub.listWorkflowRuns("testWorkspace", "testRepo", "completed", "ai-teammate.yml", 100, 3, null);
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(spyGitHub).execute(captor.capture());
+        String url = captor.getValue().url();
+        assertTrue(url.contains("/repos/testWorkspace/testRepo/actions/workflows/ai-teammate.yml/runs?"));
+        assertTrue(url.contains("status=completed"));
+        assertTrue(url.contains("per_page=100"));
+        assertTrue(url.contains("&page=3"));
+    }
+
+    @Test
+    public void testListWorkflowRunsOmitsPageWhenNotProvided() throws Exception {
+        GitHub spyGitHub = spy(gitHub);
+        doReturn("{\"workflow_runs\":[]}").when(spyGitHub).execute(any(GenericRequest.class));
+
+        spyGitHub.listWorkflowRuns("testWorkspace", "testRepo", "failure", null, 50, null, null);
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(spyGitHub).execute(captor.capture());
+        String url = captor.getValue().url();
+        assertTrue(url.contains("/repos/testWorkspace/testRepo/actions/runs?"));
+        assertTrue(url.contains("status=failure"));
+        assertTrue(url.contains("per_page=50"));
+        assertFalse(url.contains("&page="));
+    }
+
+    @Test
+    public void testListWorkflowRunsAddsCreatedFilter() throws Exception {
+        GitHub spyGitHub = spy(gitHub);
+        doReturn("{\"workflow_runs\":[]}").when(spyGitHub).execute(any(GenericRequest.class));
+
+        spyGitHub.listWorkflowRuns("testWorkspace", "testRepo", "completed", "ai-teammate.yml", 100, 1, "2026-05-01..2026-05-31");
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(spyGitHub).execute(captor.capture());
+        String url = captor.getValue().url();
+        assertTrue(url.contains("status=completed"));
+        assertTrue(url.contains("per_page=100"));
+        assertTrue(url.contains("&page=1"));
+        assertTrue(url.contains("created=2026-05-01..2026-05-31"));
     }
 
     // ── parseUris tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
Extends github_list_workflow_runs with optional page and created parameters so JS agents can page through historical workflow runs beyond GitHub's 1000-result cap by splitting created-date/time windows.\n\nValidation:\n- ./gradlew :dmtools-core:test --tests com.github.istin.dmtools.github.GitHubTest\n- ./buildInstallLocal.sh (from working repo, installed local dmtools.jar)