### PR TITLE
fix: BasicJiraClient now respects DMTOOLS_CACHE_ENABLED for JiraClient cache layer

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/BasicJiraClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/jira/BasicJiraClient.java
@@ -24,6 +24,7 @@ public class BasicJiraClient extends JiraClient<Ticket> {
 
     private static final boolean IS_JIRA_LOGGING_ENABLED;
     private static final boolean IS_JIRA_CLEAR_CACHE;
+    private static final boolean IS_JIRA_CACHE_ENABLED;
 
     private static final boolean IS_JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES;
 
@@ -77,6 +78,7 @@ public class BasicJiraClient extends JiraClient<Ticket> {
         AUTH_TYPE = propertyReader.getJiraAuthType();
         IS_JIRA_LOGGING_ENABLED = propertyReader.isJiraLoggingEnabled();
         IS_JIRA_CLEAR_CACHE = propertyReader.isJiraClearCache();
+        IS_JIRA_CACHE_ENABLED = propertyReader.isCacheEnabled();
         IS_JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES = propertyReader.isJiraTransformCustomFieldsToNames();
         IS_JIRA_WAIT_BEFORE_PERFORM = propertyReader.isJiraWaitBeforePerform();
         SLEEP_TIME_REQUEST = propertyReader.getSleepTimeRequest();
@@ -115,6 +117,7 @@ public class BasicJiraClient extends JiraClient<Ticket> {
         setWaitBeforePerform(IS_JIRA_WAIT_BEFORE_PERFORM);
         setSleepTimeRequest(SLEEP_TIME_REQUEST);
         setClearCache(IS_JIRA_CLEAR_CACHE);
+        setCacheGetRequestsEnabled(IS_JIRA_CACHE_ENABLED);
         setTransformCustomFieldsToNames(IS_JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES);
         setProjectContext(JIRA_EXTRA_FIELDS_PROJECT);
 


### PR DESCRIPTION
## Problem

`JiraClient` has its own `isReadCacheGetRequestsEnabled` field (default: `true`) that is **separate** from `AbstractRestClient.isCacheGetRequestsEnabled`. `BasicJiraClient` never called `setCacheGetRequestsEnabled()`, so setting `DMTOOLS_CACHE_ENABLED=false` in `dmtools.env` had no effect — the JiraClient file cache remained active regardless.

This caused `jira_get_ticket()` calls issued immediately after `jira_update_field()` to return the **pre-write cached response** instead of fresh data — confirmed via simulation (write marker + immediate re-read returned same byte length, `cacheHit=true`).

## Fix

Read `DMTOOLS_CACHE_ENABLED` via `propertyReader.isCacheEnabled()` at static init time (`IS_JIRA_CACHE_ENABLED`) and call `setCacheGetRequestsEnabled(IS_JIRA_CACHE_ENABLED)` in the constructor — consistent with how `IS_JIRA_CLEAR_CACHE` is already applied.

## Changes

- `BasicJiraClient.java`: add `IS_JIRA_CACHE_ENABLED` static field + `setCacheGetRequestsEnabled()` call in constructor

## Testing

Verified locally: with `DMTOOLS_CACHE_ENABLED=false`, `jira_get_ticket()` after `jira_update_field()` now returns fresh data.