### PR TITLE
DMC-1042 Update MYTUBE portal tagline copy

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ temp
 .settings/**
 .codemie
 .claude
+.codegraph/
 
 # Temporary working notes with local paths / internal data
 KB_FIXES*.md

--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,6 @@ temp
 .settings/**
 .codemie
 .claude
-.codegraph/
 
 # Temporary working notes with local paths / internal data
 KB_FIXES*.md


### PR DESCRIPTION
## Issues/Notes
- `instruction.md` is not present in the repository root.
- The requested portal copy source is not present in this repository. A repo-wide search found no occurrence of `MYTUBE: personal video portal`, `MYTUBE: corp video portal`, or a MYTUBE portal UI/content implementation in `dmtools-core` or elsewhere in this codebase.
- `existing_questions.json` contains clarification items, but all recorded answers are `null`, so the active source of truth and in-scope user surfaces remain unspecified.
- Because the ticket targets a portal branding change and this repository is the DMtools CLI/core codebase, implementing the requested copy update here would be a no-op or an unrelated change.

## Approach
- Read the prepared ticket bundle in `input/DMC-1042/` and verified that no root `instruction.md` was available.
- Searched the repository for the exact old/new tagline text and broader MYTUBE portal/tagline references to locate the active source before making changes.
- Avoided modifying unrelated Jira example strings and test fixtures because they are not the requested user-facing portal copy source.
- Added `.codegraph/` to `.gitignore` because it is an untracked generated workspace artifact and the post-processing step stages all files.

## Files Modified
- `.gitignore` — ignored `.codegraph/` to prevent accidental staging of the generated code graph workspace.
- `outputs/response.md` — added the technical handoff and verification notes for the PR description.

## Test Coverage
- No production code or unit tests were added because the requested portal copy source does not exist in this repository.
- Verification performed in this repository:
  - `./gradlew :dmtools-core:compileJava`
  - `./gradlew :dmtools-core:test`
