### PR TITLE
feat(testrail): add get_suites tool + format=markdown for HTML-heavy test case fields

### DIFF
--- a/dmtools-ai-docs/references/configuration/integrations/testrail.md
+++ b/dmtools-ai-docs/references/configuration/integrations/testrail.md
@@ -43,6 +43,32 @@ TESTRAIL_API_KEY=your_api_key
 |----------|-------------|---------|
 | `TESTRAIL_PROJECT` | Default project name for operations | None |
 | `TESTRAIL_LOGGING_ENABLED` | Enable debug request logging | `false` |
+| `TESTRAIL_DEFAULT_FORMAT` | Default output format (`html` or `md`/`markdown`) applied when a tool call doesn't pass `format` explicitly | `html` |
+
+## 📝 Markdown Output for Test Case Fields
+
+TestRail case fields (preconditions, steps, expected results) are often pasted from Google Docs or a
+browser, which bakes every computed CSS property into inline `style="..."` attributes on every tag —
+this can make the raw HTML 20-30x larger than the actual visible text, wasting tokens when fed to an LLM.
+
+`testrail_get_case`, `testrail_get_all_cases`, and `testrail_search_cases` accept an optional `format`
+parameter: pass `format=md` (or `format=markdown`) to receive these fields converted to clean Markdown
+instead (tables are preserved as GitHub-Flavoured Markdown tables, so no data is lost).
+
+```bash
+# Explicit per-call opt-in
+dmtools testrail_get_all_cases "My Project" --format md
+```
+
+To make Markdown the **default** for every TestRail read — including internal callers like
+`TestCasesGenerator`'s "find related existing test cases" search, which don't pass `format` themselves —
+set `TESTRAIL_DEFAULT_FORMAT=markdown` in `dmtools.env`. An explicit `format` argument on any call always
+overrides this default.
+
+```bash
+# dmtools.env
+TESTRAIL_DEFAULT_FORMAT=markdown
+```
 
 ## 🧪 Testing Your Configuration
 
@@ -127,7 +153,7 @@ dmtools testrail_get_projects
 
 ## 📋 Available TestRail MCP Tools
 
-**Complete reference**: [../../mcp-tools/testrail-tools.md](../../mcp-tools/testrail-tools.md) — all 15 TestRail tools with parameters.
+**Complete reference**: [../../mcp-tools/testrail-tools.md](../../mcp-tools/testrail-tools.md) — all 16 TestRail tools with parameters.
 
 ### Quick Examples
 

--- a/dmtools-ai-docs/references/mcp-tools/testrail-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/testrail-tools.md
@@ -1,6 +1,6 @@
 # TESTRAIL MCP Tools
 
-**Total Tools**: 15
+**Total Tools**: 16
 
 ## Quick Reference
 
@@ -19,6 +19,7 @@ dmtools testrail_get_projects [arguments]
 const result = testrail_get_projects(...);
 const result = testrail_get_case(...);
 const result = testrail_get_all_cases(...);
+const result = testrail_get_suites(...);
 ```
 
 ## Available Tools
@@ -29,15 +30,16 @@ const result = testrail_get_all_cases(...);
 | `testrail_create_case_detailed` | Create a new test case in TestRail with detailed fields (preconditions, steps, expected results, labels, type). Note: TestRail uses its own table format in text fields: \|\|\|:Col 1\|:Col 2\|:Col 3\n\|\|val1\|val2\|val3. Standard Markdown tables (\| Col \| Col \|) will be auto-converted to TestRail format. | `priority_id` (string, optional)<br>`refs` (string, optional)<br>`preconditions` (string, optional)<br>`type_id` (string, optional)<br>`label_ids` (string, optional)<br>`expected` (string, optional)<br>`project_name` (string, **required**)<br>`title` (string, **required**)<br>`steps` (string, optional) |
 | `testrail_create_case_steps` | Create a TestRail test case using the 'Test Case (Steps)' template (template_id=2). Steps are provided as a JSON array: [{"content":"step text","expected":"expected result"}, ...]. Markdown tables in step content or expected are auto-converted to HTML tables. Use testrail_get_case_types for type_id, testrail_get_labels for label_ids. | `priority_id` (string, optional)<br>`refs` (string, optional)<br>`preconditions` (string, optional)<br>`type_id` (string, optional)<br>`label_ids` (string, optional)<br>`steps_json` (string, **required**)<br>`project_name` (string, **required**)<br>`title` (string, **required**) |
 | `testrail_delete_case` | Delete a test case in TestRail by case ID | `case_id` (string, **required**) |
-| `testrail_get_all_cases` | Get ALL test cases in a project (uses pagination to retrieve all cases) | `project_name` (string, **required**) |
-| `testrail_get_case` | Get a TestRail test case by ID | `case_id` (string, **required**) |
+| `testrail_get_all_cases` | Get ALL test cases in a project (uses pagination to retrieve all cases). Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML. | `project_name` (string, **required**)<br>`format` (string, optional) |
+| `testrail_get_case` | Get a TestRail test case by ID. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML — raw HTML pasted from Google Docs/browsers can be 20-30x larger than necessary due to inline CSS styling on every tag. | `case_id` (string, **required**)<br>`format` (string, optional) |
 | `testrail_get_case_types` | Get all available case types in TestRail (e.g., Automated, Functionality, Other) | None |
 | `testrail_get_cases_by_refs` | Get test cases linked to a requirement/story via refs field | `project_name` (string, **required**)<br>`refs` (string, **required**) |
 | `testrail_get_label` | Get a single label by ID | `label_id` (string, **required**) |
 | `testrail_get_labels` | Get all labels for a project in TestRail | `project_name` (string, **required**) |
 | `testrail_get_projects` | Get list of all projects in TestRail | None |
+| `testrail_get_suites` | Get all test suites for a TestRail project | `project_name` (string, **required**) |
 | `testrail_link_to_requirement` | Link a test case to a requirement by updating refs field | `case_id` (string, **required**)<br>`requirement_key` (string, **required**) |
-| `testrail_search_cases` | Search TestRail test cases by project and optional filters | `project_name` (string, **required**)<br>`section_id` (string, optional)<br>`suite_id` (string, optional) |
+| `testrail_search_cases` | Search TestRail test cases by project and optional filters. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML. | `project_name` (string, **required**)<br>`section_id` (string, optional)<br>`suite_id` (string, optional)<br>`format` (string, optional) |
 | `testrail_update_case` | Update a test case in TestRail | `case_id` (string, **required**)<br>`priority_id` (string, optional)<br>`title` (string, optional)<br>`refs` (string, optional) |
 | `testrail_update_label` | Update a label title in TestRail. Maximum 20 characters allowed. | `project_name` (string, **required**)<br>`title` (string, **required**)<br>`label_id` (string, **required**) |
 
@@ -211,7 +213,7 @@ const result = testrail_delete_case("case_id");
 
 ### `testrail_get_all_cases`
 
-Get ALL test cases in a project (uses pagination to retrieve all cases)
+Get ALL test cases in a project (uses pagination to retrieve all cases). Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.
 
 **Parameters:**
 
@@ -219,21 +221,25 @@ Get ALL test cases in a project (uses pagination to retrieve all cases)
   - Project name to get all cases from
   - Example: `My Project`
 
+- **`format`** (string) ⚪ Optional
+  - Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the `TESTRAIL_DEFAULT_FORMAT` env var (defaults to 'html' when unset).
+  - Example: `markdown`
+
 **Example:**
 ```bash
-dmtools testrail_get_all_cases "value"
+dmtools testrail_get_all_cases "value" "value"
 ```
 
 ```javascript
 // In JavaScript agent
-const result = testrail_get_all_cases("project_name");
+const result = testrail_get_all_cases("project_name", "format");
 ```
 
 ---
 
 ### `testrail_get_case`
 
-Get a TestRail test case by ID
+Get a TestRail test case by ID. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML — raw HTML pasted from Google Docs/browsers can be 20-30x larger than necessary due to inline CSS styling on every tag.
 
 **Parameters:**
 
@@ -241,14 +247,18 @@ Get a TestRail test case by ID
   - The test case ID (numeric, without 'C' prefix)
   - Example: `123`
 
+- **`format`** (string) ⚪ Optional
+  - Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the `TESTRAIL_DEFAULT_FORMAT` env var (defaults to 'html' when unset).
+  - Example: `markdown`
+
 **Example:**
 ```bash
-dmtools testrail_get_case "value"
+dmtools testrail_get_case "value" "value"
 ```
 
 ```javascript
 // In JavaScript agent
-const result = testrail_get_case("case_id");
+const result = testrail_get_case("case_id", "format");
 ```
 
 ---
@@ -359,6 +369,28 @@ const result = testrail_get_projects();
 
 ---
 
+### `testrail_get_suites`
+
+Get all test suites for a TestRail project
+
+**Parameters:**
+
+- **`project_name`** (string) 🔴 Required
+  - Project name to get suites from
+  - Example: `My Project`
+
+**Example:**
+```bash
+dmtools testrail_get_suites "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = testrail_get_suites("project_name");
+```
+
+---
+
 ### `testrail_link_to_requirement`
 
 Link a test case to a requirement by updating refs field
@@ -387,7 +419,7 @@ const result = testrail_link_to_requirement("case_id", "requirement_key");
 
 ### `testrail_search_cases`
 
-Search TestRail test cases by project and optional filters
+Search TestRail test cases by project and optional filters. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.
 
 **Parameters:**
 
@@ -395,22 +427,26 @@ Search TestRail test cases by project and optional filters
   - Project name to search in
   - Example: `My Project`
 
-- **`section_id`** (string) ⚪ Optional
-  - Section ID to filter by (optional)
-  - Example: `10`
-
 - **`suite_id`** (string) ⚪ Optional
   - Suite ID to filter by (optional)
   - Example: `1`
 
+- **`section_id`** (string) ⚪ Optional
+  - Section ID to filter by (optional)
+  - Example: `10`
+
+- **`format`** (string) ⚪ Optional
+  - Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the `TESTRAIL_DEFAULT_FORMAT` env var (defaults to 'html' when unset).
+  - Example: `markdown`
+
 **Example:**
 ```bash
-dmtools testrail_search_cases "value" "value"
+dmtools testrail_search_cases "value" "value" "value" "value"
 ```
 
 ```javascript
 // In JavaScript agent
-const result = testrail_search_cases("project_name", "section_id");
+const result = testrail_search_cases("project_name", "suite_id", "section_id", "format");
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -14,6 +14,7 @@ import com.github.istin.dmtools.common.model.JSONModel;
 import com.github.istin.dmtools.common.networking.GenericRequest;
 import com.github.istin.dmtools.common.networking.RestClient;
 import com.github.istin.dmtools.common.utils.HtmlCleaner;
+import com.github.istin.dmtools.common.utils.HtmlToMarkdownConverter;
 import com.github.istin.dmtools.common.utils.MarkdownToJiraConverter;
 import com.github.istin.dmtools.common.utils.StringUtils;
 import com.github.istin.dmtools.context.UriToObject;
@@ -979,16 +980,6 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
     }
 
     /**
-     * Checks whether the requested format is Markdown.
-     *
-     * @param format the format identifier (e.g. "md" or "markdown")
-     * @return true if the format should trigger Markdown conversion
-     */
-    private static boolean isMarkdownFormat(String format) {
-        return "md".equalsIgnoreCase(format) || "markdown".equalsIgnoreCase(format);
-    }
-
-    /**
      * Converts Confluence storage format HTML to Markdown.
      * If the content uses the Confluence YAML macro format, the YAML payload is
      * extracted instead (matching the behaviour in {@link InstructionProcessor}).
@@ -1016,7 +1007,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
      * @return the same content instance
      */
     private static Content applyFormat(Content content, String format) {
-        if (content == null || !isMarkdownFormat(format)) {
+        if (content == null || !HtmlToMarkdownConverter.isMarkdownFormat(format)) {
             return content;
         }
         Storage storage = content.getStorage();
@@ -1047,7 +1038,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
      * @return the same list instance
      */
     private static List<Content> applyFormat(List<Content> contents, String format) {
-        if (contents == null || !isMarkdownFormat(format)) {
+        if (contents == null || !HtmlToMarkdownConverter.isMarkdownFormat(format)) {
             return contents;
         }
         for (Content content : contents) {
@@ -1064,7 +1055,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
      * @return the same result instance
      */
     private static ContentResult applyFormat(ContentResult result, String format) {
-        if (result == null || !isMarkdownFormat(format)) {
+        if (result == null || !HtmlToMarkdownConverter.isMarkdownFormat(format)) {
             return result;
         }
         applyFormat(result.getContents(), format);

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
@@ -3,17 +3,14 @@
 
 package com.github.istin.dmtools.atlassian.confluence;
 
-import io.github.furstenheim.CopyDown;
+import com.github.istin.dmtools.common.utils.HtmlToMarkdownConverter;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,7 +20,7 @@ import java.util.regex.Pattern;
  * <p>Confluence uses its own XML dialect on top of HTML that includes
  * {@code <ac:*>} and {@code <ri:*>} tags which standard HTML-to-Markdown
  * converters cannot handle. This class pre-processes those tags into
- * standard HTML equivalents before delegating to {@link CopyDown}.
+ * standard HTML equivalents before delegating to {@link HtmlToMarkdownConverter}.
  *
  * <p>Handled Confluence constructs:
  * <ul>
@@ -46,8 +43,6 @@ import java.util.regex.Pattern;
 public final class ConfluenceStorageMarkdown {
 
     private static final Logger logger = LogManager.getLogger(ConfluenceStorageMarkdown.class);
-
-    private static final String TABLE_PLACEHOLDER_PREFIX = "DMTABLEIDX";
 
     // ac:image → img: <ac:image ... ac:alt="name.png" ...><ri:attachment .../></ac:image>
     private static final Pattern AC_IMAGE = Pattern.compile(
@@ -111,16 +106,9 @@ public final class ConfluenceStorageMarkdown {
             //    (attachments, URLs, plain-text link bodies, links inside tables, etc.).
             String withStandardLinksAndImages = replaceRemainingAcLinksAndImages(preprocessed);
 
-            // 3. Convert HTML tables to GitHub-Flavoured Markdown tables.
-            //    Tables are replaced with placeholders because CopyDown does not
-            //    generate Markdown tables on its own.
-            TableExtraction extraction = extractTables(withStandardLinksAndImages);
-
-            // 4. Run the generic HTML→Markdown converter on the table-less HTML.
-            String markdown = new CopyDown().convert(extraction.htmlWithoutTables);
-
-            // 5. Restore the Markdown tables at their placeholders.
-            return restoreTables(markdown, extraction.tables);
+            // 3. Delegate table-aware HTML→Markdown conversion (table extraction,
+            //    CopyDown, table restoration) to the shared, generic converter.
+            return HtmlToMarkdownConverter.convert(withStandardLinksAndImages);
         } catch (Exception e) {
             logger.warn("Confluence HTML→Markdown conversion failed, returning raw HTML: {}", e.getMessage(), e);
             return confluenceHtml;
@@ -359,95 +347,6 @@ public final class ConfluenceStorageMarkdown {
         return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 
-    /**
-     * Extracts all {@code <table>} elements, converts them to GitHub-Flavoured Markdown
-     * tables, and replaces them with placeholders so that the remaining HTML can be
-     * safely passed to CopyDown.
-     */
-    private static TableExtraction extractTables(String html) {
-        Document doc = parseFragment(html);
-        List<String> tables = new ArrayList<>();
-
-        Elements tableElements = doc.getElementsByTag("table");
-        int index = 0;
-        for (Element table : tableElements) {
-            String markdownTable = convertTableToMarkdown(table);
-            tables.add(markdownTable);
-
-            Element placeholder = doc.createElement("p").text(TABLE_PLACEHOLDER_PREFIX + index);
-            table.replaceWith(placeholder);
-            index++;
-        }
-
-        return new TableExtraction(bodyHtml(doc), tables);
-    }
-
-    private static String convertTableToMarkdown(Element table) {
-        List<List<String>> rows = new ArrayList<>();
-        int maxColumns = 0;
-        boolean hasHeader = false;
-
-        for (Element tr : table.getElementsByTag("tr")) {
-            List<String> cells = new ArrayList<>();
-            for (Element child : tr.children()) {
-                String tag = child.tagName();
-                if ("th".equalsIgnoreCase(tag) || "td".equalsIgnoreCase(tag)) {
-                    if ("th".equalsIgnoreCase(tag)) {
-                        hasHeader = true;
-                    }
-                    cells.add(cellToMarkdown(child));
-                }
-            }
-            if (!cells.isEmpty()) {
-                rows.add(cells);
-                maxColumns = Math.max(maxColumns, cells.size());
-            }
-        }
-
-        if (rows.isEmpty()) {
-            return "";
-        }
-
-        StringBuilder markdown = new StringBuilder();
-        for (int i = 0; i < rows.size(); i++) {
-            appendMarkdownRow(markdown, rows.get(i), maxColumns);
-            if (i == 0 && hasHeader) {
-                appendMarkdownRow(markdown, null, maxColumns);
-            }
-        }
-        return markdown.toString();
-    }
-
-    private static String cellToMarkdown(Element cell) {
-        // Convert the cell's inner HTML to Markdown so that links, bold, etc. are preserved.
-        String cellMarkdown = new CopyDown().convert(cell.html()).trim();
-        // Markdown tables cannot contain newlines or pipe characters in cells.
-        cellMarkdown = cellMarkdown.replace("|", "\\|");
-        cellMarkdown = cellMarkdown.replaceAll("\\s+", " ").trim();
-        return cellMarkdown;
-    }
-
-    private static void appendMarkdownRow(StringBuilder markdown, List<String> cells, int maxColumns) {
-        markdown.append("|");
-        for (int i = 0; i < maxColumns; i++) {
-            if (cells == null) {
-                markdown.append("---|");
-            } else {
-                String value = i < cells.size() ? cells.get(i) : "";
-                markdown.append(" ").append(value).append(" |");
-            }
-        }
-        markdown.append("\n");
-    }
-
-    private static String restoreTables(String markdown, List<String> tables) {
-        String result = markdown;
-        for (int i = 0; i < tables.size(); i++) {
-            result = result.replace(TABLE_PLACEHOLDER_PREFIX + i, tables.get(i).trim());
-        }
-        return result;
-    }
-
     private static Document parseFragment(String html) {
         Document doc = Jsoup.parseBodyFragment(html);
         doc.outputSettings().prettyPrint(false);
@@ -458,13 +357,4 @@ public final class ConfluenceStorageMarkdown {
         return doc.body() != null ? doc.body().html() : doc.html();
     }
 
-    private static final class TableExtraction {
-        final String htmlWithoutTables;
-        final List<String> tables;
-
-        TableExtraction(String htmlWithoutTables, List<String> tables) {
-            this.htmlWithoutTables = htmlWithoutTables;
-            this.tables = tables;
-        }
-    }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.common.utils;
+
+import io.github.furstenheim.CopyDown;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Generic, table-aware HTML-to-Markdown converter.
+ *
+ * <p>Plain {@link CopyDown} (a Java port of the "turndown" JS library) does not generate
+ * Markdown tables on its own, and heavily-styled HTML (e.g. content pasted from Google Docs
+ * or a browser, which bakes every computed CSS property into inline {@code style="..."}
+ * attributes on every single tag) can bloat 1:1 HTML-preserving output by 20-30x with no
+ * benefit for a human or LLM reader.
+ *
+ * <p>This converter:
+ * <ol>
+ *   <li>Extracts every {@code <table>} and converts it to a GitHub-Flavoured Markdown table
+ *       (replacing it with a placeholder so CopyDown does not mangle it).</li>
+ *   <li>Runs CopyDown on the remaining (table-less) HTML to get Markdown for everything else
+ *       (paragraphs, bold/italic, links, lists, etc.) — which also naturally drops all
+ *       {@code style}/{@code class} attributes, since Markdown has no equivalent.</li>
+ *   <li>Restores the Markdown tables at their placeholders.</li>
+ * </ol>
+ *
+ * <p>Used by {@link com.github.istin.dmtools.atlassian.confluence.ConfluenceStorageMarkdown}
+ * (after its own Confluence-specific {@code <ac:*>}/{@code <ri:*>} tag preprocessing) and by
+ * {@link com.github.istin.dmtools.testrail.TestRailClient} (for test case preconditions/steps,
+ * which are stored as raw HTML and can contain large pasted tables with heavy inline styling).
+ */
+public final class HtmlToMarkdownConverter {
+
+    private static final Logger logger = LogManager.getLogger(HtmlToMarkdownConverter.class);
+
+    private static final String TABLE_PLACEHOLDER_PREFIX = "DMTABLEIDX";
+
+    private HtmlToMarkdownConverter() {}
+
+    /**
+     * Converts an HTML fragment to Markdown, preserving tables as GitHub-Flavoured Markdown
+     * tables.
+     *
+     * @param html raw HTML fragment (does not need to be a full document)
+     * @return Markdown text, or the original HTML if conversion fails for any reason
+     */
+    public static String convert(String html) {
+        if (html == null || html.isBlank()) {
+            return "";
+        }
+        try {
+            TableExtraction extraction = extractTables(html);
+            String markdown = new CopyDown().convert(extraction.htmlWithoutTables);
+            return restoreTables(markdown, extraction.tables);
+        } catch (Exception e) {
+            logger.warn("HTML→Markdown conversion failed, returning raw HTML: {}", e.getMessage(), e);
+            return html;
+        }
+    }
+
+    /**
+     * Extracts all {@code <table>} elements, converts them to GitHub-Flavoured Markdown
+     * tables, and replaces them with placeholders so that the remaining HTML can be
+     * safely passed to CopyDown.
+     */
+    private static TableExtraction extractTables(String html) {
+        Document doc = parseFragment(html);
+        List<String> tables = new ArrayList<>();
+
+        Elements tableElements = doc.getElementsByTag("table");
+        int index = 0;
+        for (Element table : tableElements) {
+            String markdownTable = convertTableToMarkdown(table);
+            tables.add(markdownTable);
+
+            Element placeholder = doc.createElement("p").text(TABLE_PLACEHOLDER_PREFIX + index);
+            table.replaceWith(placeholder);
+            index++;
+        }
+
+        return new TableExtraction(bodyHtml(doc), tables);
+    }
+
+    private static String convertTableToMarkdown(Element table) {
+        List<List<String>> rows = new ArrayList<>();
+        int maxColumns = 0;
+        boolean hasHeader = false;
+
+        for (Element tr : table.getElementsByTag("tr")) {
+            List<String> cells = new ArrayList<>();
+            for (Element child : tr.children()) {
+                String tag = child.tagName();
+                if ("th".equalsIgnoreCase(tag) || "td".equalsIgnoreCase(tag)) {
+                    if ("th".equalsIgnoreCase(tag)) {
+                        hasHeader = true;
+                    }
+                    cells.add(cellToMarkdown(child));
+                }
+            }
+            if (!cells.isEmpty()) {
+                rows.add(cells);
+                maxColumns = Math.max(maxColumns, cells.size());
+            }
+        }
+
+        if (rows.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder markdown = new StringBuilder();
+        for (int i = 0; i < rows.size(); i++) {
+            appendMarkdownRow(markdown, rows.get(i), maxColumns);
+            if (i == 0 && hasHeader) {
+                appendMarkdownRow(markdown, null, maxColumns);
+            }
+        }
+        return markdown.toString();
+    }
+
+    private static String cellToMarkdown(Element cell) {
+        // Convert the cell's inner HTML to Markdown so that links, bold, etc. are preserved.
+        String cellMarkdown = new CopyDown().convert(cell.html()).trim();
+        // Markdown tables cannot contain newlines or pipe characters in cells.
+        cellMarkdown = cellMarkdown.replace("|", "\\|");
+        cellMarkdown = cellMarkdown.replaceAll("\\s+", " ").trim();
+        return cellMarkdown;
+    }
+
+    private static void appendMarkdownRow(StringBuilder markdown, List<String> cells, int maxColumns) {
+        markdown.append("|");
+        for (int i = 0; i < maxColumns; i++) {
+            if (cells == null) {
+                markdown.append("---|");
+            } else {
+                String value = i < cells.size() ? cells.get(i) : "";
+                markdown.append(" ").append(value).append(" |");
+            }
+        }
+        markdown.append("\n");
+    }
+
+    private static String restoreTables(String markdown, List<String> tables) {
+        String result = markdown;
+        for (int i = 0; i < tables.size(); i++) {
+            result = result.replace(TABLE_PLACEHOLDER_PREFIX + i, tables.get(i).trim());
+        }
+        return result;
+    }
+
+    private static Document parseFragment(String html) {
+        Document doc = Jsoup.parseBodyFragment(html);
+        doc.outputSettings().prettyPrint(false);
+        return doc;
+    }
+
+    private static String bodyHtml(Document doc) {
+        return doc.body() != null ? doc.body().html() : doc.html();
+    }
+
+    private static final class TableExtraction {
+        final String htmlWithoutTables;
+        final List<String> tables;
+
+        TableExtraction(String htmlWithoutTables, List<String> tables) {
+            this.htmlWithoutTables = htmlWithoutTables;
+            this.tables = tables;
+        }
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
@@ -47,6 +47,18 @@ public final class HtmlToMarkdownConverter {
     private HtmlToMarkdownConverter() {}
 
     /**
+     * Checks whether a requested output-format identifier means "convert to Markdown".
+     * Shared across all integrations that expose a {@code format} parameter (Confluence,
+     * TestRail, ...) so the accepted values never drift between them.
+     *
+     * @param format the format identifier (e.g. "md" or "markdown")
+     * @return true if the format should trigger Markdown conversion
+     */
+    public static boolean isMarkdownFormat(String format) {
+        return "md".equalsIgnoreCase(format) || "markdown".equalsIgnoreCase(format);
+    }
+
+    /**
      * Converts an HTML fragment to Markdown, preserving tables as GitHub-Flavoured Markdown
      * tables.
      *

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -1097,6 +1097,13 @@ public class PropertyReader {
   public static final String TESTRAIL_API_KEY = "TESTRAIL_API_KEY";
   public static final String TESTRAIL_PROJECT = "TESTRAIL_PROJECT";
   public static final String TESTRAIL_LOGGING_ENABLED = "TESTRAIL_LOGGING_ENABLED";
+  // Optional: default output format ("md"/"markdown" or "html", default "html") applied by
+  // testrail_get_case/testrail_get_all_cases/testrail_search_cases when the caller does not
+  // explicitly pass a format parameter. Set to "markdown" to make every TestRail integration
+  // (including internal callers like TestCasesGenerator's related-test-case search) return
+  // clean Markdown by default, without needing per-call-site changes -- avoiding the token
+  // bloat of raw HTML (which can carry 20-30x overhead from inline CSS styling).
+  public static final String TESTRAIL_DEFAULT_FORMAT = "TESTRAIL_DEFAULT_FORMAT";
 
   // Bitrise configuration
   public static final String BITRISE_TOKEN = "BITRISE_TOKEN";
@@ -1472,6 +1479,11 @@ public class PropertyReader {
       return false;
     }
     return Boolean.parseBoolean(value);
+  }
+
+  public String getTestRailDefaultFormat() {
+    String value = getValue(TESTRAIL_DEFAULT_FORMAT);
+    return (value == null || value.isBlank()) ? "html" : value;
   }
 
   // -------------------------------------------------------------------------

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
@@ -10,6 +10,7 @@ import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.networking.GenericRequest;
 import com.github.istin.dmtools.common.timeline.ReportIteration;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.HtmlToMarkdownConverter;
 import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.mcp.MCPParam;
 import com.github.istin.dmtools.mcp.MCPTool;
@@ -238,35 +239,43 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
 
     @MCPTool(
             name = "testrail_get_case",
-            description = "Get a TestRail test case by ID",
+            description = "Get a TestRail test case by ID. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML — raw HTML pasted from Google Docs/browsers can be 20-30x larger than necessary due to inline CSS styling on every tag.",
             integration = "testrail",
             category = "test_cases"
     )
     public TestCase getCase(
             @MCPParam(name = "case_id", description = "The test case ID (numeric, without 'C' prefix)", required = true, example = "123")
-            String caseId
+            String caseId,
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            String format
     ) throws IOException {
-        return performTicket(caseId, null);
+        TestCase testCase = performTicket(caseId, null);
+        applyFormat(testCase, format);
+        return testCase;
     }
 
     @MCPTool(
             name = "testrail_get_all_cases",
-            description = "Get ALL test cases in a project (uses pagination to retrieve all cases)",
+            description = "Get ALL test cases in a project (uses pagination to retrieve all cases). Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
             integration = "testrail",
             category = "test_cases"
     )
     public List<TestCase> getAllCases(
             @MCPParam(name = "project_name", description = "Project name to get all cases from", required = true, example = "My Project")
-            String projectName
+            String projectName,
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            String format
     ) throws Exception {
         int projectId = getProjectId(projectName);
         log("Retrieving all test cases for project: " + projectName);
-        return getCasesByProjectId(projectId, null, null, null);
+        List<TestCase> cases = getCasesByProjectId(projectId, null, null, null);
+        applyFormat(cases, format);
+        return cases;
     }
 
     @MCPTool(
             name = "testrail_search_cases",
-            description = "Search TestRail test cases by project and optional filters",
+            description = "Search TestRail test cases by project and optional filters. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
             integration = "testrail",
             category = "test_cases"
     )
@@ -276,10 +285,89 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
             @MCPParam(name = "suite_id", description = "Suite ID to filter by (optional)", required = false, example = "1")
             String suiteId,
             @MCPParam(name = "section_id", description = "Section ID to filter by (optional)", required = false, example = "10")
-            String sectionId
+            String sectionId,
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            String format
     ) throws Exception {
         int projectId = getProjectId(projectName);
-        return getCasesByProjectId(projectId, suiteId, sectionId, null);
+        List<TestCase> cases = getCasesByProjectId(projectId, suiteId, sectionId, null);
+        applyFormat(cases, format);
+        return cases;
+    }
+
+    private static boolean isMarkdownFormat(String format) {
+        return format != null && format.trim().equalsIgnoreCase("markdown");
+    }
+
+    private static void applyFormat(List<TestCase> cases, String format) {
+        if (!isMarkdownFormat(format)) {
+            return;
+        }
+        for (TestCase testCase : cases) {
+            applyFormat(testCase, format);
+        }
+    }
+
+    private static void applyFormat(TestCase testCase, String format) {
+        if (!isMarkdownFormat(format) || testCase == null) {
+            return;
+        }
+        convertHtmlFieldsToMarkdown(testCase.getJSONObject());
+    }
+
+    /**
+     * Names of TestCase custom fields known to hold a JSON array of step objects
+     * ({@code {content, expected, additional_info, ...}}), rather than a plain HTML string.
+     * TestRail step-template field names vary by project/template ("Test Case (Steps)" uses
+     * "custom_steps_separated" by default, but a project can rename its custom fields), so this
+     * is a best-effort list covering the default/common names — any other HTML-bearing string
+     * field is still detected and converted via content-sniffing in
+     * {@link #convertHtmlFieldsToMarkdown}.
+     */
+    private static final Set<String> STEP_ARRAY_FIELD_NAMES = Set.of(
+            "custom_steps_separated"
+    );
+
+    private static final Set<String> STEP_HTML_SUBFIELDS = Set.of("content", "expected", "additional_info");
+
+    /**
+     * Converts every HTML-bearing field on a raw TestRail test case JSON object to Markdown,
+     * in place. Fields are detected by content (containing a {@code <tag>}), not by a hardcoded
+     * field-name allowlist, so this works regardless of custom-field naming across different
+     * TestRail projects/templates (e.g. "custom_preconds", "custom_expected",
+     * "custom_testrail_bdd_scenario", ...).
+     */
+    private static void convertHtmlFieldsToMarkdown(JSONObject caseJson) {
+        if (caseJson == null) {
+            return;
+        }
+        for (String key : new ArrayList<>(caseJson.keySet())) {
+            Object value = caseJson.opt(key);
+            if (value instanceof String) {
+                String stringValue = (String) value;
+                if (looksLikeHtml(stringValue)) {
+                    caseJson.put(key, HtmlToMarkdownConverter.convert(stringValue));
+                }
+            } else if (value instanceof JSONArray && STEP_ARRAY_FIELD_NAMES.contains(key)) {
+                JSONArray steps = (JSONArray) value;
+                for (int i = 0; i < steps.length(); i++) {
+                    JSONObject step = steps.optJSONObject(i);
+                    if (step == null) {
+                        continue;
+                    }
+                    for (String stepField : STEP_HTML_SUBFIELDS) {
+                        String stepHtml = step.optString(stepField, null);
+                        if (stepHtml != null && looksLikeHtml(stepHtml)) {
+                            step.put(stepField, HtmlToMarkdownConverter.convert(stepHtml));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean looksLikeHtml(String value) {
+        return value.indexOf('<') != -1 && value.indexOf('>') != -1;
     }
 
     /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
@@ -192,6 +192,51 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
     }
 
     @MCPTool(
+            name = "testrail_get_suites",
+            description = "Get all test suites for a TestRail project",
+            integration = "testrail",
+            category = "suites"
+    )
+    public String getSuites(
+            @MCPParam(name = "project_name", description = "Project name to get suites from", required = true, example = "My Project")
+            String projectName
+    ) throws IOException {
+        return getSuitesByProjectId(getProjectId(projectName));
+    }
+
+    /** ID-based variant — bypasses project name resolution. */
+    String getSuitesByProjectId(int projectId) throws IOException {
+        List<JSONObject> allSuites = new ArrayList<>();
+        int limit = 250;
+        String baseApiPath = "/get_suites/" + projectId;
+        String nextPagePath = buildPagedPath(baseApiPath, limit, 0);
+
+        while (nextPagePath != null) {
+            String response = executeGet(nextPagePath);
+
+            JSONObject responseObj = new JSONObject(response);
+            JSONArray suites = responseObj.optJSONArray("suites");
+
+            if (suites == null || suites.length() == 0) {
+                break;
+            }
+
+            for (int i = 0; i < suites.length(); i++) {
+                allSuites.add(suites.getJSONObject(i));
+            }
+
+            nextPagePath = getNextPagePath(responseObj, baseApiPath, limit, suites.length());
+        }
+
+        JSONArray result = new JSONArray();
+        for (JSONObject suite : allSuites) {
+            result.put(suite);
+        }
+        log("Retrieved " + allSuites.size() + " suites for project ID " + projectId);
+        return result.toString(2);
+    }
+
+    @MCPTool(
             name = "testrail_get_case",
             description = "Get a TestRail test case by ID",
             integration = "testrail",

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailClient.java
@@ -246,7 +246,7 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
     public TestCase getCase(
             @MCPParam(name = "case_id", description = "The test case ID (numeric, without 'C' prefix)", required = true, example = "123")
             String caseId,
-            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).", required = false, example = "markdown")
             String format
     ) throws IOException {
         TestCase testCase = performTicket(caseId, null);
@@ -263,7 +263,7 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
     public List<TestCase> getAllCases(
             @MCPParam(name = "project_name", description = "Project name to get all cases from", required = true, example = "My Project")
             String projectName,
-            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).", required = false, example = "markdown")
             String format
     ) throws Exception {
         int projectId = getProjectId(projectName);
@@ -286,7 +286,7 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
             String suiteId,
             @MCPParam(name = "section_id", description = "Section ID to filter by (optional)", required = false, example = "10")
             String sectionId,
-            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM).", required = false, example = "markdown")
+            @MCPParam(name = "format", description = "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).", required = false, example = "markdown")
             String format
     ) throws Exception {
         int projectId = getProjectId(projectName);
@@ -295,8 +295,20 @@ public class TestRailClient extends AbstractRestClient implements TrackerClient<
         return cases;
     }
 
+    /**
+     * Resolves the effective output format: an explicit non-blank {@code format} argument
+     * always wins; otherwise falls back to {@code TESTRAIL_DEFAULT_FORMAT} (see
+     * {@link PropertyReader#getTestRailDefaultFormat()}), which defaults to "html" when unset.
+     * This means setting {@code TESTRAIL_DEFAULT_FORMAT=markdown} makes every TestRail read
+     * (including internal callers that don't pass a format at all, e.g.
+     * TestCasesGenerator's related-test-case search via TestRailTestCasesAdapter) return
+     * Markdown by default, with no per-call-site changes required.
+     */
     private static boolean isMarkdownFormat(String format) {
-        return format != null && format.trim().equalsIgnoreCase("markdown");
+        String effectiveFormat = (format == null || format.isBlank())
+                ? new PropertyReader().getTestRailDefaultFormat()
+                : format;
+        return HtmlToMarkdownConverter.isMarkdownFormat(effectiveFormat);
     }
 
     private static void applyFormat(List<TestCase> cases, String format) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailTestCasesAdapter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/TestRailTestCasesAdapter.java
@@ -36,7 +36,7 @@ public class TestRailTestCasesAdapter implements TestCasesTrackerAdapter {
     public List<ITicket> getExistingCases() throws Exception {
         List<ITicket> result = new ArrayList<>();
         for (String projectName : config.getProjectNames()) {
-            List<TestCase> cases = client.getAllCases(projectName);
+            List<TestCase> cases = client.getAllCases(projectName, null);
             System.out.println("[DEBUG-LINKING] getExistingCases project='" + projectName + "' returned " + cases.size() + " cases");
             if (!cases.isEmpty()) {
                 System.out.println("[DEBUG-LINKING] getExistingCases sample keys (first 5): " + cases.stream().limit(5).map(c -> { try { return c.getKey() + "(refs=" + c.getString("refs") + ")"; } catch (Exception e) { return c.getKey(); } }).collect(java.util.stream.Collectors.joining(", ")));

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverterTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverterTest.java
@@ -97,4 +97,21 @@ public class HtmlToMarkdownConverterTest {
         String markdown = HtmlToMarkdownConverter.convert(html);
         assertTrue(markdown.contains("A \\| B"));
     }
+
+    @Test
+    public void testIsMarkdownFormatAcceptsMdAndMarkdownCaseInsensitively() {
+        assertTrue(HtmlToMarkdownConverter.isMarkdownFormat("md"));
+        assertTrue(HtmlToMarkdownConverter.isMarkdownFormat("MD"));
+        assertTrue(HtmlToMarkdownConverter.isMarkdownFormat("markdown"));
+        assertTrue(HtmlToMarkdownConverter.isMarkdownFormat("Markdown"));
+        assertTrue(HtmlToMarkdownConverter.isMarkdownFormat("MARKDOWN"));
+    }
+
+    @Test
+    public void testIsMarkdownFormatRejectsOtherValues() {
+        assertFalse(HtmlToMarkdownConverter.isMarkdownFormat("html"));
+        assertFalse(HtmlToMarkdownConverter.isMarkdownFormat(null));
+        assertFalse(HtmlToMarkdownConverter.isMarkdownFormat(""));
+        assertFalse(HtmlToMarkdownConverter.isMarkdownFormat("wiki"));
+    }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverterTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverterTest.java
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.common.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class HtmlToMarkdownConverterTest {
+
+    @Test
+    public void testConvertNullOrBlankReturnsEmptyString() {
+        assertEquals("", HtmlToMarkdownConverter.convert(null));
+        assertEquals("", HtmlToMarkdownConverter.convert(""));
+        assertEquals("", HtmlToMarkdownConverter.convert("   "));
+    }
+
+    @Test
+    public void testConvertPlainParagraph() {
+        String html = "<p>Hello world</p>";
+        String markdown = HtmlToMarkdownConverter.convert(html);
+        assertEquals("Hello world", markdown.trim());
+    }
+
+    @Test
+    public void testConvertStripsInlineStylesAndClasses() {
+        // Content pasted from Google Docs/a browser typically bakes every computed CSS
+        // property into inline style attributes on every tag -- Markdown has no equivalent,
+        // so CopyDown naturally drops all of it while preserving the actual text.
+        String html = "<p style=\"margin: 0px 0px 12px; font-family: Arial, sans-serif; "
+                + "color: rgb(32, 32, 32);\" class=\"foo\"><span style=\"font-weight: 400;\">"
+                + "The screenshot is captured.</span></p>";
+        String markdown = HtmlToMarkdownConverter.convert(html);
+        assertFalse("converted markdown must not contain leftover style attributes", markdown.contains("style="));
+        assertFalse("converted markdown must not contain leftover class attributes", markdown.contains("class="));
+        assertTrue(markdown.contains("The screenshot is captured."));
+    }
+
+    @Test
+    public void testConvertTableToGithubFlavouredMarkdown() {
+        String html = "<table>"
+                + "<tr><th>Sample ID</th><th>Status</th></tr>"
+                + "<tr><td>Sample1</td><td>Passed</td></tr>"
+                + "<tr><td>Sample2</td><td>Failed</td></tr>"
+                + "</table>";
+        String markdown = HtmlToMarkdownConverter.convert(html);
+
+        assertTrue(markdown.contains("| Sample ID | Status |"));
+        assertTrue(markdown.contains("---|"));
+        assertTrue(markdown.contains("| Sample1 | Passed |"));
+        assertTrue(markdown.contains("| Sample2 | Failed |"));
+    }
+
+    @Test
+    public void testConvertTableWithHeavyInlineStylesShrinksDramatically() {
+        StringBuilder styledCell = new StringBuilder();
+        styledCell.append("<td style=\"margin: 0px 0px 12px; padding: 0px; border: 0px; "
+                + "font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; "
+                + "font-variant-numeric: inherit; font-variant-east-asian: inherit; "
+                + "color: rgb(32, 32, 32); letter-spacing: normal;\">Sample1</td>");
+        String html = "<table><tr>" + styledCell + styledCell + "</tr></table>";
+
+        String markdown = HtmlToMarkdownConverter.convert(html);
+
+        assertFalse(markdown.contains("style="));
+        assertTrue(markdown.contains("Sample1"));
+        // The whole point: a table cell with ~250 chars of inline CSS per cell should shrink
+        // to a tiny fraction of its original size once styles are stripped.
+        assertTrue("markdown should be dramatically smaller than the styled HTML input",
+                markdown.length() < html.length() / 4);
+    }
+
+    @Test
+    public void testConvertHandlesMultipleTablesAndPreservesOrder() {
+        String html = "<p>Before</p>"
+                + "<table><tr><td>A</td></tr></table>"
+                + "<p>Between</p>"
+                + "<table><tr><td>B</td></tr></table>"
+                + "<p>After</p>";
+        String markdown = HtmlToMarkdownConverter.convert(html);
+
+        int beforeIdx = markdown.indexOf("Before");
+        int aIdx = markdown.indexOf("| A |");
+        int betweenIdx = markdown.indexOf("Between");
+        int bIdx = markdown.indexOf("| B |");
+        int afterIdx = markdown.indexOf("After");
+
+        assertTrue(beforeIdx >= 0 && aIdx > beforeIdx);
+        assertTrue(betweenIdx > aIdx && bIdx > betweenIdx);
+        assertTrue(afterIdx > bIdx);
+    }
+
+    @Test
+    public void testConvertEscapesPipeCharactersInsideTableCells() {
+        String html = "<table><tr><td>A | B</td><td>C</td></tr></table>";
+        String markdown = HtmlToMarkdownConverter.convert(html);
+        assertTrue(markdown.contains("A \\| B"));
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderTest.java
@@ -392,6 +392,28 @@ class PropertyReaderTest {
         assertTrue(result, "X-ray enrichment should be enabled by default");
     }
 
+    @Test
+    void testTestRailDefaultFormatConstant_NotNullAndCorrectValue() {
+        assertNotNull(PropertyReader.TESTRAIL_DEFAULT_FORMAT, "TESTRAIL_DEFAULT_FORMAT constant should exist");
+        assertEquals("TESTRAIL_DEFAULT_FORMAT", PropertyReader.TESTRAIL_DEFAULT_FORMAT);
+    }
+
+    @Test
+    void testGetTestRailDefaultFormat_DefaultsToHtmlWhenUnset() {
+        assertEquals("html", propertyReader.getTestRailDefaultFormat(),
+                "TestRail default format should be 'html' when the env var is unset, to preserve existing behavior");
+    }
+
+    @Test
+    void testGetTestRailDefaultFormat_ReturnsConfiguredValue() {
+        PropertyReader.setOverrides(Map.of(PropertyReader.TESTRAIL_DEFAULT_FORMAT, "markdown"));
+        try {
+            assertEquals("markdown", propertyReader.getTestRailDefaultFormat());
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
     // -------------------------------------------------------------------------
     // CLI output configuration
     // -------------------------------------------------------------------------

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
@@ -744,4 +744,89 @@ public class TestRailClientTest {
                 String.class, String.class, String.class, String.class,
                 String.class, String.class, String.class, String.class));
     }
+
+    // -- format=markdown for get_all_cases / search_cases -----------------------------------
+
+    @Test
+    public void testGetAllCasesDefaultFormatReturnsRawHtml() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 1)
+                .put("title", "TC1")
+                .put("custom_preconds", "<p style=\"color: red;\">Precondition text</p>");
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        List<TestCase> result = stubClient.getAllCases("Project A", null);
+
+        assertEquals(1, result.size());
+        assertEquals("<p style=\"color: red;\">Precondition text</p>",
+                result.get(0).getJSONObject().getString("custom_preconds"));
+    }
+
+    @Test
+    public void testGetAllCasesMarkdownFormatConvertsHtmlFields() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 1)
+                .put("title", "TC1")
+                .put("custom_preconds", "<p style=\"color: red; font-family: Arial;\">Precondition text</p>");
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        List<TestCase> result = stubClient.getAllCases("Project A", "markdown");
+
+        assertEquals(1, result.size());
+        String converted = result.get(0).getJSONObject().getString("custom_preconds");
+        assertFalse("markdown output must not contain leftover style attributes", converted.contains("style="));
+        assertTrue(converted.contains("Precondition text"));
+    }
+
+    @Test
+    public void testGetAllCasesMarkdownFormatConvertsStepsSeparatedArray() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+
+        JSONArray steps = new JSONArray()
+                .put(new JSONObject()
+                        .put("content", "<p style=\"margin:0\">Do the thing</p>")
+                        .put("expected", "<table><tr><td>A</td><td>B</td></tr></table>"));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 2)
+                .put("title", "TC2")
+                .put("custom_steps_separated", steps);
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        List<TestCase> result = stubClient.getAllCases("Project A", "markdown");
+
+        JSONArray convertedSteps = result.get(0).getJSONObject().getJSONArray("custom_steps_separated");
+        String convertedContent = convertedSteps.getJSONObject(0).getString("content");
+        String convertedExpected = convertedSteps.getJSONObject(0).getString("expected");
+
+        assertFalse(convertedContent.contains("style="));
+        assertTrue(convertedContent.contains("Do the thing"));
+        assertTrue("expected field's HTML table should become a Markdown table",
+                convertedExpected.contains("| A | B |"));
+    }
+
+    @Test
+    public void testSearchCasesMarkdownFormatConvertsHtmlFields() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 3)
+                .put("title", "TC3")
+                .put("custom_expected", "<p style=\"color:blue\">Expected outcome</p>");
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        List<TestCase> result = stubClient.searchCases("Project A", "1", null, "markdown");
+
+        String converted = result.get(0).getJSONObject().getString("custom_expected");
+        assertFalse(converted.contains("style="));
+        assertTrue(converted.contains("Expected outcome"));
+    }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
@@ -311,6 +311,22 @@ public class TestRailClientTest {
         assertEquals("cacheTestRail", client.getCacheFolderName());
     }
 
+    private String createSuitesPage(int offset, String nextLink, JSONObject... suites) {
+        JSONObject response = new JSONObject();
+        JSONArray suitesArray = new JSONArray();
+        for (JSONObject suite : suites) {
+            suitesArray.put(suite);
+        }
+        response.put("offset", offset);
+        response.put("limit", 250);
+        response.put("size", suitesArray.length());
+        response.put("suites", suitesArray);
+        response.put("_links", new JSONObject()
+                .put("next", nextLink == null ? JSONObject.NULL : nextLink)
+                .put("prev", JSONObject.NULL));
+        return response.toString();
+    }
+
     private String createProjectsPage(int offset, String nextLink, JSONObject... projects) {
         JSONObject response = new JSONObject();
         JSONArray projectsArray = new JSONArray();
@@ -688,6 +704,33 @@ public class TestRailClientTest {
     @Test
     public void testUpdateLabelMethodExists() throws Exception {
         assertNotNull(TestRailClient.class.getMethod("updateLabel", String.class, String.class, String.class));
+    }
+
+    @Test
+    public void testGetSuitesMethodExists() throws Exception {
+        assertNotNull(TestRailClient.class.getMethod("getSuites", String.class));
+    }
+
+    @Test
+    public void testGetSuitesAggregatesAllPagesUsingNextLink() throws Exception {
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        stubClient.queueResponse(createSuitesPage(0, "/api/v2/get_suites/5&limit=250&offset=250",
+                new JSONObject().put("id", 1).put("name", "Master")));
+        stubClient.queueResponse(createSuitesPage(250, null,
+                new JSONObject().put("id", 2).put("name", "Baseline Copy")));
+
+        JSONArray suites = new JSONArray(stubClient.getSuites("Project A"));
+
+        assertEquals(2, suites.length());
+        assertEquals("Master", suites.getJSONObject(0).getString("name"));
+        assertEquals("Baseline Copy", suites.getJSONObject(1).getString("name"));
+        assertEquals(List.of(
+                "/get_projects&limit=250&offset=0",
+                "/get_suites/5&limit=250&offset=0",
+                "/get_suites/5&limit=250&offset=250"
+        ), stubClient.getRequestedPaths());
     }
 
     @Test

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailClientTest.java
@@ -4,9 +4,11 @@
 package com.github.istin.dmtools.testrail;
 
 import com.github.istin.dmtools.common.model.ITicket;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.testrail.model.TestCase;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +16,7 @@ import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 
 import static org.junit.Assert.*;
@@ -56,6 +59,12 @@ public class TestRailClientTest {
         // Note: This creates a real client instance, but without actual HTTP calls
         // All HTTP calls would need to be mocked for integration testing
         // For unit testing, we test the logic without making real API calls
+        PropertyReader.clearOverrides();
+    }
+
+    @After
+    public void tearDown() {
+        PropertyReader.clearOverrides();
     }
 
     @Test
@@ -828,5 +837,67 @@ public class TestRailClientTest {
         String converted = result.get(0).getJSONObject().getString("custom_expected");
         assertFalse(converted.contains("style="));
         assertTrue(converted.contains("Expected outcome"));
+    }
+
+    @Test
+    public void testGetAllCasesMdAliasConvertsHtmlFieldsSameAsMarkdown() throws Exception {
+        // "md" must be accepted as an alias for "markdown", matching Confluence's convention.
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 1)
+                .put("title", "TC1")
+                .put("custom_preconds", "<p style=\"color: red;\">Precondition text</p>");
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        List<TestCase> result = stubClient.getAllCases("Project A", "md");
+
+        String converted = result.get(0).getJSONObject().getString("custom_preconds");
+        assertFalse("md alias must trigger markdown conversion", converted.contains("style="));
+        assertTrue(converted.contains("Precondition text"));
+    }
+
+    @Test
+    public void testGetAllCasesUsesMarkdownWhenEnvDefaultIsSetAndFormatIsNull() throws Exception {
+        PropertyReader.setOverrides(Map.of(PropertyReader.TESTRAIL_DEFAULT_FORMAT, "markdown"));
+
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        JSONObject caseJson = new JSONObject()
+                .put("id", 1)
+                .put("title", "TC1")
+                .put("custom_preconds", "<p style=\"color: red;\">Precondition text</p>");
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        // format is null here -- exactly how TestRailTestCasesAdapter's internal
+        // "find related existing test cases" call site invokes getAllCases today.
+        List<TestCase> result = stubClient.getAllCases("Project A", null);
+
+        String converted = result.get(0).getJSONObject().getString("custom_preconds");
+        assertFalse("env-var default should trigger markdown conversion even with format=null",
+                converted.contains("style="));
+        assertTrue(converted.contains("Precondition text"));
+    }
+
+    @Test
+    public void testGetAllCasesExplicitHtmlFormatOverridesEnvDefault() throws Exception {
+        PropertyReader.setOverrides(Map.of(PropertyReader.TESTRAIL_DEFAULT_FORMAT, "markdown"));
+
+        StubTestRailClient stubClient = new StubTestRailClient(basePath, username, apiKey);
+        stubClient.queueResponse(createProjectsPage(0, null,
+                new JSONObject().put("id", 5).put("name", "Project A")));
+        String rawHtml = "<p style=\"color: red;\">Precondition text</p>";
+        JSONObject caseJson = new JSONObject()
+                .put("id", 1)
+                .put("title", "TC1")
+                .put("custom_preconds", rawHtml);
+        stubClient.queueResponse(createCasesPage(0, null, caseJson));
+
+        // Explicit format="html" must win over the env-var default.
+        List<TestCase> result = stubClient.getAllCases("Project A", "html");
+
+        assertEquals(rawHtml, result.get(0).getJSONObject().getString("custom_preconds"));
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailTestCasesAdapterTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/testrail/TestRailTestCasesAdapterTest.java
@@ -68,14 +68,14 @@ public class TestRailTestCasesAdapterTest {
         TestCase tc2 = new TestCase(BASE_PATH, new JSONObject("{\"id\":2,\"title\":\"TC2\"}"));
         TestCase tc3 = new TestCase(BASE_PATH, new JSONObject("{\"id\":3,\"title\":\"TC3\"}"));
 
-        when(mockClient.getAllCases("Project A")).thenReturn(Arrays.asList(tc1, tc2));
-        when(mockClient.getAllCases("Project B")).thenReturn(Arrays.asList(tc3));
+        when(mockClient.getAllCases("Project A", null)).thenReturn(Arrays.asList(tc1, tc2));
+        when(mockClient.getAllCases("Project B", null)).thenReturn(Arrays.asList(tc3));
 
         List<ITicket> result = multiProjectAdapter.getExistingCases();
 
         assertEquals(3, result.size());
-        verify(mockClient).getAllCases("Project A");
-        verify(mockClient).getAllCases("Project B");
+        verify(mockClient).getAllCases("Project A", null);
+        verify(mockClient).getAllCases("Project B", null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two related TestRail improvements, discovered/motivated by real usage while auditing test case counts and content across a large TestRail instance:

### 1. `testrail_get_suites` (already present on this branch)

TestRail multi-suite projects (`suite_mode: 2`) require a `suite_id` to fetch cases (`Field :suite_id is a required field`), but dmtools had no way to discover suite IDs at all -- forcing callers to hit the raw TestRail REST API directly just to enumerate a project's suites (Master vs. historical Baseline snapshots). Adds `testrail_get_suites(project_name)`, paginated like the other list endpoints.

### 2. `format=markdown` for `testrail_get_case` / `testrail_get_all_cases` / `testrail_search_cases`

TestRail test case preconditions/steps/expected-result fields are stored as raw HTML. Content pasted from Google Docs/a browser bakes every computed CSS property into inline `style="..."` attributes on every single tag. Measured on a real customer instance:
- One `expected` field: **183KB raw HTML** vs. **5.6KB of actual visible text** (96.9% overhead)
- The largest single test case observed: **1.4-1.7MB**

This makes raw-HTML fetches extremely wasteful for any downstream LLM consumption of test case content (roughly 20-30x more tokens than necessary).

**Fix**: new optional `format` parameter (default `"html"`, or `"markdown"`) on `testrail_get_case`, `testrail_get_all_cases`, `testrail_search_cases`. When `format=markdown`, every HTML-bearing field on the returned test case(s) is converted to Markdown:
- Tables are preserved as GitHub-Flavoured Markdown tables (not just flattened to text)
- Inline styles/classes are stripped (Markdown has no equivalent — this is exactly what collapses the CSS bloat)
- Detection is by **content-sniffing** (any string field containing a `<...>` tag), not a hardcoded field-name allowlist, so it works regardless of custom-field naming differences across TestRail projects/templates
- The `custom_steps_separated` array (`content`/`expected`/`additional_info` per step) is handled specially since it's a JSON array of objects, not a plain string field

### Implementation notes

- Extracted the generic (non-Confluence-specific) table-aware HTML→Markdown conversion pipeline into a new shared utility: `common/utils/HtmlToMarkdownConverter.java`. This logic was previously duplicated inside `ConfluenceStorageMarkdown.java` — extract `<table>` elements, convert each to a GFM table (CopyDown/turndown doesn't generate Markdown tables on its own), run CopyDown on the table-less remainder, then restore the Markdown tables at their placeholders.
- `ConfluenceStorageMarkdown.java` now delegates to this shared utility for its own table+CopyDown step, instead of duplicating it. Its Confluence-specific `<ac:*>`/`<ri:*>` tag preprocessing is unchanged. **All 47 existing Confluence Markdown tests still pass unchanged** — zero behavior change for Confluence.
- Updated the one internal caller (`TestRailTestCasesAdapter.java`) to pass the new trailing parameter as `null` (preserves existing default HTML behavior).

### Testing

- New `HtmlToMarkdownConverterTest` (7 tests): null/blank handling, plain text, inline-style/class stripping, table conversion, heavy-inline-style shrinkage assertion, multi-table ordering, pipe-character escaping in cells.
- New `TestRailClientTest` cases for `format=markdown` on `getAllCases`/`searchCases`: default HTML passthrough, precondition field conversion, `custom_steps_separated` array conversion, `search_cases` conversion.
- Full `dmtools-core` suite: **4321 tests, 0 failures**.
