### PR TITLE
fix: use REST API endpoint for Confluence attachment download (fixes 401)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -593,15 +593,26 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         // Ensure the target directory exists using atomic method
         java.nio.file.Files.createDirectories(targetDir.toPath());
         
-        // Build the full download URL - ensure proper path joining
+        // Build the full download URL using the REST API endpoint which accepts
+        // API-token Basic auth (the /download/attachments/ path is browser-only and returns 401).
+        // REST path: /rest/api/content/{pageId}/child/attachment/{attachmentId}/download
+        String attachmentId = attachment.getId();
+        String pageId = attachment.getContainerContentId();
         String basePath = getBasePath();
         String fullUrl;
-        if (basePath.endsWith("/") && downloadLink.startsWith("/")) {
-            fullUrl = basePath + downloadLink.substring(1);
-        } else if (!basePath.endsWith("/") && !downloadLink.startsWith("/")) {
-            fullUrl = basePath + "/" + downloadLink;
+        if (attachmentId != null && pageId != null) {
+            // Strip trailing /wiki from basePath if present — REST path already includes it
+            String base = basePath.endsWith("/") ? basePath.substring(0, basePath.length() - 1) : basePath;
+            fullUrl = base + "/rest/api/content/" + pageId + "/child/attachment/" + attachmentId + "/download";
         } else {
-            fullUrl = basePath + downloadLink;
+            // Fallback: use download link directly
+            if (basePath.endsWith("/") && downloadLink.startsWith("/")) {
+                fullUrl = basePath + downloadLink.substring(1);
+            } else if (!basePath.endsWith("/") && !downloadLink.startsWith("/")) {
+                fullUrl = basePath + "/" + downloadLink;
+            } else {
+                fullUrl = basePath + downloadLink;
+            }
         }
         
         // Sanitize filename to prevent directory traversal attacks

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/model/Attachment.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/model/Attachment.java
@@ -30,6 +30,28 @@ public class Attachment extends JSONModel {
     }
 
     /**
+     * Gets the attachment ID (e.g. "att6223691792").
+     */
+    public String getId() {
+        return getString("id");
+    }
+
+    /**
+     * Extracts the page/container content ID from the download link.
+     * E.g. "/download/attachments/6180601871/file.png" → "6180601871"
+     */
+    public String getContainerContentId() {
+        String link = getDownloadLink();
+        if (link == null) return null;
+        String prefix = "/download/attachments/";
+        int start = link.indexOf(prefix);
+        if (start < 0) return null;
+        start += prefix.length();
+        int end = link.indexOf("/", start);
+        return end > start ? link.substring(start, end) : null;
+    }
+
+    /**
      * Gets the download link for this attachment.
      * @return the download path (relative to base URL) or null if not available
      */


### PR DESCRIPTION
## Problem

`Confluence.downloadAttachment()` used the path `/download/attachments/{pageId}/{filename}` which is designed for browser access and returns **401** when called with API token Basic auth on Confluence Cloud:

```
www-authenticate: OAuth realm="https://compony.atlassian.net/wiki"
```

## Fix

Use the REST API endpoint instead, which accepts API token Basic auth:

```
GET /rest/api/content/{pageId}/child/attachment/{attachmentId}/download
```

## Changes
- `Attachment.getId()` — new method returning the attachment ID (e.g. `att6223691792`)
- `Attachment.getContainerContentId()` — extracts page/container ID from the download link path
- `Confluence.downloadAttachment()` — builds the REST API URL when both IDs are available; falls back to old path otherwise

## Verified locally
```bash
# Old: 401 Unauthorized
curl -H 'Authorization: Basic ...' 'https://compony.atlassian.net/wiki/download/attachments/...'

# New: 200 OK + PNG file
curl -L -H 'Authorization: Basic ...' 'https://compony.atlassian.net/wiki/rest/api/content/6180601871/child/attachment/att6223691792/download'
```

Ref: https://community.atlassian.com/forums/Confluence-questions/API-token-based-Basic-authentication-not-working-for-download/qaq-p/3237749