### PR TITLE
feat(#301): configurable Jira issue key ignore/allowed lists and JQL keyword handling

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/JiraClient.java
@@ -1970,17 +1970,29 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
         return cached != null ? cached : new ArrayList<>();
     }
 
+    private static final Set<String> JQL_KEYWORDS = new HashSet<>(Arrays.asList(
+            "AND", "OR", "NOT", "IN", "IS", "WAS", "CHANGED", "EMPTY", "NULL",
+            "ORDER", "BY", "ASC", "DESC", "LIKE", "CONTAINS", "~", "!=", "<=", ">="
+    ));
+
+    private boolean isJqlKeyword(String value) {
+        return value != null && JQL_KEYWORDS.contains(value.toUpperCase(Locale.ROOT));
+    }
+
     private String extractProjectKeyFromJQL(String jql) {
         if (jql == null || jql.trim().isEmpty()) {
             return "";
         }
 
-        String upperJql = jql.toUpperCase();
+        String upperJql = jql.toUpperCase(Locale.ROOT);
         // Sort by length descending so longer keys (e.g. "MYPROJ") are checked before shorter ones (e.g. "MY")
         Optional<String> match = getKnownProjectKeys().stream()
                 .sorted(Comparator.comparingInt(String::length).reversed())
                 .filter(key -> {
-                    String upperKey = key.toUpperCase();
+                    String upperKey = key.toUpperCase(Locale.ROOT);
+                    if (isJqlKeyword(upperKey)) {
+                        return false;
+                    }
                     return upperJql.contains(upperKey + "-")
                             || Pattern.compile("\\b" + Pattern.quote(upperKey) + "\\b").matcher(upperJql).find();
                 })
@@ -1997,16 +2009,20 @@ public abstract class JiraClient<T extends Ticket> implements RestClient, Tracke
                 "\\bproject\\s*(?:=|in)\\s*[\"'(]?([A-Z][A-Z0-9_]+)[\"')]?", Pattern.CASE_INSENSITIVE
         ).matcher(jql);
         if (projectMatcher.find()) {
-            String extracted = projectMatcher.group(1).toUpperCase();
-            logger.debug("Extracted project key '{}' from JQL via pattern (not in member list): {}", extracted, jql);
-            return extracted;
+            String extracted = projectMatcher.group(1).toUpperCase(Locale.ROOT);
+            if (!isJqlKeyword(extracted)) {
+                logger.debug("Extracted project key '{}' from JQL via pattern (not in member list): {}", extracted, jql);
+                return extracted;
+            }
         }
         // Also try to extract from a ticket key pattern like "MYTUBE-123"
         java.util.regex.Matcher keyMatcher = Pattern.compile("\\b([A-Z][A-Z0-9_]+)-\\d+\\b").matcher(upperJql);
-        if (keyMatcher.find()) {
+        while (keyMatcher.find()) {
             String extracted = keyMatcher.group(1);
-            logger.debug("Extracted project key '{}' from ticket key pattern in JQL: {}", extracted, jql);
-            return extracted;
+            if (!isJqlKeyword(extracted)) {
+                logger.debug("Extracted project key '{}' from ticket key pattern in JQL: {}", extracted, jql);
+                return extracted;
+            }
         }
 
         return "";

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/utils/IssuesIDsParser.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/utils/IssuesIDsParser.java
@@ -8,11 +8,14 @@ import lombok.Setter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.github.istin.dmtools.common.utils.PropertyReader;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class IssuesIDsParser {
     private static final Logger logger = LogManager.getLogger(IssuesIDsParser.class);
@@ -80,6 +83,11 @@ public class IssuesIDsParser {
     }
 
     public static Set<String> extractAllJiraIDs(String text) {
+        PropertyReader propertyReader = new PropertyReader();
+        return extractAllJiraIDs(text, propertyReader.getJiraIssueIgnorePrefixes(), propertyReader.getJiraIssueAllowedPrefixes());
+    }
+
+    public static Set<String> extractAllJiraIDs(String text, Set<String> ignorePrefixes, Set<String> allowedPrefixes) {
         if (text == null || text.isEmpty()) {
             return Collections.emptySet();
         }
@@ -88,9 +96,8 @@ public class IssuesIDsParser {
         String jiraKeyPattern = "(?:\\b|\\/browse\\/)[A-Z]+-\\d+\\b";
 
         Set<String> keys = new HashSet<>();
-        if (text == null) {
-            return keys;
-        }
+        Set<String> normalizedIgnorePrefixes = normalizePrefixes(ignorePrefixes);
+        Set<String> normalizedAllowedPrefixes = normalizePrefixes(allowedPrefixes);
 
         Pattern pattern = Pattern.compile(jiraKeyPattern);
         Matcher matcher = pattern.matcher(text);
@@ -102,10 +109,29 @@ public class IssuesIDsParser {
             if (found.contains("/browse/")) {
                 found = found.substring(found.indexOf("/browse/") + 8);
             }
+            String prefix = found.split("-")[0].toUpperCase(Locale.ROOT);
+            if (!normalizedAllowedPrefixes.isEmpty() && !normalizedAllowedPrefixes.contains(prefix)) {
+                logger.debug("Skipping JIRA key {} because prefix {} is not in allowed list", found, prefix);
+                continue;
+            }
+            if (!normalizedIgnorePrefixes.isEmpty() && normalizedIgnorePrefixes.contains(prefix)) {
+                logger.debug("Skipping JIRA key {} because prefix {} is in ignore list", found, prefix);
+                continue;
+            }
             keys.add(found);
             logger.info("Found JIRA Key: {}", found);
         }
         return keys;
+    }
+
+    private static Set<String> normalizePrefixes(Set<String> prefixes) {
+        if (prefixes == null || prefixes.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return prefixes.stream()
+                .map(prefix -> prefix.trim().toUpperCase(Locale.ROOT))
+                .filter(prefix -> !prefix.isEmpty())
+                .collect(Collectors.toSet());
     }
 
     public static Set<String> extractAttachmentUrls(String basePath, String jiraJson) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -374,6 +374,31 @@ public class PropertyReader {
     return value.split(",");
   }
 
+  public static final String JIRA_ISSUE_IGNORE_PREFIXES = "JIRA_ISSUE_IGNORE_PREFIXES";
+  public static final String JIRA_ISSUE_ALLOWED_PREFIXES = "JIRA_ISSUE_ALLOWED_PREFIXES";
+
+  public Set<String> getJiraIssueIgnorePrefixes() {
+    return parseUpperCasePrefixSet(getValue(JIRA_ISSUE_IGNORE_PREFIXES));
+  }
+
+  public Set<String> getJiraIssueAllowedPrefixes() {
+    return parseUpperCasePrefixSet(getValue(JIRA_ISSUE_ALLOWED_PREFIXES));
+  }
+
+  private Set<String> parseUpperCasePrefixSet(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<String> result = new HashSet<>();
+    for (String prefix : value.split(",")) {
+      String trimmed = prefix.trim().toUpperCase(Locale.ROOT);
+      if (!trimmed.isEmpty()) {
+        result.add(trimmed);
+      }
+    }
+    return Collections.unmodifiableSet(result);
+  }
+
   public String getXrayClientId() {
     return getValue("XRAY_CLIENT_ID");
   }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/context/ContextOrchestrator.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/context/ContextOrchestrator.java
@@ -149,7 +149,7 @@ public class ContextOrchestrator {
                         } catch (Exception e) {
                             long uriProcessDuration = System.currentTimeMillis() - uriProcessStart;
                             logger.info("TIMING: uriToObject() for {} failed after {}ms: {}", uri, uriProcessDuration, e.getMessage());
-                            e.printStackTrace();
+                            logger.debug("uriToObject() failed for {}", uri, e);
                             return new ObjectUriPair(uri, null);
                         }
                     });

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
@@ -241,11 +241,23 @@ public class JobRunner {
             Object paramsByClass = jobParams.getParamsByClass(job.getParamsClass());
             
             // Apply per-job env variable overrides (from envVariables in JSON params)
+            // Job-level params take precedence over envVariables.
             if (paramsByClass instanceof TrackerParams) {
-                java.util.Map<String, String> envVariables = ((TrackerParams) paramsByClass).getEnvVariables();
+                TrackerParams trackerParams = (TrackerParams) paramsByClass;
+                java.util.Map<String, String> overrides = new java.util.LinkedHashMap<>();
+                java.util.Map<String, String> envVariables = trackerParams.getEnvVariables();
                 if (envVariables != null && !envVariables.isEmpty()) {
-                    logger.info("Applying {} env variable override(s) for job: {}", envVariables.size(), jobParams.getName());
-                    PropertyReader.setOverrides(envVariables);
+                    overrides.putAll(envVariables);
+                }
+                if (trackerParams.getIssueIgnorePrefixes() != null && !trackerParams.getIssueIgnorePrefixes().isBlank()) {
+                    overrides.put(PropertyReader.JIRA_ISSUE_IGNORE_PREFIXES, trackerParams.getIssueIgnorePrefixes());
+                }
+                if (trackerParams.getIssueAllowedPrefixes() != null && !trackerParams.getIssueAllowedPrefixes().isBlank()) {
+                    overrides.put(PropertyReader.JIRA_ISSUE_ALLOWED_PREFIXES, trackerParams.getIssueAllowedPrefixes());
+                }
+                if (!overrides.isEmpty()) {
+                    logger.info("Applying {} env variable override(s) for job: {}", overrides.size(), jobParams.getName());
+                    PropertyReader.setOverrides(overrides);
                 }
             }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/TrackerParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/TrackerParams.java
@@ -109,4 +109,14 @@ public class TrackerParams implements CliPostComment {
     @SerializedName(ENV_VARIABLES)
     private java.util.Map<String, String> envVariables;
 
+    public static final String ISSUE_IGNORE_PREFIXES = "issueIgnorePrefixes";
+
+    @SerializedName(ISSUE_IGNORE_PREFIXES)
+    private String issueIgnorePrefixes;
+
+    public static final String ISSUE_ALLOWED_PREFIXES = "issueAllowedPrefixes";
+
+    @SerializedName(ISSUE_ALLOWED_PREFIXES)
+    private String issueAllowedPrefixes;
+
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/networking/AbstractRestClient.java
@@ -218,7 +218,11 @@ public abstract class AbstractRestClient implements RestClient {
         }
         String sanitizedUrl = sanitizeUrl(request.url().toString());
         String responseError = "printAndCreateException error: " + sanitizedUrl + "\n" + body + "\n" + response.message() + "\n" + code;
-        logger.error(responseError);
+        if (code == 404 && sanitizedUrl.contains("/issue/")) {
+            logger.debug(responseError);
+        } else {
+            logger.error(responseError);
+        }
         return new RestClient.RestClientException(responseError, body, code);
     }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/TicketContextTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/TicketContextTest.java
@@ -9,6 +9,7 @@ import com.github.istin.dmtools.common.model.IComment;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -442,6 +443,26 @@ public class TicketContextTest {
             // Format: "TIMING: Starting TicketContext.prepareContext() for {ticket} at {timestamp}"
             // Format: "TIMING: IssuesIDsParser.extractAllJiraIDs() took {duration}ms for {ticket}"
             // Format: "TIMING: All extra tickets fetch took {duration}ms for {ticket}"
+        }
+    }
+
+    @Test
+    void testPrepareContextFiltersIgnoredPrefixes() throws IOException {
+        PropertyReader.setOverrides(java.util.Map.of(PropertyReader.JIRA_ISSUE_IGNORE_PREFIXES, "PSR"));
+        try {
+            when(mockTicket.toText()).thenReturn("This ticket references PSR-18 and DMC-403");
+            when(mockTrackerClient.getExtendedQueryFields()).thenReturn(new String[]{"description", "summary"});
+            when(mockTrackerClient.performTicket("DMC-403", new String[]{"description", "summary"}))
+                .thenReturn(mockExtraTicket1);
+
+            ticketContext.prepareContext(false);
+
+            List<ITicket> extraTickets = ticketContext.getExtraTickets();
+            assertEquals(1, extraTickets.size());
+            assertEquals("DMC-403", extraTickets.get(0).getKey());
+            verify(mockTrackerClient, never()).performTicket(eq("PSR-18"), any());
+        } finally {
+            PropertyReader.clearOverrides();
         }
     }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/JiraClientTest.java
@@ -377,4 +377,17 @@ public class JiraClientTest {
         assertTrue(spyClient.isValidImageUrl(validUrl));
     }
 
+    @Test
+    public void testExtractProjectKeyFromJQLIgnoresKeywords() throws Exception {
+        JiraClient<Ticket> spyClient = spy(jiraClient);
+        doReturn(Arrays.asList("IN", "PROJ", "TEAM")).when(spyClient).getKnownProjectKeys();
+
+        Method method = JiraClient.class.getDeclaredMethod("extractProjectKeyFromJQL", String.class);
+        method.setAccessible(true);
+
+        assertNotEquals("IN", method.invoke(spyClient, "parent in (PSR-18,PSR-17)"));
+        assertEquals("PROJ", method.invoke(spyClient, "project = PROJ AND status = Open"));
+        assertEquals("TEAM", method.invoke(spyClient, "key = TEAM-123"));
+    }
+
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/utils/IssuesIDsParserTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/jira/utils/IssuesIDsParserTest.java
@@ -3,11 +3,16 @@
 
 package com.github.istin.dmtools.atlassian.jira.utils;
 
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -68,5 +73,80 @@ public class IssuesIDsParserTest {
         Set<String> result = IssuesIDsParser.extractAllJiraIDs(null);
 
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testExtractAllJiraIDsWithIgnoreList() {
+        String text = "PROJ-860 uses PSR-18 and PSR-17 factories, see RFC-6749";
+        Set<String> ignorePrefixes = new HashSet<>(Collections.singletonList("PSR"));
+        Set<String> result = IssuesIDsParser.extractAllJiraIDs(text, ignorePrefixes, Collections.emptySet());
+
+        assertEquals(2, result.size());
+        assertTrue(result.contains("PROJ-860"));
+        assertTrue(result.contains("RFC-6749"));
+    }
+
+    @Test
+    public void testExtractAllJiraIDsWithAllowedList() {
+        String text = "PROJ-860 uses PSR-18 and TEAM-123 factories, see RFC-6749";
+        Set<String> allowedPrefixes = new HashSet<>(Collections.singletonList("PROJ"));
+        Set<String> result = IssuesIDsParser.extractAllJiraIDs(text, Collections.emptySet(), allowedPrefixes);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains("PROJ-860"));
+    }
+
+    @Test
+    public void testExtractAllJiraIDsWithBothLists() {
+        String text = "PROJ-860 uses PSR-18 and TEAM-123 factories";
+        Set<String> ignorePrefixes = new HashSet<>(Collections.singletonList("TEAM"));
+        Set<String> allowedPrefixes = new HashSet<>(Collections.singletonList("PROJ"));
+        Set<String> result = IssuesIDsParser.extractAllJiraIDs(text, ignorePrefixes, allowedPrefixes);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains("PROJ-860"));
+    }
+
+    @Test
+    public void testExtractAllJiraIDsWithCaseInsensitivePrefixes() {
+        String text = "PROJ-860 uses PSR-18 factories";
+        Set<String> ignorePrefixes = new HashSet<>(Collections.singletonList("psr"));
+        Set<String> allowedPrefixes = new HashSet<>(Collections.singletonList("proj"));
+        Set<String> result = IssuesIDsParser.extractAllJiraIDs(text, ignorePrefixes, allowedPrefixes);
+
+        assertEquals(1, result.size());
+        assertTrue(result.contains("PROJ-860"));
+    }
+
+    @Test
+    public void testExtractAllJiraIDsReadsPropertyReaderConfig() {
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(PropertyReader.JIRA_ISSUE_IGNORE_PREFIXES, "PSR,RFC");
+        PropertyReader.setOverrides(overrides);
+        try {
+            String text = "PROJ-860 uses PSR-18 and RFC-6749";
+            Set<String> result = IssuesIDsParser.extractAllJiraIDs(text);
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains("PROJ-860"));
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    public void testExtractAllJiraIDsAllowedListFromPropertyReaderConfig() {
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put(PropertyReader.JIRA_ISSUE_ALLOWED_PREFIXES, "TEAM");
+        PropertyReader.setOverrides(overrides);
+        try {
+            String text = "PROJ-860 and TEAM-123";
+            Set<String> result = IssuesIDsParser.extractAllJiraIDs(text);
+
+            assertEquals(1, result.size());
+            assertTrue(result.contains("TEAM-123"));
+        } finally {
+            PropertyReader.clearOverrides();
+        }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -438,6 +439,56 @@ class PropertyReaderTest {
             } finally {
                 PropertyReader.clearOverrides();
             }
+        }
+    }
+
+    @Test
+    @DisplayName("getJiraIssueIgnorePrefixes() returns empty set by default")
+    void testGetJiraIssueIgnorePrefixes_DefaultValue() {
+        Set<String> result = propertyReader.getJiraIssueIgnorePrefixes();
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getJiraIssueAllowedPrefixes() returns empty set by default")
+    void testGetJiraIssueAllowedPrefixes_DefaultValue() {
+        Set<String> result = propertyReader.getJiraIssueAllowedPrefixes();
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("getJiraIssueIgnorePrefixes() parses comma-separated values and upper-cases them")
+    void testGetJiraIssueIgnorePrefixes_Parsing() {
+        Map<String, String> overrides = new java.util.HashMap<>();
+        overrides.put(PropertyReader.JIRA_ISSUE_IGNORE_PREFIXES, "PSR, rfc ,CVE");
+        PropertyReader.setOverrides(overrides);
+        try {
+            Set<String> result = new PropertyReader().getJiraIssueIgnorePrefixes();
+            assertEquals(3, result.size());
+            assertTrue(result.contains("PSR"));
+            assertTrue(result.contains("RFC"));
+            assertTrue(result.contains("CVE"));
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    @DisplayName("getJiraIssueAllowedPrefixes() parses comma-separated values and upper-cases them")
+    void testGetJiraIssueAllowedPrefixes_Parsing() {
+        Map<String, String> overrides = new java.util.HashMap<>();
+        overrides.put(PropertyReader.JIRA_ISSUE_ALLOWED_PREFIXES, "PROJ, TEAM, PLATFORM");
+        PropertyReader.setOverrides(overrides);
+        try {
+            Set<String> result = new PropertyReader().getJiraIssueAllowedPrefixes();
+            assertEquals(3, result.size());
+            assertTrue(result.contains("PROJ"));
+            assertTrue(result.contains("TEAM"));
+            assertTrue(result.contains("PLATFORM"));
+        } finally {
+            PropertyReader.clearOverrides();
         }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/TrackerParamsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/TrackerParamsTest.java
@@ -52,7 +52,9 @@ class TrackerParamsTest {
             customParams,
             "https://ci.example.com/runs/42",
             true,
-            null
+            null,
+            "PSR,RFC",
+            "PROJ,TEAM"
         );
 
         assertEquals("project = TEST", params.getInputJql());
@@ -70,6 +72,8 @@ class TrackerParamsTest {
         assertEquals(customParams, params.getCustomParams());
         assertEquals("https://ci.example.com/runs/42", params.getCiRunUrl());
         assertTrue(params.getAlwaysPostComments());
+        assertEquals("PSR,RFC", params.getIssueIgnorePrefixes());
+        assertEquals("PROJ,TEAM", params.getIssueAllowedPrefixes());
     }
 
     @Test
@@ -118,6 +122,12 @@ class TrackerParamsTest {
 
         trackerParams.setChunkProcessingTimeoutInMinutes(60);
         assertEquals(60, trackerParams.getChunkProcessingTimeoutInMinutes());
+
+        trackerParams.setIssueIgnorePrefixes("PSR,RFC");
+        assertEquals("PSR,RFC", trackerParams.getIssueIgnorePrefixes());
+
+        trackerParams.setIssueAllowedPrefixes("PROJ,TEAM");
+        assertEquals("PROJ,TEAM", trackerParams.getIssueAllowedPrefixes());
     }
 
     @Test
@@ -147,6 +157,8 @@ class TrackerParamsTest {
         assertEquals("chunksProcessingTimeout", TrackerParams.CHUNKS_PROCESSING_TIMEOUT_IN_MINUTES);
         assertEquals("preJSAction", TrackerParams.PRE_ACTION);
         assertEquals("ciRunUrl", TrackerParams.CI_RUN_URL);
+        assertEquals("issueIgnorePrefixes", TrackerParams.ISSUE_IGNORE_PREFIXES);
+        assertEquals("issueAllowedPrefixes", TrackerParams.ISSUE_ALLOWED_PREFIXES);
     }
 
     @Test


### PR DESCRIPTION
Closes #301

## Summary
Adds configurable filtering of parsed Jira issue keys to suppress false positives (PSR-*, RFC-*, CVE-*, etc.) while preserving full backward compatibility.

## What's changed
- **Env/config support**: new `JIRA_ISSUE_IGNORE_PREFIXES` and `JIRA_ISSUE_ALLOWED_PREFIXES` variables read via `PropertyReader`.
- **Job-level params**: new `issueIgnorePrefixes` / `issueAllowedPrefixes` fields in `TrackerParams`; job-level values take precedence over env variables.
- **Parser filtering**: `IssuesIDsParser.extractAllJiraIDs()` now applies ignore/allowed lists. The original no-arg method still works exactly as before when nothing is configured.
- **JQL keyword guard**: `JiraClient.extractProjectKeyFromJQL` no longer treats JQL keywords such as `IN`, `AND`, `OR` as project keys.
- **Graceful 404**: 404 responses for `/issue/{key}` URLs are logged at DEBUG instead of ERROR; `ContextOrchestrator` no longer prints full stack traces for failed URI resolution.

## Test coverage
- `IssuesIDsParserTest` – ignore/allowed list behavior and PropertyReader integration
- `PropertyReaderTest` – parsing of new env variables
- `TrackerParamsTest` – new fields/constants
- `JiraClientTest` – JQL keyword handling
- `TicketContextTest` – ignored prefixes do not trigger ticket fetches

## Backward compatibility
Default behavior is unchanged. Filtering is only applied when ignore or allowed prefixes are explicitly configured globally or per-job.