### PR TITLE
Allow Read/Write permissions in Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__codegraph__codegraph_search",
+      "mcp__codegraph__codegraph_context",
+      "mcp__codegraph__codegraph_callers",
+      "mcp__codegraph__codegraph_callees",
+      "mcp__codegraph__codegraph_impact",
+      "mcp__codegraph__codegraph_node",
+      "mcp__codegraph__codegraph_status",
+      "mcp__codegraph__codegraph_files",
+      "Write",
+      "Read"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ temp
 .settings/**
 .codemie
 .claude
+!.claude/settings.json
 
 # Temporary working notes with local paths / internal data
 KB_FIXES*.md


### PR DESCRIPTION
Add `.claude/settings.json` to allow Claude Code CLI to read and write files without interactive permission prompts in CI (headless) mode.

This fixes the issue where the pr_rework agent was interrupted before writing `outputs/response.md` and `outputs/review_replies.json` due to Claude Code requesting file write permissions that were never approved in headless CI environment.