### PR TITLE
fix(install): make dmtools available immediately in CI sessions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1781,6 +1781,29 @@ update_shell_config() {
     done
 }
 
+# Ensure dmtools is reachable in the current session without requiring a shell restart.
+# In CI environments shell rc files are usually not sourced between steps, so create a
+# symlink in a directory that is already on PATH (commonly ~/.local/bin).
+ensure_dmtools_in_path() {
+    # If BIN_DIR is already in PATH, the existing shell config updates are enough.
+    case ":${PATH}:" in
+        *:"$BIN_DIR":*) return 0 ;;
+    esac
+
+    local preferred_dir="$HOME/.local/bin"
+
+    # Create ~/.local/bin if it does not exist yet.
+    if ! mkdir -p "$preferred_dir" 2>/dev/null; then
+        return 0
+    fi
+
+    if [ -w "$preferred_dir" ]; then
+        if ln -sf "$SCRIPT_PATH" "$preferred_dir/dmtools" 2>/dev/null; then
+            info "Created symlink at $preferred_dir/dmtools so dmtools is available immediately."
+        fi
+    fi
+}
+
 # Verify installation
 verify_installation() {
     progress "Verifying installation..."
@@ -1915,6 +1938,9 @@ main() {
     
     # Update shell configuration
     update_shell_config
+    
+    # Make dmtools available in the current session (important for CI)
+    ensure_dmtools_in_path
     
     # Verify installation
     verify_installation


### PR DESCRIPTION
## Problem

The installer updates shell rc files (`~/.zshrc`, `~/.profile`) with the `export PATH` line, but in CI environments like Bitrise those files are not sourced between steps. As a result, `dmtools` is not found right after installation:

```
zsh: command not found: dmtools
```

## Fix

Create a symlink in `~/.local/bin` (which is already on PATH on most modern images, including Bitrise macOS stacks) pointing to `~/.dmtools/bin/dmtools`. This makes the command available immediately, without requiring a shell restart or manual `export PATH`.

## Changes

- Added `ensure_dmtools_in_path()` helper in `install.sh`.
- Called it after `update_shell_config()` in the main install flow.

## Verification

```bash
bash -n install.sh  # OK
```