### PR TITLE
fix(github): add github_get_pr_diff_text MCP tool returning raw diff text

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -1639,6 +1639,30 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
         }
     }
 
+    @MCPTool(
+            name = "github_get_pr_diff_text",
+            description = "Get the raw unified diff text for a GitHub pull request. Requires IS_READ_PULL_REQUEST_DIFF env/config to be enabled.",
+            integration = "github",
+            category = "pull_requests"
+    )
+    public String getPullRequestDiffText(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "pullRequestID", description = "The pull request number", required = true, example = "74")
+            String pullRequestID) throws IOException {
+        if (!IS_READ_PULL_REQUEST_DIFF) {
+            return "";
+        }
+        try {
+            return getPullRequestResponse(workspace, repository, pullRequestID, true);
+        } catch (AtlassianRestClient.RestClientException e) {
+            logger.warn("Skipping PR diff text for {}/{} PR#{}: {}", workspace, repository, pullRequestID, e.getMessage());
+            return "";
+        }
+    }
+
     public static IDiffStats parseDiffStats(String diff) {
         int addedLines = 0;
         int removedLines = 0;


### PR DESCRIPTION
The existing `github_get_pr_diff` tool returns `IDiffStats` and serializes as a Java object toString in MCP responses (e.g. `com.github.istin.dmtools.github.GitHub$1@...`), so agents that call it expecting a diff string fall back to general PR comments instead of review threads.

This PR adds a new `github_get_pr_diff_text` MCP tool that returns the raw unified diff text from GitHub's `repos/{owner}/{repo}/pulls/{id}` endpoint with `Accept: application/vnd.github.diff`.

Tested locally against https://github.com/IstiN/trackstate/pull/1789 using `dmtools.env`; the new tool returns the expected diff text.