### PR TITLE
feat: CliAgent env exclusion and timer JS action

### DIFF
--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -490,6 +490,77 @@ Teammate can execute external CLI agents with full workspace context:
 
 ---
 
+### CliAgent
+
+Lightweight CLI-agent orchestrator. Takes the CLI-execution parts of `Teammate` and removes the tracker-ticket plumbing, so it can run cursor-agent / claude / copilot-style tools without an `inputJql` or ticket system.
+
+**Purpose**: Run external CLI agents with aggregated prompts and optional setup/cache/reset hooks, without binding to Jira/ADO/Rally.
+
+**Usage**:
+```bash
+dmtools CliAgent --cliCommands '["cursor-agent"]' --cliPrompts '["Implement the feature"]'
+
+# Use configuration file
+dmtools run agents/cli_agent.json
+```
+
+**Configuration** (`agents/cli_agent.json`):
+```json
+{
+  "name": "CliAgent",
+  "params": {
+    "metadata": {
+      "contextId": "story_development"
+    },
+    "cliCommands": ["./agents/scripts/run-agent.sh"],
+    "cliPrompts": [
+      "Senior Developer Engineer",
+      "./agents/instructions/common/coding_guidelines.md"
+    ],
+    "setup": "./agents/scripts/setup.sh",
+    "preJSAction": "agents/js/checkWipLabel.js",
+    "preCliJSAction": "agents/js/preCliDevelopmentSetup.js",
+    "postJSAction": "agents/js/developTicketAndCreatePR.js",
+    "cache": "./agents/scripts/cache.sh",
+    "reset": "./agents/scripts/reset.sh",
+    "customParams": {
+      "mode": "development",
+      "maxFiles": 10
+    },
+    "outputType": "none",
+    "cleanupInputFolder": true
+  }
+}
+```
+
+**Execution lifecycle**:
+```
+setup → preJSAction → preCliJSAction → cliCommands → postJSAction → cache → reset
+```
+
+**Core Parameters**:
+- `cliCommands` - Array of CLI commands to execute (e.g., `["cursor-agent"]`)
+- `cliPrompt` - Single base CLI prompt (optional)
+- `cliPrompts` - Array of prompts/instructions; files, URLs and plain text are supported
+- `cliPromptsByTracker` - Tracker-specific prompt overrides (same merging as `Teammate`)
+- `setup` - Shell or JS script executed before everything else
+- `preJSAction` - JavaScript executed before CLI commands
+- `preCliJSAction` - JavaScript executed after input context is prepared
+- `postJSAction` - JavaScript executed after CLI commands finish
+- `cache` - Shell or JS script executed after post-action
+- `reset` - Shell or JS script executed in `finally` (always runs, even on failure)
+- `customParams` - Arbitrary key-value map forwarded to JS actions as `customParams`
+- `workingDirectory` - Working directory for CLI execution (defaults to `user.dir`)
+- `cleanupInputFolder` - Clean up `input/{contextId}/` after execution (default: **true**)
+- `requireCliOutputFile` - Require `output/response.md` from CLI agent (default: **false**)
+
+**Differences from `Teammate`**:
+- No `inputJql`, no ticket context, no tracker integration required.
+- No shell-injection whitelist: any shell syntax (`&&`, `|`, `>`, etc.) is allowed in `cliCommands`, `setup`, `cache`, `reset`.
+- Simpler lifecycle focused purely on CLI execution.
+
+---
+
 ### Expert
 
 Domain expert that answers questions based on context (tickets, documentation, code).

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -554,6 +554,18 @@ setup → preJSAction → preCliJSAction → cliCommands → postJSAction → ca
 - `cleanupInputFolder` - Clean up `input/{contextId}/` after execution (default: **true**)
 - `requireCliOutputFile` - Require `output/response.md` from CLI agent (default: **false**)
 
+**Environment Security**:
+- `excludedEnvVariables` - Array of exact env variable names to remove from the subprocess environment (e.g., `["OPENAI_API_KEY", "ANTHROPIC_API_KEY"]`)
+- `excludeEnvVariablesByRegex` - Array of regex patterns; matching env variable names are removed (e.g., `[".*_API_KEY", "SECRET_.*"]`)
+
+> Useful when you want to hide sensitive keys from `cliCommands` while still keeping them available to DMtools itself.
+
+**Timer JS Action**:
+- `timerJSAction` - JavaScript executed periodically while CLI commands are running
+- `timerIntervalSeconds` - Interval between timer firings in seconds (default: **60**)
+
+> The timer action receives `currentCliOutput` variable containing accumulated CLI output so far, same as `Teammate`.
+
 **Differences from `Teammate`**:
 - No `inputJql`, no ticket context, no tracker integration required.
 - No shell-injection whitelist: any shell syntax (`&&`, `|`, `>`, etc.) is allowed in `cliCommands`, `setup`, `cache`, `reset`.

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.cliagent;
+
+import com.github.istin.dmtools.ai.AI;
+import com.github.istin.dmtools.atlassian.confluence.Confluence;
+import com.github.istin.dmtools.common.config.ApplicationConfiguration;
+import com.github.istin.dmtools.common.utils.CommandLineUtils;
+import com.github.istin.dmtools.common.utils.PropertyReader;
+import com.github.istin.dmtools.di.ServerManagedIntegrationsModule;
+import com.github.istin.dmtools.job.AbstractJob;
+import com.github.istin.dmtools.job.JavaScriptExecutor;
+import com.github.istin.dmtools.job.ResultItem;
+import com.github.istin.dmtools.job.TrackerParams;
+import com.github.istin.dmtools.teammate.AgentParamsFileWriter;
+import com.github.istin.dmtools.teammate.CliCommandBuilder;
+import com.github.istin.dmtools.teammate.CliExecutionHelper;
+import com.github.istin.dmtools.teammate.InstructionProcessor;
+import lombok.Getter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Lightweight CLI-agent orchestrator.
+ * <p>
+ * {@code CliAgent} takes the CLI-execution parts of {@code Teammate} and removes the
+ * tracker-ticket plumbing. It is designed for running cursor-agent / claude / copilot-style
+ * CLI tools with aggregated prompts and optional setup/cache/reset hooks, without needing
+ * an {@code inputJql} or a ticket system.
+ * <p>
+ * Execution lifecycle:
+ * <pre>
+ *   setup → preJSAction → preCliJSAction → cliCommands → postJSAction → cache → reset
+ * </pre>
+ */
+public class CliAgent extends AbstractJob<CliAgentParams, List<ResultItem>> {
+
+    private static final Logger logger = LogManager.getLogger(CliAgent.class);
+
+    @Inject
+    @Getter
+    AI ai;
+
+    @Inject
+    Confluence confluence;
+
+    @Inject
+    ApplicationConfiguration configuration;
+
+    private InstructionProcessor instructionProcessor;
+    private AgentParamsFileWriter agentParamsFileWriter;
+
+    /**
+     * Server-managed Dagger component. Reuses the same integrations module as Teammate.
+     */
+    @Singleton
+    @dagger.Component(modules = {ServerManagedIntegrationsModule.class})
+    public interface ServerManagedCliAgentComponent {
+        void inject(CliAgent agent);
+    }
+
+    @Override
+    protected void initializeStandalone() {
+        logger.info("Initializing CliAgent in STANDALONE mode");
+        this.instructionProcessor = new InstructionProcessor(confluence);
+        this.agentParamsFileWriter = new AgentParamsFileWriter(instructionProcessor);
+        logger.info("CliAgent standalone initialization completed");
+    }
+
+    @Override
+    protected void initializeServerManaged(JSONObject resolvedIntegrations) {
+        logger.info("Initializing CliAgent in SERVER_MANAGED mode");
+        ServerManagedIntegrationsModule module = new ServerManagedIntegrationsModule(resolvedIntegrations);
+        ServerManagedCliAgentComponent component = DaggerCliAgent_ServerManagedCliAgentComponent.builder()
+                .serverManagedIntegrationsModule(module)
+                .build();
+        component.inject(this);
+        this.instructionProcessor = new InstructionProcessor(confluence);
+        this.agentParamsFileWriter = new AgentParamsFileWriter(instructionProcessor);
+        logger.info("CliAgent server-managed initialization completed");
+    }
+
+    @Override
+    protected List<ResultItem> runJobImpl(CliAgentParams params) throws Exception {
+        if (params.getCliCommands() == null || params.getCliCommands().length == 0) {
+            logger.info("No cliCommands provided - nothing to do");
+            return Collections.emptyList();
+        }
+
+        String contextId = getContextId(params);
+        Path workingDirectory = resolveWorkingDirectory(params);
+        Path inputContextPath = null;
+        CliExecutionHelper cliHelper = new CliExecutionHelper();
+        CliExecutionHelper.CliExecutionResult cliResult = null;
+
+        try {
+            // 1. Setup hook
+            executeScriptHook(params.getSetup(), "setup", params, workingDirectory, null);
+
+            // 2. Pre-JS action
+            executeJsAction(params.getPreJSAction(), "preJSAction", params, null, null);
+
+            // 3. Build input context and pre-CLI JS action
+            inputContextPath = createInputContext(params, workingDirectory);
+
+            // 4. Pre-CLI JS action
+            executeJsAction(params.getPreCliJSAction(), "preCliJSAction", params, null,
+                    inputContextPath != null ? inputContextPath.toAbsolutePath().toString() : null);
+
+            // 5. Build and execute CLI commands with aggregated prompt
+            CliCommandBuilder commandBuilder = new CliCommandBuilder(instructionProcessor, configuration);
+            String[] finalCommands = commandBuilder.buildCommands(
+                    params.getCliCommands(),
+                    params.getCliPrompt(),
+                    params.getCliPrompts(),
+                    params.getCliPromptsByTracker());
+
+            AtomicReference<String> liveOutput = new AtomicReference<>("");
+            cliResult = cliHelper.executeCliCommandsWithResult(
+                    finalCommands,
+                    workingDirectory,
+                    null,
+                    null,
+                    0,
+                    liveOutput,
+                    true); // allow arbitrary shell syntax
+
+            // 6. Post-JS action
+            String response = extractResponse(cliResult, params);
+            executeJsAction(params.getPostJSAction(), "postJSAction", params, response,
+                    inputContextPath != null ? inputContextPath.toAbsolutePath().toString() : null);
+
+            // 7. Cache hook
+            executeScriptHook(params.getCache(), "cache", params, workingDirectory, response);
+
+            return Collections.singletonList(new ResultItem(contextId, response));
+
+        } catch (Exception e) {
+            logger.error("CliAgent execution failed: {}", e.getMessage(), e);
+            throw e;
+        } finally {
+            // 8. Reset hook (always run, even on failure)
+            try {
+                executeScriptHook(params.getReset(), "reset", params, workingDirectory,
+                        cliResult != null ? extractResponse(cliResult, params) : null);
+            } catch (Exception resetException) {
+                logger.warn("Reset hook failed: {}", resetException.getMessage(), resetException);
+            }
+
+            // Clean up input context
+            if (inputContextPath != null && params.isCleanupInputFolder()) {
+                try {
+                    cliHelper.cleanupInputContext(inputContextPath);
+                    logger.info("Cleaned up input folder: {}", inputContextPath.toAbsolutePath());
+                } catch (Exception cleanupException) {
+                    logger.warn("Failed to clean up input folder: {}", cleanupException.getMessage());
+                }
+            }
+        }
+    }
+
+    private String getContextId(CliAgentParams params) {
+        if (params.getMetadata() != null && params.getMetadata().getContextId() != null) {
+            return params.getMetadata().getContextId();
+        }
+        return "cli-agent";
+    }
+
+    private Path resolveWorkingDirectory(CliAgentParams params) {
+        if (params.getWorkingDirectory() != null && !params.getWorkingDirectory().trim().isEmpty()) {
+            Path path = Paths.get(params.getWorkingDirectory());
+            if (Files.exists(path) && Files.isDirectory(path)) {
+                return path;
+            }
+            logger.warn("Configured workingDirectory does not exist or is not a directory: {}", params.getWorkingDirectory());
+        }
+        return Paths.get(System.getProperty("user.dir"));
+    }
+
+    private Path createInputContext(CliAgentParams params, Path workingDirectory) throws IOException {
+        Path inputContextPath = Paths.get("input", getContextId(params));
+        Files.createDirectories(inputContextPath);
+        return inputContextPath;
+    }
+
+    private void executeJsAction(String action, String actionName, CliAgentParams params, String response,
+                                  String inputFolderPath) {
+        if (action == null || action.trim().isEmpty()) {
+            return;
+        }
+        try {
+            logger.info("Executing {}: {}", actionName, action);
+            JavaScriptExecutor executor = js(action)
+                    .mcp(null, ai, confluence, null)
+                    .withJobContext(params, null, response);
+            if (inputFolderPath != null) {
+                executor.with("inputFolderPath", inputFolderPath);
+            }
+            if (params.getCustomParams() != null && !params.getCustomParams().isEmpty()) {
+                executor.with("customParams", params.getCustomParams());
+            }
+            executor.execute();
+        } catch (Exception e) {
+            logger.warn("{} failed, continuing: {}", actionName, e.getMessage(), e);
+        }
+    }
+
+    private void executeScriptHook(String script, String hookName, CliAgentParams params, Path workingDirectory,
+                                    String response) {
+        if (script == null || script.trim().isEmpty()) {
+            return;
+        }
+        logger.info("Executing {} hook: {}", hookName, script);
+        try {
+            if (script.endsWith(".js")) {
+                JavaScriptExecutor executor = js(script)
+                        .mcp(null, ai, confluence, null)
+                        .withJobContext(params, null, response)
+                        .with("workingDirectory", workingDirectory.toAbsolutePath().toString());
+                if (params.getCustomParams() != null && !params.getCustomParams().isEmpty()) {
+                    executor.with("customParams", params.getCustomParams());
+                }
+                executor.execute();
+            } else {
+                CommandLineUtils.runCommand(script, workingDirectory.toFile(), PropertyReader.getOverrides(), null, false);
+            }
+        } catch (Exception e) {
+            logger.warn("{} hook failed, continuing: {}", hookName, e.getMessage(), e);
+        }
+    }
+
+    private String extractResponse(CliExecutionHelper.CliExecutionResult cliResult, CliAgentParams params) {
+        if (cliResult == null) {
+            return "No CLI result available.";
+        }
+        if (params.isRequireCliOutputFile() && !cliResult.hasOutputResponse()) {
+            return "CLI command executed but did not produce output file:\n" + cliResult.getCommandResponses();
+        }
+        if (cliResult.hasOutputResponse()) {
+            return cliResult.getOutputResponse();
+        }
+        return cliResult.getCommandResponses().toString();
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
@@ -130,14 +130,18 @@ public class CliAgent extends AbstractJob<CliAgentParams, List<ResultItem>> {
                     params.getCliPromptsByTracker());
 
             AtomicReference<String> liveOutput = new AtomicReference<>("");
+            Runnable timerRunnable = buildTimerRunnable(params, liveOutput);
+            int timerIntervalSeconds = params.getTimerIntervalSeconds();
             cliResult = cliHelper.executeCliCommandsWithResult(
                     finalCommands,
                     workingDirectory,
                     null,
-                    null,
-                    0,
+                    timerRunnable,
+                    timerIntervalSeconds,
                     liveOutput,
-                    true); // allow arbitrary shell syntax
+                    true, // allow arbitrary shell syntax
+                    params.getExcludedEnvVariables(),
+                    params.getExcludeEnvVariablesByRegex());
 
             // 6. Post-JS action
             String response = extractResponse(cliResult, params);
@@ -241,6 +245,28 @@ public class CliAgent extends AbstractJob<CliAgentParams, List<ResultItem>> {
         } catch (Exception e) {
             logger.warn("{} hook failed, continuing: {}", hookName, e.getMessage(), e);
         }
+    }
+
+    private Runnable buildTimerRunnable(CliAgentParams params, AtomicReference<String> liveOutput) {
+        String timerJSAction = params.getTimerJSAction();
+        if (timerJSAction == null || timerJSAction.trim().isEmpty()) {
+            return null;
+        }
+        return () -> {
+            try {
+                logger.info("Executing timerJSAction: {}", timerJSAction);
+                JavaScriptExecutor executor = js(timerJSAction)
+                        .mcp(null, ai, confluence, null)
+                        .withJobContext(params, null, null)
+                        .with("currentCliOutput", liveOutput.get());
+                if (params.getCustomParams() != null && !params.getCustomParams().isEmpty()) {
+                    executor.with("customParams", params.getCustomParams());
+                }
+                executor.execute();
+            } catch (Exception e) {
+                logger.warn("timerJSAction execution failed (CLI continues): {}", e.getMessage(), e);
+            }
+        };
     }
 
     private String extractResponse(CliExecutionHelper.CliExecutionResult cliResult, CliAgentParams params) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgentParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgentParams.java
@@ -35,6 +35,10 @@ public class CliAgentParams extends TrackerParams {
     public static final String CLEANUP_INPUT_FOLDER = "cleanupInputFolder";
     public static final String REQUIRE_CLI_OUTPUT_FILE = "requireCliOutputFile";
     public static final String WORKING_DIRECTORY = "workingDirectory";
+    public static final String EXCLUDED_ENV_VARIABLES = "excludedEnvVariables";
+    public static final String EXCLUDE_ENV_VARIABLES_BY_REGEX = "excludeEnvVariablesByRegex";
+    public static final String TIMER_JS_ACTION = "timerJSAction";
+    public static final String TIMER_INTERVAL_SECONDS = "timerIntervalSeconds";
 
     @SerializedName(CLI_COMMANDS)
     private String[] cliCommands;
@@ -71,4 +75,16 @@ public class CliAgentParams extends TrackerParams {
 
     @SerializedName(WORKING_DIRECTORY)
     private String workingDirectory;
+
+    @SerializedName(EXCLUDED_ENV_VARIABLES)
+    private String[] excludedEnvVariables;
+
+    @SerializedName(EXCLUDE_ENV_VARIABLES_BY_REGEX)
+    private String[] excludeEnvVariablesByRegex;
+
+    @SerializedName(TIMER_JS_ACTION)
+    private String timerJSAction;
+
+    @SerializedName(TIMER_INTERVAL_SECONDS)
+    private int timerIntervalSeconds = 60;
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgentParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgentParams.java
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.cliagent;
+
+import com.github.istin.dmtools.job.TrackerParams;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+/**
+ * Parameters for the {@link CliAgent} job.
+ * <p>
+ * Extends {@link TrackerParams} to inherit common job plumbing (outputType, envVariables,
+ * metadata, etc.) but does not require {@code inputJql}. The job is designed to run CLI agents
+ * in a lightweight, ticket-agnostic mode.
+ */
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class CliAgentParams extends TrackerParams {
+
+    public static final String CLI_COMMANDS = "cliCommands";
+    public static final String CLI_PROMPT = "cliPrompt";
+    public static final String CLI_PROMPTS = "cliPrompts";
+    public static final String CLI_PROMPTS_BY_TRACKER = "cliPromptsByTracker";
+    public static final String SETUP = "setup";
+    public static final String CACHE = "cache";
+    public static final String RESET = "reset";
+    public static final String PRE_CLI_JS_ACTION = "preCliJSAction";
+    public static final String CUSTOM_PARAMS = "customParams";
+    public static final String CLEANUP_INPUT_FOLDER = "cleanupInputFolder";
+    public static final String REQUIRE_CLI_OUTPUT_FILE = "requireCliOutputFile";
+    public static final String WORKING_DIRECTORY = "workingDirectory";
+
+    @SerializedName(CLI_COMMANDS)
+    private String[] cliCommands;
+
+    @SerializedName(CLI_PROMPT)
+    private String cliPrompt;
+
+    @SerializedName(CLI_PROMPTS)
+    private String[] cliPrompts;
+
+    @SerializedName(CLI_PROMPTS_BY_TRACKER)
+    private Map<String, String[]> cliPromptsByTracker;
+
+    @SerializedName(SETUP)
+    private String setup;
+
+    @SerializedName(CACHE)
+    private String cache;
+
+    @SerializedName(RESET)
+    private String reset;
+
+    @SerializedName(PRE_CLI_JS_ACTION)
+    private String preCliJSAction;
+
+    @SerializedName(CUSTOM_PARAMS)
+    private Map<String, Object> customParams;
+
+    @SerializedName(CLEANUP_INPUT_FOLDER)
+    private boolean cleanupInputFolder = true;
+
+    @SerializedName(REQUIRE_CLI_OUTPUT_FILE)
+    private boolean requireCliOutputFile = false;
+
+    @SerializedName(WORKING_DIRECTORY)
+    private String workingDirectory;
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -62,7 +62,7 @@ public class CommandLineUtils {
      */
     public static String runCommand(String command, File workingDirectory, Map<String, String> additionalEnv)
             throws IOException, InterruptedException {
-        return runCommand(command, workingDirectory, additionalEnv, null);
+        return runCommand(command, workingDirectory, additionalEnv, null, true);
     }
 
     /**
@@ -79,9 +79,33 @@ public class CommandLineUtils {
     public static String runCommand(String command, File workingDirectory, Map<String, String> additionalEnv,
                                     Consumer<String> lineConsumer)
             throws IOException, InterruptedException {
+        return runCommand(command, workingDirectory, additionalEnv, lineConsumer, true);
+    }
+
+    /**
+     * Runs a command-line command with full options, optional per-line output consumer,
+     * and optional shell-injection validation bypass.
+     *
+     * @param command The command to run
+     * @param workingDirectory The working directory for the command (null to use current directory)
+     * @param additionalEnv Additional environment variables to set
+     * @param lineConsumer Optional consumer called for each output line as it is produced (null to skip)
+     * @param validateCommand When {@code false}, skips {@link #validateNoShellInjection(String)}.
+     *                        Use only for trusted job configs where arbitrary shell syntax is required.
+     * @return The output of the command as a string
+     * @throws IOException If an I/O error occurs
+     * @throws InterruptedException If the current thread is interrupted
+     */
+    public static String runCommand(String command, File workingDirectory, Map<String, String> additionalEnv,
+                                    Consumer<String> lineConsumer, boolean validateCommand)
+            throws IOException, InterruptedException {
 
         logger.debug("Running command: {}", SecurityUtils.maskCommand(command));
-        validateNoShellInjection(command);
+        if (validateCommand) {
+            validateNoShellInjection(command);
+        } else {
+            logger.info("Skipping shell-injection validation for command: {}", SecurityUtils.maskCommand(command));
+        }
 
         // Write command to a temp shell script to avoid shell-escaping issues with
         // special characters (em-dash, embedded quotes, etc.) in the command string.

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
@@ -29,6 +29,7 @@ import com.github.istin.dmtools.sm.ScrumMasterDaily;
 import com.github.istin.dmtools.sync.SourceCodeCommitTrackerSyncJob;
 import com.github.istin.dmtools.sync.SourceCodeTrackerSyncJob;
 import com.github.istin.dmtools.teammate.Teammate;
+import com.github.istin.dmtools.cliagent.CliAgent;
 import com.github.istin.dmtools.js.JSRunner;
 import com.github.istin.dmtools.kb.KBProcessingJob;
 import com.github.istin.dmtools.mcp.cli.McpCliHandler;
@@ -78,6 +79,7 @@ public class JobRunner {
             case "scrummasterdaily": return new ScrumMasterDaily();
             case "expert": return new Expert();
             case "teammate": return new Teammate();
+            case "cliagent": return new CliAgent();
             case "sourcecodetrackersyncjob": return new SourceCodeTrackerSyncJob();
             case "sourcecodecommittrackersyncjob": return new SourceCodeCommitTrackerSyncJob();
             case "userstorygenerator": return new UserStoryGenerator();

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliCommandBuilder.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliCommandBuilder.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.teammate;
+
+import com.github.istin.dmtools.common.config.ApplicationConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Builds final CLI commands by aggregating {@code cliPrompt} and {@code cliPrompts}
+ * through {@link InstructionProcessor} and appending the combined prompt to each command.
+ * <p>
+ * Extracted from {@link Teammate} so that {@code CliAgent} and other jobs can reuse the
+ * same prompt-aggregation logic without duplicating it.
+ */
+public class CliCommandBuilder {
+
+    private static final Logger logger = LogManager.getLogger(CliCommandBuilder.class);
+
+    private final InstructionProcessor instructionProcessor;
+    private final ApplicationConfiguration configuration;
+
+    public CliCommandBuilder(InstructionProcessor instructionProcessor, ApplicationConfiguration configuration) {
+        this.instructionProcessor = instructionProcessor;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Resolves the effective CLI prompts by merging base {@code cliPrompts} with tracker-specific
+     * prompts from {@code cliPromptsByTracker} when a matching tracker type is configured.
+     */
+    public static String[] resolveCliPrompts(String[] baseCliPrompts,
+                                              Map<String, String[]> cliPromptsByTracker,
+                                              String trackerType) {
+        String effectiveTracker = trackerType;
+        if (effectiveTracker == null || effectiveTracker.isBlank()) {
+            effectiveTracker = "ado";
+        }
+        if (cliPromptsByTracker == null || !cliPromptsByTracker.containsKey(effectiveTracker)) {
+            return baseCliPrompts;
+        }
+
+        String[] trackerPrompts = cliPromptsByTracker.get(effectiveTracker);
+        if (trackerPrompts == null || trackerPrompts.length == 0) {
+            return baseCliPrompts;
+        }
+
+        List<String> merged = new ArrayList<>();
+        if (baseCliPrompts != null) {
+            for (String prompt : baseCliPrompts) {
+                merged.add(prompt);
+            }
+        }
+        for (String prompt : trackerPrompts) {
+            merged.add(prompt);
+        }
+        return merged.toArray(new String[0]);
+    }
+
+    /**
+     * Builds the final CLI commands for execution.
+     *
+     * @param cliCommands       base CLI commands from the job config
+     * @param cliPrompt         single base CLI prompt (may be null)
+     * @param cliPrompts        array of CLI prompts (may be null)
+     * @param cliPromptsByTracker tracker-specific prompts (may be null)
+     * @return commands with aggregated prompt appended, or original commands if no prompt provided
+     */
+    public String[] buildCommands(String[] cliCommands, String cliPrompt, String[] cliPrompts,
+                                   Map<String, String[]> cliPromptsByTracker) throws IOException {
+        if (cliCommands == null || cliCommands.length == 0) {
+            return cliCommands;
+        }
+
+        String trackerType = configuration != null ? configuration.getDefaultTracker() : null;
+        String[] mergedCliPrompts = resolveCliPrompts(cliPrompts, cliPromptsByTracker, trackerType);
+        if (mergedCliPrompts != cliPrompts) {
+            logger.info("Merged tracker-specific cliPrompts ({} total prompts)", mergedCliPrompts.length);
+        }
+
+        String processedPrompt = instructionProcessor.buildCombinedPrompt(cliPrompt, mergedCliPrompts);
+        if (processedPrompt == null || processedPrompt.trim().isEmpty()) {
+            logger.info("No CLI prompt provided, running commands as-is");
+            return cliCommands;
+        }
+
+        logger.info("Combined CLI prompt ready ({} chars)", processedPrompt.length());
+        String[] finalCommands = CliExecutionHelper.appendPromptToCommands(cliCommands, processedPrompt);
+        logger.info("Appended prompt to {} CLI commands", finalCommands.length);
+        return finalCommands;
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -24,10 +24,14 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -339,7 +343,7 @@ public class CliExecutionHelper {
      * @return StringBuilder containing all command responses
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile) {
-        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, null, false);
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, null, false, null, null);
     }
 
     /**
@@ -355,7 +359,7 @@ public class CliExecutionHelper {
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
                                             AtomicReference<String> liveOutput) {
-        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, false);
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, false, null, null);
     }
 
     /**
@@ -373,13 +377,34 @@ public class CliExecutionHelper {
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
                                             AtomicReference<String> liveOutput, boolean allowAnyCommand) {
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, allowAnyCommand, null, null);
+    }
+
+    /**
+     * Executes CLI commands and collects their responses.
+     * Each output line is also published to {@code liveOutput} (if non-null) so that a
+     * concurrent timer thread can read accumulated output between command lines.
+     *
+     * @param cliCommands            Array of CLI commands to execute
+     * @param workingDirectory       Working directory for command execution (optional)
+     * @param envVariablesFile       Path to environment file (null → resolve dmtools.env relative to workingDirectory)
+     * @param liveOutput             Optional AtomicReference updated with accumulated output after each line
+     * @param allowAnyCommand        When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                               Use only for trusted job configs.
+     * @param excludedEnvVariables   Exact env variable names to exclude from the subprocess
+     * @param excludedEnvRegexes     Regex patterns; matching env variable names are excluded
+     * @return StringBuilder containing all command responses
+     */
+    public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
+                                            AtomicReference<String> liveOutput, boolean allowAnyCommand,
+                                            String[] excludedEnvVariables, String[] excludedEnvRegexes) {
         StringBuilder cliResponses = new StringBuilder();
-        
+
         if (cliCommands == null || cliCommands.length == 0) {
             logger.info("No CLI commands to execute");
             return cliResponses;
         }
-        
+
         // Load environment variables from dmtools.env for CLI tools like cursor-agent
         if (envVariablesFile == null) {
             envVariablesFile = workingDirectory.resolve("dmtools.env").toString();
@@ -416,20 +441,23 @@ public class CliExecutionHelper {
                     mergedCount, skipped);
             envVars = merged;
         }
-        
+
+        // Apply explicit exclusions before spawning subprocess
+        envVars = filterEnvVariables(envVars, excludedEnvVariables, excludedEnvRegexes);
+
         // Convert Path to File for ProcessBuilder - safer than changing system properties
         File workingDir = null;
         if (workingDirectory != null && Files.exists(workingDirectory) && Files.isDirectory(workingDirectory)) {
             workingDir = workingDirectory.toFile();
             logger.info("Set working directory to: {}", workingDirectory.toAbsolutePath());
         }
-        
+
         for (String command : cliCommands) {
             if (command == null || command.trim().isEmpty()) {
                 logger.warn("Skipping empty CLI command");
                 continue;
             }
-            
+
             try {
                 logger.info("Executing CLI command: {}", command);
                 // Build a per-line consumer that also updates liveOutput so timer JS can read partial output
@@ -483,7 +511,7 @@ public class CliExecutionHelper {
      * @return CliExecutionResult containing command responses and output response
      */
     public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory, String envVariablesFile) {
-        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, false);
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, false, null, null);
     }
 
     /**
@@ -492,7 +520,7 @@ public class CliExecutionHelper {
      */
     public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
                                                            String envVariablesFile, boolean allowAnyCommand) {
-        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, allowAnyCommand);
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, allowAnyCommand, null, null);
     }
 
     /**
@@ -515,7 +543,7 @@ public class CliExecutionHelper {
     public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
                                                            String envVariablesFile,
                                                            Runnable timerAction, int timerIntervalSeconds) {
-        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction, timerIntervalSeconds, null);
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction, timerIntervalSeconds, null, false, null, null);
     }
 
     /**
@@ -535,7 +563,7 @@ public class CliExecutionHelper {
                                                            Runnable timerAction, int timerIntervalSeconds,
                                                            AtomicReference<String> liveCliOutput) {
         return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction,
-                timerIntervalSeconds, liveCliOutput, false);
+                timerIntervalSeconds, liveCliOutput, false, null, null);
     }
 
     /**
@@ -558,6 +586,34 @@ public class CliExecutionHelper {
                                                            Runnable timerAction, int timerIntervalSeconds,
                                                            AtomicReference<String> liveCliOutput,
                                                            boolean allowAnyCommand) {
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction,
+                timerIntervalSeconds, liveCliOutput, allowAnyCommand, null, null);
+    }
+
+    /**
+     * Executes CLI commands with an optional background timer, shared live output reference,
+     * optional shell-injection validation bypass, and optional env variable exclusion.
+     *
+     * @param cliCommands            Array of CLI commands to execute
+     * @param workingDirectory       Working directory for command execution (optional)
+     * @param envVariablesFile       Path to environment file (null → auto-resolve)
+     * @param timerAction            Optional runnable executed on the timer thread
+     * @param timerIntervalSeconds   Interval between timer firings in seconds; timer is disabled if &lt;= 0
+     * @param liveCliOutput          Optional shared AtomicReference updated with accumulated CLI output;
+     *                               if null, an internal reference is created when timerAction is non-null
+     * @param allowAnyCommand        When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                               Use only for trusted job configs.
+     * @param excludedEnvVariables   Exact env variable names to exclude from the subprocess
+     * @param excludedEnvRegexes     Regex patterns; matching env variable names are excluded
+     * @return CliExecutionResult containing command responses and output response
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile,
+                                                           Runnable timerAction, int timerIntervalSeconds,
+                                                           AtomicReference<String> liveCliOutput,
+                                                           boolean allowAnyCommand,
+                                                           String[] excludedEnvVariables,
+                                                           String[] excludedEnvRegexes) {
         AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
                 : (timerAction != null ? new AtomicReference<>("") : null);
 
@@ -579,7 +635,8 @@ public class CliExecutionHelper {
         }
 
         try {
-            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, allowAnyCommand);
+            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput,
+                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes);
             String outputResponse = processOutputResponse(workingDirectory);
             return new CliExecutionResult(cliResponses, outputResponse);
         } finally {
@@ -603,6 +660,56 @@ public class CliExecutionHelper {
                 }
             }
         }
+    }
+
+    /**
+     * Filters environment variables by exact name and/or regex patterns.
+     * Returns a new map with matching keys removed.
+     */
+    public static Map<String, String> filterEnvVariables(Map<String, String> envVars,
+                                                         String[] excludedEnvVariables,
+                                                         String[] excludedEnvRegexes) {
+        if (envVars == null || envVars.isEmpty()) {
+            return envVars;
+        }
+        Set<String> exactExclusions = new HashSet<>();
+        if (excludedEnvVariables != null) {
+            for (String key : excludedEnvVariables) {
+                if (key != null && !key.isBlank()) {
+                    exactExclusions.add(key);
+                }
+            }
+        }
+        java.util.List<java.util.regex.Pattern> patterns = new java.util.ArrayList<>();
+        if (excludedEnvRegexes != null) {
+            for (String regex : excludedEnvRegexes) {
+                if (regex != null && !regex.isBlank()) {
+                    patterns.add(java.util.regex.Pattern.compile(regex));
+                }
+            }
+        }
+        if (exactExclusions.isEmpty() && patterns.isEmpty()) {
+            return envVars;
+        }
+        Map<String, String> filtered = new java.util.HashMap<>(envVars);
+        int removed = 0;
+        for (String key : envVars.keySet()) {
+            if (exactExclusions.contains(key)) {
+                filtered.remove(key);
+                removed++;
+                continue;
+            }
+            for (java.util.regex.Pattern pattern : patterns) {
+                if (pattern.matcher(key).matches()) {
+                    filtered.remove(key);
+                    removed++;
+                    break;
+                }
+            }
+        }
+        logger.info("Excluded {} environment variable(s) from subprocess env (exact={}, regex={})",
+                removed, exactExclusions.size(), patterns.size());
+        return filtered;
     }
     
     /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -339,7 +339,7 @@ public class CliExecutionHelper {
      * @return StringBuilder containing all command responses
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile) {
-        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, null);
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, null, false);
     }
 
     /**
@@ -355,6 +355,24 @@ public class CliExecutionHelper {
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
                                             AtomicReference<String> liveOutput) {
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, false);
+    }
+
+    /**
+     * Executes CLI commands and collects their responses.
+     * Each output line is also published to {@code liveOutput} (if non-null) so that a
+     * concurrent timer thread can read accumulated output between command lines.
+     *
+     * @param cliCommands      Array of CLI commands to execute
+     * @param workingDirectory Working directory for command execution (optional)
+     * @param envVariablesFile Path to environment file (null → resolve dmtools.env relative to workingDirectory)
+     * @param liveOutput       Optional AtomicReference updated with accumulated output after each line
+     * @param allowAnyCommand  When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                         Use only for trusted job configs.
+     * @return StringBuilder containing all command responses
+     */
+    public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
+                                            AtomicReference<String> liveOutput, boolean allowAnyCommand) {
         StringBuilder cliResponses = new StringBuilder();
         
         if (cliCommands == null || cliCommands.length == 0) {
@@ -420,7 +438,9 @@ public class CliExecutionHelper {
                     commandOutput.append(line).append(System.lineSeparator());
                     liveOutput.set(cliResponses + commandOutput.toString());
                 };
-                String response = CommandLineUtils.runCommand(command.trim(), workingDir, envVars, lineConsumer);
+                String response = allowAnyCommand
+                        ? CommandLineUtils.runCommand(command.trim(), workingDir, envVars, lineConsumer, false)
+                        : CommandLineUtils.runCommand(command.trim(), workingDir, envVars, lineConsumer);
                 
                 if (response != null && !response.trim().isEmpty()) {
                     cliResponses.append("CLI Command: ").append(command).append("\n");
@@ -463,7 +483,16 @@ public class CliExecutionHelper {
      * @return CliExecutionResult containing command responses and output response
      */
     public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory, String envVariablesFile) {
-        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0);
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, false);
+    }
+
+    /**
+     * Executes CLI commands in the specified working directory and processes output response,
+     * allowing arbitrary shell syntax when {@code allowAnyCommand} is {@code true}.
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile, boolean allowAnyCommand) {
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, null, 0, null, allowAnyCommand);
     }
 
     /**
@@ -505,6 +534,30 @@ public class CliExecutionHelper {
                                                            String envVariablesFile,
                                                            Runnable timerAction, int timerIntervalSeconds,
                                                            AtomicReference<String> liveCliOutput) {
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction,
+                timerIntervalSeconds, liveCliOutput, false);
+    }
+
+    /**
+     * Executes CLI commands with an optional background timer, shared live output reference,
+     * and optional shell-injection validation bypass.
+     *
+     * @param cliCommands          Array of CLI commands to execute
+     * @param workingDirectory     Working directory for command execution (optional)
+     * @param envVariablesFile     Path to environment file (null → auto-resolve)
+     * @param timerAction          Optional runnable executed on the timer thread
+     * @param timerIntervalSeconds Interval between timer firings in seconds; timer is disabled if &lt; 0
+     * @param liveCliOutput        Optional shared AtomicReference updated with accumulated CLI output;
+     *                             if null, an internal reference is created when timerAction is non-null
+     * @param allowAnyCommand      When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                             Use only for trusted job configs.
+     * @return CliExecutionResult containing command responses and output response
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile,
+                                                           Runnable timerAction, int timerIntervalSeconds,
+                                                           AtomicReference<String> liveCliOutput,
+                                                           boolean allowAnyCommand) {
         AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
                 : (timerAction != null ? new AtomicReference<>("") : null);
 
@@ -526,7 +579,7 @@ public class CliExecutionHelper {
         }
 
         try {
-            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput);
+            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, allowAnyCommand);
             String outputResponse = processOutputResponse(workingDirectory);
             return new CliExecutionResult(cliResponses, outputResponse);
         } finally {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -453,26 +453,13 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
 
             if (cliCommands != null && cliCommands.length > 0) {
                 try {
-                    // Merge base cliPrompts with tracker-specific prompts
-                    String[] mergedCliPrompts = resolveCliPrompts(
-                            expertParams.getCliPrompts(), expertParams.getCliPromptsByTracker(), configuration != null ? configuration.getDefaultTracker() : null);
-                    if (mergedCliPrompts != expertParams.getCliPrompts()) {
-                        logger.info("Merged tracker-specific cliPrompts ({} total prompts)", mergedCliPrompts.length);
-                    }
-
-                    // Build combined CLI prompt from cliPrompt + merged cliPrompts via InstructionProcessor
-                    String processedPrompt = instructionProcessor.buildCombinedPrompt(
-                            expertParams.getCliPrompt(), mergedCliPrompts);
-                    if (processedPrompt != null) {
-                        logger.info("Combined CLI prompt ready ({} chars)", processedPrompt.length());
-                    }
-
-                    // Append processed prompt to each CLI command if available
-                    String[] finalCliCommands = cliCommands;
-                    if (processedPrompt != null && !processedPrompt.trim().isEmpty()) {
-                        finalCliCommands = CliExecutionHelper.appendPromptToCommands(cliCommands, processedPrompt);
-                        logger.info("Appended prompt to {} CLI commands", finalCliCommands.length);
-                    }
+                    // Build final CLI commands with aggregated prompt (shared logic with CliAgent)
+                    CliCommandBuilder cliCommandBuilder = new CliCommandBuilder(instructionProcessor, configuration);
+                    String[] finalCliCommands = cliCommandBuilder.buildCommands(
+                            cliCommands,
+                            expertParams.getCliPrompt(),
+                            expertParams.getCliPrompts(),
+                            expertParams.getCliPromptsByTracker());
 
                     // Create input context for CLI commands
                     inputContextPath = cliHelper.createInputContext(ticket, inputParams.toString(), trackerClient);
@@ -732,26 +719,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
      * @return merged array of CLI prompts, or base prompts if no tracker-specific match found
      */
     static String[] resolveCliPrompts(String[] baseCliPrompts, Map<String, String[]> cliPromptsByTracker, String trackerType) {
-        String effectiveTracker = trackerType;
-        if (effectiveTracker == null || effectiveTracker.isBlank()) {
-            // Default to Markdown-based formatting when no tracker is configured.
-            effectiveTracker = "ado";
-        }
-        if (cliPromptsByTracker == null || !cliPromptsByTracker.containsKey(effectiveTracker)) {
-            return baseCliPrompts;
-        }
-
-        String[] trackerPrompts = cliPromptsByTracker.get(effectiveTracker);
-        if (trackerPrompts == null || trackerPrompts.length == 0) {
-            return baseCliPrompts;
-        }
-
-        List<String> merged = new ArrayList<>();
-        if (baseCliPrompts != null) {
-            merged.addAll(List.of(baseCliPrompts));
-        }
-        merged.addAll(List.of(trackerPrompts));
-        return merged.toArray(new String[0]);
+        return CliCommandBuilder.resolveCliPrompts(baseCliPrompts, cliPromptsByTracker, trackerType);
     }
 
     public void attachResponse(Object orchestratorClass, String file, String result, String ticketKey, String contentType) throws IOException {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/cliagent/CliAgentTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/cliagent/CliAgentTest.java
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.cliagent;
+
+import com.github.istin.dmtools.common.utils.CommandLineUtils;
+import com.github.istin.dmtools.job.ResultItem;
+import com.github.istin.dmtools.job.TrackerParams;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class CliAgentTest {
+
+    @TempDir
+    Path tempDir;
+
+    private CliAgent buildAgent() {
+        CliAgent agent = new CliAgent();
+        agent.initializeStandalone();
+        return agent;
+    }
+
+    @Test
+    void testEmptyCliCommandsReturnsEmptyResult() throws Exception {
+        CliAgentParams params = new CliAgentParams();
+        params.setCliCommands(new String[]{});
+
+        CliAgent agent = buildAgent();
+        List<ResultItem> results = agent.runJobImpl(params);
+
+        assertTrue(results.isEmpty());
+    }
+
+    @Test
+    void testExecutesCliCommandsAndReturnsResponse() throws Exception {
+        CliAgentParams params = new CliAgentParams();
+        params.setCliCommands(new String[]{"echo hello"});
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setRequireCliOutputFile(false);
+        params.setCleanupInputFolder(true);
+        params.setWorkingDirectory(tempDir.toString());
+
+        CliAgent agent = buildAgent();
+
+        try (MockedStatic<CommandLineUtils> mocked = mockStatic(CommandLineUtils.class)) {
+            mocked.when(() -> CommandLineUtils.runCommand(anyString(), any(), any(), any(), anyBoolean()))
+                    .thenReturn("hello\nExit Code: 0");
+            mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
+                    .thenReturn(Map.of());
+
+            List<ResultItem> results = agent.runJobImpl(params);
+
+            assertEquals(1, results.size());
+            assertNotNull(results.get(0).getResult());
+            assertTrue(results.get(0).getResult().contains("hello"));
+            mocked.verify(() -> CommandLineUtils.runCommand(eq("echo hello"), any(), any(), any(), eq(false)));
+        }
+    }
+
+    @Test
+    void testAggregatesCliPromptsIntoCommands() throws Exception {
+        CliAgentParams params = new CliAgentParams();
+        params.setCliCommands(new String[]{"cursor-agent"});
+        params.setCliPrompts(new String[]{"Review the code"});
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setRequireCliOutputFile(false);
+        params.setCleanupInputFolder(true);
+        params.setWorkingDirectory(tempDir.toString());
+
+        CliAgent agent = buildAgent();
+
+        try (MockedStatic<CommandLineUtils> mocked = mockStatic(CommandLineUtils.class)) {
+            mocked.when(() -> CommandLineUtils.runCommand(anyString(), any(), any(), any(), anyBoolean()))
+                    .thenReturn("done\nExit Code: 0");
+            mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
+                    .thenReturn(Map.of());
+
+            agent.runJobImpl(params);
+
+            mocked.verify(() -> CommandLineUtils.runCommand(
+                    argThat(cmd -> cmd.startsWith("cursor-agent") && cmd.contains("dmtools_cli_prompt_")),
+                    any(), any(), any(), eq(false)));
+        }
+    }
+
+    @Test
+    void testAllowsShellSyntaxWithoutWhitelist() throws Exception {
+        CliAgentParams params = new CliAgentParams();
+        params.setCliCommands(new String[]{"echo hello && echo world"});
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setRequireCliOutputFile(false);
+        params.setCleanupInputFolder(true);
+        params.setWorkingDirectory(tempDir.toString());
+
+        CliAgent agent = buildAgent();
+
+        try (MockedStatic<CommandLineUtils> mocked = mockStatic(CommandLineUtils.class)) {
+            mocked.when(() -> CommandLineUtils.runCommand(anyString(), any(), any(), any(), anyBoolean()))
+                    .thenReturn("hello\nworld\nExit Code: 0");
+            mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
+                    .thenReturn(Map.of());
+
+            assertDoesNotThrow(() -> agent.runJobImpl(params));
+
+            mocked.verify(() -> CommandLineUtils.runCommand(
+                    eq("echo hello && echo world"), any(), any(), any(), eq(false)));
+        }
+    }
+
+    @Test
+    void testSetupAndResetHooksExecuted() throws Exception {
+        CliAgentParams params = new CliAgentParams();
+        params.setCliCommands(new String[]{"echo hello"});
+        params.setSetup("echo setup");
+        params.setReset("echo reset");
+        params.setOutputType(TrackerParams.OutputType.none);
+        params.setRequireCliOutputFile(false);
+        params.setCleanupInputFolder(true);
+        params.setWorkingDirectory(tempDir.toString());
+
+        CliAgent agent = buildAgent();
+
+        try (MockedStatic<CommandLineUtils> mocked = mockStatic(CommandLineUtils.class)) {
+            mocked.when(() -> CommandLineUtils.runCommand(anyString(), any(), any(), any(), anyBoolean()))
+                    .thenReturn("ok\nExit Code: 0");
+            mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
+                    .thenReturn(Map.of());
+
+            agent.runJobImpl(params);
+
+            mocked.verify(() -> CommandLineUtils.runCommand(eq("echo setup"), any(), any(), any(), eq(false)));
+            mocked.verify(() -> CommandLineUtils.runCommand(eq("echo reset"), any(), any(), any(), eq(false)));
+        }
+    }
+
+    @Test
+    void testCustomParamsStoredInParams() {
+        CliAgentParams params = new CliAgentParams();
+        params.setCustomParams(Map.of("mode", "test", "count", 42));
+
+        assertEquals("test", params.getCustomParams().get("mode"));
+        assertEquals(42, params.getCustomParams().get("count"));
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -25,6 +25,9 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -885,6 +888,110 @@ public class CliExecutionHelperTest {
             }
         } finally {
             com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        }
+    }
+
+    // ── env variable exclusion tests ─────────────────────────────────────────
+
+    @Test
+    void testFilterEnvVariables_ExactAndRegex() {
+        Map<String, String> env = Map.of(
+                "OPENAI_API_KEY", "secret1",
+                "ANTHROPIC_API_KEY", "secret2",
+                "CURSOR_API_KEY", "secret3",
+                "PUBLIC_VAR", "visible"
+        );
+
+        Map<String, String> result = CliExecutionHelper.filterEnvVariables(
+                env,
+                new String[]{"OPENAI_API_KEY"},
+                new String[]{".*_API_KEY"}
+        );
+
+        assertFalse(result.containsKey("OPENAI_API_KEY"));
+        assertFalse(result.containsKey("ANTHROPIC_API_KEY"));
+        assertFalse(result.containsKey("CURSOR_API_KEY"));
+        assertTrue(result.containsKey("PUBLIC_VAR"));
+        assertEquals("visible", result.get("PUBLIC_VAR"));
+    }
+
+    @Test
+    void testFilterEnvVariables_NullOrEmptyInputs_ReturnsOriginal() {
+        Map<String, String> env = Map.of("KEY", "value");
+        assertSame(env, CliExecutionHelper.filterEnvVariables(env, null, null));
+        assertSame(env, CliExecutionHelper.filterEnvVariables(env, new String[0], new String[0]));
+        assertSame(env, CliExecutionHelper.filterEnvVariables(env, new String[]{"   "}, new String[]{""}));
+    }
+
+    @Test
+    void testExecuteCliCommands_ExcludesEnvVariablesByExactName() {
+        String[] commands = {"echo test"};
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                    .thenReturn(Map.of("KEEP_ME", "keep", "DROP_ME", "drop"));
+            mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class), any()))
+                    .thenReturn("test");
+
+            cliHelper.executeCliCommands(commands, null, "dmtools.env", null, false,
+                    new String[]{"DROP_ME"}, null);
+
+            mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                    anyString(),
+                    isNull(),
+                    argThat((Map<String, String> env) ->
+                            env.containsKey("KEEP_ME") && !env.containsKey("DROP_ME")
+                    ),
+                    any()
+            ));
+        }
+    }
+
+    @Test
+    void testExecuteCliCommands_ExcludesEnvVariablesByRegex() {
+        String[] commands = {"echo test"};
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                    .thenReturn(Map.of("SECRET_TOKEN", "x", "PUBLIC", "y"));
+            mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class), any()))
+                    .thenReturn("test");
+
+            cliHelper.executeCliCommands(commands, null, "dmtools.env", null, false,
+                    null, new String[]{".*TOKEN"});
+
+            mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                    anyString(),
+                    isNull(),
+                    argThat((Map<String, String> env) ->
+                            !env.containsKey("SECRET_TOKEN") && env.containsKey("PUBLIC")
+                    ),
+                    any()
+            ));
+        }
+    }
+
+    @Test
+    void testExecuteCliCommandsWithResult_TimerActionFired() throws Exception {
+        Path workingDir = Files.createTempDirectory(tempDir, "working");
+        String[] commands = {"echo hello"};
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicInteger fireCount = new AtomicInteger(0);
+
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                    .thenReturn(Map.of());
+            mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), any(File.class), any(Map.class), any()))
+                    .thenReturn("hello");
+
+            Runnable timerAction = () -> {
+                fireCount.incrementAndGet();
+                latch.countDown();
+            };
+
+            cliHelper.executeCliCommandsWithResult(commands, workingDir, "dmtools.env",
+                    timerAction, 1, null, false, null, null);
+
+            assertTrue(latch.await(5, TimeUnit.SECONDS), "Timer action should fire within 5 seconds");
+            assertTrue(fireCount.get() >= 1, "Timer action should have fired at least once");
         }
     }
 


### PR DESCRIPTION
Adds environment-variable filtering and timer JS action support to the new CliAgent job.

### Changes
- Filter subprocess env by exact names (`excludedEnvVariables`) and regex patterns (`excludeEnvVariablesByRegex`).
- Wire `timerJSAction` / `timerIntervalSeconds` in CliAgent, same as Teammate (provides `currentCliOutput`).
- Extend `CliExecutionHelper` overloads to pass exclusions through without breaking existing callers.
- Add unit tests and update jobs reference docs.