### PR TITLE
feat(report): add JSONL data source, generic example, and Copilot usa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,8 @@ RELEASE_NOTES*.md
 agents/reports/output/
 agents/reports/cursor_usage.csv
 
+# Local tooling state
+.codegraph/
+.cursor/
+.worktrees/
+

--- a/dmtools-ai-docs/references/examples/copilot-usage-report.json
+++ b/dmtools-ai-docs/references/examples/copilot-usage-report.json
@@ -1,0 +1,268 @@
+{
+  "name": "ReportGenerator",
+  "params": {
+    "reportName": "Copilot Usage Report",
+    "startDate": "2026-01-01",
+    "endDate": "2026-06-30",
+    "dataSources": [
+      {
+        "name": "jsonl",
+        "params": {
+          "folderPath": "/path/to/copilot/jsonl/data"
+        },
+        "metrics": [
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Interactions",
+              "weightField": "user_initiated_interaction_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Code Generation",
+              "weightField": "code_generation_activity_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Code Acceptances",
+              "weightField": "code_acceptance_activity_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "LOC Added",
+              "weightField": "loc_added_sum",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "LOC Deleted",
+              "weightField": "loc_deleted_sum",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "CLI Sessions",
+              "weightField": "totals_by_cli.session_count",
+              "filterField": "used_cli",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "CLI Requests",
+              "weightField": "totals_by_cli.request_count",
+              "filterField": "used_cli",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "CLI Output Tokens",
+              "weightField": "totals_by_cli.token_usage.output_tokens_sum",
+              "filterField": "used_cli",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "CLI Prompt Tokens",
+              "weightField": "totals_by_cli.token_usage.prompt_tokens_sum",
+              "filterField": "used_cli",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Feature: Code Completion",
+              "arrayField": "totals_by_feature",
+              "arrayFilterField": "feature",
+              "arrayFilterValue": "code_completion",
+              "weightField": "code_acceptance_activity_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Feature: Chat Agent",
+              "arrayField": "totals_by_feature",
+              "arrayFilterField": "feature",
+              "arrayFilterValue": "chat_panel_agent_mode",
+              "weightField": "user_initiated_interaction_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Feature: Agent Edit",
+              "arrayField": "totals_by_feature",
+              "arrayFilterField": "feature",
+              "arrayFilterValue": "agent_edit",
+              "weightField": "code_acceptance_activity_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "IDE: VSCode",
+              "arrayField": "totals_by_ide",
+              "arrayFilterField": "ide",
+              "arrayFilterValue": "vscode",
+              "weightField": "code_acceptance_activity_count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "All Models by Acceptances",
+              "arrayField": "totals_by_model_feature",
+              "arrayFilterField": "model",
+              "arrayFilterValue": "*",
+              "weightField": "code_acceptance_activity_count",
+              "groupByField": "model",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "All Features by Acceptances",
+              "arrayField": "totals_by_feature",
+              "arrayFilterField": "feature",
+              "arrayFilterValue": "*",
+              "weightField": "code_acceptance_activity_count",
+              "groupByField": "feature",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "All IDEs by Acceptances",
+              "arrayField": "totals_by_ide",
+              "arrayFilterField": "ide",
+              "arrayFilterValue": "*",
+              "weightField": "code_acceptance_activity_count",
+              "groupByField": "ide",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "All Models by Interactions",
+              "arrayField": "totals_by_model_feature",
+              "arrayFilterField": "model",
+              "arrayFilterValue": "*",
+              "weightField": "user_initiated_interaction_count",
+              "groupByField": "model",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "All Languages by Acceptances",
+              "arrayField": "totals_by_language_model",
+              "arrayFilterField": "language",
+              "arrayFilterValue": "*",
+              "weightField": "code_acceptance_activity_count",
+              "groupByField": "language",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Used Agent",
+              "weightField": "user_initiated_interaction_count",
+              "filterField": "used_agent",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Used Chat",
+              "weightField": "user_initiated_interaction_count",
+              "filterField": "used_chat",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Used CLI",
+              "weightField": "user_initiated_interaction_count",
+              "filterField": "used_cli",
+              "filterValue": "true",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          }
+        ]
+      }
+    ],
+    "timeGrouping": [
+      {"type": "bi-weekly"},
+      {"type": "monthly"},
+      {"type": "weekly"}
+    ],
+    "aggregation": {
+      "label": "Copilot Score",
+      "formula": "${Code Acceptances} + ${LOC Added} * 0.01 + ${Interactions} * 0.1"
+    },
+    "output": {
+      "mode": "combined",
+      "saveRawMetadata": true,
+      "outputPath": "reports/output/copilot",
+      "visualizer": "default"
+    }
+  }
+}

--- a/dmtools-ai-docs/references/examples/report-generator-jsonl-job.json
+++ b/dmtools-ai-docs/references/examples/report-generator-jsonl-job.json
@@ -1,0 +1,89 @@
+{
+  "name": "ReportGenerator",
+  "params": {
+    "reportName": "JSONL Generic Report",
+    "startDate": "2026-01-01",
+    "endDate": "2026-01-31",
+    "dataSources": [
+      {
+        "name": "jsonl",
+        "params": {
+          "folderPath": "/path/to/jsonl/data",
+          "whoField": "user",
+          "whenField": "date"
+        },
+        "metrics": [
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Total Events",
+              "weightField": "count",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Critical Events",
+              "weightField": "count",
+              "filterField": "category",
+              "filterValue": "critical",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Bug Impact",
+              "arrayField": "items",
+              "arrayFilterField": "type",
+              "arrayFilterValue": "bug",
+              "weightField": "impact",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Score by Category",
+              "arrayField": "categories",
+              "arrayFilterField": "name",
+              "arrayFilterValue": "*",
+              "weightField": "score",
+              "groupByField": "name",
+              "isPersonalized": true,
+              "isWeight": true
+            }
+          },
+          {
+            "name": "JsonlMetricSource",
+            "params": {
+              "label": "Scaled Value (K)",
+              "weightField": "value",
+              "weightMultiplier": 0.001,
+              "isPersonalized": false,
+              "isWeight": true
+            }
+          }
+        ]
+      }
+    ],
+    "timeGrouping": [
+      {"type": "weekly"},
+      {"type": "monthly"}
+    ],
+    "aggregation": {
+      "label": "Total Score",
+      "formula": "${Total Events} + ${Critical Events} * 2 + ${Scaled Value (K)}"
+    },
+    "output": {
+      "mode": "combined",
+      "saveRawMetadata": true,
+      "outputPath": "reports/output/jsonl",
+      "visualizer": "default"
+    }
+  }
+}

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -100,7 +100,7 @@ The `"name"` field is a **technical identifier** that maps to a Java class in DM
 | `DevProductivityReport` | Produces developer productivity metrics from tracker, source control, and optional spreadsheet inputs. | `DevProductivityReport` | [dev-productivity-report.json](../examples/dev-productivity-report.json) |
 | `BAProductivityReport` | Calculates BA delivery metrics such as created work, field updates, and workflow movement over time. | `BAProductivityReport` | [ba-productivity-report.json](../examples/ba-productivity-report.json) |
 | `QAProductivityReport` | Calculates QA metrics such as bugs, tests, comments, and key status transitions across releases. | `QAProductivityReport` | [qa-productivity-report.json](../examples/qa-productivity-report.json) |
-| `ReportGenerator` | Generates configurable analytics reports as JSON and HTML from tracker, SCM, CSV, or Figma data. | `ReportGenerator` / `ReportGeneratorJob` | [report-generator-job.json](../examples/report-generator-job.json) |
+| `ReportGenerator` | Generates configurable analytics reports as JSON and HTML from tracker, SCM, CSV, JSONL, or Figma data. | `ReportGenerator` / `ReportGeneratorJob` | [report-generator-job.json](../examples/report-generator-job.json), [report-generator-jsonl-job.json](../examples/report-generator-jsonl-job.json) |
 | `ReportVisualizer` | Renders a saved JSON report as an interactive HTML dashboard without regenerating report data. | `ReportVisualizer` / `ReportVisualizerJob` | [report-visualizer-job.json](../examples/report-visualizer-job.json) |
 | `KBProcessingJob` | Runs the knowledge-base pipeline that processes source content and aggregates searchable KB output. | `KBProcessingJob` / `KBProcessing` | [kb-processing-job.json](../examples/kb-processing-job.json) |
 
@@ -966,7 +966,7 @@ dmtools run agents/test/test-postprocess.json
 
 ### ReportGenerator
 
-Generate configurable analytics reports from tracker, SCM, CSV, or Figma data.
+Generate configurable analytics reports from tracker, SCM, CSV, JSONL, or Figma data.
 
 **Purpose**: Build JSON output and, when configured, paired HTML reports from reusable metric definitions and time groupings.
 
@@ -976,10 +976,17 @@ Generate configurable analytics reports from tracker, SCM, CSV, or Figma data.
 
 **Usage**:
 ```bash
+# Tracker / SCM / CSV example
 dmtools run dmtools-ai-docs/references/examples/report-generator-job.json
+
+# Generic JSONL example
+dmtools run dmtools-ai-docs/references/examples/report-generator-jsonl-job.json
+
+# Copilot usage export example
+dmtools run dmtools-ai-docs/references/examples/copilot-usage-report.json
 ```
 
-**Example config**: [report-generator-job.json](../examples/report-generator-job.json)
+**Example configs**: [report-generator-job.json](../examples/report-generator-job.json), [report-generator-jsonl-job.json](../examples/report-generator-jsonl-job.json), [copilot-usage-report.json](../examples/copilot-usage-report.json)
 
 → **See also**: [Report Generator Guide](../reporting/report-generation.md)
 

--- a/dmtools-ai-docs/references/reporting/report-generation.md
+++ b/dmtools-ai-docs/references/reporting/report-generation.md
@@ -69,6 +69,7 @@ Supported data sources in the example config:
 - `pullRequests`: Pull requests from GitHub, GitLab, or Bitbucket (via `sourceType`).
 - `commits`: Git commits from GitHub, GitLab, or Bitbucket (via `sourceType`).
 - `csv`: Custom CSV files.
+- `jsonl`: Line-delimited JSON files (generic structured data).
 - `figma`: Figma comments from one or more Figma files.
 
 **Tracker Source**
@@ -244,6 +245,30 @@ CSV source parameters:
 - `filePath`: Absolute or relative path.
 - `whenColumn`: Column name for date.
 - `defaultWho`: Who to attribute if CSV has no person column.
+
+**JSONL Source**
+
+Reads JSON Lines (`.jsonl`) or JSON (`.json`) files from a folder or a single file. Useful for custom event logs, Copilot usage exports, CI metrics, or any line-delimited JSON data.
+
+```json
+{
+  "name": "jsonl",
+  "params": {
+    "folderPath": "path/to/jsonl/data",
+    "whoField": "user",
+    "whenField": "date"
+  },
+  "metrics": [ ... ]
+}
+```
+
+JSONL source parameters:
+
+- `folderPath`: Directory scanned recursively for `.json` and `.jsonl` files.
+- `filePath`: Alternative to `folderPath` — read a single file.
+- `whoField`: Field name for the person (default: `user_login`). Supports dot-notation for nested fields.
+- `whenField`: Field name for the date (default: `day`). Supports dot-notation and custom `dateFormat`.
+- `dateFormat`: Optional Java `SimpleDateFormat` pattern (default: `yyyy-MM-dd`).
 
 **Figma Source**
 
@@ -490,6 +515,67 @@ CSV parsing notes:
 - Invalid values like `NaN`, `N/A`, empty strings are skipped.
 - Filter matching is case-insensitive.
 
+**JSONL Metrics**
+
+JSONL metrics use `JsonlMetricSource` at the metric level.
+
+```json
+{
+  "name": "JsonlMetricSource",
+  "params": {
+    "label": "Total Events",
+    "weightField": "count",
+    "isWeight": true,
+    "isPersonalized": true
+  }
+}
+```
+
+JSONL metric parameters:
+
+- `weightField` (required): Field path with numeric value. Supports dot-notation for nested objects (e.g. `totals.by_model.acceptances`).
+- `whoField`: Overrides source-level `whoField` for this metric.
+- `whenField`: Overrides source-level `whenField` for this metric.
+- `weightMultiplier`: Multiply each value by this factor before aggregation.
+- `filterField` + `filterValue`: Include only top-level rows where the field equals the value (case-insensitive).
+- `arrayField`: Path to a JSON array inside the row.
+- `arrayFilterField` + `arrayFilterValue`: Within `arrayField`, include only objects whose field equals the value. Use `"*"` for `arrayFilterValue` to include every object.
+- `groupByField`: When set, the metric value is attributed to the value of this field instead of the person. Useful for breaking down by model, feature, IDE, language, etc.
+- `dateFormat`: Custom date format for this metric.
+
+Example breakdowns:
+
+```json
+{
+  "name": "JsonlMetricSource",
+  "params": {
+    "label": "Feature Acceptances",
+    "arrayField": "totals_by_feature",
+    "arrayFilterField": "feature",
+    "arrayFilterValue": "code_completion",
+    "weightField": "code_acceptance_activity_count",
+    "isWeight": true,
+    "isPersonalized": true
+  }
+}
+```
+
+```json
+{
+  "name": "JsonlMetricSource",
+  "params": {
+    "label": "Acceptances by Model",
+    "arrayField": "totals_by_model",
+    "arrayFilterField": "model",
+    "arrayFilterValue": "*",
+    "weightField": "code_acceptance_activity_count",
+    "groupByField": "model",
+    "isWeight": true,
+    "isPersonalized": true
+  }
+}
+```
+
 **Figma Metrics**
 
 Figma metrics use one of these names:
@@ -612,5 +698,7 @@ Multiple time groupings can be generated in a single run.
 Use the example config as a template:
 
 - `dmtools-ai-docs/references/examples/report-generator-job.json`
+- `dmtools-ai-docs/references/examples/report-generator-jsonl-job.json`
+- `dmtools-ai-docs/references/examples/copilot-usage-report.json`
 - [ReportGenerator quick reference](../jobs/README.md#reportgenerator)
 - [ReportVisualizer quick reference](../jobs/README.md#reportvisualizer)

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/metrics/source/JsonlMetricSource.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/metrics/source/JsonlMetricSource.java
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.metrics.source;
+
+import com.github.istin.dmtools.report.model.KeyTime;
+import com.github.istin.dmtools.team.IEmployees;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Reads JSONL (line-delimited JSON) files from a folder or single file
+ * and produces KeyTime entries for reporting metrics.
+ *
+ * Supports:
+ * - folderPath: scans all .json / .jsonl files in directory
+ * - filePath: single file (alternative to folderPath)
+ * - whoField, whenField, weightField with dot-notation for nested objects
+ * - arrayField + arrayFilterField + arrayFilterValue: extract from arrays
+ * - filterField + filterValue: top-level row filtering
+ * - weightMultiplier: scale numeric values
+ * - Caching by file path + lastModified
+ */
+public class JsonlMetricSource extends CommonSourceCollector {
+
+    private static final Logger logger = LogManager.getLogger(JsonlMetricSource.class);
+    private static final Map<String, CachedJsonl> CACHE = new ConcurrentHashMap<>();
+
+    private final String folderPath;
+    private final String filePath;
+    private final String whoField;
+    private final String whenField;
+    private final String weightField;
+    private final double weightMultiplier;
+    private final String filterField;
+    private final String filterValue;
+    private final String arrayField;
+    private final String arrayFilterField;
+    private final String arrayFilterValue;
+    private final String dateFormat;
+    private final String groupByField;
+
+    public JsonlMetricSource(IEmployees employees,
+                             String folderPath,
+                             String filePath,
+                             String whoField,
+                             String whenField,
+                             String weightField,
+                             double weightMultiplier,
+                             String filterField,
+                             String filterValue,
+                             String arrayField,
+                             String arrayFilterField,
+                             String arrayFilterValue,
+                             String dateFormat,
+                             String groupByField) {
+        super(employees);
+        this.folderPath = folderPath;
+        this.filePath = filePath;
+        this.whoField = whoField != null ? whoField : "user_login";
+        this.whenField = whenField != null ? whenField : "day";
+        this.weightField = weightField;
+        this.weightMultiplier = weightMultiplier;
+        this.filterField = filterField;
+        this.filterValue = filterValue;
+        this.arrayField = arrayField;
+        this.arrayFilterField = arrayFilterField;
+        this.arrayFilterValue = arrayFilterValue;
+        this.dateFormat = dateFormat;
+        this.groupByField = groupByField;
+    }
+
+    @Override
+    public List<KeyTime> performSourceCollection(boolean isPersonalized, String metricName) throws Exception {
+        List<KeyTime> keyTimes = new ArrayList<>();
+
+        List<File> files = resolveFiles();
+        if (files.isEmpty()) {
+            logger.warn("No JSON/JSONL files found for path: folderPath={}, filePath={}", folderPath, filePath);
+            return keyTimes;
+        }
+
+        SimpleDateFormat sdf = dateFormat != null && !dateFormat.isEmpty()
+                ? new SimpleDateFormat(dateFormat)
+                : new SimpleDateFormat("yyyy-MM-dd");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        int fileIndex = 0;
+        for (File file : files) {
+            List<JSONObject> rows = loadJsonl(file);
+            int rowIndex = 0;
+            for (JSONObject row : rows) {
+                try {
+                    // Top-level filter
+                    if (!passesFilter(row)) {
+                        continue;
+                    }
+
+                    List<JSONObject> targets = resolveTargetObjects(row);
+                    if (targets.isEmpty() && (arrayField == null || arrayField.isEmpty())) {
+                        // Try top-level only if no array configured
+                        targets = Collections.singletonList(row);
+                    }
+                    if (targets.isEmpty()) {
+                        continue;
+                    }
+
+                    for (JSONObject target : targets) {
+                        Double weight = extractNumeric(target, weightField);
+                        if (weight == null) {
+                            continue;
+                        }
+
+                        String whenStr = extractString(target, whenField);
+                        if (whenStr == null) {
+                            whenStr = extractString(row, whenField);
+                        }
+                        if (whenStr == null || whenStr.isEmpty()) {
+                            continue;
+                        }
+
+                        Date parsedDate = sdf.parse(whenStr);
+                        Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+                        cal.setTime(parsedDate);
+
+                        String who = resolveWho(row, target, isPersonalized, metricName);
+                        if (who == null || who.isEmpty()) {
+                            continue;
+                        }
+
+                        String key = file.getName() + "_" + fileIndex + "_" + rowIndex;
+                        KeyTime keyTime = new KeyTime(key, cal, who);
+                        keyTime.setWeight(weight * weightMultiplier);
+
+                        // Build summary from available context
+                        String summary = buildSummary(row, target);
+                        if (summary != null) {
+                            keyTime.setSummary(summary);
+                        }
+
+                        keyTimes.add(keyTime);
+                    }
+                } catch (Exception e) {
+                    logger.debug("Skipping malformed row {} in {}: {}", rowIndex, file.getName(), e.getMessage());
+                }
+                rowIndex++;
+            }
+            fileIndex++;
+        }
+
+        logger.info("JSONL collected {} entries for metric '{}' (weightField={})",
+                keyTimes.size(), metricName, weightField);
+        return keyTimes;
+    }
+
+    private List<File> resolveFiles() {
+        if (filePath != null && !filePath.isEmpty()) {
+            File f = new File(filePath);
+            return f.exists() ? Collections.singletonList(f) : Collections.emptyList();
+        }
+        if (folderPath != null && !folderPath.isEmpty()) {
+            File dir = new File(folderPath);
+            if (dir.isDirectory()) {
+                try (Stream<Path> walk = Files.walk(dir.toPath())) {
+                    return walk
+                            .filter(Files::isRegularFile)
+                            .filter(p -> {
+                                String name = p.getFileName().toString().toLowerCase();
+                                return name.endsWith(".json") || name.endsWith(".jsonl");
+                            })
+                            .map(Path::toFile)
+                            .sorted(Comparator.comparing(File::getAbsolutePath))
+                            .collect(Collectors.toList());
+                } catch (IOException e) {
+                    logger.warn("Failed to walk directory {}: {}", folderPath, e.getMessage());
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private List<JSONObject> loadJsonl(File file) throws IOException {
+        String canonicalPath = file.getCanonicalPath();
+        long lastModified = file.lastModified();
+        long length = file.length();
+
+        CachedJsonl cached = CACHE.get(canonicalPath);
+        if (cached != null && cached.lastModified == lastModified && cached.length == length) {
+            return cached.rows;
+        }
+
+        List<JSONObject> rows = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8), 256 * 1024)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.isEmpty()) continue;
+                try {
+                    rows.add(new JSONObject(line));
+                } catch (Exception e) {
+                    logger.debug("Skipping invalid JSON line in {}: {}", file.getName(), e.getMessage());
+                }
+            }
+        }
+
+        CachedJsonl fresh = new CachedJsonl(rows, lastModified, length);
+        CACHE.put(canonicalPath, fresh);
+        return rows;
+    }
+
+    private boolean passesFilter(JSONObject row) {
+        if (filterField == null || filterValue == null) {
+            return true;
+        }
+        Object value = extractValue(row, filterField);
+        if (value == null) {
+            return false;
+        }
+        String strValue = value.toString();
+        if (value instanceof Boolean) {
+            strValue = value.toString();
+        }
+        return filterValue.equalsIgnoreCase(strValue);
+    }
+
+    private List<JSONObject> resolveTargetObjects(JSONObject row) {
+        if (arrayField == null || arrayField.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Object arrObj = extractValue(row, arrayField);
+        if (!(arrObj instanceof JSONArray)) {
+            return Collections.emptyList();
+        }
+        JSONArray arr = (JSONArray) arrObj;
+        List<JSONObject> result = new ArrayList<>();
+        boolean matchAll = "*".equals(arrayFilterValue);
+        for (int i = 0; i < arr.length(); i++) {
+            Object item = arr.opt(i);
+            if (item instanceof JSONObject) {
+                JSONObject obj = (JSONObject) item;
+                if (arrayFilterField == null || arrayFilterValue == null) {
+                    result.add(obj);
+                } else if (matchAll) {
+                    result.add(obj);
+                } else {
+                    Object fv = extractValue(obj, arrayFilterField);
+                    if (fv != null && arrayFilterValue.equalsIgnoreCase(fv.toString())) {
+                        result.add(obj);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private String resolveWho(JSONObject row, JSONObject target, boolean isPersonalized, String metricName) {
+        if (!isPersonalized) {
+            return metricName;
+        }
+        String who;
+        if (groupByField != null && !groupByField.isEmpty()) {
+            who = extractString(target, groupByField);
+            if (who == null || who.isEmpty()) {
+                who = extractString(row, groupByField);
+            }
+        } else {
+            who = extractString(target, whoField);
+            if (who == null || who.isEmpty()) {
+                who = extractString(row, whoField);
+            }
+        }
+        if (who == null || who.isEmpty()) {
+            who = metricName;
+        }
+        who = transformName(who);
+        if (groupByField == null || groupByField.isEmpty()) {
+            if (getEmployees() != null && !getEmployees().contains(who)) {
+                who = IEmployees.UNKNOWN;
+            }
+        }
+        return who;
+    }
+
+    private String buildSummary(JSONObject row, JSONObject target) {
+        StringBuilder sb = new StringBuilder();
+        // Add useful context fields for summary
+        appendSummaryField(sb, row, "user_login");
+        appendSummaryField(sb, row, "day");
+        if (arrayFilterField != null) {
+            appendSummaryField(sb, target, arrayFilterField);
+        }
+        return sb.length() > 0 ? sb.toString() : null;
+    }
+
+    private void appendSummaryField(StringBuilder sb, JSONObject obj, String field) {
+        String value = extractString(obj, field);
+        if (value != null && !value.isEmpty()) {
+            if (sb.length() > 0) sb.append(" | ");
+            sb.append(field).append(": ").append(value);
+        }
+    }
+
+    // ======== Dot-notation value extraction ========
+
+    static Object extractValue(Object root, String path) {
+        if (path == null || path.isEmpty()) {
+            return null;
+        }
+        String[] parts = path.split("\\.");
+        Object current = root;
+        for (String part : parts) {
+            if (current == null) {
+                return null;
+            }
+            current = extractChild(current, part);
+        }
+        return current;
+    }
+
+    private static Object extractChild(Object parent, String key) {
+        if (parent instanceof JSONObject) {
+            JSONObject json = (JSONObject) parent;
+            if (json.has(key)) {
+                return json.opt(key);
+            }
+            // Try case-insensitive
+            for (String k : json.keySet()) {
+                if (k.equalsIgnoreCase(key)) {
+                    return json.opt(k);
+                }
+            }
+            return null;
+        }
+        if (parent instanceof JSONArray) {
+            JSONArray arr = (JSONArray) parent;
+            try {
+                int idx = Integer.parseInt(key);
+                if (idx >= 0 && idx < arr.length()) {
+                    return arr.opt(idx);
+                }
+            } catch (NumberFormatException e) {
+                // key is not an index, try to find object with matching field
+                for (int i = 0; i < arr.length(); i++) {
+                    Object item = arr.opt(i);
+                    if (item instanceof JSONObject) {
+                        JSONObject obj = (JSONObject) item;
+                        if (obj.has(key) || hasKeyIgnoreCase(obj, key)) {
+                            return obj;
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+
+    private static boolean hasKeyIgnoreCase(JSONObject obj, String key) {
+        for (String k : obj.keySet()) {
+            if (k.equalsIgnoreCase(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static String extractString(Object root, String path) {
+        Object value = extractValue(root, path);
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    static Double extractNumeric(Object root, String path) {
+        Object value = extractValue(root, path);
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        try {
+            double d = Double.parseDouble(value.toString());
+            if (Double.isNaN(d) || Double.isInfinite(d)) {
+                return null;
+            }
+            return d;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static class CachedJsonl {
+        private final List<JSONObject> rows;
+        private final long lastModified;
+        private final long length;
+
+        CachedJsonl(List<JSONObject> rows, long lastModified, long length) {
+            this.rows = rows;
+            this.lastModified = lastModified;
+            this.length = length;
+        }
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/datasource/DataSourceFactory.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/datasource/DataSourceFactory.java
@@ -47,6 +47,9 @@ public class DataSourceFactory {
             case "csv":
                 return new CsvDataSource(params);
 
+            case "jsonl":
+                return new JsonlDataSource(params);
+
             default:
                 throw new IllegalArgumentException("Unknown data source: " + name);
         }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/datasource/JsonlDataSource.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/datasource/JsonlDataSource.java
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.reporting.datasource;
+
+import com.github.istin.dmtools.metrics.Metric;
+import com.github.istin.dmtools.metrics.source.SourceCollector;
+import com.github.istin.dmtools.report.model.KeyTime;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Data source for JSONL files. Delegates metric collection to the metric's SourceCollector
+ * (JsonlMetricSource), similar to how CsvDataSource works.
+ */
+public class JsonlDataSource extends DataSource {
+
+    private final Map<String, Object> params;
+
+    public JsonlDataSource(Map<String, Object> params) {
+        this.params = params;
+    }
+
+    @Override
+    public void performMetricCollection(Metric metric, KeyTimeCollector collector) throws Exception {
+        SourceCollector sourceCollector = metric.getSourceCollector();
+        if (sourceCollector == null) {
+            return;
+        }
+
+        List<KeyTime> keyTimes = sourceCollector.performSourceCollection(
+            metric.isPersonalized(),
+            metric.getName()
+        );
+
+        for (KeyTime kt : keyTimes) {
+            JSONObject metadata = new JSONObject();
+            metadata.put("key", kt.getKey());
+            metadata.put("who", kt.getWho());
+            if (kt.getSummary() != null) {
+                metadata.put("summary", kt.getSummary());
+            }
+            collector.collect(Arrays.asList(kt), metadata, kt.getKey());
+        }
+    }
+
+    @Override
+    public JSONObject extractRawMetadata(Object item) {
+        return new JSONObject();
+    }
+
+    @Override
+    public String getSourceName() {
+        return "jsonl";
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/metrics/MetricFactory.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/reporting/metrics/MetricFactory.java
@@ -25,6 +25,7 @@ import com.github.istin.dmtools.metrics.source.PullRequestsApprovalsMetricSource
 import com.github.istin.dmtools.metrics.source.PullRequestsMergedByMetricSource;
 import com.github.istin.dmtools.metrics.source.PullRequestsDeclinedMetricSource;
 import com.github.istin.dmtools.metrics.source.SourceCodeCommitsMetricSource;
+import com.github.istin.dmtools.metrics.source.JsonlMetricSource;
 import com.github.istin.dmtools.csv.CsvMetricSource;
 import com.github.istin.dmtools.team.Employees;
 import com.github.istin.dmtools.team.IEmployees;
@@ -113,6 +114,9 @@ public class MetricFactory {
             metric = new Metric(label, isWeight, isPersonalized, collector);
         } else if ("csv".equals(dataSourceType)) {
             SourceCollector collector = createCsvCollector(params);
+            metric = new Metric(label, isWeight, isPersonalized, collector);
+        } else if ("jsonl".equals(dataSourceType)) {
+            SourceCollector collector = createJsonlCollector(params);
             metric = new Metric(label, isWeight, isPersonalized, collector);
         } else {
             throw new IllegalArgumentException("Unknown data source type: " + dataSourceType);
@@ -338,6 +342,31 @@ public class MetricFactory {
             default:
                 throw new IllegalArgumentException("Unknown figma source collector: " + metricName);
         }
+    }
+
+    private SourceCollector createJsonlCollector(Map<String, Object> params) {
+        String folderPath = (String) params.get("folderPath");
+        String filePath = (String) params.get("filePath");
+        if ((folderPath == null || folderPath.isEmpty()) && (filePath == null || filePath.isEmpty())) {
+            throw new IllegalArgumentException("JSONL data source requires 'folderPath' or 'filePath' parameter");
+        }
+        String whoField = (String) params.getOrDefault("whoField", "user_login");
+        String whenField = (String) params.getOrDefault("whenField", "day");
+        String weightField = (String) params.get("weightField");
+        if (weightField == null || weightField.isEmpty()) {
+            throw new IllegalArgumentException("JSONL metric requires 'weightField' parameter");
+        }
+        double weightMultiplier = parseDivider(params.get("weightMultiplier"));
+        String filterField = (String) params.getOrDefault("filterField", null);
+        String filterValue = (String) params.getOrDefault("filterValue", null);
+        String arrayField = (String) params.getOrDefault("arrayField", null);
+        String arrayFilterField = (String) params.getOrDefault("arrayFilterField", null);
+        String arrayFilterValue = (String) params.getOrDefault("arrayFilterValue", null);
+        String dateFormat = (String) params.getOrDefault("dateFormat", null);
+        String groupByField = (String) params.getOrDefault("groupByField", null);
+
+        return new JsonlMetricSource(employees, folderPath, filePath, whoField, whenField, weightField,
+                weightMultiplier, filterField, filterValue, arrayField, arrayFilterField, arrayFilterValue, dateFormat, groupByField);
     }
 
     private SourceCollector createCsvCollector(Map<String, Object> params) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/reporting/metrics/MetricFactoryTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/reporting/metrics/MetricFactoryTest.java
@@ -486,4 +486,66 @@ class MetricFactoryTest {
         assertThrows(IllegalArgumentException.class,
             () -> factory.createMetric("CsvMetricSource", params, "csv"));
     }
+
+    @Test
+    void testCreateJsonlMetricSource_withFolderPath() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("folderPath", "/path/to/jsonl");
+        params.put("weightField", "count");
+        params.put("label", "JSONL Events");
+        params.put("isWeight", true);
+        params.put("isPersonalized", true);
+
+        Metric metric = factory.createMetric("JsonlMetricSource", params, "jsonl");
+
+        assertNotNull(metric);
+        assertEquals("JSONL Events", metric.getName());
+        assertTrue(metric.isWeight());
+        assertTrue(metric.isPersonalized());
+        assertNotNull(metric.getSourceCollector());
+    }
+
+    @Test
+    void testCreateJsonlMetricSource_withFilePath() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("filePath", "/path/to/data.jsonl");
+        params.put("weightField", "value");
+        params.put("label", "JSONL File Metric");
+        params.put("isWeight", true);
+        params.put("isPersonalized", false);
+
+        Metric metric = factory.createMetric("JsonlMetricSource", params, "jsonl");
+
+        assertNotNull(metric);
+        assertEquals("JSONL File Metric", metric.getName());
+        assertTrue(metric.isWeight());
+        assertFalse(metric.isPersonalized());
+        assertNotNull(metric.getSourceCollector());
+    }
+
+    @Test
+    void testCreateJsonlMetricSource_missingPath() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("weightField", "count");
+        params.put("label", "Test");
+        params.put("isWeight", false);
+        params.put("isPersonalized", false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> factory.createMetric("JsonlMetricSource", params, "jsonl"));
+        assertTrue(exception.getMessage().contains("folderPath"));
+    }
+
+    @Test
+    void testCreateJsonlMetricSource_missingWeightField() {
+        Map<String, Object> params = new HashMap<>();
+        params.put("folderPath", "/path/to/jsonl");
+        params.put("label", "Test");
+        params.put("isWeight", false);
+        params.put("isPersonalized", false);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> factory.createMetric("JsonlMetricSource", params, "jsonl"));
+        assertTrue(exception.getMessage().contains("weightField"));
+    }
 }


### PR DESCRIPTION
…ge report

- Add JsonlDataSource and JsonlMetricSource for line-delimited JSON reports.
- Register jsonl source in DataSourceFactory and JsonlMetricSource in MetricFactory.
- Add generic report-generator-jsonl-job.json example covering filters, arrays, groupByField, and weightMultiplier.
- Add copilot-usage-report.json real-world example with Copilot metrics.
- Update report-generation.md and jobs/README.md with JSONL docs and links.
- Add unit tests for JsonlMetricSource creation in MetricFactoryTest.
- Ignore local tooling state (.codegraph, .cursor, .worktrees) in .gitignore.