### PR TITLE
feat(teammate/jira): parent Confluence context + default MCP fields

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -461,14 +461,20 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
     public List<T> searchAndPerform(
             @MCPParam(name = "jql", description = "JQL query string to search tickets", required = true, example = "project = DEMO AND status = Open", aliases = {"searchQueryJQL", "query"})
             String jql,
-            @MCPParam(name = "fields", description = "Optional array of field names to include in response", required = false, example = "[\"summary\", \"status\", \"assignee\"]")
+            @MCPParam(name = "fields", description = "Optional array of field names to include in response. When omitted, the project's extended default fields are used.", required = false, example = "[\"summary\", \"status\", \"assignee\"]")
             String[] fields
     ) throws Exception {
+        String[] effectiveFields = fields;
+        if (effectiveFields == null || effectiveFields.length == 0 ||
+                (effectiveFields.length == 1 && effectiveFields[0] != null && effectiveFields[0].isBlank())) {
+            effectiveFields = getExtendedQueryFields();
+            logger.info("jira_search_by_jql: no fields specified, using extended default fields");
+        }
         List<T> tickets = new ArrayList<>();
         searchAndPerform(ticket -> {
             tickets.add(ticket);
             return false;
-        }, jql, fields);
+        }, jql, effectiveFields);
         return tickets;
     }
 
@@ -771,9 +777,15 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
             category = "ticket_management",
             aliases = {"tracker_get_ticket"}
     )
-    public T performTicket(@MCPParam(name = "key", description = "The Jira ticket key to retrieve", required = true) String ticketKey, 
-                          @MCPParam(name = "fields", description = "Optional array of fields to include in the response", required = false) String[] fields) throws IOException {
-        GenericRequest jiraRequest = createPerformTicketRequest(ticketKey, fields);
+    public T performTicket(@MCPParam(name = "key", description = "The Jira ticket key to retrieve", required = true) String ticketKey,
+                          @MCPParam(name = "fields", description = "Optional array of fields to include in the response. When omitted, the project's extended default fields are used.", required = false) String[] fields) throws IOException {
+        String[] effectiveFields = fields;
+        if (effectiveFields == null || effectiveFields.length == 0 ||
+                (effectiveFields.length == 1 && effectiveFields[0] != null && effectiveFields[0].isBlank())) {
+            effectiveFields = getExtendedQueryFields();
+            logger.info("jira_get_ticket: no fields specified, using extended default fields");
+        }
+        GenericRequest jiraRequest = createPerformTicketRequest(ticketKey, effectiveFields);
         String response = jiraRequest.execute();
         if (isErrorResponse(response)) {
             return null;

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -12,6 +12,7 @@ import com.github.istin.dmtools.ai.agent.RequestDecompositionAgent;
 import com.github.istin.dmtools.ai.agent.SourceImpactAssessmentAgent;
 import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.atlassian.jira.model.Fields;
+import com.github.istin.dmtools.atlassian.jira.model.Ticket;
 import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.config.ApplicationConfiguration;
 import com.github.istin.dmtools.common.model.IAttachment;
@@ -486,9 +487,10 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     // Write comments.md alongside request.md — same toText() format as chunks sent to AI
                     cliHelper.writeCommentsFile(inputContextPath, ticketContext.getComments());
 
-                    // Write Confluence pages linked in the ticket text to input/confluence/
+                    // Write Confluence pages linked in the ticket text (and its parent's text) to input/confluence/
+                    String confluenceScanText = buildConfluenceScanText(ticket, textFieldsOnly, trackerClient);
                     cliHelper.writeConfluencePagesFile(
-                        textFieldsOnly,
+                        confluenceScanText,
                         inputContextPath,
                         confluence,
                         expertParams.getConfluenceDepth(),
@@ -801,6 +803,43 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             return Collections.emptyList();
         }
         return mermaidIndexTools.read(config.getIntegration(), config.getStoragePath());
+    }
+
+    /**
+     * Builds the text used to discover Confluence URLs for the CLI input folder.
+     * In addition to the current ticket's text fields, it also includes the parent
+     * ticket's text fields (for Jira sub-tasks) so that Confluence pages linked from
+     * the parent story are downloaded too.
+     *
+     * @param ticket          the ticket being processed
+     * @param textFieldsOnly  the current ticket's text fields
+     * @param trackerClient   tracker client for fetching the parent ticket
+     * @return combined text to scan for Confluence URLs
+     */
+    private String buildConfluenceScanText(ITicket ticket, String textFieldsOnly, TrackerClient<?> trackerClient) {
+        StringBuilder scanText = new StringBuilder(textFieldsOnly != null ? textFieldsOnly : "");
+        if (ticket instanceof Ticket) {
+            Ticket jiraTicket = (Ticket) ticket;
+            if (jiraTicket.getFields() != null) {
+                Ticket parent = jiraTicket.getFields().getParent();
+                if (parent != null && parent.getKey() != null && !parent.getKey().isBlank()) {
+                    String parentKey = parent.getKey();
+                    try {
+                        ITicket parentTicket = trackerClient.performTicket(parentKey, trackerClient.getExtendedQueryFields());
+                        if (parentTicket != null) {
+                            String parentTextFields = trackerClient.getTextFieldsOnly(parentTicket);
+                            if (parentTextFields != null && !parentTextFields.isBlank()) {
+                                scanText.append("\n\n").append(parentTextFields);
+                                logger.info("Including parent ticket {} text in Confluence URL scan", parentKey);
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.warn("Could not fetch parent ticket {} for Confluence URL scan (skipping): {}", parentKey, e.getMessage());
+                    }
+                }
+            }
+        }
+        return scanText.toString();
     }
 
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -126,6 +126,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
         @SerializedName("confluenceAttachments")
         private boolean confluenceAttachments = true;
 
+        @SerializedName("includeParentConfluence")
+        private boolean includeParentConfluence = true;
+
     }
 
     /**
@@ -488,7 +491,8 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     cliHelper.writeCommentsFile(inputContextPath, ticketContext.getComments());
 
                     // Write Confluence pages linked in the ticket text (and its parent's text) to input/confluence/
-                    String confluenceScanText = buildConfluenceScanText(ticket, textFieldsOnly, trackerClient);
+                    String confluenceScanText = buildConfluenceScanText(
+                        ticket, textFieldsOnly, trackerClient, expertParams.isIncludeParentConfluence());
                     cliHelper.writeConfluencePagesFile(
                         confluenceScanText,
                         inputContextPath,
@@ -811,14 +815,16 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
      * ticket's text fields (for Jira sub-tasks) so that Confluence pages linked from
      * the parent story are downloaded too.
      *
-     * @param ticket          the ticket being processed
-     * @param textFieldsOnly  the current ticket's text fields
-     * @param trackerClient   tracker client for fetching the parent ticket
+     * @param ticket                   the ticket being processed
+     * @param textFieldsOnly           the current ticket's text fields
+     * @param trackerClient            tracker client for fetching the parent ticket
+     * @param includeParentConfluence  whether to include the parent ticket's text fields
      * @return combined text to scan for Confluence URLs
      */
-    private String buildConfluenceScanText(ITicket ticket, String textFieldsOnly, TrackerClient<?> trackerClient) {
+    private String buildConfluenceScanText(ITicket ticket, String textFieldsOnly,
+                                            TrackerClient<?> trackerClient, boolean includeParentConfluence) {
         StringBuilder scanText = new StringBuilder(textFieldsOnly != null ? textFieldsOnly : "");
-        if (ticket instanceof Ticket) {
+        if (includeParentConfluence && ticket instanceof Ticket) {
             Ticket jiraTicket = (Ticket) ticket;
             if (jiraTicket.getFields() != null) {
                 Ticket parent = jiraTicket.getFields().getParent();


### PR DESCRIPTION
## What\n\n- When a Jira sub-task is processed by Teammate, the parent story text fields are now also scanned for Confluence URLs, so pages linked from the parent are downloaded into input/confluence/.\n- Added TeammateParams.includeParentConfluence (default true) to allow disabling this behavior.\n- jira_get_ticket / jira_search_by_jql now use the project extended default fields when no explicit fields are provided, instead of returning only issue keys.\n\n## Tests\n\n- ./gradlew :dmtools-core:test passes.\n- Verified end-to-end on DMC-531 (child with no Confluence URL, parent DMC-520 with Template Core link) — Template Core was downloaded.\n- Verified jira_search_by_jql without fields now returns summary, status, parent, etc.