### PR TITLE
feat: add DEFAULT_TRACKER=jira to ai-teammate workflow

### DIFF
--- a/.github/workflows/ai-teammate.yml
+++ b/.github/workflows/ai-teammate.yml
@@ -206,6 +206,7 @@ jobs:
 
           # DMTools Integration Settings
           DMTOOLS_INTEGRATIONS: "jira,confluence,ado,figma,ai,cli,file,github"
+          DEFAULT_TRACKER: "jira"
 
           # Encoded config input
           ENCODED_CONFIG: ${{ inputs.encoded_config }}


### PR DESCRIPTION
Adds `DEFAULT_TRACKER=jira` environment variable to the `ai-teammate.yml` workflow to explicitly set Jira as the default tracker for DMTools runs.