### PR TITLE
fix(figma): support configurable oauth scopes from env/param

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -672,6 +672,14 @@ public class PropertyReader {
     return getValue("FIGMA_OAUTH_ACCESS_TOKEN");
   }
 
+  public String getFigmaOAuth2Scopes() {
+    String value = getValue("FIGMA_SCOPE");
+    if (value != null && !value.trim().isEmpty()) {
+      return value;
+    }
+    return getValue("FIGMA_OAUTH_SCOPES");
+  }
+
   public Integer getDefaultTicketWeightIfNoSPs() {
     String value = getValue("DEFAULT_TICKET_WEIGHT_IF_NO_SP");
     if (value == null || value.isEmpty()) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
@@ -123,13 +123,15 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         description = "Generates the Figma OAuth2 authorization URL for the initial authorization code flow. "
             + "Open the returned URL in a browser, authorize the app, and copy the 'code' parameter from the redirect URL. "
             + "Then call figma_oauth2_exchange_code to get access and refresh tokens. "
-            + "Requires FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET to be configured.",
+            + "Requires FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET to be configured. "
+            + "Optional scope can be passed explicitly or via FIGMA_SCOPE/FIGMA_OAUTH_SCOPES env variable.",
         integration = "figma",
         category = "auth"
     )
     public String oauth2GetAuthUrl(
         @MCPParam(name = "redirectUri", description = "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback)", required = true, example = "http://localhost:8080/callback") String redirectUri,
-        @MCPParam(name = "state", description = "Random state string for CSRF protection", required = false, example = "random_state_123") String state
+        @MCPParam(name = "state", description = "Random state string for CSRF protection", required = false, example = "random_state_123") String state,
+        @MCPParam(name = "scope", description = "Optional OAuth scope list (space-separated), e.g. file_content:read file_metadata:read. If omitted, uses FIGMA_SCOPE (or FIGMA_OAUTH_SCOPES) env or default minimal read scope.", required = false, example = "file_content:read file_metadata:read") String scope
     ) {
         com.github.istin.dmtools.common.utils.PropertyReader propertyReader = new com.github.istin.dmtools.common.utils.PropertyReader();
         String clientId = propertyReader.getFigmaClientId();
@@ -147,7 +149,10 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         if (state == null || state.isEmpty()) {
             state = Long.toHexString(Double.doubleToLongBits(Math.random()));
         }
-        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager(clientId, clientSecret);
+        String effectiveScope = (scope != null && !scope.trim().isEmpty())
+                ? scope
+                : propertyReader.getFigmaOAuth2Scopes();
+        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager(clientId, clientSecret, effectiveScope);
         String authUrl = manager.buildAuthorizationUrl(redirectUri, state);
         return new JSONObject()
                 .put("authorization_url", authUrl)

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
@@ -30,18 +30,24 @@ public class FigmaOAuth2TokenManager {
 
     public static final String FIGMA_OAUTH_AUTHORIZE_URL = "https://www.figma.com/oauth";
     public static final String FIGMA_OAUTH_TOKEN_URL = "https://www.figma.com/api/oauth/token";
-    public static final String FIGMA_OAUTH_SCOPE = "file_read";
+    public static final String DEFAULT_FIGMA_OAUTH_SCOPE = "file_content:read file_metadata:read";
 
     private final String clientId;
     private final String clientSecret;
+    private final String oauthScope;
     private final OkHttpClient httpClient;
 
     private String cachedAccessToken;
     private long tokenExpiryTimeMs = 0;
 
     public FigmaOAuth2TokenManager(String clientId, String clientSecret) {
+        this(clientId, clientSecret, null);
+    }
+
+    public FigmaOAuth2TokenManager(String clientId, String clientSecret, String oauthScope) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
+        this.oauthScope = normalizeScope(oauthScope);
         this.httpClient = new OkHttpClient.Builder()
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS)
@@ -60,7 +66,7 @@ public class FigmaOAuth2TokenManager {
             return FIGMA_OAUTH_AUTHORIZE_URL
                     + "?client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8.name())
                     + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8.name())
-                    + "&scope=" + URLEncoder.encode(FIGMA_OAUTH_SCOPE, StandardCharsets.UTF_8.name())
+                    + "&scope=" + URLEncoder.encode(oauthScope, StandardCharsets.UTF_8.name())
                     + "&state=" + URLEncoder.encode(state, StandardCharsets.UTF_8.name())
                     + "&response_type=code";
         } catch (Exception e) {
@@ -152,6 +158,13 @@ public class FigmaOAuth2TokenManager {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static String normalizeScope(String scope) {
+        if (scope == null || scope.trim().isEmpty()) {
+            return DEFAULT_FIGMA_OAUTH_SCOPE;
+        }
+        return scope.trim();
     }
 
     public static class TokenResponse {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
@@ -26,11 +26,24 @@ public class FigmaOAuth2TokenManagerTest {
     }
 
     @Test
-    public void testBuildAuthorizationUrl_containsFileReadScope() {
+    public void testBuildAuthorizationUrl_containsDefaultReadScopes() {
         FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager("cid", "csecret");
         String url = manager.buildAuthorizationUrl("http://localhost/cb", "state1");
 
-        assertTrue("Auth URL should contain file_read scope", url.contains("file_read"));
+        assertTrue("Auth URL should contain file_content:read scope", url.contains("file_content%3Aread"));
+        assertTrue("Auth URL should contain file_metadata:read scope", url.contains("file_metadata%3Aread"));
+    }
+
+    @Test
+    public void testBuildAuthorizationUrl_usesCustomScopeWhenProvided() {
+        FigmaOAuth2TokenManager manager = new FigmaOAuth2TokenManager(
+                "cid",
+                "csecret",
+                "file_content:read file_metadata:read file_versions:read"
+        );
+        String url = manager.buildAuthorizationUrl("http://localhost/cb", "state1");
+
+        assertTrue("Auth URL should contain custom scope value", url.contains("file_versions%3Aread"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- make Figma OAuth authorization scope configurable via MCP param `scope`
- add env fallback support for `FIGMA_SCOPE` (with `FIGMA_OAUTH_SCOPES` as secondary fallback)
- keep safe default read scopes when no scope is provided
- add/update unit coverage for default and custom scope URL generation

## Why
Figma app uses granular scopes and rejects the old hardcoded scope, so OAuth URL generation must support configurable scopes.