### PR TITLE
Add GitLab release/artefact MCP tools (Generic Package Registry + Release Links)

### DIFF
--- a/dmtools-ai-docs/CHANGELOG.md
+++ b/dmtools-ai-docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [skill-v1.0.30] - 2026-07-04
+
+### Added
+
+- **New GitLab release/artefact MCP tools** (mirroring GitHub's release-asset tools, adapted to GitLab's Generic Package Registry + Release Links model):
+  - `gitlab_get_or_create_release` — find an existing GitLab release by tag, or create one if missing.
+  - `gitlab_upload_release_asset` — publish a local file to the project's Generic Package Registry and attach it to the release as an asset link; supports `overwrite=true` to replace an existing asset (GitLab rejects duplicate uploads with 409 Conflict otherwise).
+  - `gitlab_list_release_assets` — list all asset links attached to a release.
+  - `gitlab_delete_release_asset` — delete an asset's release link and its underlying Generic Package Registry file by name.
+  - `gitlab_download_release_asset` — download a release asset to a local file path.
+  - Enables GitLab-backed repositories to use the same "stable release as artefact storage" pattern already supported for GitHub via `github_get_or_create_draft_release`/`github_upload_release_asset`.
+- Updated **Total tools** count in `gitlab-tools.md`: 23 → 28
+
 ## [skill-v1.0.29] - 2026-07-03
 
 ### Added

--- a/dmtools-ai-docs/references/mcp-tools/README.md
+++ b/dmtools-ai-docs/references/mcp-tools/README.md
@@ -3,7 +3,7 @@
 Complete reference for all MCP tools available in DMtools.
 
 **Total Integrations**: 20
-**Total Tools**: 271
+**Total Tools**: 276
 
 *Auto-generated from `dmtools list` on: 2026-06-15 14:42:13*
 
@@ -34,7 +34,7 @@ dmtools <tool_name> [arguments]
 | **FILE** | 5 | [file-tools.md](file-tools.md) |
 | **GEMINI** | 2 | [gemini-tools.md](gemini-tools.md) |
 | **GITHUB** | 33 | [github-tools.md](github-tools.md) |
-| **GITLAB** | 23 | [gitlab-tools.md](gitlab-tools.md) |
+| **GITLAB** | 28 | [gitlab-tools.md](gitlab-tools.md) |
 | **JIRA** | 66 | [jira-tools.md](jira-tools.md) |
 | **KB** | 5 | [kb-tools.md](kb-tools.md) |
 | **MERMAID** | 3 | [mermaid-tools.md](mermaid-tools.md) |

--- a/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
@@ -1,6 +1,6 @@
 # GITLAB MCP Tools
 
-**Total Tools**: 23
+**Total Tools**: 28
 
 ## Quick Reference
 
@@ -31,6 +31,8 @@ const result = gitlab_remove_mr_label(...);
 | `gitlab_approve_mr` | Approve a GitLab merge request. Adds your approval to the MR. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_cancel_job` | Cancel a GitLab CI job. | `repository` (string, **required**)<br>`jobId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_create_mr` | Create a GitLab merge request from a source branch into a target branch. | `removeSourceBranch` (string, optional)<br>`workspace` (string, **required**)<br>`targetBranch` (string, **required**)<br>`sourceBranch` (string, **required**)<br>`description` (string, optional)<br>`repository` (string, **required**)<br>`title` (string, **required**) |
+| `gitlab_delete_release_asset` | Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`assetName` (string, **required**)<br>`packageName` (string, optional) |
+| `gitlab_download_release_asset` | Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`assetName` (string, **required**)<br>`targetFilePath` (string, **required**)<br>`packageName` (string, optional) |
 | `gitlab_get_job_logs` | Get GitLab CI job trace logs. | `repository` (string, **required**)<br>`jobId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr` | Get details of a specific GitLab merge request including title, description, state, author, diff_refs (base_sha, head_sha, start_sha needed for inline comments). | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_activities` | Get all activities for a GitLab merge request including approvals and general discussion notes. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
@@ -38,16 +40,19 @@ const result = gitlab_remove_mr_label(...);
 | `gitlab_get_mr_diff` | Get diff stats and changed files for a GitLab merge request. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_diff_text` | Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments). | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_get_mr_discussions` | Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
+| `gitlab_get_or_create_release` | Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`releaseName` (string, optional)<br>`targetCommitish` (string, optional)<br>`body` (string, optional) |
 | `gitlab_get_pipeline_jobs` | List jobs for a GitLab CI pipeline. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`pipelineId` (string, **required**) |
 | `gitlab_list_mrs` | List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`state` (string, **required**) |
 | `gitlab_list_pipeline_runs` | List recent GitLab CI pipelines. Optionally filter by status, ref, and limit. | `limit` (string, optional)<br>`workspace` (string, **required**)<br>`ref` (string, optional)<br>`repository` (string, **required**)<br>`status` (string, optional) |
 | `gitlab_list_project_jobs` | List recent GitLab CI jobs for a project. | `repository` (string, **required**)<br>`workspace` (string, **required**) |
+| `gitlab_list_release_assets` | List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**) |
 | `gitlab_merge_mr` | Merge a GitLab merge request. Optionally provide a custom merge commit message. | `workspace` (string, **required**)<br>`mergeCommitMessage` (string, optional)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
 | `gitlab_rebase_mr` | Ask GitLab to rebase/update a merge request source branch with its target branch. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
 | `gitlab_remove_mr_label` | Remove a label from a GitLab merge request. | `workspace` (string, **required**)<br>`label` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
 | `gitlab_reply_to_mr_thread` | Reply to an existing discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions. | `workspace` (string, **required**)<br>`text` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`discussionId` (string, **required**) |
 | `gitlab_resolve_mr_thread` | Resolve (close) a review discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`discussionId` (string, **required**) |
 | `gitlab_trigger_pipeline` | Trigger a GitLab CI pipeline for a branch or tag using the authenticated API token. | `variablesJson` (string, optional)<br>`workspace` (string, **required**)<br>`ref` (string, **required**)<br>`repository` (string, **required**) |
+| `gitlab_upload_release_asset` | Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise). | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`filePath` (string, **required**)<br>`assetName` (string, optional)<br>`contentType` (string, optional)<br>`packageName` (string, optional)<br>`overwrite` (string, optional) |
 
 ## Detailed Parameter Information
 
@@ -817,3 +822,205 @@ const result = gitlab_trigger_pipeline("variablesJson", "workspace");
 
 ---
 
+
+### `gitlab_get_or_create_release`
+
+Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`tagName`** (string) 🔴 Required
+  - The Git tag name for the release. Reused to find an existing release.
+  - Example: `pr-attachments-storage`
+
+- **`releaseName`** (string) ⚪ Optional
+  - The human-readable release name. If empty, tagName is used.
+  - Example: `PR Attachments Storage`
+
+- **`targetCommitish`** (string) ⚪ Optional
+  - Optional branch or commit SHA the release's tag should point to when created (GitLab 'ref'). Required if the tag does not already exist.
+  - Example: `main`
+
+- **`body`** (string) ⚪ Optional
+  - Optional Markdown release notes/description.
+  - Example: `Internal storage release for PR attachments.`
+
+**Example:**
+```bash
+dmtools gitlab_get_or_create_release "value" "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_get_or_create_release("workspace", "repository", "tagName");
+```
+
+---
+
+### `gitlab_upload_release_asset`
+
+Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise).
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`tagName`** (string) 🔴 Required
+  - The tag name of the release returned by gitlab_get_or_create_release.
+  - Example: `pr-attachments-storage`
+
+- **`filePath`** (string) 🔴 Required
+  - Absolute or relative path to the local file to upload.
+  - Example: `/tmp/preview.png`
+
+- **`assetName`** (string) ⚪ Optional
+  - Optional asset filename shown in GitLab. Defaults to the local filename.
+  - Example: `clip_123.png`
+
+- **`contentType`** (string) ⚪ Optional
+  - Optional MIME type. Defaults to detected type or application/octet-stream.
+  - Example: `image/png`
+
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.
+  - Example: `release-assets`
+
+- **`overwrite`** (string) ⚪ Optional
+  - If true, delete any existing asset (release link + underlying generic package file) with the same name before uploading. Defaults to false.
+  - Example: `true`
+
+**Example:**
+```bash
+dmtools gitlab_upload_release_asset "value" "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_upload_release_asset("workspace", "repository", "tagName");
+```
+
+---
+
+### `gitlab_list_release_assets`
+
+List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`tagName`** (string) 🔴 Required
+  - The tag name of the release.
+  - Example: `pr-attachments-storage`
+
+**Example:**
+```bash
+dmtools gitlab_list_release_assets "value" "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_list_release_assets("workspace", "repository", "tagName");
+```
+
+---
+
+### `gitlab_delete_release_asset`
+
+Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`tagName`** (string) 🔴 Required
+  - The tag name of the release.
+  - Example: `pr-attachments-storage`
+
+- **`assetName`** (string) 🔴 Required
+  - The name of the asset to delete, as returned by gitlab_list_release_assets.
+  - Example: `clip_123.png`
+
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
+  - Example: `release-assets`
+
+**Example:**
+```bash
+dmtools gitlab_delete_release_asset "value" "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_delete_release_asset("workspace", "repository", "tagName");
+```
+
+---
+
+### `gitlab_download_release_asset`
+
+Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
+- **`tagName`** (string) 🔴 Required
+  - The tag name of the release.
+  - Example: `pr-attachments-storage`
+
+- **`assetName`** (string) 🔴 Required
+  - The name of the asset to download, as returned by gitlab_list_release_assets.
+  - Example: `clip_123.png`
+
+- **`targetFilePath`** (string) 🔴 Required
+  - Local file path where the downloaded asset should be saved.
+  - Example: `/tmp/downloaded_clip_123.png`
+
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
+  - Example: `release-assets`
+
+**Example:**
+```bash
+dmtools gitlab_download_release_asset "value" "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = gitlab_download_release_asset("workspace", "repository", "tagName");
+```
+
+---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/gitlab/GitLab.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/gitlab/GitLab.java
@@ -19,7 +19,10 @@ import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -1038,6 +1041,298 @@ public abstract class GitLab extends AbstractRestClient implements SourceCode {
         GenericRequest getRequest = new GenericRequest(this, path);
         String response = execute(getRequest);
         return response != null ? response : "";
+    }
+
+    @MCPTool(
+        name = "gitlab_get_or_create_release",
+        description = "Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created.",
+        integration = "gitlab",
+        category = "releases"
+    )
+    public String getOrCreateRelease(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "tagName", description = "The Git tag name for the release. Reused to find an existing release.", required = true, example = "pr-attachments-storage") String tagName,
+            @MCPParam(name = "releaseName", description = "The human-readable release name. If empty, tagName is used.", required = false, example = "PR Attachments Storage") String releaseName,
+            @MCPParam(name = "targetCommitish", description = "Optional branch or commit SHA the release's tag should point to when created (GitLab 'ref'). Required if the tag does not already exist.", required = false, example = "main") String targetCommitish,
+            @MCPParam(name = "body", description = "Optional Markdown release notes/description.", required = false, example = "Internal storage release for PR attachments.") String body) throws IOException {
+        String normalizedReleaseName = isBlank(releaseName) ? tagName : releaseName.trim();
+        JSONObject existingRelease = findReleaseByTag(workspace, repository, tagName);
+        if (existingRelease != null) {
+            return existingRelease.toString();
+        }
+        return createRelease(workspace, repository, tagName, normalizedReleaseName, targetCommitish, body);
+    }
+
+    @MCPTool(
+        name = "gitlab_upload_release_asset",
+        description = "Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise).",
+        integration = "gitlab",
+        category = "releases"
+    )
+    public String uploadReleaseAsset(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "tagName", description = "The tag name of the release returned by gitlab_get_or_create_release.", required = true, example = "pr-attachments-storage") String tagName,
+            @MCPParam(name = "filePath", description = "Absolute or relative path to the local file to upload.", required = true, example = "/tmp/preview.png") String filePath,
+            @MCPParam(name = "assetName", description = "Optional asset filename shown in GitLab. Defaults to the local filename.", required = false, example = "clip_123.png") String assetName,
+            @MCPParam(name = "contentType", description = "Optional MIME type. Defaults to detected type or application/octet-stream.", required = false, example = "image/png") String contentType,
+            @MCPParam(name = "packageName", description = "Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.", required = false, example = "release-assets") String packageName,
+            @MCPParam(name = "overwrite", description = "If true, delete any existing asset (release link + underlying generic package file) with the same name before uploading. Defaults to false.", required = false, example = "true") String overwrite) throws IOException {
+        File assetFile = new File(filePath);
+        if (!assetFile.exists()) {
+            throw new FileNotFoundException("Release asset file not found: " + assetFile.getAbsolutePath());
+        }
+        if (!assetFile.isFile()) {
+            throw new IllegalArgumentException("Release asset path must point to a file: " + assetFile.getAbsolutePath());
+        }
+        String resolvedAssetName = isBlank(assetName) ? assetFile.getName() : assetName.trim();
+        String resolvedPackageName = sanitizePackageComponent(isBlank(packageName) ? "release-assets" : packageName.trim());
+        String packageVersion = sanitizePackageComponent(tagName);
+        if (Boolean.parseBoolean(overwrite)) {
+            deleteExistingAssetByName(workspace, repository, tagName, resolvedPackageName, packageVersion, resolvedAssetName);
+        }
+        String resolvedContentType = resolveAssetContentType(assetFile, contentType);
+        String uploadUrl = path(String.format("projects/%s/packages/generic/%s/%s/%s",
+                getEncodedProject(workspace, repository), resolvedPackageName, packageVersion, urlEncodePathSegment(resolvedAssetName)));
+        uploadGenericPackageBinary(uploadUrl, assetFile, resolvedContentType);
+
+        String directAssetPath = "/" + resolvedPackageName + "/" + packageVersion + "/" + resolvedAssetName;
+        String downloadUrl = uploadUrl;
+
+        String linksPath = path(String.format("projects/%s/releases/%s/assets/links",
+                getEncodedProject(workspace, repository), urlEncodePathSegment(tagName)));
+        GenericRequest postRequest = new GenericRequest(this, linksPath);
+        JSONObject linkBody = new JSONObject();
+        linkBody.put("name", resolvedAssetName);
+        linkBody.put("url", downloadUrl);
+        linkBody.put("direct_asset_path", directAssetPath);
+        linkBody.put("link_type", "package");
+        postRequest.setBody(linkBody.toString());
+        return post(postRequest);
+    }
+
+    @MCPTool(
+        name = "gitlab_list_release_assets",
+        description = "List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url.",
+        integration = "gitlab",
+        category = "releases"
+    )
+    public String listReleaseAssets(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "tagName", description = "The tag name of the release.", required = true, example = "pr-attachments-storage") String tagName) throws IOException {
+        String path = path(String.format("projects/%s/releases/%s/assets/links",
+                getEncodedProject(workspace, repository), urlEncodePathSegment(tagName)));
+        GenericRequest getRequest = new GenericRequest(this, path);
+        String response = execute(getRequest);
+        return response != null ? response : "[]";
+    }
+
+    @MCPTool(
+        name = "gitlab_delete_release_asset",
+        description = "Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names.",
+        integration = "gitlab",
+        category = "releases"
+    )
+    public void deleteReleaseAsset(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "tagName", description = "The tag name of the release.", required = true, example = "pr-attachments-storage") String tagName,
+            @MCPParam(name = "assetName", description = "The name of the asset to delete, as returned by gitlab_list_release_assets.", required = true, example = "clip_123.png") String assetName,
+            @MCPParam(name = "packageName", description = "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.", required = false, example = "release-assets") String packageName) throws IOException {
+        String resolvedPackageName = sanitizePackageComponent(isBlank(packageName) ? "release-assets" : packageName.trim());
+        String packageVersion = sanitizePackageComponent(tagName);
+        deleteExistingAssetByName(workspace, repository, tagName, resolvedPackageName, packageVersion, assetName);
+    }
+
+    @MCPTool(
+        name = "gitlab_download_release_asset",
+        description = "Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path.",
+        integration = "gitlab",
+        category = "releases"
+    )
+    public String downloadReleaseAsset(
+            @MCPParam(name = "workspace", description = "GitLab group or namespace", required = true, example = "mygroup") String workspace,
+            @MCPParam(name = "repository", description = "Repository name", required = true, example = "myrepo") String repository,
+            @MCPParam(name = "tagName", description = "The tag name of the release.", required = true, example = "pr-attachments-storage") String tagName,
+            @MCPParam(name = "assetName", description = "The name of the asset to download, as returned by gitlab_list_release_assets.", required = true, example = "clip_123.png") String assetName,
+            @MCPParam(name = "targetFilePath", description = "Local file path where the downloaded asset should be saved.", required = true, example = "/tmp/downloaded_clip_123.png") String targetFilePath,
+            @MCPParam(name = "packageName", description = "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.", required = false, example = "release-assets") String packageName) throws IOException {
+        String resolvedPackageName = sanitizePackageComponent(isBlank(packageName) ? "release-assets" : packageName.trim());
+        String packageVersion = sanitizePackageComponent(tagName);
+        String downloadPath = path(String.format("projects/%s/packages/generic/%s/%s/%s",
+                getEncodedProject(workspace, repository), resolvedPackageName, packageVersion, urlEncodePathSegment(assetName)));
+        return downloadBinaryToFile(downloadPath, new File(targetFilePath));
+    }
+
+    private JSONObject findReleaseByTag(String workspace, String repository, String tagName) throws IOException {
+        int perPage = 100;
+        int page = 1;
+        while (true) {
+            String releasesPath = path(String.format("projects/%s/releases", getEncodedProject(workspace, repository)));
+            GenericRequest getRequest = new GenericRequest(this, releasesPath);
+            getRequest.param("per_page", perPage);
+            getRequest.param("page", page);
+            String response = execute(getRequest);
+            if (response == null || response.isEmpty()) {
+                return null;
+            }
+            JSONArray releases = new JSONArray(response);
+            for (int i = 0; i < releases.length(); i++) {
+                JSONObject release = releases.getJSONObject(i);
+                if (tagName.equals(release.optString("tag_name"))) {
+                    return release;
+                }
+            }
+            if (releases.length() < perPage) {
+                return null;
+            }
+            page++;
+        }
+    }
+
+    private String createRelease(String workspace, String repository, String tagName, String releaseName,
+                                  String targetCommitish, String body) throws IOException {
+        String releasesPath = path(String.format("projects/%s/releases", getEncodedProject(workspace, repository)));
+        GenericRequest postRequest = new GenericRequest(this, releasesPath);
+        JSONObject releaseBody = new JSONObject();
+        releaseBody.put("tag_name", tagName);
+        releaseBody.put("name", releaseName);
+        if (!isBlank(targetCommitish)) {
+            releaseBody.put("ref", targetCommitish.trim());
+        }
+        if (!isBlank(body)) {
+            releaseBody.put("description", body);
+        }
+        postRequest.setBody(releaseBody.toString());
+        return post(postRequest);
+    }
+
+    private void deleteExistingAssetByName(String workspace, String repository, String tagName,
+                                            String packageName, String packageVersion, String assetName) throws IOException {
+        // Delete the release link first (if present), then the underlying generic package file.
+        String linksPath = path(String.format("projects/%s/releases/%s/assets/links",
+                getEncodedProject(workspace, repository), urlEncodePathSegment(tagName)));
+        GenericRequest getLinksRequest = new GenericRequest(this, linksPath);
+        String linksResponse = execute(getLinksRequest);
+        if (linksResponse != null && !linksResponse.isEmpty()) {
+            JSONArray links = new JSONArray(linksResponse);
+            for (int i = 0; i < links.length(); i++) {
+                JSONObject link = links.getJSONObject(i);
+                if (assetName.equals(link.optString("name"))) {
+                    String linkId = String.valueOf(link.getLong("id"));
+                    String deleteLinkPath = path(String.format("projects/%s/releases/%s/assets/links/%s",
+                            getEncodedProject(workspace, repository), urlEncodePathSegment(tagName), linkId));
+                    GenericRequest deleteLinkRequest = new GenericRequest(this, deleteLinkPath);
+                    delete(deleteLinkRequest);
+                    break;
+                }
+            }
+        }
+
+        String packageId = findGenericPackageId(workspace, repository, packageName, packageVersion);
+        if (packageId != null) {
+            String deletePackagePath = path(String.format("projects/%s/packages/%s",
+                    getEncodedProject(workspace, repository), packageId));
+            GenericRequest deletePackageRequest = new GenericRequest(this, deletePackagePath);
+            delete(deletePackageRequest);
+        }
+    }
+
+    private String findGenericPackageId(String workspace, String repository, String packageName, String packageVersion) throws IOException {
+        String packagesPath = path(String.format("projects/%s/packages", getEncodedProject(workspace, repository)));
+        GenericRequest getRequest = new GenericRequest(this, packagesPath);
+        getRequest.param("package_type", "generic");
+        getRequest.param("package_name", packageName);
+        getRequest.param("package_version", packageVersion);
+        String response = execute(getRequest);
+        if (response == null || response.isEmpty()) {
+            return null;
+        }
+        JSONArray packages = new JSONArray(response);
+        for (int i = 0; i < packages.length(); i++) {
+            JSONObject pkg = packages.getJSONObject(i);
+            if (packageName.equals(pkg.optString("name")) && packageVersion.equals(pkg.optString("version"))) {
+                return String.valueOf(pkg.getLong("id"));
+            }
+        }
+        return null;
+    }
+
+    private String resolveAssetContentType(File assetFile, String explicitContentType) throws IOException {
+        if (!isBlank(explicitContentType)) {
+            return explicitContentType.trim();
+        }
+        String detected = Files.probeContentType(assetFile.toPath());
+        if (isBlank(detected)) {
+            detected = java.net.URLConnection.guessContentTypeFromName(assetFile.getName());
+        }
+        return isBlank(detected) ? "application/octet-stream" : detected;
+    }
+
+    protected String uploadGenericPackageBinary(String uploadUrl, File assetFile, String contentType) throws IOException {
+        okhttp3.MediaType mediaType = okhttp3.MediaType.parse(contentType);
+        if (mediaType == null) {
+            throw new IllegalArgumentException("Invalid content type for release asset upload: " + contentType);
+        }
+        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(assetFile, mediaType);
+        okhttp3.Request request = sign(new okhttp3.Request.Builder())
+                .url(uploadUrl)
+                .header("Content-Type", contentType)
+                .put(requestBody)
+                .build();
+        try (okhttp3.Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw AbstractRestClient.printAndCreateException(request, response);
+            }
+            return response.body() != null ? response.body().string() : "";
+        }
+    }
+
+    protected String downloadBinaryToFile(String downloadUrl, File targetFile) throws IOException {
+        okhttp3.Request request = sign(new okhttp3.Request.Builder())
+                .url(downloadUrl)
+                .get()
+                .build();
+        try (okhttp3.Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw AbstractRestClient.printAndCreateException(request, response);
+            }
+            File parentDir = targetFile.getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                parentDir.mkdirs();
+            }
+            try (java.io.InputStream inputStream = response.body() != null ? response.body().byteStream() : null) {
+                if (inputStream == null) {
+                    throw new IOException("Empty response body while downloading: " + downloadUrl);
+                }
+                Files.copy(inputStream, targetFile.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+        }
+        return targetFile.getAbsolutePath();
+    }
+
+
+    // GitLab Generic Package Registry names/versions only allow letters, digits, '.', '_', '+', '-'.
+    private String sanitizePackageComponent(String value) {
+        if (value == null) {
+            return "unknown";
+        }
+        String sanitized = value.trim().replaceAll("[^a-zA-Z0-9_.+-]", "-");
+        return sanitized.isEmpty() ? "unknown" : sanitized;
+    }
+
+    private String urlEncodePathSegment(String value) {
+        try {
+            return java.net.URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+        } catch (java.io.UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
     }
 
     private String normalizePipelineStatus(String status) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/gitlab/GitLabReleaseTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/gitlab/GitLabReleaseTest.java
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.gitlab;
+
+import com.github.istin.dmtools.common.code.model.SourceCodeConfig;
+import com.github.istin.dmtools.common.networking.GenericRequest;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+public class GitLabReleaseTest {
+
+    private static final String BASE_PATH = "https://gitlab.example.com";
+    private static final String WORKSPACE = "mygroup";
+    private static final String REPOSITORY = "myrepo";
+
+    private GitLab gitLab;
+    private File tempAsset;
+
+    @Before
+    public void setUp() throws IOException {
+        SourceCodeConfig config = SourceCodeConfig.builder()
+                .path(BASE_PATH)
+                .auth("test-token")
+                .workspaceName(WORKSPACE)
+                .repoName(REPOSITORY)
+                .branchName("main")
+                .type(SourceCodeConfig.Type.GITLAB)
+                .build();
+        gitLab = mock(BasicGitLab.class, withSettings().useConstructor(config).defaultAnswer(CALLS_REAL_METHODS));
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        if (tempAsset != null) {
+            Files.deleteIfExists(tempAsset.toPath());
+        }
+    }
+
+    @Test
+    public void testGetOrCreateRelease_returnsExistingReleaseWithoutCreate() throws IOException {
+        JSONArray releases = new JSONArray()
+                .put(buildReleaseJson("pr-attachments-storage", "PR Attachments Storage"));
+        doReturn(releases.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String result = gitLab.getOrCreateRelease(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", "PR Attachments Storage", "main", "storage");
+
+        JSONObject release = new JSONObject(result);
+        assertEquals("pr-attachments-storage", release.getString("tag_name"));
+        verify(gitLab, never()).post(any(GenericRequest.class));
+    }
+
+    @Test
+    public void testGetOrCreateRelease_createsReleaseWhenMissing() throws IOException {
+        doReturn("[]").when(gitLab).execute(any(GenericRequest.class));
+        doReturn(buildReleaseJson("pr-attachments-storage", "PR Attachments Storage").toString())
+                .when(gitLab).post(any(GenericRequest.class));
+
+        String result = gitLab.getOrCreateRelease(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", "PR Attachments Storage", "main", "storage");
+
+        JSONObject release = new JSONObject(result);
+        assertEquals("pr-attachments-storage", release.getString("tag_name"));
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab).post(captor.capture());
+        GenericRequest request = captor.getValue();
+        assertTrue(request.url().contains("projects/mygroup%2Fmyrepo/releases"));
+
+        JSONObject requestBody = new JSONObject(request.getBody());
+        assertEquals("pr-attachments-storage", requestBody.getString("tag_name"));
+        assertEquals("PR Attachments Storage", requestBody.getString("name"));
+        assertEquals("main", requestBody.getString("ref"));
+        assertEquals("storage", requestBody.getString("description"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_uploadsBinaryAndCreatesReleaseLink() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("").when(gitLab).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+        doReturn("{\"id\":2,\"name\":\"preview.png\",\"direct_asset_url\":\"https://gitlab.example.com/download\"}")
+                .when(gitLab).post(any(GenericRequest.class));
+
+        String result = gitLab.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", tempAsset.getAbsolutePath(),
+                "preview.png", "image/png", null, null);
+
+        assertTrue(result.contains("direct_asset_url"));
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<File> fileCaptor = ArgumentCaptor.forClass(File.class);
+        ArgumentCaptor<String> typeCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitLab).uploadGenericPackageBinary(urlCaptor.capture(), fileCaptor.capture(), typeCaptor.capture());
+        assertEquals(tempAsset.getAbsolutePath(), fileCaptor.getValue().getAbsolutePath());
+        assertEquals("image/png", typeCaptor.getValue());
+        assertTrue(urlCaptor.getValue().contains("packages/generic/release-assets/pr-attachments-storage/preview.png"));
+
+        ArgumentCaptor<GenericRequest> postCaptor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab).post(postCaptor.capture());
+        assertTrue(postCaptor.getValue().url().contains("releases/pr-attachments-storage/assets/links"));
+        JSONObject linkBody = new JSONObject(postCaptor.getValue().getBody());
+        assertEquals("preview.png", linkBody.getString("name"));
+        assertEquals("package", linkBody.getString("link_type"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_defaultsAssetNameToLocalFileName() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".txt");
+        Files.writeString(tempAsset.toPath(), "hello");
+
+        doReturn("").when(gitLab).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+        doReturn("{}").when(gitLab).post(any(GenericRequest.class));
+
+        gitLab.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", tempAsset.getAbsolutePath(),
+                null, "text/plain", null, null);
+
+        ArgumentCaptor<GenericRequest> postCaptor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab).post(postCaptor.capture());
+        JSONObject linkBody = new JSONObject(postCaptor.getValue().getBody());
+        assertEquals(tempAsset.getName(), linkBody.getString("name"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteFalse_doesNotCheckExistingAssets() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("").when(gitLab).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+        doReturn("{}").when(gitLab).post(any(GenericRequest.class));
+
+        gitLab.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", tempAsset.getAbsolutePath(),
+                "screenshot.png", "image/png", null, "false");
+
+        verify(gitLab, never()).execute(any(GenericRequest.class));
+        verify(gitLab, never()).delete(any(GenericRequest.class));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteTrue_deletesExistingLinkAndPackage() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        JSONArray existingLinks = new JSONArray()
+                .put(buildLinkJson(5L, "screenshot.png"));
+        JSONArray existingPackages = new JSONArray()
+                .put(buildPackageJson(77L, "release-assets", "pr-attachments-storage"));
+        doReturn(existingLinks.toString(), existingPackages.toString())
+                .when(gitLab).execute(any(GenericRequest.class));
+        doReturn(null).when(gitLab).delete(any(GenericRequest.class));
+        doReturn("").when(gitLab).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+        doReturn("{}").when(gitLab).post(any(GenericRequest.class));
+
+        gitLab.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", tempAsset.getAbsolutePath(),
+                "screenshot.png", "image/png", null, "true");
+
+        ArgumentCaptor<GenericRequest> deleteCaptor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab, times(2)).delete(deleteCaptor.capture());
+        assertTrue(deleteCaptor.getAllValues().get(0).url().contains("assets/links/5"));
+        assertTrue(deleteCaptor.getAllValues().get(1).url().contains("packages/77"));
+    }
+
+    @Test
+    public void testUploadReleaseAsset_overwriteTrue_noExistingAsset_uploadsDirectly() throws IOException {
+        tempAsset = File.createTempFile("release-asset-", ".png");
+        Files.writeString(tempAsset.toPath(), "png-data");
+
+        doReturn("[]").when(gitLab).execute(any(GenericRequest.class));
+        doReturn("").when(gitLab).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+        doReturn("{}").when(gitLab).post(any(GenericRequest.class));
+
+        gitLab.uploadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", tempAsset.getAbsolutePath(),
+                "new.png", "image/png", null, "true");
+
+        verify(gitLab, never()).delete(any(GenericRequest.class));
+        verify(gitLab, times(1)).uploadGenericPackageBinary(anyString(), any(File.class), anyString());
+    }
+
+    @Test
+    public void testListReleaseAssets_returnsLinksForRelease() throws IOException {
+        JSONArray links = new JSONArray()
+                .put(buildLinkJson(1L, "file-a.zip"))
+                .put(buildLinkJson(2L, "file-b.txt"));
+        doReturn(links.toString()).when(gitLab).execute(any(GenericRequest.class));
+
+        String result = gitLab.listReleaseAssets(WORKSPACE, REPOSITORY, "pr-attachments-storage");
+
+        JSONArray resultArray = new JSONArray(result);
+        assertEquals(2, resultArray.length());
+        assertEquals("file-a.zip", resultArray.getJSONObject(0).getString("name"));
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab).execute(captor.capture());
+        assertTrue(captor.getValue().url().contains("releases/pr-attachments-storage/assets/links"));
+    }
+
+    @Test
+    public void testDeleteReleaseAsset_deletesLinkAndPackage() throws IOException {
+        JSONArray existingLinks = new JSONArray()
+                .put(buildLinkJson(9L, "old.zip"));
+        JSONArray existingPackages = new JSONArray()
+                .put(buildPackageJson(44L, "release-assets", "pr-attachments-storage"));
+        doReturn(existingLinks.toString(), existingPackages.toString())
+                .when(gitLab).execute(any(GenericRequest.class));
+        doReturn(null).when(gitLab).delete(any(GenericRequest.class));
+
+        gitLab.deleteReleaseAsset(WORKSPACE, REPOSITORY, "pr-attachments-storage", "old.zip", null);
+
+        ArgumentCaptor<GenericRequest> deleteCaptor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(gitLab, times(2)).delete(deleteCaptor.capture());
+        assertTrue(deleteCaptor.getAllValues().get(0).url().contains("assets/links/9"));
+        assertTrue(deleteCaptor.getAllValues().get(1).url().contains("packages/44"));
+    }
+
+    @Test
+    public void testDownloadReleaseAsset_buildsCorrectUrlAndDelegatesToBinaryDownload() throws IOException {
+        File targetFile = File.createTempFile("downloaded-", ".png");
+        targetFile.deleteOnExit();
+
+        doReturn(targetFile.getAbsolutePath())
+                .when(gitLab).downloadBinaryToFile(anyString(), any(File.class));
+
+        String result = gitLab.downloadReleaseAsset(
+                WORKSPACE, REPOSITORY, "pr-attachments-storage", "preview.png", targetFile.getAbsolutePath(), null);
+
+        assertEquals(targetFile.getAbsolutePath(), result);
+
+        ArgumentCaptor<String> urlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(gitLab).downloadBinaryToFile(urlCaptor.capture(), any(File.class));
+        assertTrue(urlCaptor.getValue().contains("packages/generic/release-assets/pr-attachments-storage/preview.png"));
+    }
+
+    private JSONObject buildLinkJson(long id, String name) {
+        JSONObject json = new JSONObject();
+        json.put("id", id);
+        json.put("name", name);
+        json.put("url", "https://gitlab.example.com/download/" + name);
+        json.put("direct_asset_url", "https://gitlab.example.com/direct/" + name);
+        json.put("link_type", "package");
+        return json;
+    }
+
+    private JSONObject buildPackageJson(long id, String name, String version) {
+        JSONObject json = new JSONObject();
+        json.put("id", id);
+        json.put("name", name);
+        json.put("version", version);
+        json.put("package_type", "generic");
+        return json;
+    }
+
+    private JSONObject buildReleaseJson(String tagName, String name) {
+        JSONObject json = new JSONObject();
+        json.put("tag_name", tagName);
+        json.put("name", name);
+        return json;
+    }
+}


### PR DESCRIPTION
## Summary

Adds GitLab equivalents of GitHub's release/asset MCP tools, so GitLab-backed repositories can use the same "stable release used as artefact/session storage" pattern that's already available for GitHub via `github_get_or_create_draft_release` / `github_upload_release_asset` / `github_list_release_assets` / `github_delete_release_asset`.

### Why

GitLab has no direct "upload binary as release asset" API like GitHub. The closest analog is:
1. Publish the file to the project's Generic Package Registry (`PUT /projects/:id/packages/generic/:name/:version/:file`)
2. Attach it to the release as a Release Link (`POST /projects/:id/releases/:tag_name/assets/links`) so it's discoverable the same way `release.assets[]` works on GitHub.

This was discovered as a real production bug: a job running against a GitLab-hosted repo called `github_get_or_create_draft_release` (hardcoded) with a GitLab workspace path, which obviously failed. There was previously no GitLab tool at all to fall back to.

### New MCP tools (category: releases)

- `gitlab_get_or_create_release` - find an existing release by tag (`GET /projects/:id/releases`, matched by tag_name), or create one (`POST /projects/:id/releases`) if missing.
- `gitlab_upload_release_asset` - upload a local file to the Generic Package Registry, then attach it as a release link (link_type=package). Supports overwrite=true: since GitLab's Generic Package Registry rejects duplicate name+version uploads with 409 Conflict (no native overwrite), this deletes the existing release link + underlying package first.
- `gitlab_list_release_assets` - list all asset links for a release (`GET .../releases/:tag_name/assets/links`).
- `gitlab_delete_release_asset` - delete an asset's release link + underlying Generic Package Registry file by name.
- `gitlab_download_release_asset` - download an asset's bytes to a local file path (GitLab has no gh-release-download-equivalent CLI).

### Design notes

- Mirrors the exact code shape of `GitHub.java`'s release methods (getOrCreateDraftRelease, uploadReleaseAsset, findReleaseByTagOrName, createRelease, deleteExistingAssetByName) for consistency and easy side-by-side maintenance.
- Binary I/O (uploadGenericPackageBinary, downloadBinaryToFile) uses raw OkHttp requests (bypassing GenericRequest, which only supports string bodies) - same approach as GitHub.uploadReleaseAssetBinary. Both are protected so they can be stubbed in tests, matching GitHubReleaseTest.java's pattern.
- Package name/version values are sanitized to GitLab's allowed character set ([a-zA-Z0-9_.+-]) since tag names may contain characters the Generic Package Registry rejects.
- direct_asset_path is set on the release link so GitLab exposes a stable, permanent download URL under the release itself (/-/releases/:tag/downloads/...).

### Testing

Added GitLabReleaseTest.java (10 tests) mirroring GitHubReleaseTest.java's Mockito-based pattern (mocking execute/post/delete/uploadGenericPackageBinary/downloadBinaryToFile - no real network calls):
- get-or-create: returns existing release without creating; creates when missing
- upload: uploads binary + creates release link; defaults asset name to local filename; overwrite=false skips existing-asset lookup; overwrite=true deletes existing link+package before uploading, or uploads directly when nothing exists
- list: returns all links for a release
- delete: deletes both the link and the underlying package
- download: builds the correct Generic Package Registry URL and delegates to the binary downloader

All existing GitLab tests (GitLabTest, model tests) continue to pass - 109 tests total in the gitlab package, 0 failures.

### Docs

- Added detailed parameter docs for all 5 new tools to dmtools-ai-docs/references/mcp-tools/gitlab-tools.md (Total Tools: 23 -> 28)
- Updated dmtools-ai-docs/references/mcp-tools/README.md tool counts (271 -> 276)
- Added a dmtools-ai-docs/CHANGELOG.md entry
