### PR TITLE
fix(figma): correct OAuth2 token endpoint URL

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -680,6 +680,10 @@ public class PropertyReader {
     return getValue("FIGMA_OAUTH_SCOPES");
   }
 
+  public String getFigmaRedirectUri() {
+    return getValue("FIGMA_REDIRECT_URI");
+  }
+
   public Integer getDefaultTicketWeightIfNoSPs() {
     String value = getValue("DEFAULT_TICKET_WEIGHT_IF_NO_SP");
     if (value == null || value.isEmpty()) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaClient.java
@@ -133,7 +133,7 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         category = "auth"
     )
     public String oauth2GetAuthUrl(
-        @MCPParam(name = "redirectUri", description = "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback)", required = true, example = "http://localhost:8080/callback") String redirectUri,
+        @MCPParam(name = "redirectUri", description = "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback). If omitted, uses FIGMA_REDIRECT_URI env variable.", required = false, example = "http://localhost:8080/callback") String redirectUri,
         @MCPParam(name = "state", description = "Random state string for CSRF protection", required = false, example = "random_state_123") String state,
         @MCPParam(name = "scope", description = "Optional OAuth scope list (space-separated), e.g. file_content:read file_metadata:read. If omitted, uses FIGMA_SCOPE (or FIGMA_OAUTH_SCOPES) env or default minimal read scope.", required = false, example = "file_content:read file_metadata:read") String scope
     ) {
@@ -148,6 +148,14 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         if (clientSecret == null || clientSecret.isEmpty()) {
             return new JSONObject()
                     .put("error", "FIGMA_CLIENT_SECRET is not configured")
+                    .toString();
+        }
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            redirectUri = propertyReader.getFigmaRedirectUri();
+        }
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            return new JSONObject()
+                    .put("error", "redirectUri is required (or set FIGMA_REDIRECT_URI in dmtools.env)")
                     .toString();
         }
         if (state == null || state.isEmpty()) {
@@ -175,7 +183,7 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
     )
     public String oauth2ExchangeCode(
         @MCPParam(name = "code", description = "Authorization code received from Figma OAuth2 redirect", required = true, example = "figma_auth_code_abc123") String code,
-        @MCPParam(name = "redirectUri", description = "Same redirect URI used in figma_oauth2_get_auth_url", required = true, example = "http://localhost:8080/callback") String redirectUri
+        @MCPParam(name = "redirectUri", description = "Same redirect URI used in figma_oauth2_get_auth_url. If omitted, uses FIGMA_REDIRECT_URI env variable.", required = false, example = "http://localhost:8080/callback") String redirectUri
     ) {
         com.github.istin.dmtools.common.utils.PropertyReader propertyReader = new com.github.istin.dmtools.common.utils.PropertyReader();
         String clientId = propertyReader.getFigmaClientId();
@@ -183,6 +191,14 @@ public class FigmaClient extends AbstractRestClient implements ContentUtils.UrlT
         if (clientId == null || clientId.isEmpty() || clientSecret == null || clientSecret.isEmpty()) {
             return new JSONObject()
                     .put("error", "FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET must be configured")
+                    .toString();
+        }
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            redirectUri = propertyReader.getFigmaRedirectUri();
+        }
+        if (redirectUri == null || redirectUri.isEmpty()) {
+            return new JSONObject()
+                    .put("error", "redirectUri is required (or set FIGMA_REDIRECT_URI in dmtools.env)")
                     .toString();
         }
         try {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManager.java
@@ -22,14 +22,14 @@ import java.util.concurrent.TimeUnit;
  *   <li>Refreshing an access token using a stored refresh token</li>
  * </ul>
  *
- * <p>Token endpoint: {@code https://www.figma.com/api/oauth/token}
+ * <p>Token endpoint: {@code https://api.figma.com/v1/oauth/token}
  */
 public class FigmaOAuth2TokenManager {
 
     private static final Logger logger = LogManager.getLogger(FigmaOAuth2TokenManager.class);
 
     public static final String FIGMA_OAUTH_AUTHORIZE_URL = "https://www.figma.com/oauth";
-    public static final String FIGMA_OAUTH_TOKEN_URL = "https://www.figma.com/api/oauth/token";
+    public static final String FIGMA_OAUTH_TOKEN_URL = "https://api.figma.com/v1/oauth/token";
     public static final String DEFAULT_FIGMA_OAUTH_SCOPE = "file_content:read file_metadata:read";
 
     private final String clientId;

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/figma/FigmaOAuth2TokenManagerTest.java
@@ -48,7 +48,7 @@ public class FigmaOAuth2TokenManagerTest {
 
     @Test
     public void testTokenEndpointUrl_isCorrect() {
-        assertEquals("https://www.figma.com/api/oauth/token", FigmaOAuth2TokenManager.FIGMA_OAUTH_TOKEN_URL);
+        assertEquals("https://api.figma.com/v1/oauth/token", FigmaOAuth2TokenManager.FIGMA_OAUTH_TOKEN_URL);
     }
 
     @Test


### PR DESCRIPTION
## Problem
`figma_oauth2_exchange_code` always returned 404 because the token endpoint was wrong.

## Fix
Change from:
```
https://www.figma.com/api/oauth/token  ← returns 404
```
To:
```
https://api.figma.com/v1/oauth/token   ← correct endpoint
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>