### PR TITLE
fix(testrail): fallback to 'name' field when resolving label IDs

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
@@ -800,7 +800,11 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
             String trimmed = name.trim();
             for (int i = 0; i < labels.length(); i++) {
                 JSONObject label = labels.getJSONObject(i);
-                if (trimmed.equalsIgnoreCase(label.optString("title"))) {
+                String labelName = label.optString("title");
+                if (labelName == null || labelName.isEmpty()) {
+                    labelName = label.optString("name");
+                }
+                if (trimmed.equalsIgnoreCase(labelName)) {
                     ids.add(String.valueOf(label.getInt("id")));
                     break;
                 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
@@ -343,6 +343,22 @@ public class TestRailClientTest {
         return response.toString();
     }
 
+    private String createLabelsPage(int offset, String nextLink, JSONObject... labels) {
+        JSONObject response = new JSONObject();
+        JSONArray labelsArray = new JSONArray();
+        for (JSONObject label : labels) {
+            labelsArray.put(label);
+        }
+        response.put("offset", offset);
+        response.put("limit", 250);
+        response.put("size", labelsArray.length());
+        response.put("labels", labelsArray);
+        response.put("_links", new JSONObject()
+                .put("next", nextLink == null ? JSONObject.NULL : nextLink)
+                .put("prev", JSONObject.NULL));
+        return response.toString();
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testMoveToStatusThrowsException() throws IOException {
         client = new TestRailClient(basePath, username, apiKey);
@@ -617,6 +633,51 @@ public class TestRailClientTest {
     @Test
     public void testGetLabelsMethodExists() throws Exception {
         assertNotNull(TestRailClient.class.getMethod("getLabels", String.class));
+    }
+
+    @Test
+    public void testResolveLabelIdsByProjectId_matchesTitleField() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createLabelsPage(0, null,
+                new JSONObject().put("id", 12).put("title", "ai_generated"),
+                new JSONObject().put("id", 7).put("title", "Login")));
+
+        String result = stubClient.resolveLabelIdsByProjectId(8, new String[]{"ai_generated"});
+
+        assertEquals("12", result);
+        assertEquals(List.of("/get_labels/8&limit=250&offset=0"), stubClient.getRequestedPaths());
+    }
+
+    @Test
+    public void testResolveLabelIdsByProjectId_fallsBackToNameField() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createLabelsPage(0, null,
+                new JSONObject().put("id", 12).put("name", "ai_generated"),
+                new JSONObject().put("id", 7).put("name", "Login")));
+
+        String result = stubClient.resolveLabelIdsByProjectId(8, new String[]{"ai_generated", "Login"});
+
+        assertEquals("12,7", result);
+    }
+
+    @Test
+    public void testResolveLabelIdsByProjectId_prefersTitleOverName() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createLabelsPage(0, null,
+                new JSONObject().put("id", 12).put("title", "ai_generated").put("name", "ignored_name")));
+
+        String result = stubClient.resolveLabelIdsByProjectId(8, new String[]{"ai_generated"});
+
+        assertEquals("12", result);
+    }
+
+    @Test(expected = IOException.class)
+    public void testResolveLabelIdsByProjectId_throwsWhenNoLabelsMatch() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createLabelsPage(0, null,
+                new JSONObject().put("id", 12).put("name", "other_label")));
+
+        stubClient.resolveLabelIdsByProjectId(8, new String[]{"ai_generated"});
     }
 
     @Test


### PR DESCRIPTION
## Problem

TestRail Cloud returns label names under the `name` field in the `get_labels/{project_id}` list endpoint, while the existing `TestRailClient.resolveLabelIdsByProjectId` only matched against `title`. This caused `TestCasesGenerator` to fail during case creation when `labelNames` was configured:

```
Caused by: java.io.IOException: No labels found for names: ai_generated in project ID: 8
```

## Fix

In `resolveLabelIdsByProjectId`, check `title` first and fall back to `name` when `title` is absent or empty. This keeps compatibility with both API shapes without breaking existing behavior.

## Tests

Added unit tests in `TestRailClientTest`:
- `testResolveLabelIdsByProjectId_matchesTitleField` — existing `title`-based lookup still works.
- `testResolveLabelIdsByProjectId_fallsBackToNameField` — `name`-only labels resolve correctly.
- `testResolveLabelIdsByProjectId_prefersTitleOverName` — when both fields are present, `title` wins.
- `testResolveLabelIdsByProjectId_throwsWhenNoLabelsMatch` — no-match case still throws `IOException`.