### PR TITLE
feat(release): include conventional-commits changelog in GitHub Release notes

### DIFF
--- a/.github/scripts/generate-release-changelog.sh
+++ b/.github/scripts/generate-release-changelog.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Generates a markdown changelog from conventional commits between two git tags.
+# Usage: generate-release-changelog.sh <previous-tag> <new-tag> [output-file]
+
+set -euo pipefail
+
+PREV_TAG="${1:-}"
+NEW_TAG="${2:-}"
+OUTPUT="${3:-/dev/stdout}"
+
+if [[ -z "$PREV_TAG" || -z "$NEW_TAG" ]]; then
+    echo "Usage: $0 <previous-tag> <new-tag> [output-file]" >&2
+    exit 1
+fi
+
+if ! git rev-parse "$PREV_TAG" >/dev/null 2>&1 || ! git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+    echo "One or both tags not found: $PREV_TAG, $NEW_TAG" >&2
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FEATURES="$TMP_DIR/features.txt"
+BUGFIXES="$TMP_DIR/bugfixes.txt"
+PERF="$TMP_DIR/perf.txt"
+REFACTOR="$TMP_DIR/refactor.txt"
+TESTS="$TMP_DIR/tests.txt"
+DOCS="$TMP_DIR/docs.txt"
+DEPS="$TMP_DIR/deps.txt"
+MAINT="$TMP_DIR/maint.txt"
+OTHER="$TMP_DIR/other.txt"
+BREAKING="$TMP_DIR/breaking.txt"
+
+touch "$FEATURES" "$BUGFIXES" "$PERF" "$REFACTOR" "$TESTS" "$DOCS" "$DEPS" "$MAINT" "$OTHER" "$BREAKING"
+
+# Format a single commit as markdown list item.
+# Subject is everything after the conventional-commit prefix.
+format_commit() {
+    local hash="$1"
+    local subject="$2"
+    local scope_and_desc="${subject#*: }"        # strip prefix like "feat(jira): "
+    scope_and_desc="${scope_and_desc#*:}"        # handle "feat: " (no scope)
+    scope_and_desc=$(echo "$scope_and_desc" | sed 's/^[[:space:]]*//')
+    # Capitalize first letter for nicer markdown.
+    scope_and_desc="$(echo "$scope_and_desc" | awk '{print toupper(substr($0,1,1)) substr($0,2)}')"
+    echo "- ${scope_and_desc} (${hash})"
+}
+
+# Iterate over non-merge commits, excluding version-bump commits.
+git log --no-merges --pretty=format:"%H %h %s" "$PREV_TAG..$NEW_TAG" | \
+while read -r full_hash short_hash subject; do
+    # Skip "version increased" and "Merge pull request" noise.
+    if [[ "$subject" =~ ^version[[:space:]]increased[[:space:]]to[[:space:]] ]]; then
+        continue
+    fi
+    if [[ "$subject" =~ ^Merge[[:space:]]pull[[:space:]]request[[:space:]] ]]; then
+        continue
+    fi
+
+    body=$(git log -1 --pretty=format:"%b" "$full_hash" 2>/dev/null || true)
+
+    # Detect breaking changes (e.g. "feat(scope)!:" or BREAKING CHANGE in body).
+    if [[ "$subject" == *"!:"* ]] || [[ "$body" == *"BREAKING CHANGE"* ]] || [[ "$body" == *"BREAKING-CHANGE"* ]]; then
+        format_commit "$short_hash" "$subject" >> "$BREAKING"
+    fi
+
+    # Categorize by conventional commit prefix.
+    re_feat='^feat(\([^)]*\))?:'
+    re_fix='^fix(\([^)]*\))?:'
+    re_docs='^docs(\([^)]*\))?:'
+    re_test='^test(\([^)]*\))?:'
+    re_refactor='^refactor(\([^)]*\))?:'
+    re_perf='^perf(\([^)]*\))?:'
+    re_deps='^chore\(deps\)(\([^)]*\))?:|^build\(deps\)(\([^)]*\))?:|^chore\(deps\)\(deps\):'
+    re_maint='^(chore|ci|build)(\([^)]*\))?:'
+
+    if [[ "$subject" =~ $re_feat ]]; then
+        format_commit "$short_hash" "$subject" >> "$FEATURES"
+    elif [[ "$subject" =~ $re_fix ]]; then
+        format_commit "$short_hash" "$subject" >> "$BUGFIXES"
+    elif [[ "$subject" =~ $re_docs ]]; then
+        format_commit "$short_hash" "$subject" >> "$DOCS"
+    elif [[ "$subject" =~ $re_test ]]; then
+        format_commit "$short_hash" "$subject" >> "$TESTS"
+    elif [[ "$subject" =~ $re_refactor ]]; then
+        format_commit "$short_hash" "$subject" >> "$REFACTOR"
+    elif [[ "$subject" =~ $re_perf ]]; then
+        format_commit "$short_hash" "$subject" >> "$PERF"
+    elif [[ "$subject" =~ $re_deps ]]; then
+        format_commit "$short_hash" "$subject" >> "$DEPS"
+    elif [[ "$subject" =~ $re_maint ]]; then
+        format_commit "$short_hash" "$subject" >> "$MAINT"
+    else
+        format_commit "$short_hash" "$subject" >> "$OTHER"
+    fi
+done
+
+# Output markdown.
+{
+    echo "## 📝 What's Changed"
+    echo ""
+    repo_url="https://github.com/${GITHUB_REPOSITORY:-epam/dm.ai}"
+    echo "Full diff: [$PREV_TAG...$NEW_TAG]($repo_url/compare/$PREV_TAG...$NEW_TAG)"
+    echo ""
+
+    if [[ -s "$BREAKING" ]]; then
+        echo "### 💥 Breaking Changes"
+        sort -u "$BREAKING"
+        echo ""
+    fi
+
+    if [[ -s "$FEATURES" ]]; then
+        echo "### 🚀 Features"
+        sort -u "$FEATURES"
+        echo ""
+    fi
+
+    if [[ -s "$BUGFIXES" ]]; then
+        echo "### 🐛 Bug Fixes"
+        sort -u "$BUGFIXES"
+        echo ""
+    fi
+
+    if [[ -s "$PERF" ]]; then
+        echo "### ⚡ Performance"
+        sort -u "$PERF"
+        echo ""
+    fi
+
+    if [[ -s "$REFACTOR" ]]; then
+        echo "### 🔧 Refactoring"
+        sort -u "$REFACTOR"
+        echo ""
+    fi
+
+    if [[ -s "$TESTS" ]]; then
+        echo "### ✅ Tests"
+        sort -u "$TESTS"
+        echo ""
+    fi
+
+    if [[ -s "$DOCS" ]]; then
+        echo "### 📚 Documentation"
+        sort -u "$DOCS"
+        echo ""
+    fi
+
+    if [[ -s "$DEPS" ]]; then
+        echo "### 📦 Dependencies"
+        sort -u "$DEPS"
+        echo ""
+    fi
+
+    if [[ -s "$MAINT" ]]; then
+        echo "### 🛠 Maintenance"
+        sort -u "$MAINT"
+        echo ""
+    fi
+
+    if [[ -s "$OTHER" ]]; then
+        echo "### 📋 Other Changes"
+        sort -u "$OTHER"
+        echo ""
+    fi
+
+    if [[ ! -s "$FEATURES" && ! -s "$BUGFIXES" && ! -s "$PERF" && ! -s "$REFACTOR" && ! -s "$TESTS" && ! -s "$DOCS" && ! -s "$DEPS" && ! -s "$MAINT" && ! -s "$OTHER" && ! -s "$BREAKING" ]]; then
+        echo "No conventional commits found between $PREV_TAG and $NEW_TAG."
+        echo ""
+    fi
+} > "$OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,34 @@ jobs:
           git tag "v$NEW_VERSION"
           echo "Created tag: v$NEW_VERSION"
       
+      - name: Generate changelog
+        id: changelog
+        run: |
+          CURRENT_VERSION="${{ steps.current_version.outputs.current }}"
+          NEW_VERSION="${{ steps.new_version.outputs.version }}"
+          PREV_TAG="v$CURRENT_VERSION"
+          NEW_TAG="v$NEW_VERSION"
+
+          if git rev-parse "$PREV_TAG" >/dev/null 2>&1; then
+            .github/scripts/generate-release-changelog.sh "$PREV_TAG" "$NEW_TAG" changelog.md
+          else
+            echo "## 📝 What's Changed" > changelog.md
+            echo "" >> changelog.md
+            echo "Previous tag $PREV_TAG not found. See [commits since last release](https://github.com/${{ github.repository }}/commits/v$NEW_VERSION)." >> changelog.md
+            echo "" >> changelog.md
+          fi
+
+          echo "--- Generated changelog ---"
+          cat changelog.md
+          echo "--- End changelog ---"
+
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-changelog
+          path: changelog.md
+          retention-days: 7
+
       - name: Push changes and tag
         run: |
           NEW_VERSION="${{ steps.new_version.outputs.version }}"
@@ -336,6 +364,12 @@ jobs:
         with:
           name: skill-package
           path: skill/
+
+      - name: Download changelog
+        uses: actions/download-artifact@v8
+        with:
+          name: release-changelog
+          path: changelog/
       
       # - name: Download Standalone Package
       #   uses: actions/download-artifact@v8
@@ -375,8 +409,19 @@ jobs:
           # API_MACOS_X64_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-macos-x64.zip | cut -f1)
           # API_WINDOWS_X64_SIZE=$(du -h standalone/api-bundles/dmtools-server-api-windows-x64.zip | cut -f1)
 
+          CHANGELOG_FILE="changelog/changelog.md"
+          if [ -f "$CHANGELOG_FILE" ]; then
+            CHANGELOG_CONTENT=$(cat "$CHANGELOG_FILE")
+          else
+            CHANGELOG_CONTENT="## 📝 What's Changed\n\nNo changelog available for this release."
+          fi
+
           cat > release_notes.md << EOF
           # 🚀 DMTools Release v${VERSION}
+
+          ${CHANGELOG_CONTENT}
+
+          ---
 
           This release includes the **DMTools CLI** and **Agent Skill** for enterprise dark-factory orchestration across MCP tools, AI agents, and delivery workflows.
 


### PR DESCRIPTION
## Problem

Every GitHub Release body on epam/dm.ai has been an identical install/packaging template. There was no changelog describing functional changes, added/removed MCP tools, bug fixes, or breaking changes (issue #295).

## Solution

Generate a changelog from conventional commits between the previous and new release tag and prepend it to the release body.

### Files changed

- **`.github/scripts/generate-release-changelog.sh`** — new bash script that:
  - Walks non-merge commits between two tags.
  - Skips "version increased to X" noise.
  - Categorizes by conventional-commit prefix:
    - 💥 Breaking Changes
    - 🚀 Features
    - 🐛 Bug Fixes
    - ⚡ Performance
    - 🔧 Refactoring
    - ✅ Tests
    - 📚 Documentation
    - 📦 Dependencies
    - 🛠 Maintenance
    - 📋 Other Changes
  - Detects `BREAKING CHANGE` / `BREAKING-CHANGE` in commit bodies and `!:` in subjects.
  - Capitalizes the first letter of each entry for readability.
  - Includes a full-diff link.

- **`.github/workflows/release.yml`**:
  - New `Generate changelog` step in `version-and-tag` job.
  - Uploads `changelog.md` as the `release-changelog` artifact.
  - Downloads the artifact in `create-unified-release` job.
  - Prepends the changelog to the release body before the install template.

## Example output

For v1.7.212 → v1.7.213 the generated section looks like:

```markdown
## 📝 What's Changed

Full diff: [v1.7.212...v1.7.213](https://github.com/epam/dm.ai/compare/v1.7.212...v1.7.213)

### 🚀 Features
- Add jira_update_field_as_adf MCP tool for ADF/v3 rich-text fields (b598b0de)

### 🐛 Bug Fixes
- Fallback to 'name' field when resolving label IDs (d4f13ef9)

### 📚 Documentation
- Document jira_update_field_as_adf in mcp tools reference (30a7cd52)

### 📦 Dependencies
- Bump versions.jackson3 from 3.1.4 to 3.2.0 (e2a0c917)
...
```

## Testing

- `./github/scripts/generate-release-changelog.sh v1.7.212 v1.7.213 /tmp/changelog.md` was run locally and produced the expected markdown.
- `.github/workflows/release.yml` YAML was validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`.

## Backward compatibility

- The install template and artifact list are unchanged; only the release body is extended.
- If the previous tag cannot be resolved, the script falls back to a "What's Changed" section with a commits link.

Closes #295