### PR TITLE
feat(teammate): add env variable exclusion for CLI subprocess

### DIFF
--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -453,6 +453,10 @@ dmtools Teammate --inputJql "key = PROJ-123"
   - Each index has `integration` (index name) and `storagePath` (path to index)
 - `systemRequestCommentAlias` - Alias for system request in comments
 - `ignoreClonedByRelationship` - Exclude tickets linked via "is cloned by" from AI context (default: **true**). Prevents cloned duplicates from overloading the context.
+- `excludedEnvVariables` - Array of exact env variable names to exclude from the CLI subprocess (optional)
+- `excludedEnvRegexes` - Array of regex patterns; matching env variable names are excluded from the CLI subprocess (optional)
+  - Use these to prevent sensitive values from being passed to CLI agents.
+  - Default: `null` (no filtering, backward compatible).
 
 **Index Configuration** (IndexConfig):
 ```json

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -23,6 +23,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -30,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 /**
  * Helper class for CLI command execution within Teammate jobs.
@@ -306,13 +309,34 @@ public class CliExecutionHelper {
      */
     public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
                                             AtomicReference<String> liveOutput) {
+        return executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput, false, null, null);
+    }
+
+    /**
+     * Executes CLI commands and collects their responses.
+     * Each output line is also published to {@code liveOutput} (if non-null) so that a
+     * concurrent timer thread can read accumulated output between command lines.
+     *
+     * @param cliCommands          Array of CLI commands to execute
+     * @param workingDirectory     Working directory for command execution (optional)
+     * @param envVariablesFile     Path to environment file (null → resolve dmtools.env relative to workingDirectory)
+     * @param liveOutput           Optional AtomicReference updated with accumulated output after each line
+     * @param allowAnyCommand      When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                             Use only for trusted job configs.
+     * @param excludedEnvVariables Exact env variable names to exclude from the subprocess
+     * @param excludedEnvRegexes   Regex patterns; matching env variable names are excluded
+     * @return StringBuilder containing all command responses
+     */
+    public StringBuilder executeCliCommands(String[] cliCommands, Path workingDirectory, String envVariablesFile,
+                                            AtomicReference<String> liveOutput, boolean allowAnyCommand,
+                                            String[] excludedEnvVariables, String[] excludedEnvRegexes) {
         StringBuilder cliResponses = new StringBuilder();
-        
+
         if (cliCommands == null || cliCommands.length == 0) {
             logger.info("No CLI commands to execute");
             return cliResponses;
         }
-        
+
         // Load environment variables from dmtools.env for CLI tools like cursor-agent
         if (envVariablesFile == null) {
             envVariablesFile = workingDirectory.resolve("dmtools.env").toString();
@@ -349,14 +373,17 @@ public class CliExecutionHelper {
                     mergedCount, skipped);
             envVars = merged;
         }
-        
+
+        // Apply explicit exclusions before spawning subprocess
+        envVars = filterEnvVariables(envVars, excludedEnvVariables, excludedEnvRegexes);
+
         // Convert Path to File for ProcessBuilder - safer than changing system properties
         File workingDir = null;
         if (workingDirectory != null && Files.exists(workingDirectory) && Files.isDirectory(workingDirectory)) {
             workingDir = workingDirectory.toFile();
             logger.info("Set working directory to: {}", workingDirectory.toAbsolutePath());
         }
-        
+
         for (String command : cliCommands) {
             if (command == null || command.trim().isEmpty()) {
                 logger.warn("Skipping empty CLI command");
@@ -456,6 +483,34 @@ public class CliExecutionHelper {
                                                            String envVariablesFile,
                                                            Runnable timerAction, int timerIntervalSeconds,
                                                            AtomicReference<String> liveCliOutput) {
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction,
+                timerIntervalSeconds, liveCliOutput, false, null, null);
+    }
+
+    /**
+     * Executes CLI commands with an optional background timer, shared live output reference,
+     * optional shell-injection validation bypass, and optional env variable exclusion.
+     *
+     * @param cliCommands            Array of CLI commands to execute
+     * @param workingDirectory       Working directory for command execution (optional)
+     * @param envVariablesFile       Path to environment file (null → auto-resolve)
+     * @param timerAction            Optional runnable executed on the timer thread
+     * @param timerIntervalSeconds   Interval between timer firings in seconds; timer is disabled if &lt;= 0
+     * @param liveCliOutput          Optional shared AtomicReference updated with accumulated CLI output;
+     *                               if null, an internal reference is created when timerAction is non-null
+     * @param allowAnyCommand        When {@code true}, skips shell-injection validation so arbitrary shell syntax is allowed.
+     *                               Use only for trusted job configs.
+     * @param excludedEnvVariables   Exact env variable names to exclude from the subprocess
+     * @param excludedEnvRegexes     Regex patterns; matching env variable names are excluded
+     * @return CliExecutionResult containing command responses and output response
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile,
+                                                           Runnable timerAction, int timerIntervalSeconds,
+                                                           AtomicReference<String> liveCliOutput,
+                                                           boolean allowAnyCommand,
+                                                           String[] excludedEnvVariables,
+                                                           String[] excludedEnvRegexes) {
         AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
                 : (timerAction != null ? new AtomicReference<>("") : null);
 
@@ -477,7 +532,8 @@ public class CliExecutionHelper {
         }
 
         try {
-            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput);
+            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput,
+                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes);
             String outputResponse = processOutputResponse(workingDirectory);
             return new CliExecutionResult(cliResponses, outputResponse);
         } finally {
@@ -586,6 +642,63 @@ public class CliExecutionHelper {
         }
     }
     
+    /**
+     * Filters environment variables by exact name and/or regex patterns.
+     * Returns a new map with matching keys removed. If both filters are null/empty,
+     * returns the original map reference unchanged.
+     */
+    public static Map<String, String> filterEnvVariables(Map<String, String> envVars,
+                                                         String[] excludedEnvVariables,
+                                                         String[] excludedEnvRegexes) {
+        if (envVars == null || envVars.isEmpty()) {
+            return envVars;
+        }
+
+        Set<String> exactExclusions = new HashSet<>();
+        if (excludedEnvVariables != null) {
+            for (String name : excludedEnvVariables) {
+                if (name != null && !name.isBlank()) {
+                    exactExclusions.add(name);
+                }
+            }
+        }
+
+        List<Pattern> regexPatterns = new ArrayList<>();
+        if (excludedEnvRegexes != null) {
+            for (String regex : excludedEnvRegexes) {
+                if (regex != null && !regex.isBlank()) {
+                    regexPatterns.add(Pattern.compile(regex));
+                }
+            }
+        }
+
+        if (exactExclusions.isEmpty() && regexPatterns.isEmpty()) {
+            return envVars;
+        }
+
+        Map<String, String> filtered = new HashMap<>();
+        for (Map.Entry<String, String> entry : envVars.entrySet()) {
+            String key = entry.getKey();
+            if (exactExclusions.contains(key)) {
+                logger.debug("Excluding env variable {} (exact match)", key);
+                continue;
+            }
+            boolean matchesRegex = false;
+            for (Pattern pattern : regexPatterns) {
+                if (pattern.matcher(key).matches()) {
+                    logger.debug("Excluding env variable {} (regex match: {})", key, pattern.pattern());
+                    matchesRegex = true;
+                    break;
+                }
+            }
+            if (!matchesRegex) {
+                filtered.put(key, entry.getValue());
+            }
+        }
+        logger.info("Filtered environment variables: {} excluded, {} retained", envVars.size() - filtered.size(), filtered.size());
+        return filtered;
+    }
+
     /**
      * Appends processed prompt to each CLI command via temporary file.
      * Creates a temporary file with prompt content and passes file path as parameter.

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -129,6 +129,12 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
         @SerializedName("includeParentConfluence")
         private boolean includeParentConfluence = true;
 
+        @SerializedName("excludedEnvVariables")
+        private String[] excludedEnvVariables;
+
+        @SerializedName("excludedEnvRegexes")
+        private String[] excludedEnvRegexes;
+
     }
 
     /**
@@ -554,8 +560,16 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                         logger.info("timerJSAction configured: {} (interval: {}s)", timerJSAction, timerIntervalSeconds);
                     }
 
-                    cliResult = cliHelper.executeCliCommandsWithResult(finalCliCommands, projectRoot, null,
-                            timerRunnable, timerIntervalSeconds, liveCliOutput);
+                    cliResult = cliHelper.executeCliCommandsWithResult(
+                            finalCliCommands,
+                            projectRoot,
+                            null,
+                            timerRunnable,
+                            timerIntervalSeconds,
+                            liveCliOutput,
+                            false,
+                            expertParams.getExcludedEnvVariables(),
+                            expertParams.getExcludedEnvRegexes());
                     
                     // Append CLI responses to knownInfo if not empty
                     StringBuilder cliResponses = cliResult.getCommandResponses();

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -1142,4 +1142,96 @@ public class CliExecutionHelperTest {
         verify(confluence, times(1)).contentByUrl(urlA);
         verify(confluence, times(1)).contentByUrl(urlB);
     }
+
+    // ── env variable exclusion tests ─────────────────────────────────────────
+
+    @Test
+    void testExecuteCliCommands_ExcludesExactEnvVariables() {
+        com.github.istin.dmtools.common.utils.PropertyReader.setOverrides(
+                Map.of("KEEP_ME", "ok", "DROP_ME", "secret", "ALSO_DROP", "secret2")
+        );
+        try {
+            String[] commands = {"echo test"};
+            String[] excluded = {"DROP_ME", "ALSO_DROP"};
+            try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+                mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                        .thenReturn(Map.of());
+                mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class), any()))
+                        .thenReturn("test");
+
+                cliHelper.executeCliCommands(commands, null, "dmtools.env", null, false, excluded, null);
+
+                mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                        anyString(),
+                        isNull(),
+                        argThat((Map<String, String> env) ->
+                                "ok".equals(env.get("KEEP_ME"))
+                                && !env.containsKey("DROP_ME")
+                                && !env.containsKey("ALSO_DROP")
+                        ),
+                        any()
+                ));
+            }
+        } finally {
+            com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testExecuteCliCommands_ExcludesEnvVariablesByRegex() {
+        com.github.istin.dmtools.common.utils.PropertyReader.setOverrides(
+                Map.of("API_KEY", "secret1", "MY_API_KEY", "secret2", "PUBLIC", "ok")
+        );
+        try {
+            String[] commands = {"echo test"};
+            String[] excludedRegexes = {".*API_KEY$"};
+            try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+                mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                        .thenReturn(Map.of());
+                mockedUtils.when(() -> CommandLineUtils.runCommand(anyString(), isNull(), any(Map.class), any()))
+                        .thenReturn("test");
+
+                cliHelper.executeCliCommands(commands, null, "dmtools.env", null, false, null, excludedRegexes);
+
+                mockedUtils.verify(() -> CommandLineUtils.runCommand(
+                        anyString(),
+                        isNull(),
+                        argThat((Map<String, String> env) ->
+                                !env.containsKey("API_KEY")
+                                && !env.containsKey("MY_API_KEY")
+                                && "ok".equals(env.get("PUBLIC"))
+                        ),
+                        any()
+                ));
+            }
+        } finally {
+            com.github.istin.dmtools.common.utils.PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testFilterEnvVariables_BothExactAndRegexExclusions() {
+        Map<String, String> env = Map.of(
+                "KEEP", "ok",
+                "DROP_EXACT", "secret1",
+                "DROP_REGEX", "secret2"
+        );
+
+        Map<String, String> result = CliExecutionHelper.filterEnvVariables(
+                env,
+                new String[]{"DROP_EXACT"},
+                new String[]{"DROP_.*"}
+        );
+
+        assertEquals(1, result.size());
+        assertEquals("ok", result.get("KEEP"));
+        assertFalse(result.containsKey("DROP_EXACT"));
+        assertFalse(result.containsKey("DROP_REGEX"));
+    }
+
+    @Test
+    void testFilterEnvVariables_NullInputs_ReturnsOriginal() {
+        Map<String, String> env = Map.of("KEY", "value");
+        assertSame(env, CliExecutionHelper.filterEnvVariables(env, null, null));
+    }
 }


### PR DESCRIPTION
Adds `excludedEnvVariables` and `excludedEnvRegexes` to `TeammateParams` so Teammate jobs can filter which environment variables are passed to the CLI subprocess.

### What's changed
- Added `excludedEnvVariables` and `excludedEnvRegexes` fields to `Teammate.TeammateParams`
- Implemented `CliExecutionHelper.filterEnvVariables()` for exact-name and regex-based exclusion
- Wired `Teammate.runJobImpl()` to pass the filters into `executeCliCommandsWithResult()`
- Added unit tests covering exact exclusion, regex exclusion, combined filters, and null-input behavior

### Backward compatibility
Both new fields are optional and default to `null`. When unset, behavior is unchanged — all merged env variables are passed to the subprocess as before.

Example job config:
```json
{
  "excludedEnvVariables": ["SECRET_TOKEN", "PRIVATE_KEY"],
  "excludedEnvRegexes": [".*_API_KEY$", ".*_SECRET$"]
}
```