### PR TITLE
feat: extend MermaidIndex to support TestRail per-test-case diagrams

### DIFF
--- a/dmtools-ai-docs/references/configuration/integrations/testrail.md
+++ b/dmtools-ai-docs/references/configuration/integrations/testrail.md
@@ -151,6 +151,33 @@ dmtools testrail_get_projects
 
 **Full guide**: [../../test-generation/testrail-manual.md](../../test-generation/testrail-manual.md)
 
+## 🚀 Generating Diagrams from TestRail Test Cases
+
+You can generate a Mermaid diagram for every TestRail test case in a project or suite.
+
+```bash
+# Generate diagrams for all cases in a TestRail project/suite
+dmtools mermaid_index_generate testrail '["project_id=5&suite_id=3"]' '[]' ./mermaid-diagrams
+```
+
+Requirements:
+- `TESTRAIL_BASE_PATH`, `TESTRAIL_USERNAME`, and `TESTRAIL_API_KEY` must be configured.
+- The first `include_patterns` entry is passed directly to TestRail as the API query for `get_cases`.
+
+Output is stored under `./mermaid-diagrams/testrail/CASE_KEY/CaseTitle.mmd`, for example:
+
+```
+./mermaid-diagrams/testrail/
+└── C12345
+    └── Verify_Login_Page.mmd
+```
+
+Read generated diagrams back with:
+
+```bash
+dmtools mermaid_index_read testrail ./mermaid-diagrams
+```
+
 ## 📋 Available TestRail MCP Tools
 
 **Complete reference**: [../../mcp-tools/testrail-tools.md](../../mcp-tools/testrail-tools.md) — all 16 TestRail tools with parameters.

--- a/dmtools-ai-docs/references/mcp-tools/mermaid-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/mermaid-tools.md
@@ -25,7 +25,7 @@ const result = mermaid_index_read(...);
 
 | Tool Name | Description | Parameters |
 |-----------|-------------|------------|
-| `mermaid_index_generate` | Generate Mermaid diagrams from content sources (Confluence or Jira) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure. | `integration` (string, **required**)<br>`include_patterns` (array, **required**)<br>`exclude_patterns` (array, optional)<br>`storage_path` (string, **required**)<br>`custom_fields` (array, optional)<br>`include_comments` (boolean, optional) |
+| `mermaid_index_generate` | Generate Mermaid diagrams from content sources (Confluence, Jira, Jira Xray, or TestRail) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure. | `integration` (string, **required**)<br>`include_patterns` (array, **required**)<br>`exclude_patterns` (array, optional)<br>`storage_path` (string, **required**)<br>`custom_fields` (array, optional)<br>`include_comments` (boolean, optional) |
 | `mermaid_index_read` | Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of diagrams with their paths and content. | `integration` (string, **required**)<br>`storage_path` (string, **required**) |
 | `mermaid_index_read_list` | Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of ToText objects with paths and content. | `integration` (string, **required**)<br>`storage_path` (string, **required**) |
 
@@ -33,20 +33,20 @@ const result = mermaid_index_read(...);
 
 ### `mermaid_index_generate`
 
-Generate Mermaid diagrams from content sources (Confluence or Jira) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure.
+Generate Mermaid diagrams from content sources (Confluence, Jira, Jira Xray, or TestRail) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure.
 
 **Parameters:**
 
 - **`integration`** (string) 🔴 Required
-  - Integration type: 'confluence', 'jira', or 'jira_xray'
+  - Integration type: 'confluence', 'jira', 'jira_xray', or 'testrail'
   - Example: `confluence`
 
 - **`include_patterns`** (array) 🔴 Required
-  - Array of include patterns. For Confluence: ["SPACE/pages/PAGE_ID/PAGE_NAME/**"]. For Jira: ["JQL query"]
+  - Array of include patterns. For Confluence: `["SPACE/pages/PAGE_ID/PAGE_NAME/**"]`. For Jira: `["JQL query"]`. For TestRail: `["project_id=5&suite_id=3"]`
   - Example: `["AINA/pages/11665522/Templates/**"]`
 
 - **`exclude_patterns`** (array) ⚪ Optional
-  - Optional array of exclude patterns to filter out specific content (not used for Jira)
+  - Optional array of exclude patterns to filter out specific content (not used for Jira or TestRail)
   - Example: `[]`
 
 - **`storage_path`** (string) 🔴 Required
@@ -61,14 +61,26 @@ Generate Mermaid diagrams from content sources (Confluence or Jira) based on inc
   - Whether to include comments in content (only for Jira integrations, default: false)
   - Example: `false`
 
-**Example:**
+**Examples:**
+
+Confluence:
 ```bash
-dmtools mermaid_index_generate "value" "value"
+dmtools mermaid_index_generate confluence '["SPACE/pages/123/MyPage/**"]' '[]' ./mermaid-diagrams
+```
+
+Jira:
+```bash
+dmtools mermaid_index_generate jira '["project = PROJ AND type = Story"]' '[]' ./mermaid-diagrams
+```
+
+TestRail:
+```bash
+dmtools mermaid_index_generate testrail '["project_id=5&suite_id=3"]' '[]' ./mermaid-diagrams
 ```
 
 ```javascript
 // In JavaScript agent
-const result = mermaid_index_generate("integration", "include_patterns");
+const result = mermaid_index_generate("confluence", ["SPACE/pages/123/MyPage/**"], [], "./mermaid-diagrams");
 ```
 
 ---
@@ -80,7 +92,7 @@ Read all Mermaid diagram files (.mmd) from storage path recursively. Returns lis
 **Parameters:**
 
 - **`integration`** (string) 🔴 Required
-  - Integration type (currently only 'confluence' is supported)
+  - Integration type used as subfolder name under `storage_path`. Supported: 'confluence', 'jira', 'jira_xray', 'testrail', or any integration subfolder you created.
   - Example: `confluence`
 
 - **`storage_path`** (string) 🔴 Required
@@ -89,12 +101,12 @@ Read all Mermaid diagram files (.mmd) from storage path recursively. Returns lis
 
 **Example:**
 ```bash
-dmtools mermaid_index_read "value" "value"
+dmtools mermaid_index_read confluence ./mermaid-diagrams
 ```
 
 ```javascript
 // In JavaScript agent
-const result = mermaid_index_read("integration", "storage_path");
+const result = mermaid_index_read("confluence", "./mermaid-diagrams");
 ```
 
 ---
@@ -106,7 +118,7 @@ Read all Mermaid diagram files (.mmd) from storage path recursively. Returns lis
 **Parameters:**
 
 - **`integration`** (string) 🔴 Required
-  - Integration type (currently only 'confluence' is supported)
+  - Integration type used as subfolder name under `storage_path`. Supported: 'confluence', 'jira', 'jira_xray', 'testrail', or any integration subfolder you created.
   - Example: `confluence`
 
 - **`storage_path`** (string) 🔴 Required
@@ -115,12 +127,12 @@ Read all Mermaid diagram files (.mmd) from storage path recursively. Returns lis
 
 **Example:**
 ```bash
-dmtools mermaid_index_read_list "value" "value"
+dmtools mermaid_index_read_list confluence ./mermaid-diagrams
 ```
 
 ```javascript
 // In JavaScript agent
-const result = mermaid_index_read_list("integration", "storage_path");
+const result = mermaid_index_read_list("confluence", "./mermaid-diagrams");
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/index/mermaid/MermaidIndex.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/index/mermaid/MermaidIndex.java
@@ -88,15 +88,15 @@ public class MermaidIndex {
     }
     
     /**
-     * Creates a new MermaidIndex instance for Jira or Jira Xray integration.
+     * Creates a new MermaidIndex instance for Jira, Jira Xray, or TestRail integration.
      * 
-     * @param integrationName Name of the integration ("jira" or "jira_xray")
+     * @param integrationName Name of the integration ("jira", "jira_xray", or "testrail")
      * @param storagePath Base path for storing generated diagrams
-     * @param includePatterns List of patterns to include (first element should be JQL query)
-     * @param excludePatterns List of patterns to exclude (not used for Jira)
-     * @param trackerClient TrackerClient instance (BasicJiraClient or XrayClient)
-     * @param customFields Array of custom field names to include in content
-     * @param includeComments Whether to include comments in the content
+     * @param includePatterns List of patterns to include (first element should be JQL query or TestRail API query)
+     * @param excludePatterns List of patterns to exclude (not used for Jira or TestRail)
+     * @param trackerClient TrackerClient instance (BasicJiraClient, XrayClient, or TestRailClient)
+     * @param customFields Array of custom field names to include in content (only used for Jira integrations)
+     * @param includeComments Whether to include comments in the content (only used for Jira integrations)
      * @param diagramGenerator Diagram generator agent
      * @throws IllegalArgumentException if required parameters are null
      */
@@ -112,7 +112,7 @@ public class MermaidIndex {
             throw new IllegalArgumentException("Diagram generator is required");
         }
         if (trackerClient == null) {
-            throw new IllegalArgumentException("TrackerClient is required for Jira integration");
+            throw new IllegalArgumentException("TrackerClient is required for " + integrationName + " integration");
         }
         
         this.integrationName = integrationName;
@@ -125,12 +125,14 @@ public class MermaidIndex {
         // Create integration instance based on name
         // Both "jira" and "jira_xray" use JiraMermaidIndexIntegration, but with different TrackerClient instances
         // The TrackerClient (BasicJiraClient or XrayClient) is already selected in MermaidIndexTools
-        logger.info("Creating JiraMermaidIndexIntegration for integration: {} with TrackerClient: {}", 
+        logger.info("Creating integration for: {} with TrackerClient: {}", 
                 integrationName, trackerClient.getClass().getName());
         if ("jira".equalsIgnoreCase(integrationName) || "jira_xray".equalsIgnoreCase(integrationName)) {
             this.integration = new JiraMermaidIndexIntegration(trackerClient, customFields, includeComments);
+        } else if ("testrail".equalsIgnoreCase(integrationName)) {
+            this.integration = new com.github.istin.dmtools.testrail.index.TestRailMermaidIndexIntegration(trackerClient);
         } else {
-            throw new IllegalArgumentException("Unsupported integration: " + integrationName + ". Use 'jira' or 'jira_xray' for this constructor.");
+            throw new IllegalArgumentException("Unsupported integration: " + integrationName + ". Use 'jira', 'jira_xray', or 'testrail' for this constructor.");
         }
     }
     

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/index/mermaid/tool/MermaidIndexTools.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/index/mermaid/tool/MermaidIndexTools.java
@@ -9,6 +9,7 @@ import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.atlassian.jira.BasicJiraClient;
 import com.github.istin.dmtools.atlassian.jira.xray.XrayClient;
 import com.github.istin.dmtools.common.model.ITicket;
+import com.github.istin.dmtools.testrail.TestRailClient;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.index.mermaid.MermaidIndex;
@@ -47,13 +48,13 @@ public class MermaidIndexTools {
     }
     
     /**
-     * Generate Mermaid diagrams from content sources (Confluence or Jira) based on include/exclude patterns.
+     * Generate Mermaid diagrams from content sources (Confluence, Jira, Jira Xray, or TestRail) based on include/exclude patterns.
      * Processes content recursively and stores diagrams in hierarchical file structure.
      * 
-     * @param integration Integration type ("confluence", "jira", or "jira_xray")
+     * @param integration Integration type ("confluence", "jira", "jira_xray", or "testrail")
      * @param storagePath Base path for storing generated diagrams
-     * @param includePatterns Array of include patterns. For Confluence: ["SPACE/pages/PAGE_ID/PAGE_NAME/**"]. For Jira: ["JQL query"]
-     * @param excludePatterns Optional array of exclude patterns (not used for Jira)
+     * @param includePatterns Array of include patterns. For Confluence: ["SPACE/pages/PAGE_ID/PAGE_NAME/**"]. For Jira: ["JQL query"]. For TestRail: ["project_id=5&suite_id=3"]
+     * @param excludePatterns Optional array of exclude patterns (not used for Jira or TestRail)
      * @param customFields Optional array of custom field names to include (only for Jira integrations)
      * @param includeComments Whether to include comments in content (only for Jira integrations, default: false)
      * @return JSON string with operation result and statistics
@@ -67,7 +68,7 @@ public class MermaidIndexTools {
     public String mermaidIndexGenerate(
             @MCPParam(
                 name = "integration",
-                description = "Integration type: 'confluence', 'jira', or 'jira_xray'",
+                description = "Integration type: 'confluence', 'jira', 'jira_xray', or 'testrail'",
                 required = true,
                 example = "confluence"
             ) String integration,
@@ -79,7 +80,7 @@ public class MermaidIndexTools {
             ) String storagePath,
             @MCPParam(
                 name = "include_patterns",
-                description = "Array of include patterns. For Confluence: [\"SPACE/pages/PAGE_ID/PAGE_NAME/**\"]. For Jira: [\"JQL query\"]",
+                description = "Array of include patterns. For Confluence: [\"SPACE/pages/PAGE_ID/PAGE_NAME/**\"]. For Jira: [\"JQL query\"]. For TestRail: [\"project_id=5&suite_id=3\"]",
                 required = true,
                 example = "[\"AINA/pages/11665522/Templates/**\"]",
                 type = "array"
@@ -191,8 +192,35 @@ public class MermaidIndexTools {
                         includeCommentsValue,
                         diagramGenerator
                 );
+            }
+            // Handle TestRail integration
+            else if ("testrail".equalsIgnoreCase(integration)) {
+                TrackerClient<? extends ITicket> trackerClient;
+                try {
+                    logger.info("Using TestRailClient for integration: {}", integration);
+                    trackerClient = TestRailClient.getInstance();
+                    if (trackerClient == null) {
+                        logger.error("TestRailClient.getInstance() returned null");
+                        return "{\"success\": false, \"error\": \"TestRail is not configured. Please configure TestRail credentials.\"}";
+                    }
+                    logger.info("TestRailClient instance obtained successfully: {}", trackerClient.getClass().getName());
+                } catch (IOException e) {
+                    logger.error("Failed to get TestRail client instance for integration: {}", integration, e);
+                    return "{\"success\": false, \"error\": \"Failed to get TestRail client instance: " + e.getMessage() + "\"}";
+                }
+
+                mermaidIndex = new MermaidIndex(
+                        integration,
+                        storagePath,
+                        includePatterns,
+                        normalizedExclude,
+                        trackerClient,
+                        customFieldsArray,
+                        includeCommentsValue,
+                        diagramGenerator
+                );
             } else {
-                return "{\"success\": false, \"error\": \"Unsupported integration: " + integration + ". Supported: 'confluence', 'jira', 'jira_xray'.\"}";
+                return "{\"success\": false, \"error\": \"Unsupported integration: " + integration + ". Supported: 'confluence', 'jira', 'jira_xray', 'testrail'.\"}";
             }
             
             // Execute indexing
@@ -216,7 +244,7 @@ public class MermaidIndexTools {
      * Read all Mermaid diagram files (.mmd) from storage path recursively.
      * Returns a list of ToText objects containing file path and content.
      * 
-     * @param integration Integration type (currently only "confluence" is supported)
+     * @param integration Integration type (used as subfolder name under storage path)
      * @param storagePath Base path where diagrams are stored
      * @return List of ToText objects, each containing path and content of a diagram file
      * @throws IOException if an error occurs reading files
@@ -230,7 +258,7 @@ public class MermaidIndexTools {
     public List<ToText> read(
             @MCPParam(
                 name = "integration",
-                description = "Integration type (currently only 'confluence' is supported)",
+                description = "Integration type (used as subfolder name under storage path)",
                 required = true,
                 example = "confluence"
             ) String integration,
@@ -243,23 +271,25 @@ public class MermaidIndexTools {
     ) throws IOException {
         logger.info("Reading Mermaid diagrams: integration={}, storagePath={}", integration, storagePath);
         
-        // Validate integration type
-        if (!"confluence".equalsIgnoreCase(integration)) {
-            throw new IllegalArgumentException("Unsupported integration: " + integration + ". Only 'confluence' is currently supported.");
-        }
-        
         // Validate storage path
         if (storagePath == null || storagePath.trim().isEmpty()) {
             throw new IllegalArgumentException("Storage path is required");
         }
         
-        Path storagePathObj = Paths.get(storagePath, integration);
-        if (!Files.exists(storagePathObj)) {
-            throw new IOException("Storage path does not exist: " + storagePathObj);
+        Path basePathObj = Paths.get(storagePath);
+        if (!Files.exists(basePathObj)) {
+            throw new IOException("Storage path does not exist: " + basePathObj);
         }
         
         // Recursively find all .mmd files
         List<ToText> diagrams = new ArrayList<>();
+        
+        Path storagePathObj = basePathObj.resolve(integration);
+        if (!Files.exists(storagePathObj)) {
+            logger.info("Integration subfolder does not exist: {}, returning empty list", storagePathObj);
+            return diagrams;
+        }
+        
         try (Stream<Path> paths = Files.walk(storagePathObj)) {
             paths.filter(Files::isRegularFile)
                  .filter(path -> path.toString().endsWith(".mmd"))
@@ -283,7 +313,7 @@ public class MermaidIndexTools {
      * Read all Mermaid diagram files (.mmd) from storage path recursively.
      * Returns JSON string with list of diagram files (path and content).
      * 
-     * @param integration Integration type (currently only "confluence" is supported)
+     * @param integration Integration type (used as subfolder name under storage path)
      * @param storagePath Base path where diagrams are stored
      * @return JSON string with list of diagram files (path and content)
      */
@@ -296,7 +326,7 @@ public class MermaidIndexTools {
     public String mermaidIndexRead(
             @MCPParam(
                 name = "integration",
-                description = "Integration type (currently only 'confluence' is supported)",
+                description = "Integration type (used as subfolder name under storage path)",
                 required = true,
                 example = "confluence"
             ) String integration,

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/index/TestRailMermaidIndexIntegration.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/testrail/index/TestRailMermaidIndexIntegration.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.testrail.index;
+
+import com.github.istin.dmtools.common.model.ITicket;
+import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.index.mermaid.MermaidIndexIntegration;
+import com.github.istin.dmtools.testrail.model.TestCase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * TestRail implementation of {@link MermaidIndexIntegration}.
+ * <p>
+ * Iterates over TestRail test cases using the underlying {@link TrackerClient}
+ * and feeds each case into the Mermaid indexing pipeline. The first include
+ * pattern is treated as the TestRail API query (e.g. {@code project_id=5&suite_id=3}).
+ */
+public class TestRailMermaidIndexIntegration implements MermaidIndexIntegration {
+
+    private static final Logger logger = LogManager.getLogger(TestRailMermaidIndexIntegration.class);
+
+    private final TrackerClient<? extends ITicket> trackerClient;
+
+    public TestRailMermaidIndexIntegration(TrackerClient<? extends ITicket> trackerClient) {
+        if (trackerClient == null) {
+            throw new IllegalArgumentException("TrackerClient is required");
+        }
+        this.trackerClient = trackerClient;
+    }
+
+    @Override
+    public void getContentForIndex(List<String> includePatterns, List<String> excludePatterns, ContentProcessor processor) {
+        if (includePatterns == null || includePatterns.isEmpty()) {
+            logger.warn("No include patterns provided, no TestRail content will be retrieved");
+            return;
+        }
+
+        String query = includePatterns.get(0);
+        if (query == null || query.trim().isEmpty()) {
+            logger.warn("Empty TestRail query pattern, skipping");
+            return;
+        }
+
+        logger.info("Processing TestRail cases with query: {}", query);
+
+        try {
+            @SuppressWarnings("unchecked")
+            TrackerClient<TestCase> client = (TrackerClient<TestCase>) trackerClient;
+            client.searchAndPerform(testCase -> {
+                processTestCase(testCase, processor);
+                return false; // continue processing all cases
+            }, query, trackerClient.getDefaultQueryFields());
+        } catch (Exception e) {
+            logger.error("Error retrieving content from TestRail", e);
+            throw new RuntimeException("Failed to retrieve content from TestRail", e);
+        }
+    }
+
+    private void processTestCase(TestCase testCase, ContentProcessor processor) {
+        if (testCase == null) {
+            return;
+        }
+
+        String caseKey = testCase.getTicketKey();
+        if (caseKey == null || caseKey.isEmpty()) {
+            logger.warn("Skipping TestRail case without key");
+            return;
+        }
+
+        String title;
+        try {
+            title = testCase.getTicketTitle();
+        } catch (Exception e) {
+            title = caseKey;
+        }
+
+        String content;
+        try {
+            content = testCase.toText();
+        } catch (Exception e) {
+            logger.warn("Failed to convert {} to text, falling back to description", caseKey, e);
+            content = testCase.getTicketDescription();
+        }
+
+        if (content == null || content.trim().isEmpty()) {
+            logger.debug("No content for TestRail case {}, skipping", caseKey);
+            return;
+        }
+
+        List<String> metadata = new ArrayList<>();
+        metadata.add("testCaseKey:" + caseKey);
+        try {
+            String issueType = testCase.getIssueType();
+            if (issueType != null) {
+                metadata.add("issueType:" + issueType);
+            }
+        } catch (Exception e) {
+            logger.debug("Failed to get issue type for {}: {}", caseKey, e.getMessage());
+        }
+
+        Long updatedMillis = testCase.getUpdatedAsMillis();
+        Date lastModified = updatedMillis != null && updatedMillis > 0
+                ? new Date(updatedMillis)
+                : new Date();
+
+        // TestRail attachments are not supported yet; pass empty list
+        List<File> attachments = Collections.emptyList();
+
+        processor.process(caseKey, title, content, metadata, attachments, lastModified);
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/index/mermaid/tool/MermaidIndexToolsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/index/mermaid/tool/MermaidIndexToolsTest.java
@@ -175,14 +175,34 @@ class MermaidIndexToolsTest {
     }
 
     @Test
-    void testRead_WithUnsupportedIntegration_ThrowsException() {
+    void testRead_WithUnsupportedIntegration_ReturnsEmptyList() throws IOException {
         // Given
         Path storagePath = tempDir.resolve("test-storage");
+        Files.createDirectories(storagePath);
         
-        // When/Then
-        assertThrows(IllegalArgumentException.class, () -> {
-            tools.read("unsupported", storagePath.toString());
-        }, "Should throw IllegalArgumentException for unsupported integration");
+        // When
+        List<ToText> result = tools.read("unsupported", storagePath.toString());
+        
+        // Then
+        assertTrue(result.isEmpty(), "Should return empty list when integration subfolder does not exist");
+    }
+
+    @Test
+    void testRead_WithTestRailIntegration_ReturnsMmdFiles() throws IOException {
+        // Given
+        Path storagePath = tempDir.resolve("test-storage");
+        Path testrailPath = storagePath.resolve("testrail");
+        Path casePath = testrailPath.resolve("C1");
+        Files.createDirectories(casePath);
+        
+        Path diagram = casePath.resolve("TestCase.mmd");
+        Files.write(diagram, "flowchart TD\nA --> B".getBytes(StandardCharsets.UTF_8));
+        
+        // When
+        List<ToText> result = tools.read("testrail", storagePath.toString());
+        
+        // Then
+        assertEquals(1, result.size(), "Should find .mmd files under testrail subfolder");
     }
 
     @Test
@@ -265,18 +285,19 @@ class MermaidIndexToolsTest {
     }
 
     @Test
-    void testMermaidIndexRead_WithUnsupportedIntegration_ReturnsErrorJson() {
+    void testMermaidIndexRead_WithUnsupportedIntegration_ReturnsEmptySuccessJson() throws IOException {
         // Given
         Path storagePath = tempDir.resolve("test-storage");
+        Files.createDirectories(storagePath);
         
         // When
         String result = tools.mermaidIndexRead("unsupported", storagePath.toString());
         
         // Then
         assertNotNull(result);
-        assertTrue(result.contains("\"success\": false"));
-        assertTrue(result.contains("error"));
-        assertTrue(result.contains("Unsupported integration"));
+        assertTrue(result.contains("\"success\": true"));
+        assertTrue(result.contains("\"count\": 0"));
+        assertTrue(result.contains("\"diagrams\":[]") || result.contains("\"diagrams\": []"));
     }
 
     @Test


### PR DESCRIPTION
- Add `TestRailMermaidIndexIntegration` that iterates over TestRail test cases using the configured `TestRailClient` and feeds each `TestCase` into the Mermaid diagram generator pipeline.\n- Extend `MermaidIndex` tracker-client constructor to create the correct integration for `testrail` in addition to `jira` and `jira_xray`.\n- Extend `mermaid_index_generate` MCP tool to accept `testrail` integration with a TestRail API query as the include pattern.\n- Remove hardcoded 'confluence-only' restriction from `mermaid_index_read` and `mermaid_index_read_list` so generated `.mmd` files can be read for any integration subfolder; missing integration subfolders return an empty list.\n- Update and add unit tests for generic integration reading and TestRail subfolder reading.\n\nAll `dmtools-core` unit tests pass.