### PR TITLE
fix(gitlab): add gitlab_get_mr_diff_text tool returning raw unified diff

### DIFF
--- a/dmtools-ai-docs/CHANGELOG.md
+++ b/dmtools-ai-docs/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [skill-v1.0.29] - 2026-07-03
+
+### Added
+
+- **New GitLab MCP tool**: `gitlab_get_mr_diff_text` — returns the raw unified diff text for a GitLab merge request (as a `String`), suitable for locating file/line positions (e.g. inline PR review comments). Complements the existing `gitlab_get_mr_diff` (returns `IDiffStats`, stats-only) the same way `github_get_pr_diff_text` complements `github_get_pr_diff` on the GitHub side.
+- Updated **Total tools** count in `gitlab-tools.md`: 22 → 23, and in `mcp-tools/README.md`: 270 → 271
+
 ## [skill-v1.0.28] - 2026-05-01
 
 ### Changed

--- a/dmtools-ai-docs/references/mcp-tools/README.md
+++ b/dmtools-ai-docs/references/mcp-tools/README.md
@@ -3,7 +3,7 @@
 Complete reference for all MCP tools available in DMtools.
 
 **Total Integrations**: 20
-**Total Tools**: 270
+**Total Tools**: 271
 
 *Auto-generated from `dmtools list` on: 2026-06-15 14:42:13*
 
@@ -34,7 +34,7 @@ dmtools <tool_name> [arguments]
 | **FILE** | 5 | [file-tools.md](file-tools.md) |
 | **GEMINI** | 2 | [gemini-tools.md](gemini-tools.md) |
 | **GITHUB** | 33 | [github-tools.md](github-tools.md) |
-| **GITLAB** | 22 | [gitlab-tools.md](gitlab-tools.md) |
+| **GITLAB** | 23 | [gitlab-tools.md](gitlab-tools.md) |
 | **JIRA** | 66 | [jira-tools.md](jira-tools.md) |
 | **KB** | 5 | [kb-tools.md](kb-tools.md) |
 | **MERMAID** | 3 | [mermaid-tools.md](mermaid-tools.md) |

--- a/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
@@ -1,6 +1,6 @@
 # GITLAB MCP Tools
 
-**Total Tools**: 22
+**Total Tools**: 23
 
 ## Quick Reference
 
@@ -36,6 +36,7 @@ const result = gitlab_remove_mr_label(...);
 | `gitlab_get_mr_activities` | Get all activities for a GitLab merge request including approvals and general discussion notes. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_comments` | Get all comments for a GitLab merge request, including both inline code review comments (DiffNote) and general discussion notes. Excludes system-generated notes. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_diff` | Get diff stats and changed files for a GitLab merge request. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
+| `gitlab_get_mr_diff_text` | Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments). | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_discussions` | Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_pipeline_jobs` | List jobs for a GitLab CI pipeline. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`pipelineId` (string, **required**) |
 | `gitlab_list_mrs` | List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`state` (string, **required**) |
@@ -424,6 +425,36 @@ dmtools gitlab_get_mr_diff "value" "value"
 ```javascript
 // In JavaScript agent
 const result = gitlab_get_mr_diff("repository", "pullRequestId");
+```
+
+---
+
+### `gitlab_get_mr_diff_text`
+
+Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments).
+
+**Parameters:**
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`pullRequestId`** (string) 🔴 Required
+  - Merge request IID
+  - Example: `42`
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+**Example:**
+```bash
+dmtools gitlab_get_mr_diff_text "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_get_mr_diff_text("repository", "pullRequestId");
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/gitlab/GitLab.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/gitlab/GitLab.java
@@ -396,6 +396,66 @@ public abstract class GitLab extends AbstractRestClient implements SourceCode {
         return parseDiffStats(new JSONObject(mergeRequestChanges));
     }
 
+    @MCPTool(
+        name = "gitlab_get_mr_diff_text",
+        description = "Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments).",
+        integration = "gitlab",
+        category = "merge_requests"
+    )
+    public String getPullRequestDiffText(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "pullRequestId", description = "Merge request IID", required = true, example = "42") String pullRequestID) throws IOException {
+        String mergeRequestChanges = getMergeRequestChanges(workspace, repository, pullRequestID);
+        if (mergeRequestChanges == null) {
+            return "";
+        }
+        return buildUnifiedDiffText(new JSONObject(mergeRequestChanges));
+    }
+
+    /**
+     * The GitLab "changes" API returns each file's diff as a bare hunk body (starting at
+     * {@code @@ ... @@}), without the leading {@code diff --git a/... b/...} / {@code --- a/...}
+     * / {@code +++ b/...} header lines that a standard {@code git diff}/unified diff produces.
+     * Callers that parse unified diff text (e.g. to map an inline review comment to a specific
+     * file/line) need those headers to identify which file a hunk belongs to, so we reconstruct
+     * them here from the per-change metadata.
+     */
+    private static String buildUnifiedDiffText(JSONObject response) {
+        JSONArray changes = response.optJSONArray("changes");
+        if (changes == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < changes.length(); i++) {
+            JSONObject change = changes.getJSONObject(i);
+            String oldPath = change.optString("old_path", change.optString("new_path", ""));
+            String newPath = change.optString("new_path", oldPath);
+            boolean isNewFile = change.optBoolean("new_file", false);
+            boolean isDeletedFile = change.optBoolean("deleted_file", false);
+            String diff = change.optString("diff", "");
+
+            sb.append("diff --git a/").append(oldPath).append(" b/").append(newPath).append("\n");
+            if (isNewFile) {
+                sb.append("new file mode 100644\n");
+                sb.append("--- /dev/null\n");
+                sb.append("+++ b/").append(newPath).append("\n");
+            } else if (isDeletedFile) {
+                sb.append("deleted file mode 100644\n");
+                sb.append("--- a/").append(oldPath).append("\n");
+                sb.append("+++ /dev/null\n");
+            } else {
+                sb.append("--- a/").append(oldPath).append("\n");
+                sb.append("+++ b/").append(newPath).append("\n");
+            }
+            sb.append(diff);
+            if (!diff.endsWith("\n")) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
     private boolean isMRChangesError = false;
     private String getMergeRequestChanges(String workspace, String repository, String pullRequestId) throws IOException {
         if (isMRChangesError) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/gitlab/GitLabTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/gitlab/GitLabTest.java
@@ -457,4 +457,103 @@ public class GitLabTest {
                 .put("system", false)
                 .put("author", new JSONObject().put("id", 10).put("username", "user1"));
     }
+
+    // ── gitlab_get_mr_diff_text ──────────────────────────────────────────────
+    //
+    // GitLab's /merge_requests/:iid/changes endpoint returns each file's diff as a bare
+    // hunk body (starting at "@@ ... @@"), without the "diff --git a/... b/...",
+    // "--- a/...", "+++ b/..." header lines that a standard unified diff has. Callers
+    // that parse unified diff text to locate a specific file/line (e.g. inline PR review
+    // comments) need those headers, so getPullRequestDiffText() reconstructs them.
+
+    @Test
+    public void testGetPullRequestDiffText_modifiedFile() throws IOException {
+        JSONObject change = new JSONObject()
+                .put("old_path", "src/Foo.java")
+                .put("new_path", "src/Foo.java")
+                .put("new_file", false)
+                .put("deleted_file", false)
+                .put("diff", "@@ -1,3 +1,4 @@\n context\n+added line\n-removed line\n unchanged\n");
+        JSONObject response = new JSONObject().put("changes", new JSONArray().put(change));
+
+        doReturn(response.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String diffText = gitLab.getPullRequestDiffText("workspace", "repo", "42");
+
+        assertTrue("Should contain diff --git header", diffText.contains("diff --git a/src/Foo.java b/src/Foo.java"));
+        assertTrue("Should contain --- a/ header", diffText.contains("--- a/src/Foo.java"));
+        assertTrue("Should contain +++ b/ header", diffText.contains("+++ b/src/Foo.java"));
+        assertTrue("Should contain the hunk", diffText.contains("@@ -1,3 +1,4 @@"));
+        assertTrue("Should contain added line", diffText.contains("+added line"));
+        assertFalse("Should not be a broken Java object toString", diffText.matches("^[A-Za-z0-9_.$]+@[0-9a-f]+$"));
+    }
+
+    @Test
+    public void testGetPullRequestDiffText_newFile() throws IOException {
+        JSONObject change = new JSONObject()
+                .put("old_path", "src/New.java")
+                .put("new_path", "src/New.java")
+                .put("new_file", true)
+                .put("deleted_file", false)
+                .put("diff", "@@ -0,0 +1,2 @@\n+line one\n+line two\n");
+        JSONObject response = new JSONObject().put("changes", new JSONArray().put(change));
+
+        doReturn(response.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String diffText = gitLab.getPullRequestDiffText("workspace", "repo", "42");
+
+        assertTrue(diffText.contains("diff --git a/src/New.java b/src/New.java"));
+        assertTrue("New file marker expected", diffText.contains("new file mode 100644"));
+        assertTrue("Old side must be /dev/null", diffText.contains("--- /dev/null"));
+        assertTrue(diffText.contains("+++ b/src/New.java"));
+    }
+
+    @Test
+    public void testGetPullRequestDiffText_deletedFile() throws IOException {
+        JSONObject change = new JSONObject()
+                .put("old_path", "src/Old.java")
+                .put("new_path", "src/Old.java")
+                .put("new_file", false)
+                .put("deleted_file", true)
+                .put("diff", "@@ -1,2 +0,0 @@\n-line one\n-line two\n");
+        JSONObject response = new JSONObject().put("changes", new JSONArray().put(change));
+
+        doReturn(response.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String diffText = gitLab.getPullRequestDiffText("workspace", "repo", "42");
+
+        assertTrue(diffText.contains("diff --git a/src/Old.java b/src/Old.java"));
+        assertTrue("Deleted file marker expected", diffText.contains("deleted file mode 100644"));
+        assertTrue("Old side must reference the original path", diffText.contains("--- a/src/Old.java"));
+        assertTrue("New side must be /dev/null", diffText.contains("+++ /dev/null"));
+    }
+
+    @Test
+    public void testGetPullRequestDiffText_multipleFiles() throws IOException {
+        JSONObject change1 = new JSONObject()
+                .put("old_path", "a.java").put("new_path", "a.java")
+                .put("new_file", false).put("deleted_file", false)
+                .put("diff", "@@ -1,1 +1,1 @@\n-old\n+new\n");
+        JSONObject change2 = new JSONObject()
+                .put("old_path", "b.java").put("new_path", "b.java")
+                .put("new_file", false).put("deleted_file", false)
+                .put("diff", "@@ -1,1 +1,1 @@\n-old2\n+new2\n");
+        JSONObject response = new JSONObject().put("changes", new JSONArray().put(change1).put(change2));
+
+        doReturn(response.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String diffText = gitLab.getPullRequestDiffText("workspace", "repo", "42");
+
+        assertTrue(diffText.contains("diff --git a/a.java b/a.java"));
+        assertTrue(diffText.contains("diff --git a/b.java b/b.java"));
+        assertTrue("a.java diff --git must appear before b.java's",
+                diffText.indexOf("a/a.java") < diffText.indexOf("a/b.java"));
+    }
+
+    @Test
+    public void testGetPullRequestDiffText_nullChangesReturnsEmptyString() throws IOException {
+        doReturn(null).when(gitLab).execute(any(GenericRequest.class));
+        String diffText = gitLab.getPullRequestDiffText("workspace", "repo", "42");
+        assertEquals("", diffText);
+    }
 }


### PR DESCRIPTION
## Problem

The existing `gitlab_get_mr_diff` MCP tool returns an `IDiffStats` object. When this object is exposed through the MCP/CLI/GraalJS bridge, it gets serialized via its default `Object.toString()` (e.g. `com.github.istin.dmtools.gitlab.GitLab$4@b2c4a8b`) instead of any usable diff content — `IDiffStats` has no defined string/JSON representation.

Any caller that expects raw unified diff text (e.g. to locate a specific file/line in order to post an inline PR review comment) receives this garbage string and can never find its target line, silently degrading to non-inline behavior.

This is the exact same limitation the GitHub integration already had — solved previously by adding a dedicated `github_get_pr_diff_text` tool (returns `String`) alongside the existing `github_get_pr_diff` (returns `IDiffStats`, unchanged, still used for stats-only callers).

## Fix

Add `gitlab_get_mr_diff_text` (returns `String`) to `GitLab.java`, mirroring the GitHub pattern exactly:

- Reuses the same underlying `/merge_requests/:iid/changes` API call (`getMergeRequestChanges`)
- Reconstructs a standard unified diff (`diff --git a/... b/...`, `--- a/...`, `+++ b/...` headers + hunks) since GitLab's `changes` API returns only the bare hunk body per file, without those header lines
- Handles new files, deleted files, and modified files correctly

**Purely additive** — does not touch `gitlab_get_mr_diff`, `getPullRequestDiff`, or any other GitLab caller/consumer. No breaking changes.

## Testing

- Added 5 unit tests in `GitLabTest.java`: modified file, new file, deleted file, multiple files, null-response handling
- Full `dmtools-core` test suite passes (no regressions)

## Consumer-side context

This was discovered while debugging why an AI-driven PR review agent's inline comments on GitLab MRs were silently falling back to generic top-level comments instead of proper inline diff threads — the agent's diff-parsing logic received the broken `IDiffStats` toString from `gitlab_get_mr_diff` and could never match a line. Once this tool ships, the consumer can be updated to prefer `gitlab_get_mr_diff_text` the same way it already prefers `github_get_pr_diff_text` over `github_get_pr_diff`.