### PR TITLE
feat(jira): add jira_update_field_as_adf MCP tool for ADF/v3 rich-text fields

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/jira-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/jira-tools.md
@@ -1,6 +1,6 @@
 # JIRA MCP Tools
 
-**Total Tools**: 66
+**Total Tools**: 67
 
 ## Quick Reference
 
@@ -79,6 +79,7 @@ const result = jira_xray_get_test_details(...);
 | `jira_update_all_fields_with_name` | Update ALL fields with the same name in a Jira ticket. Useful when there are multiple custom fields with the same display name. | `value` (object, **required**)<br>`key` (string, **required**)<br>`fieldName` (string, **required**) |
 | `jira_update_description` | Update the description of a Jira ticket. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists | `description` (string, **required**)<br>`key` (string, **required**) |
 | `jira_update_field` | Update field(s) in a Jira ticket. When using field names (e.g., 'Dependencies'), updates ALL fields with that name. When using custom field IDs (e.g., 'customfield_10091'), updates only that specific field. | `field` (string, **required**)<br>`value` (object, **required**)<br>`key` (string, **required**) |
+| `jira_update_field_as_adf` | Update a rich-text field in a Jira ticket using Jira API v3 and Atlassian Document Format (ADF). The value can be a plain string (wrapped into a paragraph) or a JSON object/array representing an ADF document. Required for interactive task-list checkboxes in Jira Cloud. | `field` (string, **required**)<br>`value` (object, **required**)<br>`key` (string, **required**) |
 | `jira_update_ticket` | Update a Jira ticket using JSON parameters following the standard Jira REST API format | `params` (object, **required**)<br>`key` (string, **required**) |
 | `jira_update_ticket_parent` | Update the parent of a Jira ticket. Can be used for setting up epic relationships and parent-child relationships for subtasks | `key` (string, **required**)<br>`parentKey` (string, **required**) |
 | `jira_xray_add_precondition_to_test` | Add a single precondition to a test issue using X-ray GraphQL API. Returns JSONObject with result. | `testIssueId` (string, **required**)<br>`preconditionIssueId` (string, **required**) |
@@ -1391,6 +1392,59 @@ dmtools jira_update_field "value" "value"
 ```javascript
 // In JavaScript agent
 const result = jira_update_field("field", "value");
+```
+
+---
+
+### `jira_update_field_as_adf`
+
+Update a rich-text field in a Jira ticket using Jira API v3 and Atlassian Document Format (ADF). The value can be a plain string (wrapped into a paragraph) or a JSON object/array representing an ADF document. Required for interactive task-list checkboxes in Jira Cloud.
+
+**Parameters:**
+
+- **`field`** (string) 🔴 Required
+  - The rich-text field to update, e.g. 'description' or 'comment'
+
+- **`value`** (object) 🔴 Required
+  - Plain text or ADF JSON. Plain text is wrapped into an ADF paragraph; JSON object is sent as-is; JSON array is used as the ADF content.
+
+- **`key`** (string) 🔴 Required
+  - The Jira ticket key to update
+
+**Example:**
+
+```bash
+# Plain text (wrapped into ADF automatically)
+dmtools jira_update_field_as_adf --data '{"key":"TP-1523","field":"description","value":"Plain text description"}'
+
+# ADF with interactive task-list checkboxes
+./dmtools.sh jira_update_field_as_adf --data '{"key":"TP-1523","field":"description","value":"{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"taskList\",\"attrs\":{\"localId\":\"\"},\"content\":[{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"DONE\"},\"content\":[{\"type\":\"text\",\"text\":\"E2E\"}]},{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"TODO\"},\"content\":[{\"type\":\"text\",\"text\":\"Component\"}]},{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"TODO\"},\"content\":[{\"type\":\"text\",\"text\":\"Unit\"}]}]}]}"}'
+```
+
+```javascript
+// In JavaScript agent
+const adfDoc = {
+    version: 1,
+    type: "doc",
+    content: [
+        { type: "paragraph", content: [{ type: "text", text: "Test Levels:" }] },
+        {
+            type: "taskList",
+            attrs: { localId: "" },
+            content: [
+                { type: "taskItem", attrs: { localId: "", state: "DONE" }, content: [{ type: "text", text: "E2E" }] },
+                { type: "taskItem", attrs: { localId: "", state: "TODO" }, content: [{ type: "text", text: "Component" }] },
+                { type: "taskItem", attrs: { localId: "", state: "TODO" }, content: [{ type: "text", text: "Unit" }] }
+            ]
+        }
+    ]
+};
+
+const result = jira_update_field_as_adf({
+    key: "TP-1523",
+    field: "description",
+    value: JSON.stringify(adfDoc)
+});
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -6,6 +6,7 @@ package com.github.istin.dmtools.atlassian.jira;
 import com.github.istin.dmtools.atlassian.common.model.Assignee;
 import com.github.istin.dmtools.atlassian.common.networking.AtlassianRestClient;
 import com.github.istin.dmtools.atlassian.jira.model.*;
+import com.github.istin.dmtools.atlassian.jira.utils.AtlassianDocumentFormat;
 import com.github.istin.dmtools.atlassian.jira.utils.IssuesIDsParser;
 import com.github.istin.dmtools.atlassian.jira.utils.JiraResponseUtils;
 import com.github.istin.dmtools.common.model.*;
@@ -2144,6 +2145,35 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
         return updateResult;
     }
 
+    /**
+     * Updates a rich-text field using Jira REST API v3 and Atlassian Document Format (ADF).
+     * This bypasses {@link #path(String)} because v3 requires an explicit API version path
+     * and ADF payloads for fields such as description, comment and environment.
+     */
+    private String performFieldUpdateAsAdf(String key, String fieldIdentifier, Object value, String errorMessage) throws IOException {
+        JSONObject adfValue = AtlassianDocumentFormat.normalize(value);
+
+        GenericRequest jiraRequest = createV3IssueRequest(key);
+        JSONObject body = new JSONObject();
+        body.put("update", new JSONObject()
+                .put(fieldIdentifier, new JSONArray()
+                        .put(new JSONObject()
+                                .put("set", adfValue)
+                        )));
+        jiraRequest.setBody(body.toString());
+
+        String updateResult = jiraRequest.put();
+        validateFieldUpdateResponse(updateResult, errorMessage);
+        return updateResult;
+    }
+
+    /**
+     * Factory for v3 issue update requests. Package-private so tests can spy/mock it.
+     */
+    GenericRequest createV3IssueRequest(String issueKey) {
+        return new GenericRequest(this, getBasePath() + "/rest/api/3/issue/" + issueKey);
+    }
+
     private void validateFieldUpdateResponse(String updateResult, String defaultMessage) throws IOException {
         if (updateResult == null || updateResult.trim().isEmpty()) {
             return;
@@ -2409,6 +2439,36 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
                 return results.toString();
             }
         }
+    }
+
+    @MCPTool(
+            name = "jira_update_field_as_adf",
+            description = "Update a rich-text field in a Jira ticket using Jira API v3 and Atlassian Document Format (ADF). The value can be a plain string (wrapped into a paragraph) or a JSON object/array representing an ADF document. Required for interactive task-list checkboxes in Jira Cloud.",
+            integration = "jira",
+            category = "ticket_management"
+    )
+    public String updateFieldAsAdf(
+            @MCPParam(name = "key", description = "The Jira ticket key to update", required = true) String key,
+            @MCPParam(name = "field", description = "The rich-text field to update, e.g. 'description' or 'comment'", required = true) String field,
+            @MCPParam(name = "value", description = "Plain text or ADF JSON. Plain text is wrapped into an ADF paragraph; JSON object is sent as-is; JSON array is used as the ADF content.", required = true) Object value) throws IOException {
+        if ("".equals(value)) {
+            return clearField(key, field);
+        }
+        value = coerceFieldValue(value);
+
+        String updateResult = performFieldUpdateAsAdf(
+                key,
+                field,
+                value,
+                "Failed to update field '" + field + "' as ADF on ticket " + key
+        );
+
+        if (updateResult == null || updateResult.trim().isEmpty()) {
+            log("Updated field '" + field + "' as ADF on ticket " + key);
+            return "Field '" + field + "' updated as ADF successfully on ticket " + key;
+        }
+        log("Updated field '" + field + "' as ADF on ticket " + key + " with result: " + updateResult);
+        return updateResult;
     }
 
     @MCPTool(

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/utils/AtlassianDocumentFormat.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/utils/AtlassianDocumentFormat.java
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.jira.utils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+/**
+ * Utility for constructing and normalizing Atlassian Document Format (ADF) payloads
+ * used by the Jira REST API v3 for rich-text fields such as description, comment and
+ * environment.
+ */
+public class AtlassianDocumentFormat {
+
+    private AtlassianDocumentFormat() {
+        // utility class
+    }
+
+    /**
+     * Wraps a plain-text string into a minimal ADF document ({@code {version:1, type:doc,
+     * content:[{type:paragraph, content:[{type:text, text:...}]}]}).
+     *
+     * @param text plain text to wrap
+     * @return ADF document as {@link JSONObject}
+     */
+    public static JSONObject wrapPlainText(String text) {
+        JSONObject document = new JSONObject();
+        document.put("version", 1);
+        document.put("type", "doc");
+
+        JSONArray content = new JSONArray();
+        content.put(paragraph(text));
+
+        document.put("content", content);
+        return document;
+    }
+
+    /**
+     * Builds a paragraph node containing the supplied plain text.
+     */
+    public static JSONObject paragraph(String text) {
+        JSONObject paragraph = new JSONObject();
+        paragraph.put("type", "paragraph");
+        paragraph.put("content", new JSONArray().put(textNode(text)));
+        return paragraph;
+    }
+
+    /**
+     * Builds a text node.
+     */
+    public static JSONObject textNode(String text) {
+        JSONObject node = new JSONObject();
+        node.put("type", "text");
+        node.put("text", text);
+        return node;
+    }
+
+    /**
+     * Normalizes a value that should be sent to a Jira v3 rich-text field.
+     * <ul>
+     *   <li>If the value is already a {@link JSONObject}, it is returned as-is (assumed ADF).</li>
+     *   <li>If the value is a {@link JSONArray}, it is wrapped into an ADF document content array.</li>
+     *   <li>If the value is a string that parses as a JSON object/array, it is parsed and treated as ADF.</li>
+     *   <li>Otherwise the string is wrapped into a plain-text ADF document.</li>
+     * </ul>
+     *
+     * @param value user-provided value
+     * @return ADF {@link JSONObject} ready to be sent to Jira v3
+     */
+    public static JSONObject normalize(Object value) {
+        if (value instanceof JSONObject) {
+            return (JSONObject) value;
+        }
+
+        if (value instanceof JSONArray) {
+            JSONObject document = new JSONObject();
+            document.put("version", 1);
+            document.put("type", "doc");
+            document.put("content", value);
+            return document;
+        }
+
+        String str = String.valueOf(value);
+        if (looksLikeJson(str)) {
+            try {
+                JSONTokener tokener = new JSONTokener(str);
+                Object parsed = tokener.nextValue();
+                if (parsed instanceof JSONObject) {
+                    return (JSONObject) parsed;
+                }
+                if (parsed instanceof JSONArray) {
+                    JSONObject document = new JSONObject();
+                    document.put("version", 1);
+                    document.put("type", "doc");
+                    document.put("content", parsed);
+                    return document;
+                }
+            } catch (JSONException ignored) {
+                // fall through to plain text wrapping
+            }
+        }
+
+        return wrapPlainText(str);
+    }
+
+    private static boolean looksLikeJson(String str) {
+        if (str == null || str.isEmpty()) {
+            return false;
+        }
+        String trimmed = str.trim();
+        return (trimmed.startsWith("{") && trimmed.endsWith("}"))
+                || (trimmed.startsWith("[") && trimmed.endsWith("]"));
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientTest.java
@@ -148,6 +148,68 @@ public class JiraClientTest {
     }
 
     @Test
+    public void testUpdateFieldAsAdf_wrapsPlainTextAndCallsV3Endpoint() throws IOException {
+        JiraClient<Ticket> spyClient = spy(jiraClient);
+        doNothing().when(spyClient).log(anyString());
+        doReturn(mockRequest).when(spyClient).createV3IssueRequest("TEST-123");
+        when(mockRequest.put()).thenReturn("");
+
+        String result = spyClient.updateFieldAsAdf("TEST-123", "description", "Plain text");
+
+        assertEquals("Field 'description' updated as ADF successfully on ticket TEST-123", result);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockRequest).setBody(bodyCaptor.capture());
+
+        JSONObject requestBody = new JSONObject(bodyCaptor.getValue());
+        JSONObject setValue = requestBody.getJSONObject("update")
+                .getJSONArray("description")
+                .getJSONObject(0)
+                .getJSONObject("set");
+
+        assertEquals("doc", setValue.getString("type"));
+        assertEquals("Plain text",
+                setValue.getJSONArray("content")
+                        .getJSONObject(0)
+                        .getJSONArray("content")
+                        .getJSONObject(0)
+                        .getString("text"));
+    }
+
+    @Test
+    public void testUpdateFieldAsAdf_passesThroughAdfJson() throws IOException {
+        JiraClient<Ticket> spyClient = spy(jiraClient);
+        doNothing().when(spyClient).log(anyString());
+        doReturn(mockRequest).when(spyClient).createV3IssueRequest("TEST-123");
+        when(mockRequest.put()).thenReturn("");
+
+        String adfJson = "{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"ADF\"}]}]}";
+        spyClient.updateFieldAsAdf("TEST-123", "description", adfJson);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockRequest).setBody(bodyCaptor.capture());
+
+        JSONObject requestBody = new JSONObject(bodyCaptor.getValue());
+        JSONObject setValue = requestBody.getJSONObject("update")
+                .getJSONArray("description")
+                .getJSONObject(0)
+                .getJSONObject("set");
+
+        assertEquals("ADF",
+                setValue.getJSONArray("content")
+                        .getJSONObject(0)
+                        .getJSONArray("content")
+                        .getJSONObject(0)
+                        .getString("text"));
+    }
+
+    @Test
+    public void testCreateV3IssueRequest_buildsV3Url() {
+        GenericRequest request = jiraClient.createV3IssueRequest("TEST-123");
+        assertEquals("http://example.com/rest/api/3/issue/TEST-123", request.url());
+    }
+
+    @Test
     public void testUpdateField_MultiselectCustomFieldWrapsStringValueAsOptionArray() throws IOException {
         JiraClient<Ticket> spyClient = spy(jiraClient);
         doNothing().when(spyClient).log(anyString());

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/utils/AtlassianDocumentFormatTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/utils/AtlassianDocumentFormatTest.java
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.jira.utils;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class AtlassianDocumentFormatTest {
+
+    @Test
+    public void testWrapPlainTextProducesAdfDocument() {
+        JSONObject doc = AtlassianDocumentFormat.wrapPlainText("Hello ADF");
+
+        assertEquals(1, doc.getInt("version"));
+        assertEquals("doc", doc.getString("type"));
+
+        JSONArray content = doc.getJSONArray("content");
+        assertEquals(1, content.length());
+
+        JSONObject paragraph = content.getJSONObject(0);
+        assertEquals("paragraph", paragraph.getString("type"));
+
+        JSONArray paragraphContent = paragraph.getJSONArray("content");
+        assertEquals(1, paragraphContent.length());
+
+        JSONObject textNode = paragraphContent.getJSONObject(0);
+        assertEquals("text", textNode.getString("type"));
+        assertEquals("Hello ADF", textNode.getString("text"));
+    }
+
+    @Test
+    public void testNormalize_passesThroughJSONObject() {
+        JSONObject adf = new JSONObject();
+        adf.put("version", 1);
+        adf.put("type", "doc");
+        adf.put("content", new JSONArray());
+
+        assertSame(adf, AtlassianDocumentFormat.normalize(adf));
+    }
+
+    @Test
+    public void testNormalize_wrapsJSONArrayAsContent() {
+        JSONArray content = new JSONArray()
+                .put(new JSONObject().put("type", "paragraph").put("content", new JSONArray()));
+
+        JSONObject doc = AtlassianDocumentFormat.normalize(content);
+
+        assertEquals("doc", doc.getString("type"));
+        assertSame(content, doc.getJSONArray("content"));
+    }
+
+    @Test
+    public void testNormalize_parsesAdfJsonObjectString() {
+        String adfJson = "{\"version\":1,\"type\":\"doc\",\"content\":[]}";
+
+        JSONObject doc = AtlassianDocumentFormat.normalize(adfJson);
+
+        assertEquals("doc", doc.getString("type"));
+        assertTrue(doc.getJSONArray("content").isEmpty());
+    }
+
+    @Test
+    public void testNormalize_parsesAdfJsonArrayStringAsContent() {
+        String adfJson = "[{\"type\":\"paragraph\",\"content\":[]}]";
+
+        JSONObject doc = AtlassianDocumentFormat.normalize(adfJson);
+
+        assertEquals("doc", doc.getString("type"));
+        assertEquals(1, doc.getJSONArray("content").length());
+    }
+
+    @Test
+    public void testNormalize_wrapsPlainString() {
+        JSONObject doc = AtlassianDocumentFormat.normalize("Plain text value");
+
+        assertEquals("doc", doc.getString("type"));
+        assertEquals("Plain text value",
+                doc.getJSONArray("content")
+                        .getJSONObject(0)
+                        .getJSONArray("content")
+                        .getJSONObject(0)
+                        .getString("text"));
+    }
+
+    @Test
+    public void testNormalize_wrapsJiraWikiMarkupString() {
+        // Wiki markup like {code} must NOT be treated as JSON
+        String wiki = "{code}\nSome code\n{code}";
+
+        JSONObject doc = AtlassianDocumentFormat.normalize(wiki);
+
+        assertEquals("paragraph", doc.getJSONArray("content").getJSONObject(0).getString("type"));
+        assertEquals(wiki,
+                doc.getJSONArray("content")
+                        .getJSONObject(0)
+                        .getJSONArray("content")
+                        .getJSONObject(0)
+                        .getString("text"));
+    }
+
+    @Test
+    public void testNormalize_taskListAdfPassesThrough() {
+        String taskListJson = """
+                {
+                  "version": 1,
+                  "type": "doc",
+                  "content": [
+                    {
+                      "type": "taskList",
+                      "attrs": { "localId": "" },
+                      "content": [
+                        { "type": "taskItem", "attrs": { "localId": "", "state": "DONE" }, "content": [{ "type": "text", "text": "E2E" }] }
+                      ]
+                    }
+                  ]
+                }
+                """;
+
+        JSONObject doc = AtlassianDocumentFormat.normalize(taskListJson);
+
+        assertEquals("doc", doc.getString("type"));
+        JSONObject taskList = doc.getJSONArray("content").getJSONObject(0);
+        assertEquals("taskList", taskList.getString("type"));
+        assertEquals("DONE", taskList.getJSONArray("content")
+                .getJSONObject(0)
+                .getJSONObject("attrs")
+                .getString("state"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new MCP tool `jira_update_field_as_adf` that updates Jira rich-text fields using Jira REST API v3 and Atlassian Document Format (ADF). This enables interactive task-list checkboxes in Jira Cloud descriptions.

## Why a new tool instead of FORCE_V3?

A separate tool keeps full backward compatibility:
- `jira_update_field` continues to use `/rest/api/latest` and plain-text/wiki markup values.
- `jira_update_field_as_adf` explicitly targets `/rest/api/3/issue/{key}` and sends ADF payloads.
- No global flag that could break other operations (comments, transitions, custom fields).

## Changes

- `AtlassianDocumentFormat` helper in `dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/utils/`:
  - `wrapPlainText(String)` → ADF paragraph document.
  - `normalize(Object)` → passes through `JSONObject`/`JSONArray`/ADF JSON strings, wraps plain strings, and guards against wiki-markup strings.
- `JiraClient`:
  - New `@MCPTool` `jira_update_field_as_adf(key, field, value)`.
  - `performFieldUpdateAsAdf` builds the v3 `update` payload.
  - `createV3IssueRequest` constructs `PUT /rest/api/3/issue/{key}` and is package-private for testability.
- Tests:
  - `AtlassianDocumentFormatTest` covers plain text, ADF JSON, JSON arrays, taskList ADF, and wiki-markup regression.
  - `JiraClientTest` verifies v3 URL and payload for plain-text and ADF-JSON inputs.
- Docs:
  - Updated `dmtools-ai-docs/references/mcp-tools/jira-tools.md` with tool description, CLI examples, and JS agent example.

## CLI validation

Built locally with `./gradlew :dmtools-core:shadowJar` and installed to `~/.dmtools/dmtools.jar`.

Created test ticket **TP-1523** and updated its description with an ADF taskList:

```bash
./dmtools.sh jira_update_field_as_adf --data '{"key":"TP-1523","field":"description","value":"{\"version\":1,\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"content\":[{\"type\":\"text\",\"text\":\"Test Levels:\"}]},{\"type\":\"taskList\",\"attrs\":{\"localId\":\"\"},\"content\":[{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"DONE\"},\"content\":[{\"type\":\"text\",\"text\":\"E2E\"}]},{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"TODO\"},\"content\":[{\"type\":\"text\",\"text\":\"Component\"}]},{\"type\":\"taskItem\",\"attrs\":{\"localId\":\"\",\"state\":\"TODO\"},\"content\":[{\"type\":\"text\",\"text\":\"Unit\"}]}]}]}"}'
```

Result: `{"result": "Field 'description' updated as ADF successfully on ticket TP-1523"}`

## JS agent validation

Ran a GraalJS agent via `./dmtools.sh run agents/js/test_update_field_as_adf.js` that called `jira_update_field_as_adf` with both plain text and ADF JSON — both succeeded.

Please verify the interactive checkboxes in the Jira UI on **TP-1523**.