### PR TITLE
feat: write fetched Confluence pages to input/confluence/ for CLI agents

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -11,6 +11,7 @@ import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
 import com.github.istin.dmtools.common.utils.IOUtils;
 import com.github.istin.dmtools.common.utils.PropertyReader;
+import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -160,6 +162,63 @@ public class CliExecutionHelper {
             Files.write(inputFolderPath.resolve(COMMENTS_FILE_NAME),
                     content.toString().getBytes(StandardCharsets.UTF_8));
             logger.info("Created comments.md with {} comments ({} bytes)", comments.size(), content.length());
+        }
+    }
+
+    /**
+     * Writes Confluence pages referenced in {@code textContent} to
+     * {@code inputFolderPath/confluence/<safe-name>.md} so CLI agents can read them without
+     * requiring web access.  Uses {@link Confluence#parseUris} to detect Confluence URLs
+     * (domain-aware, same as the context orchestrator) and {@link Confluence#uriToObject}
+     * to retrieve already-cleaned content.  If {@code confluence} is null the method is a no-op.
+     *
+     * @param textContent     Any text that may contain Confluence URLs (e.g. full ticket text)
+     * @param inputFolderPath The base input folder (e.g. {@code input/PROJ-123})
+     * @param confluence      Confluence client; if {@code null} the method does nothing
+     */
+    public void writeConfluencePagesFile(String textContent, Path inputFolderPath, Confluence confluence) {
+        if (confluence == null || textContent == null || textContent.isBlank()) return;
+        try {
+            Set<String> urls = confluence.parseUris(textContent);
+            if (urls == null || urls.isEmpty()) {
+                logger.info("No Confluence URLs detected in ticket text");
+                return;
+            }
+            logger.info("Found {} Confluence URL(s), writing to input/confluence/...", urls.size());
+
+            Path confluenceFolder = inputFolderPath.resolve("confluence");
+            Files.createDirectories(confluenceFolder);
+
+            int written = 0;
+            for (String url : urls) {
+                try {
+                    Object content = confluence.uriToObject(url);
+                    if (content == null) {
+                        logger.warn("Confluence returned null for {}", url);
+                        continue;
+                    }
+                    String text = content.toString().trim();
+                    if (text.isBlank()) {
+                        logger.warn("Confluence page empty for {}", url);
+                        continue;
+                    }
+                    // Derive a safe filename from the trailing URL path segment
+                    String urlPath = url.replaceAll("\\?.*", "").replaceAll("#.*", "");
+                    String[] segments = urlPath.split("/");
+                    String rawName = segments[segments.length - 1];
+                    if (rawName.isBlank()) rawName = "page-" + written;
+                    String safeName = rawName.replaceAll("[^\\w.\\-]", "_");
+                    Path filePath = confluenceFolder.resolve(safeName + ".md");
+                    Files.write(filePath, text.getBytes(StandardCharsets.UTF_8));
+                    logger.info("Wrote Confluence page → {} ({} chars)", filePath, text.length());
+                    written++;
+                } catch (Exception e) {
+                    logger.warn("Could not write Confluence page {} (skipping): {}", url, e.getMessage());
+                }
+            }
+            logger.info("Wrote {}/{} Confluence pages to input/confluence/", written, urls.size());
+        } catch (Exception e) {
+            logger.warn("writeConfluencePagesFile failed (non-fatal): {}", e.getMessage());
         }
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -462,6 +462,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     // Write comments.md alongside request.md — same toText() format as chunks sent to AI
                     cliHelper.writeCommentsFile(inputContextPath, ticketContext.getComments());
 
+                    // Write Confluence pages linked in the ticket text to input/confluence/
+                    cliHelper.writeConfluencePagesFile(textFieldsOnly, inputContextPath, confluence);
+
                     // When writeAgentParamsToFiles=true: expand agent params into separate files in the
                     // input folder, then replace request.md with minimal ticket-only content.
                     if (expertParams.isWriteAgentParamsToFiles() && originalParams != null) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -887,4 +887,73 @@ public class CliExecutionHelperTest {
             com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
         }
     }
+
+    // ── writeConfluencePagesFile tests ────────────────────────────────────────
+
+    @Test
+    void writeConfluencePagesFile_nullConfluence_doesNothing() throws Exception {
+        // Should be a no-op and not throw
+        assertDoesNotThrow(() -> cliHelper.writeConfluencePagesFile("some text", tempDir, null));
+        assertFalse(Files.exists(tempDir.resolve("confluence")));
+    }
+
+    @Test
+    void writeConfluencePagesFile_nullText_doesNothing() throws Exception {
+        com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
+                mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
+        assertDoesNotThrow(() -> cliHelper.writeConfluencePagesFile(null, tempDir, mockConfluence));
+        assertFalse(Files.exists(tempDir.resolve("confluence")));
+    }
+
+    @Test
+    void writeConfluencePagesFile_noUrlsFound_doesNothing() throws Exception {
+        com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
+                mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
+        when(mockConfluence.parseUris("plain text without confluence links")).thenReturn(java.util.Collections.emptySet());
+
+        cliHelper.writeConfluencePagesFile("plain text without confluence links", tempDir, mockConfluence);
+
+        assertFalse(Files.exists(tempDir.resolve("confluence")));
+    }
+
+    @Test
+    void writeConfluencePagesFile_writesPageContentToFile() throws Exception {
+        com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
+                mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
+        String url = "https://wiki.example.com/wiki/spaces/SPACE/pages/12345/My+Page";
+        when(mockConfluence.parseUris(anyString())).thenReturn(java.util.Set.of(url));
+        when(mockConfluence.uriToObject(url)).thenReturn("# My Page\n\nPage content here.");
+
+        cliHelper.writeConfluencePagesFile("see " + url, tempDir, mockConfluence);
+
+        Path confluenceDir = tempDir.resolve("confluence");
+        assertTrue(Files.exists(confluenceDir), "confluence/ directory should be created");
+        long mdFiles = Files.list(confluenceDir)
+                .filter(p -> p.toString().endsWith(".md"))
+                .count();
+        assertEquals(1, mdFiles, "One .md file should be written");
+        String fileContent = Files.list(confluenceDir)
+                .filter(p -> p.toString().endsWith(".md"))
+                .findFirst()
+                .map(p -> { try { return Files.readString(p, StandardCharsets.UTF_8); } catch (Exception e) { return ""; } })
+                .orElse("");
+        assertTrue(fileContent.contains("Page content here."), "File should contain page content");
+    }
+
+    @Test
+    void writeConfluencePagesFile_nullContentFromClient_skipsFile() throws Exception {
+        com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
+                mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
+        String url = "https://wiki.example.com/wiki/spaces/SPACE/pages/99/Empty";
+        when(mockConfluence.parseUris(anyString())).thenReturn(java.util.Set.of(url));
+        when(mockConfluence.uriToObject(url)).thenReturn(null);
+
+        cliHelper.writeConfluencePagesFile("see " + url, tempDir, mockConfluence);
+
+        Path confluenceDir = tempDir.resolve("confluence");
+        // Folder may or may not be created, but no files should exist
+        if (Files.exists(confluenceDir)) {
+            assertEquals(0, Files.list(confluenceDir).count(), "No files should be written for null content");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

When a Teammate job runs with CLI commands, Confluence pages linked in the ticket text are now fetched and written to `input/<TICKET>/confluence/` so the CLI agent (Copilot, Cursor, etc.) can read them as local files.

## Changes

- **CliExecutionHelper.writeConfluencePagesFile()** — uses `Confluence.parseUris()` (domain-aware, same mechanism as ContextOrchestrator) to detect URLs, then `Confluence.uriToObject()` to retrieve already-cleaned content and write to `input/confluence/<name>.md`
- **Teammate.java** — calls `writeConfluencePagesFile(textFieldsOnly, ...)` after `writeCommentsFile()`, before CLI command execution. If Confluence is not configured, method is a no-op.
- **CliExecutionHelperTest** — 5 new unit tests: null-safety (null confluence, null text, no URLs), happy path (writes .md file), null-content from client (skips file gracefully)

## How it works

```
textFieldsOnly → Confluence.parseUris() → [urls]
                    ↓
              Confluence.uriToObject(url) → cleaned HTML string
                    ↓
              input/TICKET/confluence/PageName.md
```

The `parseUris()` method uses the configured Confluence base path for domain matching (same as how ContextOrchestrator discovers URIs), so no custom regex is needed.