### PR TITLE
Extend timerJSAction coverage to postJSAction (fixes unprotected feedback-loop quality-gate retries)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -514,6 +514,38 @@ public class CliExecutionHelper {
         AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
                 : (timerAction != null ? new AtomicReference<>("") : null);
 
+        AtomicReference<CliExecutionResult> resultRef = new AtomicReference<>();
+        runWithTimer(timerAction, timerIntervalSeconds, () -> {
+            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput,
+                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes);
+            String outputResponse = processOutputResponse(workingDirectory);
+            resultRef.set(new CliExecutionResult(cliResponses, outputResponse));
+        });
+        return resultRef.get();
+    }
+
+    /**
+     * Runs {@code work} with an optional periodic background timer, using the same
+     * scheduling/shutdown/final-tick semantics as {@link #executeCliCommandsWithResult}.
+     *
+     * <p>Useful for wrapping any long-running phase with the same auto-commit/session-save
+     * safety net used for the main CLI command phase — in particular a {@code postJSAction}
+     * that itself loops over CLI commands (e.g. a feedback-loop quality-gate retry calling
+     * {@code cli_execute_command} repeatedly from JavaScript). Without this, such a phase
+     * would run with zero periodic auto-save/auto-commit protection, since the timer
+     * previously only wrapped the main {@code cliCommands} array execution.
+     *
+     * <p>Each timer firing invokes {@code timerAction} on a dedicated daemon scheduler thread.
+     * Since {@code timerAction} is expected to spin up its own independent JS execution
+     * context (see {@code Teammate}'s {@code js(...)} helper), this is safe to run
+     * concurrently with {@code work} even when {@code work} itself is executing JavaScript,
+     * as GraalJS contexts created independently do not share thread-affinity locks.
+     *
+     * @param timerAction          Optional runnable executed on the timer thread; timer is disabled if null or timerIntervalSeconds &lt;= 0
+     * @param timerIntervalSeconds Interval between timer firings in seconds
+     * @param work                 The work to run on the calling thread while the timer fires in the background
+     */
+    public static void runWithTimer(Runnable timerAction, int timerIntervalSeconds, Runnable work) {
         ScheduledExecutorService scheduler = null;
         if (timerAction != null && timerIntervalSeconds > 0) {
             scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -525,17 +557,14 @@ public class CliExecutionHelper {
                 try {
                     timerAction.run();
                 } catch (Exception e) {
-                    logger.warn("timerJSAction threw exception (ignored, CLI execution continues): {}", e.getMessage());
+                    logger.warn("timerJSAction threw exception (ignored, execution continues): {}", e.getMessage());
                 }
             }, timerIntervalSeconds, timerIntervalSeconds, TimeUnit.SECONDS);
             logger.info("timerJSAction scheduler started (interval: {}s)", timerIntervalSeconds);
         }
 
         try {
-            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput,
-                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes);
-            String outputResponse = processOutputResponse(workingDirectory);
-            return new CliExecutionResult(cliResponses, outputResponse);
+            work.run();
         } finally {
             if (scheduler != null) {
                 scheduler.shutdown();
@@ -548,7 +577,7 @@ public class CliExecutionHelper {
                     Thread.currentThread().interrupt();
                 }
                 logger.info("timerJSAction scheduler stopped");
-                // Fire one final tick so the complete CLI output is saved to releases
+                // Fire one final tick so the complete output (commit/push, session save) is captured
                 try {
                     logger.info("timerJSAction final tick: saving complete session output");
                     timerAction.run();

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -467,6 +467,32 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             CliExecutionHelper.CliExecutionResult cliResult = null;
             Path inputContextPath = null;
 
+            // Build timer JS action runnable if configured. Declared here (outer scope) so the
+            // SAME timer also wraps postJSAction below — a postJSAction can itself run a long
+            // CLI-driven loop (e.g. a feedback-loop quality-gate retry calling cli_execute_command
+            // repeatedly from JavaScript), which previously had zero periodic auto-save/auto-commit
+            // protection since the timer only covered the main cliCommands execution.
+            String timerJSAction = expertParams.getTimerJSAction();
+            int timerIntervalSeconds = expertParams.getTimerIntervalSeconds();
+            AtomicReference<String> liveCliOutput = new AtomicReference<>("");
+            Runnable timerRunnable = null;
+            if (timerJSAction != null && !timerJSAction.trim().isEmpty() && timerIntervalSeconds > 0) {
+                timerRunnable = () -> {
+                    try {
+                        js(timerJSAction)
+                            .mcp(trackerClient, ai, confluence, null)
+                            .withJobContext(expertParams, ticket, null)
+                            .with(TrackerParams.INITIATOR, initiator)
+                            .with("systemRequest", systemRequestCommentAlias)
+                            .with("currentCliOutput", liveCliOutput.get())
+                            .execute();
+                    } catch (Exception e) {
+                        logger.warn("timerJSAction execution failed (continues): {}", e.getMessage());
+                    }
+                };
+                logger.info("timerJSAction configured: {} (interval: {}s)", timerJSAction, timerIntervalSeconds);
+            }
+
             if (cliCommands != null && cliCommands.length > 0) {
                 try {
                     // Merge base cliPrompts with tracker-specific prompts
@@ -537,28 +563,6 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
 
                     // Execute CLI commands from project root directory (where cursor-agent can find workspace config)
                     Path projectRoot = Paths.get(System.getProperty("user.dir"));
-
-                    // Build timer JS action runnable if configured
-                    String timerJSAction = expertParams.getTimerJSAction();
-                    int timerIntervalSeconds = expertParams.getTimerIntervalSeconds();
-                    AtomicReference<String> liveCliOutput = new AtomicReference<>("");
-                    Runnable timerRunnable = null;
-                    if (timerJSAction != null && !timerJSAction.trim().isEmpty() && timerIntervalSeconds > 0) {
-                        timerRunnable = () -> {
-                            try {
-                                js(timerJSAction)
-                                    .mcp(trackerClient, ai, confluence, null)
-                                    .withJobContext(expertParams, ticket, null)
-                                    .with(TrackerParams.INITIATOR, initiator)
-                                    .with("systemRequest", systemRequestCommentAlias)
-                                    .with("currentCliOutput", liveCliOutput.get())
-                                    .execute();
-                            } catch (Exception e) {
-                                logger.warn("timerJSAction execution failed (CLI continues): {}", e.getMessage());
-                            }
-                        };
-                        logger.info("timerJSAction configured: {} (interval: {}s)", timerJSAction, timerIntervalSeconds);
-                    }
 
                     cliResult = cliHelper.executeCliCommandsWithResult(
                             finalCliCommands,
@@ -679,12 +683,22 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                 GenericRequestAgent.Params genericRequesAgentParams = new GenericRequestAgent.Params(inputParams, null, chunksContext, expertParams.getChunkProcessingTimeoutInMinutes() * 60 * 1000);
                 response = genericRequestAgent.run(genericRequesAgentParams);
             }
-            js(expertParams.getPostJSAction())
-                .mcp(trackerClient, ai, confluence, null) // sourceCode not available in Teammate context
-                .withJobContext(expertParams, ticket, response)
-                .with(TrackerParams.INITIATOR, initiator)
-                .with("systemRequest", systemRequestCommentAlias)
-                .execute();
+            AtomicReference<Exception> postJsError = new AtomicReference<>();
+            CliExecutionHelper.runWithTimer(timerRunnable, timerIntervalSeconds, () -> {
+                try {
+                    js(expertParams.getPostJSAction())
+                        .mcp(trackerClient, ai, confluence, null) // sourceCode not available in Teammate context
+                        .withJobContext(expertParams, ticket, response)
+                        .with(TrackerParams.INITIATOR, initiator)
+                        .with("systemRequest", systemRequestCommentAlias)
+                        .execute();
+                } catch (Exception e) {
+                    postJsError.set(e);
+                }
+            });
+            if (postJsError.get() != null) {
+                throw postJsError.get();
+            }
             if (expertParams.isAttachResponseAsFile()) {
                 attachResponse(genericRequestAgent, "_final_answer.txt", response, ticket.getKey(), "text/plain");
             }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateTimerJSActionTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateTimerJSActionTest.java
@@ -188,4 +188,65 @@ public class TeammateTimerJSActionTest {
 
         assertEquals(1, cliCompletedCount.get(), "CLI command should have completed despite timer exception");
     }
+
+    // ── CliExecutionHelper.runWithTimer (generic, reusable for any long-running phase,
+    //    e.g. wrapping postJSAction so a feedback-loop quality-gate retry also gets
+    //    periodic auto-save/auto-commit protection) ──────────────────────────────────
+
+    @Test
+    void testRunWithTimer_runsWorkEvenWithoutTimer() {
+        AtomicInteger workRuns = new AtomicInteger(0);
+        CliExecutionHelper.runWithTimer(null, 0, workRuns::incrementAndGet);
+        assertEquals(1, workRuns.get(), "work must run exactly once");
+    }
+
+    @Test
+    void testRunWithTimer_firesPeriodicallyWhileWorkRuns() throws InterruptedException {
+        AtomicInteger fireCount = new AtomicInteger(0);
+        CountDownLatch timerFired = new CountDownLatch(1);
+        Runnable timerAction = () -> {
+            fireCount.incrementAndGet();
+            timerFired.countDown();
+        };
+
+        CliExecutionHelper.runWithTimer(timerAction, 1, () -> {
+            try {
+                Thread.sleep(1200); // longer than the 1s timer interval
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        assertTrue(timerFired.await(1, TimeUnit.SECONDS), "timer should have already fired by the time work returns");
+        assertTrue(fireCount.get() >= 1, "timer should fire at least once while work runs");
+    }
+
+    @Test
+    void testRunWithTimer_firesFinalTickAfterWorkCompletes() {
+        AtomicInteger fireCount = new AtomicInteger(0);
+        Runnable timerAction = fireCount::incrementAndGet;
+
+        // Interval longer than the (near-instant) work, so the only firing is the final tick
+        CliExecutionHelper.runWithTimer(timerAction, 300, () -> { /* fast no-op work */ });
+
+        assertEquals(1, fireCount.get(), "final tick should fire exactly once after work completes");
+    }
+
+    @Test
+    void testRunWithTimer_timerExceptionDoesNotAbortWork() {
+        AtomicInteger workRuns = new AtomicInteger(0);
+        Runnable timerAction = () -> { throw new RuntimeException("timer boom"); };
+
+        CliExecutionHelper.runWithTimer(timerAction, 300, workRuns::incrementAndGet);
+
+        assertEquals(1, workRuns.get(), "work should complete despite timer exceptions");
+    }
+
+    @Test
+    void testRunWithTimer_workExceptionPropagatesAndStopsTimer() {
+        assertThrows(RuntimeException.class, () ->
+                CliExecutionHelper.runWithTimer(() -> {}, 300, () -> {
+                    throw new RuntimeException("work boom");
+                }));
+    }
 }


### PR DESCRIPTION
## Summary

Extends `timerJSAction`/`timerIntervalSeconds` (periodic auto-commit + session-save, introduced for long-running CLI phases) to also cover `postJSAction` execution — not just the main `cliCommands` array.

### Root cause

`timerJSAction` previously only wrapped `CliExecutionHelper.executeCliCommandsWithResult()` (the main `cliCommands` phase). Any `postJSAction` that itself loops over CLI commands from JavaScript — most notably a feedback-loop quality-gate retry that repeatedly calls `cli_execute_command` (e.g. `mvn compile`/`spotbugs:check` + a Copilot CLI `--continue` re-invocation to fix findings) — ran with **zero periodic protection**.

### Real production symptom that led to this

A `pr_rework` job spent ~40 of its ~59.5 total minutes in the quality-gate retry phase (2 attempts, each running `mvn spotbugs:check` + a full Copilot continuation) and was killed by GitLab's 1-hour CI timeout mid-attempt. The timer had fired 3 times during the main CLI phase and then **never again** — all quality-gate-fix progress (commits) had no auto-commit/session-save safety net for the entire remaining ~40 minutes, so if the timeout hits mid-fix, uncommitted work is lost with no session snapshot to recover from.

### Fix

- Extracted the timer scheduling/shutdown/final-tick logic out of `CliExecutionHelper.executeCliCommandsWithResult()` into a new reusable static helper: `CliExecutionHelper.runWithTimer(Runnable timerAction, int timerIntervalSeconds, Runnable work)`. `executeCliCommandsWithResult` now delegates to it — behavior is unchanged (verified by the existing `TeammateTimerJSActionTest` suite, all passing).
- In `Teammate.java`, moved the `timerJSAction`/`timerIntervalSeconds`/`liveCliOutput`/`timerRunnable` construction out of the `cliCommands`-only branch into outer method scope, and wrapped the `postJSAction` execution with the same `CliExecutionHelper.runWithTimer(...)` call.
- This is safe: `js(...)` creates an independent GraalJS `Context` per invocation, so running the timer's own `js(timerJSAction)....execute()` concurrently with `postJSAction`'s `js(...).execute()` does not hit any GraalJS shared-context threading restriction — they're two completely separate contexts.

### Effect

The existing "auto-commit and push uncommitted changes every N seconds" safety net (`agents/js/timerAutoCommitAndSave.js` in `dmtools-agents`) now also runs throughout `postJSAction` — including feedback-loop quality-gate retries — so in-progress work is committed/pushed periodically even during that phase, and is not silently lost if the job is later killed by a CI timeout.

### Testing

- Added 5 new tests to `TeammateTimerJSActionTest.java` for the new `CliExecutionHelper.runWithTimer` helper:
  - runs `work` even without a timer configured
  - fires periodically while `work` is still running
  - fires exactly one final tick after `work` completes
  - timer exceptions don't abort `work`
  - `work` exceptions propagate (and the timer is still stopped)
- Full `dmtools-core` suite: **4289 tests, 0 failures** (including all 11 tests in `TeammateTimerJSActionTest`, all 63 in `CliExecutionHelperTest`, and the rest of the `teammate` package).
