### PR TITLE
fix: fire final timerJSAction tick after CLI completes to save full session output

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -434,6 +434,13 @@ public class CliExecutionHelper {
                     Thread.currentThread().interrupt();
                 }
                 logger.info("timerJSAction scheduler stopped");
+                // Fire one final tick so the complete CLI output is saved to releases
+                try {
+                    logger.info("timerJSAction final tick: saving complete session output");
+                    timerAction.run();
+                } catch (Exception e) {
+                    logger.warn("timerJSAction final tick failed (non-fatal): {}", e.getMessage());
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem
The timerJSAction runs periodically while the CLI agent executes. When the agent finishes, the scheduler shuts down immediately — output since the last tick is never uploaded. Result: session log in GitHub Releases is always incomplete.

## Fix
Add a final synchronous call to timerAction.run() in the finally block of CliExecutionHelper.executeCliCommandsWithResult() after the scheduler stops. This guarantees the full accumulated CLI output is saved before postJSAction runs.

## Related
Companion fix in IstiN/dmtools-agents#134: adds clear snapshot boundary markers to timerAutoCommitAndSave.js so periodic snapshots are visually distinct from real agent invocations in logs.