### PR TITLE
fix(build): register GraalVM regex language in shadow jar

### DIFF
--- a/dmtools-core/build.gradle
+++ b/dmtools-core/build.gradle
@@ -307,15 +307,20 @@ shadowJar {
         exclude(dependency('org.graalvm.js:js:.*'))
     }
 
+    // GraalVM languages are registered via META-INF/services files. Multiple jars
+    // (js-language, regex, etc.) provide the same service file and Shadow does not
+    // always merge them, so we ship an explicit merged provider list under
+    // src/main/resources/META-INF/services/com.oracle.truffle.api.provider.TruffleLanguageProvider.
+    // That file lists JavaScriptLanguageProvider and RegexLanguageProvider, which is
+    // required for JavaScript regex literals (/.../) in GraalVM 25.
+    mergeServiceFiles()
+
     manifest {
         attributes 'Main-Class': 'com.github.istin.dmtools.job.JobRunner'
         attributes 'Implementation-Version': version
         attributes 'Implementation-Title': 'DMTools'
         attributes 'Multi-Release': 'true'  // Enable multi-release JAR for Log4j Java 9+ classes
     }
-    
-    // Merge service files properly (fixes GraalJS ScriptEngineFactory issue)
-    mergeServiceFiles()
     
     // Exclude duplicate files and problematic files
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE

--- a/dmtools-core/src/main/resources/META-INF/services/com.oracle.truffle.api.provider.TruffleLanguageProvider
+++ b/dmtools-core/src/main/resources/META-INF/services/com.oracle.truffle.api.provider.TruffleLanguageProvider
@@ -1,0 +1,6 @@
+# GraalVM/Truffle language providers registered in the fat JAR.
+# The Shadow plugin does not always merge these service files, so we list
+# the languages explicitly. Required for JavaScript regex literals (/.../)
+# because GraalVM 25 registers regex as a separate Truffle language.
+com.oracle.truffle.js.lang.JavaScriptLanguageProvider
+com.oracle.truffle.regex.RegexLanguageProvider

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/js/JSRunnerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/js/JSRunnerTest.java
@@ -16,6 +16,8 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
 
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +54,53 @@ class JSRunnerTest {
         jsRunner.ai = mockAI;
         jsRunner.confluence = mockConfluence;
         jsRunner.sourceCodes = List.of(mockSourceCode);
+    }
+
+    @Test
+    void testTruffleLanguageProviderServiceFileContainsRegexLanguage() throws Exception {
+        // Regression guard for issue #298: the merged service file must list
+        // both the JS and the Regex Truffle language providers. Without the
+        // regex provider, JavaScript regex literals fail in the shadow JAR.
+        try (InputStream serviceFile = getClass().getClassLoader()
+                .getResourceAsStream("META-INF/services/com.oracle.truffle.api.provider.TruffleLanguageProvider")) {
+            assertNotNull(serviceFile, "TruffleLanguageProvider service file must be present in resources");
+
+            String content = new String(serviceFile.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(content.contains("com.oracle.truffle.js.lang.JavaScriptLanguageProvider"),
+                    "Service file must register JavaScript language provider");
+            assertTrue(content.contains("com.oracle.truffle.regex.RegexLanguageProvider"),
+                    "Service file must register Regex language provider");
+        }
+    }
+
+    @Test
+    void testJavaScriptRegexLiteralExecution() throws Exception {
+        // Regression test for issue #298: GraalJS regex literals must work.
+        String jsWithRegex = """
+            function action(params) {
+                const match = "Visit https://github.com/epam/dm.ai".match(/https:\\/\\/github\\.com\\/[^\\s]+/);
+                const globalMatches = "A https://a.com B https://b.com".match(/https:\\/\\/[^\\s]+/g);
+                return {
+                    success: true,
+                    match: match ? match[0] : null,
+                    allMatches: globalMatches
+                };
+            }
+            """;
+
+        JSRunner.JSParams params = new JSRunner.JSParams();
+        params.setJsPath(jsWithRegex);
+        params.setTicket(Map.of("key", "TEST-123"));
+        params.setResponse("");
+        params.setInitiator("test@example.com");
+
+        Object result = jsRunner.runJobImpl(params);
+
+        assertNotNull(result);
+        String resultStr = result.toString();
+        assertTrue(resultStr.contains("https://github.com/epam/dm.ai"), "Regex literal should match GitHub URL");
+        assertTrue(resultStr.contains("https://a.com"), "Global regex literal should match first URL");
+        assertTrue(resultStr.contains("https://b.com"), "Global regex literal should match second URL");
     }
 
     @Test


### PR DESCRIPTION
## Analysis

Starting in v1.7.214 (GraalVM 25.0.3), JavaScript regex literals (`/pattern/flags`) fail in all DMtools JS hooks with:

```
org.graalvm.polyglot.PolyglotException: java.lang.IllegalStateException:
No language for id regex found. Supported languages are: [js]
```

### Root cause

GraalVM 25 extracts regex into a separate Truffle language (`org.graalvm.regex`). Both `js-language` and `regex` jars ship a `META-INF/services/com.oracle.truffle.api.provider.TruffleLanguageProvider` file, listing `JavaScriptLanguageProvider` and `RegexLanguageProvider` respectively. The Shadow plugin did not merge these files, so the fat JAR only contained the JS entry and the regex language was never registered.

## Plan / Fix

1. Ship an explicit merged `TruffleLanguageProvider` service file as a project resource (`dmtools-core/src/main/resources/META-INF/services/...`) listing both providers.
2. Keep `mergeServiceFiles()` in `shadowJar` for other service files.
3. Add a regression test `testJavaScriptRegexLiteralExecution` in `JSRunnerTest`.
4. Verify with the built shadow JAR that regex literals work both in top-level scripts and in modules loaded via `require()`.

## Verification

- `./gradlew :dmtools-core:test` — ✅ BUILD SUCCESSFUL
- `./gradlew :dmtools-core:shadowJar` — ✅ BUILD SUCCESSFUL
- `dmtools.sh run` with regex literal — ✅
- `dmtools.sh run` with `require()` module containing regex — ✅

```bash
# Direct script with /.../g
./dmtools.sh run /tmp/test_regex2.js '{}'
# → {"success":true,"matches":["https://github.com/epam/dm.ai","https://github.com/user/repo"]}

# Module loaded via require()
./dmtools.sh run /tmp/test_require_regex.js '{}'
# → {"success":true,"match":"https://github.com/epam/dm.ai"}
```

Closes #298