### PR TITLE
feat(teammate): notify initiator when Teammate run completes

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -747,12 +747,56 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             } else {
                 logger.info("Output type is 'none', skipping publishing results for ticket {}", ticket.getKey());
             }
+
+            // Post completion comment so the initiator is notified when the Teammate run finishes
+            postCompletionComment(trackerClient, ticket.getTicketKey(), ciRunUrl, initiator, expertParams);
+
             results.add(new ResultItem(ticket.getTicketKey(), response));
             return false;
         }, inputJQL, trackerClient.getExtendedQueryFields());
         return results;
     }
 
+
+    /**
+     * Builds the completion comment text that tags the initiator and references the CI run URL.
+     * If tagging the initiator fails, the comment is built without the tag so the notification
+     * still goes out.
+     */
+    static String buildCompletionComment(String initiator, String ciRunUrl, TrackerClient trackerClient) {
+        if (initiator != null && !initiator.isEmpty()) {
+            try {
+                return trackerClient.tag(initiator) + ", \n\n✅ Teammate run completed. CI Run: " + ciRunUrl;
+            } catch (Exception e) {
+                logger.warn("Failed to tag initiator {} in completion comment — posting without tag. Error: {}",
+                        initiator, e.getMessage());
+            }
+        }
+        return "✅ Teammate run completed. CI Run: " + ciRunUrl;
+    }
+
+    /**
+     * Posts a completion comment to the ticket when a CI run URL is configured.
+     * Tags the initiator if available. Errors are logged and swallowed so the job continues.
+     */
+    void postCompletionComment(TrackerClient trackerClient, String ticketKey, String ciRunUrl, String initiator, TeammateParams params) {
+        if (ciRunUrl == null || ciRunUrl.isEmpty()) {
+            return;
+        }
+        if (!shouldPostComments(params)) {
+            logger.debug("CI run URL provided ({}) but comments disabled - not posting completion comment to ticket {}",
+                    ciRunUrl, ticketKey);
+            return;
+        }
+        try {
+            String completionComment = buildCompletionComment(initiator, ciRunUrl, trackerClient);
+            trackerClient.postComment(ticketKey, agentNamePrefix(params) + completionComment);
+            logger.info("Posted completion comment for ticket {} with CI run trace", ticketKey);
+        } catch (Exception e) {
+            logger.warn("Failed to post completion comment for ticket {} — continuing. Error: {}",
+                    ticketKey, e.getMessage());
+        }
+    }
 
     /**
      * Resolves the effective CLI prompts by merging base {@code cliPrompts} with tracker-specific

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateTest.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.teammate;
+
+import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.job.TrackerParams;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class TeammateTest {
+
+    private Teammate teammate;
+    private TrackerClient trackerClient;
+
+    @Before
+    public void setUp() {
+        teammate = new Teammate();
+        trackerClient = mock(TrackerClient.class);
+        when(trackerClient.tag("initiator-123")).thenReturn("[~initiator-123]");
+    }
+
+    @Test
+    public void testBuildCompletionComment_WithInitiator_TagsInitiator() {
+        String result = Teammate.buildCompletionComment("initiator-123", "https://ci.example.com/run/42", trackerClient);
+
+        assertEquals("[~initiator-123], \n\n✅ Teammate run completed. CI Run: https://ci.example.com/run/42", result);
+        verify(trackerClient).tag("initiator-123");
+    }
+
+    @Test
+    public void testBuildCompletionComment_WithoutInitiator_NoTag() {
+        String result = Teammate.buildCompletionComment(null, "https://ci.example.com/run/42", trackerClient);
+
+        assertEquals("✅ Teammate run completed. CI Run: https://ci.example.com/run/42", result);
+        verify(trackerClient, never()).tag(anyString());
+    }
+
+    @Test
+    public void testBuildCompletionComment_EmptyInitiator_NoTag() {
+        String result = Teammate.buildCompletionComment("", "https://ci.example.com/run/42", trackerClient);
+
+        assertEquals("✅ Teammate run completed. CI Run: https://ci.example.com/run/42", result);
+        verify(trackerClient, never()).tag(anyString());
+    }
+
+    @Test
+    public void testPostCompletionComment_WithCiRunUrl_PostsComment() throws IOException {
+        Teammate.TeammateParams params = new Teammate.TeammateParams();
+        params.setOutputType(TrackerParams.OutputType.comment);
+
+        teammate.postCompletionComment(trackerClient, "PROJ-123", "https://ci.example.com/run/42", "initiator-123", params);
+
+        ArgumentCaptor<String> commentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(trackerClient).postComment(eq("PROJ-123"), commentCaptor.capture());
+        String postedComment = commentCaptor.getValue();
+        assertTrue(postedComment.contains("Teammate run completed"));
+        assertTrue(postedComment.contains("https://ci.example.com/run/42"));
+        assertTrue(postedComment.contains("[~initiator-123]"));
+    }
+
+    @Test
+    public void testPostCompletionComment_NoCiRunUrl_DoesNothing() throws IOException {
+        Teammate.TeammateParams params = new Teammate.TeammateParams();
+        params.setOutputType(TrackerParams.OutputType.comment);
+
+        teammate.postCompletionComment(trackerClient, "PROJ-123", null, "initiator-123", params);
+        teammate.postCompletionComment(trackerClient, "PROJ-123", "", "initiator-123", params);
+
+        verify(trackerClient, never()).postComment(anyString(), anyString());
+    }
+
+    @Test
+    public void testPostCompletionComment_OutputTypeNone_DoesNotPost() throws IOException {
+        Teammate.TeammateParams params = new Teammate.TeammateParams();
+        params.setOutputType(TrackerParams.OutputType.none);
+
+        teammate.postCompletionComment(trackerClient, "PROJ-123", "https://ci.example.com/run/42", "initiator-123", params);
+
+        verify(trackerClient, never()).postComment(anyString(), anyString());
+    }
+
+    @Test
+    public void testPostCompletionComment_TagException_PostsWithoutTag() throws IOException {
+        Teammate.TeammateParams params = new Teammate.TeammateParams();
+        params.setOutputType(TrackerParams.OutputType.comment);
+        doThrow(new RuntimeException("tag failed")).when(trackerClient).tag(anyString());
+
+        teammate.postCompletionComment(trackerClient, "PROJ-123", "https://ci.example.com/run/42", "initiator-123", params);
+
+        ArgumentCaptor<String> commentCaptor = ArgumentCaptor.forClass(String.class);
+        verify(trackerClient).postComment(eq("PROJ-123"), commentCaptor.capture());
+        String postedComment = commentCaptor.getValue();
+        assertTrue(postedComment.contains("Teammate run completed"));
+        assertTrue(postedComment.contains("https://ci.example.com/run/42"));
+        assertFalse(postedComment.contains("[~initiator-123]"));
+    }
+}


### PR DESCRIPTION
When `ciRunUrl` is configured, Teammate now posts a completion comment per ticket that tags the initiator and references the CI run URL.

### What's changed
- Added `postCompletionComment()` and `buildCompletionComment()` helpers to `Teammate`
- Completion notification is posted at the end of per-ticket processing
- If `trackerClient.tag(initiator)` fails, the comment is posted without the tag so the notification still goes out
- Added `TeammateTest` with cases for tagged, untagged, disabled, and error scenarios

### Backward compatibility
The feature only activates when:
- `ciRunUrl` is provided in params
- comments are enabled (`outputType` != `none` or `alwaysPostComments=true`)

If no CI run URL is configured, behavior is unchanged.