### PR TITLE
docs(#301): document Jira issue key ignore/allowed lists

### DIFF
--- a/dmtools-ai-docs/references/configuration/json-config-rules.md
+++ b/dmtools-ai-docs/references/configuration/json-config-rules.md
@@ -134,10 +134,22 @@ All jobs that extend `TrackerParams` support these common parameters:
     "postJSAction": "agents/js/postprocess.js",
     "attachResponseAsFile": false,
     "ticketContextDepth": 1,
-    "chunkProcessingTimeoutInMinutes": 60
+    "chunkProcessingTimeoutInMinutes": 60,
+    "issueIgnorePrefixes": "PSR,RFC,CVE",
+    "issueAllowedPrefixes": "PROJ,TEAM,PLATFORM",
+    "envVariables": {
+      "JIRA_ISSUE_IGNORE_PREFIXES": "PSR,RFC,CVE",
+      "JIRA_ISSUE_ALLOWED_PREFIXES": "PROJ,TEAM,PLATFORM"
+    }
   }
 }
 ```
+
+- `issueIgnorePrefixes` — comma-separated list of Jira issue key prefixes to exclude when parsing ticket references (e.g. `PSR-18`, `RFC-6749`). Empty by default.
+- `issueAllowedPrefixes` — comma-separated list of allowed Jira issue key prefixes; when set, only keys matching these prefixes are kept. Empty by default.
+- `envVariables` — per-job environment variable overrides. Job-level `issueIgnorePrefixes` / `issueAllowedPrefixes` take precedence over env variables with the same name.
+
+When neither list is configured, parsing behavior remains unchanged (full backward compatibility).
 
 ## Configuration Validation
 

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -87,6 +87,35 @@ The `"name"` field is a **technical identifier** that maps to a Java class in DM
 
 ---
 
+## Common Job Parameters
+
+All jobs that inherit from `TrackerParams` support the following common parameters.
+
+### Jira Issue Key Filtering
+
+You can control which Jira issue keys are recognized when DMtools parses ticket references in text, comments, descriptions, and JQL results.
+
+| Parameter | Env Variable | Description |
+|-----------|--------------|-------------|
+| `issueIgnorePrefixes` | `JIRA_ISSUE_IGNORE_PREFIXES` | Comma-separated prefixes to ignore (e.g. `PSR,RFC,CVE`). All other keys are allowed. |
+| `issueAllowedPrefixes` | `JIRA_ISSUE_ALLOWED_PREFIXES` | Comma-separated prefixes to allow. When set, only keys with these prefixes are kept. |
+| `envVariables` | — | Per-job environment variable overrides. Job-level `issueIgnorePrefixes` / `issueAllowedPrefixes` take precedence over env variables with the same name. |
+
+```json
+{
+  "name": "Teammate",
+  "params": {
+    "inputJql": "key = PROJ-123",
+    "issueIgnorePrefixes": "PSR,RFC,CVE",
+    "issueAllowedPrefixes": "PROJ,TEAM"
+  }
+}
+```
+
+If neither list is configured, parsing behavior is unchanged (full backward compatibility).
+
+---
+
 ## 🎯 Featured Jobs
 
 ### Quick reference for common agent jobs


### PR DESCRIPTION
Related to #301

Adds documentation for the new Jira issue key filtering options introduced in #303:

- issueIgnorePrefixes / JIRA_ISSUE_IGNORE_PREFIXES
- issueAllowedPrefixes / JIRA_ISSUE_ALLOWED_PREFIXES
- Job-level precedence over env variables
- Backward compatibility note

Updated files:
- dmtools-ai-docs/references/jobs/README.md - new "Common Job Parameters" section
- dmtools-ai-docs/references/configuration/json-config-rules.md - common parameters example and descriptions