### PR TITLE
feat: download Confluence page attachments to input/confluence/ for CLI agents

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -632,6 +632,43 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
     }
 
     /**
+     * Downloads all attachments of a Confluence page to {@code targetDir}.
+     * Skips attachments with no download link and logs warnings for failures.
+     * This is a convenience wrapper reused by both MermaidIndex and CLI input folder preparation.
+     *
+     * @param contentId page/content ID whose attachments to download
+     * @param targetDir directory where attachment files will be saved
+     * @return list of successfully downloaded files (may be empty)
+     * @throws IOException if listing attachments fails
+     */
+    public List<File> downloadPageAttachments(String contentId, File targetDir) throws IOException {
+        List<File> downloaded = new ArrayList<>();
+        List<Attachment> attachments = getContentAttachments(contentId);
+        if (attachments == null || attachments.isEmpty()) return downloaded;
+        logger.info("Downloading {} attachment(s) for content {}", attachments.size(), contentId);
+        for (Attachment attachment : attachments) {
+            String title = attachment.getTitle();
+            String link = attachment.getDownloadLink();
+            if (link == null || link.isBlank()) {
+                logger.warn("Attachment '{}' has no download link, skipping", title);
+                continue;
+            }
+            try {
+                File file = downloadAttachment(attachment, targetDir);
+                if (file != null && file.exists()) {
+                    downloaded.add(file);
+                    logger.info("Downloaded attachment '{}' → {} bytes", title, file.length());
+                } else {
+                    logger.warn("Download returned null/missing file for attachment '{}'", title);
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to download attachment '{}': {}", title, e.getMessage());
+            }
+        }
+        return downloaded;
+    }
+
+    /**
      * Converts a MIME media type to a file extension.
      * @param mediaType the MIME type (e.g., "image/jpeg", "image/png")
      * @return the file extension (e.g., "jpg", "png") or null if not recognized

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/index/ConfluenceMermaidIndexIntegration.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/index/ConfluenceMermaidIndexIntegration.java
@@ -321,40 +321,17 @@ public class ConfluenceMermaidIndexIntegration implements MermaidIndexIntegratio
         metadata.add("spaceKey:" + spaceKey);
         metadata.add("contentId:" + contentId);
         
-        // Get and download attachments
+        // Get and download attachments using the shared Confluence.downloadPageAttachments()
         List<File> attachmentFiles = new ArrayList<>();
         Path tempDirPath = null;
         try {
             List<Attachment> attachments = confluence.getContentAttachments(contentId);
             if (attachments != null && !attachments.isEmpty()) {
-                // Create temp directory for attachments
                 tempDirPath = Files.createTempDirectory("confluence-attachments-" + contentId);
-                File tempDir = tempDirPath.toFile();
-                
-                for (Attachment attachment : attachments) {
-                    String title = attachment.getTitle();
-                    String downloadLink = attachment.getDownloadLink();
-                    
-                    if (downloadLink != null && !downloadLink.isEmpty()) {
-                        try {
-                            // Download attachment
-                            File downloadedFile = confluence.downloadAttachment(attachment, tempDir);
-                            if (downloadedFile != null && downloadedFile.exists()) {
-                                attachmentFiles.add(downloadedFile);
-                                logger.debug("Downloaded attachment {} for content {}", title, contentId);
-                            } else {
-                                logger.warn("Downloaded file is null or doesn't exist for attachment {} in content {}", title, contentId);
-                            }
-                        } catch (Exception e) {
-                            logger.warn("Failed to download attachment {} for content {}: {}", title, contentId, e.getMessage());
-                        }
-                    } else {
-                        logger.warn("Attachment {} has no download link for content {}", title, contentId);
-                    }
-                }
+                attachmentFiles = confluence.downloadPageAttachments(contentId, tempDirPath.toFile());
             }
         } catch (Exception e) {
-            logger.warn("Failed to get attachments for content {}: {}", contentId, e.getMessage());
+            logger.warn("Failed to get/download attachments for content {}: {}", contentId, e.getMessage());
         }
         
         // Get last modified date

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -12,6 +12,7 @@ import com.github.istin.dmtools.common.utils.CommandLineUtils;
 import com.github.istin.dmtools.common.utils.IOUtils;
 import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
+import com.github.istin.dmtools.atlassian.confluence.model.Content;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -166,11 +167,15 @@ public class CliExecutionHelper {
     }
 
     /**
-     * Writes Confluence pages referenced in {@code textContent} to
-     * {@code inputFolderPath/confluence/<safe-name>.md} so CLI agents can read them without
-     * requiring web access.  Uses {@link Confluence#parseUris} to detect Confluence URLs
-     * (domain-aware, same as the context orchestrator) and {@link Confluence#uriToObject}
-     * to retrieve already-cleaned content.  If {@code confluence} is null the method is a no-op.
+     * Fetches Confluence pages referenced in {@code textContent} and writes both the page text
+     * and all page attachments to {@code inputFolderPath/confluence/} so CLI agents can read them
+     * without web access.
+     * <p>
+     * Uses {@link Confluence#parseUris} (domain-aware, same mechanism as ContextOrchestrator)
+     * to detect URLs, then {@link Confluence#contentByUrl} to get the full {@link Content} object,
+     * {@link Confluence#getContentAttachments} + {@link Confluence#downloadAttachment} to fetch
+     * attachments — reusing the same pattern as {@code ConfluenceMermaidIndexIntegration}.
+     * If {@code confluence} is null the method is a no-op.
      *
      * @param textContent     Any text that may contain Confluence URLs (e.g. full ticket text)
      * @param inputFolderPath The base input folder (e.g. {@code input/PROJ-123})
@@ -192,34 +197,65 @@ public class CliExecutionHelper {
             int written = 0;
             for (String url : urls) {
                 try {
-                    Object content = confluence.uriToObject(url);
-                    if (content == null) {
-                        logger.warn("Confluence returned null for {}", url);
+                    Content page = confluence.contentByUrl(url);
+                    if (page == null) {
+                        logger.warn("Confluence returned null Content for {}", url);
                         continue;
                     }
-                    String text = content.toString().trim();
-                    if (text.isBlank()) {
-                        logger.warn("Confluence page empty for {}", url);
-                        continue;
+
+                    // Write page text
+                    String title = page.getTitle();
+                    String safeName = deriveSafeName(title, url, written);
+                    String bodyText = page.getStorage() != null && page.getStorage().getValue() != null
+                            ? page.getStorage().getValue().trim() : "";
+                    if (!bodyText.isBlank()) {
+                        Path mdFile = confluenceFolder.resolve(safeName + ".md");
+                        Files.write(mdFile, bodyText.getBytes(StandardCharsets.UTF_8));
+                        logger.info("Wrote Confluence page → {} ({} chars)", mdFile, bodyText.length());
+                        written++;
+                    } else {
+                        logger.warn("Confluence page '{}' has empty body, skipping text write", title);
                     }
-                    // Derive a safe filename from the trailing URL path segment
-                    String urlPath = url.replaceAll("\\?.*", "").replaceAll("#.*", "");
-                    String[] segments = urlPath.split("/");
-                    String rawName = segments[segments.length - 1];
-                    if (rawName.isBlank()) rawName = "page-" + written;
-                    String safeName = rawName.replaceAll("[^\\w.\\-]", "_");
-                    Path filePath = confluenceFolder.resolve(safeName + ".md");
-                    Files.write(filePath, text.getBytes(StandardCharsets.UTF_8));
-                    logger.info("Wrote Confluence page → {} ({} chars)", filePath, text.length());
-                    written++;
+
+                    // Download attachments (same pattern as ConfluenceMermaidIndexIntegration)
+                    String contentId = page.getId();
+                    if (contentId != null && !contentId.isBlank()) {
+                        downloadConfluenceAttachments(confluence, contentId, confluenceFolder.toFile());
+                    }
                 } catch (Exception e) {
-                    logger.warn("Could not write Confluence page {} (skipping): {}", url, e.getMessage());
+                    logger.warn("Could not fetch Confluence page {} (skipping): {}", url, e.getMessage());
                 }
             }
             logger.info("Wrote {}/{} Confluence pages to input/confluence/", written, urls.size());
         } catch (Exception e) {
             logger.warn("writeConfluencePagesFile failed (non-fatal): {}", e.getMessage());
         }
+    }
+
+    /**
+     * Downloads all attachments for a Confluence content item into {@code targetDir}
+     * via {@link Confluence#downloadPageAttachments} — the shared method used by both
+     * MermaidIndex and CLI input folder preparation.
+     */
+    private void downloadConfluenceAttachments(Confluence confluence, String contentId, File targetDir) {
+        try {
+            List<java.io.File> files = confluence.downloadPageAttachments(contentId, targetDir);
+            logger.info("Downloaded {} attachment(s) for Confluence page {} to input/confluence/",
+                    files.size(), contentId);
+        } catch (Exception e) {
+            logger.warn("Could not download attachments for content {} (skipping): {}", contentId, e.getMessage());
+        }
+    }
+
+    /** Derives a safe filesystem name from a Confluence page title or URL. */
+    private static String deriveSafeName(String title, String url, int index) {
+        if (title != null && !title.isBlank()) {
+            return title.replaceAll("[^\\w.\\-]", "_");
+        }
+        String urlPath = url.replaceAll("\\?.*", "").replaceAll("#.*", "");
+        String[] segments = urlPath.split("/");
+        String raw = segments[segments.length - 1];
+        return raw.isBlank() ? "page-" + index : raw.replaceAll("[^\\w.\\-]", "_");
     }
 
     /**

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -892,7 +892,6 @@ public class CliExecutionHelperTest {
 
     @Test
     void writeConfluencePagesFile_nullConfluence_doesNothing() throws Exception {
-        // Should be a no-op and not throw
         assertDoesNotThrow(() -> cliHelper.writeConfluencePagesFile("some text", tempDir, null));
         assertFalse(Files.exists(tempDir.resolve("confluence")));
     }
@@ -909,7 +908,8 @@ public class CliExecutionHelperTest {
     void writeConfluencePagesFile_noUrlsFound_doesNothing() throws Exception {
         com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
                 mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
-        when(mockConfluence.parseUris("plain text without confluence links")).thenReturn(java.util.Collections.emptySet());
+        when(mockConfluence.parseUris("plain text without confluence links"))
+                .thenReturn(java.util.Collections.emptySet());
 
         cliHelper.writeConfluencePagesFile("plain text without confluence links", tempDir, mockConfluence);
 
@@ -917,27 +917,51 @@ public class CliExecutionHelperTest {
     }
 
     @Test
-    void writeConfluencePagesFile_writesPageContentToFile() throws Exception {
+    void writeConfluencePagesFile_writesPageContentAndDownloadsAttachments() throws Exception {
         com.github.istin.dmtools.atlassian.confluence.Confluence mockConfluence =
                 mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
         String url = "https://wiki.example.com/wiki/spaces/SPACE/pages/12345/My+Page";
+
+        // Mock Content with Storage body and page ID
+        com.github.istin.dmtools.atlassian.confluence.model.Content mockContent =
+                mock(com.github.istin.dmtools.atlassian.confluence.model.Content.class);
+        com.github.istin.dmtools.atlassian.confluence.model.Storage mockStorage =
+                mock(com.github.istin.dmtools.atlassian.confluence.model.Storage.class);
+        when(mockStorage.getValue()).thenReturn("<p>Page content here.</p>");
+        when(mockContent.getTitle()).thenReturn("My Page");
+        when(mockContent.getStorage()).thenReturn(mockStorage);
+        when(mockContent.getId()).thenReturn("12345");
+
+        // Create a real temp file representing a downloaded attachment
+        File fakeDownloaded = tempDir.resolve("diagram.png").toFile();
+        fakeDownloaded.createNewFile();
+
         when(mockConfluence.parseUris(anyString())).thenReturn(java.util.Set.of(url));
-        when(mockConfluence.uriToObject(url)).thenReturn("# My Page\n\nPage content here.");
+        when(mockConfluence.contentByUrl(url)).thenReturn(mockContent);
+        // downloadPageAttachments is the shared method now — mock it to return the fake file
+        when(mockConfluence.downloadPageAttachments(eq("12345"), any(File.class)))
+                .thenReturn(java.util.List.of(fakeDownloaded));
 
         cliHelper.writeConfluencePagesFile("see " + url, tempDir, mockConfluence);
 
         Path confluenceDir = tempDir.resolve("confluence");
         assertTrue(Files.exists(confluenceDir), "confluence/ directory should be created");
+
+        // .md file should be written
         long mdFiles = Files.list(confluenceDir)
                 .filter(p -> p.toString().endsWith(".md"))
                 .count();
         assertEquals(1, mdFiles, "One .md file should be written");
+
         String fileContent = Files.list(confluenceDir)
                 .filter(p -> p.toString().endsWith(".md"))
                 .findFirst()
                 .map(p -> { try { return Files.readString(p, StandardCharsets.UTF_8); } catch (Exception e) { return ""; } })
                 .orElse("");
         assertTrue(fileContent.contains("Page content here."), "File should contain page content");
+
+        // Verify shared downloadPageAttachments was called with the page content ID
+        verify(mockConfluence).downloadPageAttachments(eq("12345"), any(File.class));
     }
 
     @Test
@@ -946,14 +970,14 @@ public class CliExecutionHelperTest {
                 mock(com.github.istin.dmtools.atlassian.confluence.Confluence.class);
         String url = "https://wiki.example.com/wiki/spaces/SPACE/pages/99/Empty";
         when(mockConfluence.parseUris(anyString())).thenReturn(java.util.Set.of(url));
-        when(mockConfluence.uriToObject(url)).thenReturn(null);
+        when(mockConfluence.contentByUrl(url)).thenReturn(null);
 
         cliHelper.writeConfluencePagesFile("see " + url, tempDir, mockConfluence);
 
         Path confluenceDir = tempDir.resolve("confluence");
-        // Folder may or may not be created, but no files should exist
         if (Files.exists(confluenceDir)) {
-            assertEquals(0, Files.list(confluenceDir).count(), "No files should be written for null content");
+            assertEquals(0, Files.list(confluenceDir).filter(p -> p.toString().endsWith(".md")).count(),
+                    "No .md files should be written for null content");
         }
     }
 }


### PR DESCRIPTION
Closes #249 (had submodule conflicts — this is a clean rebase on main)

## Summary

Fetches Confluence pages linked in ticket text and saves them to `input/<TICKET>/confluence/` so CLI agents can read them without web access. Also downloads page **attachments** (images, PDFs, diagrams).

## Key change: `Confluence.downloadPageAttachments()`

Both `CliExecutionHelper` and `ConfluenceMermaidIndexIntegration` had identical 25-line attachment download loops. Extracted to a single shared method:

```java
List<File> confluence.downloadPageAttachments(contentId, targetDir)
```

## Flow in `writeConfluencePagesFile()`

```
parseUris(text) → [urls]
  → contentByUrl(url) → Content (title + storage body + id)
      → write body → input/confluence/<Title>.md
      → downloadPageAttachments(id, confluenceDir) → files in input/confluence/
```

## Files changed
- `Confluence.java`: new `downloadPageAttachments()` method
- `ConfluenceMermaidIndexIntegration`: uses `downloadPageAttachments()` instead of inline loop
- `CliExecutionHelper`: `writeConfluencePagesFile()` + `downloadConfluenceAttachments()` delegate to shared method
- `Teammate.java`: calls `writeConfluencePagesFile(textFieldsOnly, ...)`
- `CliExecutionHelperTest`: 5 tests, verifies `downloadPageAttachments` is called