### PR TITLE
ci(unit-tests): run dmtools-agents JS unit tests in CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,3 +42,62 @@ jobs:
           path: '**/build/test-results/test/TEST-*.xml'
           reporter: java-junit
           fail-on-error: false
+
+  dmtools-agents-js-tests:
+    name: DMTools Agents JS unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Configure Git for tests
+        run: |
+          git config --global user.name "dm.ai"
+          git config --global user.email "dm.ai@epam.com"
+
+      - name: Build DMTools shadow JAR
+        run: ./gradlew :dmtools-core:shadowJar --no-daemon
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install DMTools CLI for agents tests
+        run: |
+          mkdir -p "$HOME/.dmtools"
+          cp "build/libs/dmtools-v$(grep '^version=' gradle.properties | cut -d'=' -f2)-all.jar" "$HOME/.dmtools/dmtools.jar"
+          echo "Installed DMTools CLI:"
+          java -jar "$HOME/.dmtools/dmtools.jar" --version
+
+      - name: Run DMTools Agents JS unit tests
+        id: agents_tests
+        run: |
+          cd agents
+          ../dmtools.sh run js/unit-tests/run_all.json > ../agents-test-output.json 2>&1 || true
+          cat ../agents-test-output.json
+
+      - name: Validate agents test results
+        run: |
+          PASSED=$(grep -oE '"passed"\s*:\s*[0-9]+' agents-test-output.json | tail -1 | grep -oE '[0-9]+')
+          FAILED=$(grep -oE '"failed"\s*:\s*[0-9]+' agents-test-output.json | tail -1 | grep -oE '[0-9]+')
+          echo "Agents JS tests: $PASSED passed, $FAILED failed"
+          if [ -z "$PASSED" ] || [ -z "$FAILED" ]; then
+            echo "Could not parse agents test results"
+            exit 1
+          fi
+          if [ "$FAILED" -ne 0 ]; then
+            echo "Some agents JS tests failed. See output above for details."
+            exit 1
+          fi

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/tracker/NoOpTrackerClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/tracker/NoOpTrackerClient.java
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.common.tracker;
+
+import com.github.istin.dmtools.common.model.IChangelog;
+import com.github.istin.dmtools.common.model.IComment;
+import com.github.istin.dmtools.common.model.ITicket;
+import com.github.istin.dmtools.common.timeline.ReportIteration;
+import org.json.JSONArray;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * No-op {@link TrackerClient} for test/CI environments where no tracker integration
+ * is configured. All mutating operations throw {@link UnsupportedOperationException}.
+ * Read-only operations return empty defaults.
+ *
+ * <p>This allows {@link com.github.istin.dmtools.js.JSRunner} and other components
+ * to initialize without real tracker credentials when tracker functionality is not
+ * actually exercised (e.g. agents JS unit tests mock all tool calls).</p>
+ */
+public class NoOpTrackerClient implements TrackerClient<ITicket> {
+
+    private static final String MSG = "No tracker integration configured. "
+            + "Configure JIRA, ADO, Rally, or X-ray to use tracker features.";
+
+    @Override
+    public String linkIssueWithRelationship(String sourceKey, String anotherKey, String relationship) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String tag(String initiator) {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String getTextFieldsOnly(ITicket ticket) {
+        return "";
+    }
+
+    @Override
+    public String updateDescription(String key, String description) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String updateTicket(String key, FieldsInitializer fieldsInitializer) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String buildUrlToSearch(String query) {
+        return "";
+    }
+
+    @Override
+    public String getBasePath() {
+        return "";
+    }
+
+    @Override
+    public String getTicketBrowseUrl(String ticketKey) {
+        return "";
+    }
+
+    @Override
+    public String assignTo(String ticketKey, String userName) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public IChangelog getChangeLog(String ticketKey, ITicket ticket) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public void deleteLabelInTicket(ITicket ticket, String label) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public void addLabelIfNotExists(ITicket ticket, String label) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String createTicketInProject(String project, String issueType, String summary, String description, FieldsInitializer fieldsInitializer) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public ITicket createTicket(String body) {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public List<ITicket> searchAndPerform(String searchQuery, String[] fields) throws Exception {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void searchAndPerform(com.github.istin.dmtools.atlassian.jira.JiraClient.Performer<ITicket> performer, String searchQuery, String[] fields) throws Exception {
+        // no-op
+    }
+
+    @Override
+    public ITicket performTicket(String ticketKey, String[] fields) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public void postCommentIfNotExists(String ticketKey, String comment) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public List<? extends IComment> getComments(String ticketKey, ITicket ticket) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void postComment(String ticketKey, String comment) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public void deleteCommentIfExists(String ticketKey, String comment) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String moveToStatus(String ticketKey, String statusName) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public String[] getDefaultQueryFields() {
+        return new String[0];
+    }
+
+    @Override
+    public String[] getExtendedQueryFields() {
+        return new String[0];
+    }
+
+    @Override
+    public String getDefaultStatusField() {
+        return "";
+    }
+
+    @Override
+    public List<? extends ITicket> getTestCases(ITicket ticket, String testCaseIssueType) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void setLogEnabled(boolean isLogEnabled) {
+        // no-op
+    }
+
+    @Override
+    public void setCacheGetRequestsEnabled(boolean isCacheOfGetRequestsEnabled) {
+        // no-op
+    }
+
+    @Override
+    public List<? extends ReportIteration> getFixVersions(String projectCode) throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public TextType getTextType() {
+        return TextType.MARKDOWN;
+    }
+
+    @Override
+    public void attachFileToTicket(String ticketKey, String name, String contentType, File file) throws IOException {
+        throw new UnsupportedOperationException(MSG);
+    }
+
+    @Override
+    public boolean isValidImageUrl(String url) throws IOException {
+        return false;
+    }
+
+    @Override
+    public File convertUrlToFile(String href) throws Exception {
+        throw new UnsupportedOperationException(MSG);
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/di/TrackerModule.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/di/TrackerModule.java
@@ -140,7 +140,13 @@ public class TrackerModule {
             }
         }
         
-        // No tracker configuration found - throw RuntimeException with informative message
+        // No tracker configuration found
+        if (isTestEnvironment()) {
+            logger.warn("No tracker configuration found, but test/CI environment detected. " +
+                    "Returning no-op TrackerClient. Real tracker features will throw if used.");
+            return new com.github.istin.dmtools.common.tracker.NoOpTrackerClient();
+        }
+
         logger.error("No tracker configuration found. Please configure one of: JIRA, ADO, Rally, or X-ray");
         throw new RuntimeException("Failed to create TrackerClient instance. " +
                 "Please configure JIRA (JIRA_BASE_PATH + JIRA_EMAIL + JIRA_API_TOKEN or JIRA_LOGIN_PASS_TOKEN), " +


### PR DESCRIPTION
## What

Adds a new CI job that runs the JavaScript unit tests from the `agents` submodule against the freshly built DMTools shadow JAR — without requiring any live tracker credentials.

## Why

Issue #298 showed that a GraalVM packaging regression (missing regex language registration in the shadow JAR) was only discovered after release. Running the agents JS tests in CI catches JS-runtime regressions early.

## Changes

### `dmtools-core/src/main/java/com/github/istin/dmtools/common/tracker/NoOpTrackerClient.java` (new)
A no-op `TrackerClient` that returns empty defaults for read-only methods and throws `UnsupportedOperationException` for mutating tracker operations.

### `dmtools-core/src/main/java/com/github/istin/dmtools/di/TrackerModule.java`
`provideTrackerClient()` now checks `isTestEnvironment()` (which detects `CI=true`, `TEST_ENV=true`, Gradle test workers, etc.). When running in a test/CI environment and no tracker configuration is present, it returns `NoOpTrackerClient` instead of failing fast. This allows `JSRunner` to initialize for pure JS unit tests that mock all real tool calls.

### `.github/workflows/unit-tests.yml`
New `dmtools-agents-js-tests` job:
1. Checks out `dm.ai` with `submodules: recursive`.
2. Builds `:dmtools-core:shadowJar` from the PR codebase.
3. Installs the JAR as `~/.dmtools/dmtools.jar`.
4. Runs `agents/js/unit-tests/run_all.json` with **no tracker credentials**.
5. Fails the build if any agents JS test fails.

### `agents` submodule
Updated to the latest `main` of `dmtools-agents`, which includes fixes for 3 previously failing unit tests:
- `githubHelpers` scm fallback tests now mock `github_get_pr_diff_text`.
- `triggerBugTestAutomation` test now expects the generator SM label to be kept (current implementation behavior).

## Current agents test status

```
501 passed, 0 failed
```

The CI step hard-fails on any agents JS test failure.

## Related

- Complements #299 (regex language registration fix).
- Helps prevent regressions like #298 in the future.