### PR TITLE
fix(install): repair download logic and validate JAR integrity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,6 +531,21 @@ jobs:
           
           echo "Release notes generated"
       
+      - name: Generate CLI Checksums
+        run: |
+          VERSION="${{ needs.version-and-tag.outputs.version }}"
+          cd cli
+          sha256sum \
+            "dmtools-v${VERSION}-all.jar" \
+            install.sh \
+            install \
+            install.bat \
+            install.ps1 \
+            dmtools.sh \
+            > dmtools-checksums.sha256
+          echo "CLI checksums generated:"
+          cat dmtools-checksums.sha256
+
       - name: Create Unified Release
         uses: softprops/action-gh-release@v3
         env:
@@ -548,6 +563,7 @@ jobs:
             cli/install.bat
             cli/install.ps1
             cli/dmtools.sh
+            cli/dmtools-checksums.sha256
             skill/dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.zip
             skill/dmtools-skill-v${{ needs.version-and-tag.outputs.version }}.tar.gz
             skill/dmtools-skill.zip

--- a/dmtools-core/build.gradle
+++ b/dmtools-core/build.gradle
@@ -331,3 +331,25 @@ shadowJar {
     // Move the JAR to the root build directory
     destinationDirectory.set(file("${project.rootDir}/build/libs"))
 }
+
+/**
+ * Smoke test that verifies the assembled shadow JAR can execute
+ * `dmtools list` successfully. This catches packaging issues such as a
+ * truncated JAR or a missing main-class manifest before the release is cut.
+ */
+tasks.named('test') {
+    // Smoke test for the packaged shadow JAR is run by shadowJarSmokeTest instead.
+    exclude 'com/github/istin/dmtools/job/CliJarSmokeTest.class'
+}
+
+task shadowJarSmokeTest(type: Test) {
+    description = 'Smoke test that runs the built shadow JAR with dmtools list'
+    group = 'verification'
+    dependsOn shadowJar
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    include 'com/github/istin/dmtools/job/CliJarSmokeTest.class'
+    systemProperty 'dmtools.shadow.jar.path', shadowJar.archiveFile.get().asFile.absolutePath
+}
+
+check.dependsOn shadowJarSmokeTest

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/CliJarSmokeTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/CliJarSmokeTest.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.job;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+/**
+ * Smoke test for the packaged CLI shadow JAR.
+ * <p>
+ * Verifies that the assembled fat JAR is executable and can run the basic
+ * {@code dmtools list} command without a {@link ClassNotFoundException} or
+ * a corrupted-archive error. The test is intended to catch packaging issues
+ * such as a truncated JAR or a missing main-class manifest.
+ */
+public class CliJarSmokeTest {
+
+    private static final long PROCESS_TIMEOUT_SECONDS = 120;
+
+    @Test
+    public void testShadowJarListCommand() throws Exception {
+        String jarPath = System.getProperty("dmtools.shadow.jar.path");
+        assertNotNull("System property 'dmtools.shadow.jar.path' must be set by the Gradle task", jarPath);
+
+        File shadowJar = new File(jarPath);
+        assertTrue("Shadow JAR does not exist: " + shadowJar, shadowJar.exists());
+        assertTrue("Shadow JAR is empty: " + shadowJar, shadowJar.length() > 0);
+
+        List<String> command = Arrays.asList(
+                "java", "-jar", shadowJar.getAbsolutePath(), "mcp", "list", "file"
+        );
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put("DMTOOLS_INTEGRATIONS", "file");
+        pb.redirectErrorStream(true);
+
+        Process process = pb.start();
+
+        List<String> outputLines = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                outputLines.add(line);
+            }
+        }
+
+        boolean finished = process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        assertTrue("dmtools mcp list file did not finish within " + PROCESS_TIMEOUT_SECONDS + " seconds", finished);
+
+        int exitCode = process.exitValue();
+        if (exitCode != 0) {
+            fail("dmtools mcp list file failed with exit code " + exitCode + ". Output:\n" + String.join("\n", outputLines));
+        }
+
+        String output = String.join("\n", outputLines).toLowerCase();
+        assertFalse("Output indicates corrupted JAR: " + output,
+                output.contains("could not find or load main class")
+                        || output.contains("zip end header not found")
+                        || output.contains("invalid or corrupt jarfile"));
+    }
+}

--- a/install.sh
+++ b/install.sh
@@ -974,6 +974,41 @@ validate_not_html() {
 }
 
 # Download file with progress and validation
+# Validate a downloaded file (JAR integrity, shell script sanity, HTML error pages).
+# Returns 0 on success, 1 on failure. Caller is responsible for removing the file on failure.
+validate_downloaded_file() {
+    local output="$1"
+    local desc="$2"
+    local url="$3"
+
+    # JAR files must be valid zip archives
+    if [[ "$output" == *.jar ]] || [[ "$desc" == *"JAR"* ]]; then
+        local jar_valid=false
+        if command -v jar >/dev/null 2>&1 && jar tf "$output" >/dev/null 2>&1; then
+            jar_valid=true
+        elif command -v unzip >/dev/null 2>&1 && unzip -t "$output" >/dev/null 2>&1; then
+            jar_valid=true
+        fi
+        if [ "$jar_valid" != true ]; then
+            warn "Downloaded JAR file appears to be corrupted (invalid zip)."
+            return 1
+        fi
+    fi
+
+    local require_shell="false"
+    # Check if this is a shell script download
+    if [[ "$desc" == *"shell script"* ]] || [[ "$url" == *.sh ]]; then
+        require_shell="true"
+    fi
+
+    if ! validate_not_html "$output" "$desc" "$require_shell"; then
+        warn "Downloaded file appears to be invalid (HTML error page or not a valid shell script)."
+        return 1
+    fi
+
+    return 0
+}
+
 download_file() {
     local url="$1"
     local output="$2"
@@ -996,7 +1031,11 @@ download_file() {
             curl_log=$(mktemp)
             local curl_exit_code=0
 
-            curl -L --fail --connect-timeout 30 --max-time 1200 -s -S "$url" -o "$output" >"$curl_log" 2>&1 || curl_exit_code=$?
+            # Resume partial downloads, abort on stalls (<1KB/s for 30s), and keep
+            # real error messages visible despite -s progress suppression.
+            curl -L --fail --connect-timeout 30 --max-time 1200 \
+                 -C - --speed-time 30 --speed-limit 1024 \
+                 -s -S "$url" -o "$output" >"$curl_log" 2>&1 || curl_exit_code=$?
 
             if [ -s "$curl_log" ]; then
                 cat "$curl_log" >&2
@@ -1006,19 +1045,34 @@ download_file() {
             if [ $curl_exit_code -eq 0 ]; then
                 download_success=true
             else
-                # Map curl exit codes to messages
+                # Map curl exit codes to messages.
+                # For transient network/timeout errors we keep the partial file so
+                # the next attempt can resume (-C -). For 404/write/range errors
+                # we wipe the partial file and start fresh.
                 case $curl_exit_code in
-                    6|7) warn "Network error or timeout when downloading $desc. Retrying..." ;;
-                    22) warn "HTTP error (404 or similar) when downloading $desc. Retrying..." ;;
-                    23) warn "Write error when saving $desc. Retrying..." ;;
-                    28) warn "Transfer timeout when downloading $desc. Retrying..." ;;
-                    *) warn "Download failed (curl exit code: $curl_exit_code). Retrying..." ;;
+                    6|7|28|35|56)
+                        warn "Network/timeout error (curl $curl_exit_code) when downloading $desc. Retrying with resume..."
+                        ;;
+                    33)
+                        warn "Server does not support resume for $desc. Restarting download..."
+                        rm -f "$output" 2>/dev/null
+                        ;;
+                    22)
+                        warn "HTTP error (404 or similar) when downloading $desc. Retrying..."
+                        rm -f "$output" 2>/dev/null
+                        ;;
+                    23)
+                        warn "Write error when saving $desc. Retrying..."
+                        rm -f "$output" 2>/dev/null
+                        ;;
+                    *)
+                        warn "Download failed (curl exit code: $curl_exit_code). Retrying..."
+                        ;;
                 esac
-                rm -f "$output" 2>/dev/null
             fi
         elif command -v wget >/dev/null 2>&1; then
-            # Use wget with better error handling
-            if wget --progress=bar --tries=1 --timeout=30 "$url" -O "$output" 2>&1; then
+            # Use wget with resume support and a reasonable overall timeout
+            if wget -c --progress=bar --tries=1 --timeout=60 --read-timeout=30 "$url" -O "$output" 2>&1; then
                 download_success=true
             else
                 warn "Download failed. Retrying..."
@@ -1028,7 +1082,18 @@ download_file() {
         fi
         
         if [ "$download_success" = true ]; then
-            break
+            # Validate while we're still inside the retry loop so a corrupted or
+            # HTML-wrapped download counts as a retryable failure.
+            if [ "$validate" = "true" ]; then
+                if validate_downloaded_file "$output" "$desc" "$url"; then
+                    return 0
+                fi
+                warn "Validation failed for $desc. Retrying..."
+                rm -f "$output" 2>/dev/null
+                download_success=false
+            else
+                return 0
+            fi
         fi
         
         retry_count=$((retry_count + 1))
@@ -1039,49 +1104,14 @@ download_file() {
         fi
     done
     
-    # Check if download was successful
-    if [ ! -f "$output" ] || [ ! -s "$output" ]; then
-        error "Failed to download $desc from $url after $max_retries attempts.
-        
+    error "Failed to download $desc from $url after $max_retries attempts.
+    
 Possible causes:
   - Network connectivity issues
   - GitHub service temporarily unavailable (503 error)
   - File not found in release (404 error)
   
 Please try again later or check: https://github.com/${REPO}/releases/latest"
-    fi
-    
-    # Validate the downloaded file if requested
-    if [ "$validate" = "true" ]; then
-        # JAR files must be valid zip archives
-        if [[ "$output" == *.jar ]] || [[ "$desc" == *"JAR"* ]]; then
-            local jar_valid=false
-            if command -v jar >/dev/null 2>&1 && jar tf "$output" >/dev/null 2>&1; then
-                jar_valid=true
-            elif command -v unzip >/dev/null 2>&1 && unzip -t "$output" >/dev/null 2>&1; then
-                jar_valid=true
-            fi
-            if [ "$jar_valid" != true ]; then
-                warn "Downloaded JAR file appears to be corrupted (invalid zip). Removing invalid file."
-                rm -f "$output"
-                return 1
-            fi
-        fi
-
-        local require_shell="false"
-        # Check if this is a shell script download
-        if [[ "$desc" == *"shell script"* ]] || [[ "$url" == *.sh ]]; then
-            require_shell="true"
-        fi
-        
-        if ! validate_not_html "$output" "$desc" "$require_shell"; then
-            warn "Downloaded file appears to be invalid (HTML error page or not a valid shell script). Removing invalid file."
-            rm -f "$output"
-            return 1
-        fi
-    fi
-    
-    return 0
 }
 
 # Create installation directory

--- a/install.sh
+++ b/install.sh
@@ -557,7 +557,14 @@ installer_managed_artifacts_present() {
 }
 
 installer_managed_jar_present() {
-    [ -s "$JAR_PATH" ]
+    [ -s "$JAR_PATH" ] || return 1
+    if command -v jar >/dev/null 2>&1 && jar tf "$JAR_PATH" >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v unzip >/dev/null 2>&1 && unzip -t "$JAR_PATH" >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
 }
 
 installer_managed_script_present() {
@@ -983,12 +990,22 @@ download_file() {
         
         if command -v curl >/dev/null 2>&1; then
             # Use curl with better error handling
-            # For large files (like JAR), skip HTTP code check and download directly
-            # This avoids double download and handles redirects better
-            if curl -L --fail --connect-timeout 30 --max-time 300 "$url" -o "$output" 2>&1 | grep -v "^[[:space:]]*[0-9]"; then
+            # For large files (like JAR), use a long max-time and suppress the
+            # progress bar while still surfacing real errors.
+            local curl_log
+            curl_log=$(mktemp)
+            local curl_exit_code=0
+
+            curl -L --fail --connect-timeout 30 --max-time 1200 -s -S "$url" -o "$output" >"$curl_log" 2>&1 || curl_exit_code=$?
+
+            if [ -s "$curl_log" ]; then
+                cat "$curl_log" >&2
+            fi
+            rm -f "$curl_log"
+
+            if [ $curl_exit_code -eq 0 ]; then
                 download_success=true
             else
-                local curl_exit_code=$?
                 # Map curl exit codes to messages
                 case $curl_exit_code in
                     6|7) warn "Network error or timeout when downloading $desc. Retrying..." ;;
@@ -1036,6 +1053,21 @@ Please try again later or check: https://github.com/${REPO}/releases/latest"
     
     # Validate the downloaded file if requested
     if [ "$validate" = "true" ]; then
+        # JAR files must be valid zip archives
+        if [[ "$output" == *.jar ]] || [[ "$desc" == *"JAR"* ]]; then
+            local jar_valid=false
+            if command -v jar >/dev/null 2>&1 && jar tf "$output" >/dev/null 2>&1; then
+                jar_valid=true
+            elif command -v unzip >/dev/null 2>&1 && unzip -t "$output" >/dev/null 2>&1; then
+                jar_valid=true
+            fi
+            if [ "$jar_valid" != true ]; then
+                warn "Downloaded JAR file appears to be corrupted (invalid zip). Removing invalid file."
+                rm -f "$output"
+                return 1
+            fi
+        fi
+
         local require_shell="false"
         # Check if this is a shell script download
         if [[ "$desc" == *"shell script"* ]] || [[ "$url" == *.sh ]]; then

--- a/install.sh
+++ b/install.sh
@@ -1489,12 +1489,120 @@ download_script_from_repo() {
     return 1
 }
 
-# Download DMTools JAR
+# Download DMTools checksum file (best-effort; returns 0 even if not present)
+download_checksum_file() {
+    local version="$1"
+    local checksum_url="https://github.com/${REPO}/releases/download/${version}/dmtools-checksums.sha256"
+    local checksum_path="$INSTALL_DIR/dmtools-checksums.sha256"
+
+    # Try standard release URL
+    if download_file "$checksum_url" "$checksum_path" "DMTools checksums" "false" >/dev/null 2>&1; then
+        echo "$checksum_path"
+        return 0
+    fi
+
+    # Try GitHub API direct URL
+    local api_asset_url
+    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-checksums.sha256")
+    if [ -n "$api_asset_url" ]; then
+        if download_file "$api_asset_url" "$checksum_path" "DMTools checksums (from API)" "false" >/dev/null 2>&1; then
+            echo "$checksum_path"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+# Verify the downloaded JAR against the published SHA-256 checksum (if available).
+# Returns 0 when verified or when no checksum is available, 1 on mismatch.
+verify_jar_checksum() {
+    local version="$1"
+    local checksum_path
+    checksum_path=$(download_checksum_file "$version") || return 0
+
+    if [ ! -s "$checksum_path" ]; then
+        return 0
+    fi
+
+    local expected_checksum
+    expected_checksum=$(grep -o "^[a-f0-9A-F]\{64\}  dmtools-${version}-all.jar" "$checksum_path" 2>/dev/null | awk '{print $1}')
+    if [ -z "$expected_checksum" ]; then
+        warn "Could not find JAR checksum in $checksum_path — skipping checksum verification"
+        return 0
+    fi
+
+    if ! command -v sha256sum >/dev/null 2>&1 && ! command -v shasum >/dev/null 2>&1; then
+        warn "Neither sha256sum nor shasum is available — skipping checksum verification"
+        return 0
+    fi
+
+    local actual_checksum
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual_checksum=$(sha256sum "$JAR_PATH" | awk '{print $1}')
+    else
+        actual_checksum=$(shasum -a 256 "$JAR_PATH" | awk '{print $1}')
+    fi
+
+    if [ "$expected_checksum" != "$actual_checksum" ]; then
+        warn "JAR checksum mismatch! Expected: $expected_checksum, got: $actual_checksum"
+        return 1
+    fi
+
+    info "JAR checksum verified successfully."
+    return 0
+}
+
+# Download DMTools JAR with fallback to the GitHub API direct asset URL.
+# Verifies SHA-256 checksum when the checksum file is published in the release.
 download_dmtools_jar() {
     local version="$1"
     local jar_url="https://github.com/${REPO}/releases/download/${version}/dmtools-${version}-all.jar"
 
-    download_file "$jar_url" "$JAR_PATH" "DMTools JAR"
+    # Method 1: Standard release URL
+    if download_file "$jar_url" "$JAR_PATH" "DMTools JAR"; then
+        if verify_jar_checksum "$version"; then
+            return 0
+        fi
+        warn "Downloaded JAR failed checksum verification, retrying from alternative source..."
+        rm -f "$JAR_PATH"
+    fi
+
+    # Method 2: GitHub API direct asset URL (different CDN/blob, may work when
+    # the redirect-based release URL is slow or blocked)
+    warn "Standard release URL failed, trying GitHub API for direct asset URL..."
+    local api_asset_url
+    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-${version}-all.jar")
+
+    if [ -n "$api_asset_url" ]; then
+        if download_file "$api_asset_url" "$JAR_PATH" "DMTools JAR (from API)"; then
+            if verify_jar_checksum "$version"; then
+                return 0
+            fi
+            warn "JAR from API failed checksum verification."
+            rm -f "$JAR_PATH"
+        fi
+    fi
+
+    # All methods failed
+    error "Failed to download DMTools JAR for ${version}.
+
+Tried:
+  1. GitHub release URL: $jar_url
+  2. GitHub API asset URL: ${api_asset_url:-'(not available)'}
+
+The JAR file is required to run DMTools.
+
+Possible causes:
+  - Network connectivity issues or a very slow/unstable connection
+  - GitHub service temporarily unavailable (503 error)
+  - Release asset not found (404 error) — the version may not exist yet
+
+You can check available releases at:
+  https://github.com/${REPO}/releases
+
+Or try installing the previous known-good version manually:
+  curl -fsSL https://github.com/${REPO}/releases/download/vPREVIOUS/install.sh | bash -s -- vPREVIOUS"
 }
 
 # Download DMTools shell script


### PR DESCRIPTION
The `install.sh` shipped with v1.7.219 has a broken `download_file()` helper that treats partial/corrupted downloads as successful.

### Root cause
The previous code used:
```bash
if curl -L --fail ... -o "" 2>&1 | grep -v "^[[:space:]]*[0-9]"; then
    download_success=true
```
Any stderr line that didn't start with a digit (including curl timeout/error messages) made the condition true, so a failed download left a truncated JAR on disk and the installer considered it successful. The next run then skipped re-downloading because the file was "already present".

### Fixes in this PR
- **Check `curl` exit code directly** instead of grepping its output.
- **Resume interrupted downloads** with `curl -C -` / `wget -c`.
- **Detect stalled transfers** with `--speed-time/--speed-limit`.
- **Validate JAR integrity** inside the retry loop using `jar tf` / `unzip -t`.
- **Regard corrupted local JARs as missing** so they are re-downloaded.
- **Generate `dmtools-checksums.sha256`** for CLI artifacts in the release workflow.
- **Verify the JAR SHA-256** after download when the checksum file is available.
- **Add GitHub API direct-asset fallback** for the JAR when the standard release URL fails.
- **Provide a clear error message** listing the tried URLs and next steps when the JAR cannot be downloaded.

### New smoke test
- `CliJarSmokeTest` runs the assembled shadow JAR with `dmtools mcp list file` during `check` via the new `shadowJarSmokeTest` Gradle task.

### Impact
Fixes the "Could not find or load main class com.github.istin.dmtools.job.JobRunner" error users see when the downloaded CLI JAR is truncated, and prevents broken JARs from being accepted by future installs.