### PR TITLE
fix(confluence): stop nested macro parameters leaking into Markdown

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -256,42 +257,78 @@ public final class ConfluenceStorageMarkdown {
             link.replaceWith(a);
         }
 
-        for (Element macro : doc.getElementsByTag("ac:structured-macro")) {
-            String macroName = macro.attr("ac:name").toLowerCase();
-            if ("code".equals(macroName)) {
-                String language = "";
-                for (Element param : macro.getElementsByTag("ac:parameter")) {
-                    if ("language".equals(param.attr("ac:name"))) {
-                        language = param.text();
-                        break;
-                    }
-                }
-                Element plainBody = macro.getElementsByTag("ac:plain-text-body").first();
-                String code = plainBody != null ? plainBody.text() : "";
-                Element pre = doc.createElement("pre");
-                Element codeEl = doc.createElement("code");
-                if (!language.isBlank()) {
-                    codeEl.addClass("language-" + language);
-                }
-                codeEl.html(StringEscapeUtils.escapeHtml4(code));
-                pre.appendChild(codeEl);
-                macro.replaceWith(pre);
-            } else if ("children".equals(macroName) || "childpages".equals(macroName)) {
-                macro.replaceWith(doc.createElement("p").text("[Child pages]"));
-            } else {
-                Element richBody = macro.getElementsByTag("ac:rich-text-body").first();
-                if (richBody != null) {
-                    Element div = doc.createElement("div");
-                    div.html(richBody.html());
-                    macro.replaceWith(div);
-                } else {
-                    // Remove unknown macros so their parameter text doesn't leak into Markdown.
-                    macro.remove();
-                }
-            }
-        }
+        resolveStructuredMacros(doc);
+
+        // Safety net: <ac:parameter> is always macro configuration, never real page
+        // content. If any survive (e.g. malformed/unexpected nesting the loop above
+        // did not anticipate), strip them so their raw text never leaks into Markdown.
+        doc.getElementsByTag("ac:parameter").remove();
 
         return bodyHtml(doc);
+    }
+
+    // Unwrapping an unknown macro's <ac:rich-text-body> can reveal further nested
+    // <ac:structured-macro> elements (e.g. third-party "live table" macros such as
+    // Table Filter/Charts' table-excerpt-include, livesearch, sparkline, pivot-table,
+    // etc. wrap their filter/sort configuration macro inside the body of an outer
+    // macro). A single pass over doc.getElementsByTag(...) does not revisit elements
+    // inserted during that same pass, so nested macros/parameters were previously left
+    // untouched and leaked as raw concatenated text once handed to the Markdown
+    // converter. Re-run the resolution loop until no structured macros remain (bounded
+    // to avoid an infinite loop on pathological/self-referential input).
+    private static void resolveStructuredMacros(Document doc) {
+        int maxIterations = 25;
+        for (int iteration = 0; iteration < maxIterations; iteration++) {
+            Elements macros = doc.getElementsByTag("ac:structured-macro");
+            if (macros.isEmpty()) {
+                return;
+            }
+            for (Element macro : macros) {
+                resolveStructuredMacro(doc, macro);
+            }
+        }
+        // Give up gracefully: remove any macros still standing rather than let their
+        // configuration parameters leak into the final Markdown.
+        doc.getElementsByTag("ac:structured-macro").remove();
+    }
+
+    private static void resolveStructuredMacro(Document doc, Element macro) {
+        String macroName = macro.attr("ac:name").toLowerCase();
+        if ("code".equals(macroName)) {
+            String language = "";
+            for (Element param : macro.getElementsByTag("ac:parameter")) {
+                if ("language".equals(param.attr("ac:name"))) {
+                    language = param.text();
+                    break;
+                }
+            }
+            Element plainBody = macro.getElementsByTag("ac:plain-text-body").first();
+            String code = plainBody != null ? plainBody.text() : "";
+            Element pre = doc.createElement("pre");
+            Element codeEl = doc.createElement("code");
+            if (!language.isBlank()) {
+                codeEl.addClass("language-" + language);
+            }
+            codeEl.html(StringEscapeUtils.escapeHtml4(code));
+            pre.appendChild(codeEl);
+            macro.replaceWith(pre);
+        } else if ("children".equals(macroName) || "childpages".equals(macroName)) {
+            macro.replaceWith(doc.createElement("p").text("[Child pages]"));
+        } else {
+            Element richBody = macro.getElementsByTag("ac:rich-text-body").first();
+            if (richBody != null) {
+                // Macro configuration (ac:parameter) never belongs inside the rendered
+                // body — strip it before unwrapping so it cannot leak as text, even
+                // before the next iteration gets a chance to process nested macros.
+                richBody.getElementsByTag("ac:parameter").remove();
+                Element div = doc.createElement("div");
+                div.html(richBody.html());
+                macro.replaceWith(div);
+            } else {
+                // Remove unknown macros so their parameter text doesn't leak into Markdown.
+                macro.remove();
+            }
+        }
     }
 
     private static String resolveLinkHref(Element link) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
@@ -292,4 +292,39 @@ public class ConfluenceHtmlToMarkdownTest {
         assertFalse("Should not leak parameter value", markdown.contains("allChildren"));
         assertFalse("Should not leak parameter value", markdown.contains("true"));
     }
+
+    // Reproduces a real-world pattern from third-party "live table" macros (e.g. the
+    // Table Filter/Charts family: table-excerpt-include, livesearch, pivot-table,
+    // sparkline). These wrap a nested configuration macro (with its own
+    // <ac:parameter> flags/filters) inside an outer macro's <ac:rich-text-body>.
+    // A single, non-recursive unwrap pass used to leave the nested macro/parameters
+    // untouched, and their raw boolean/text values leaked into the Markdown output.
+    @Test
+    public void testToMarkdown_nestedMacroInsideRichTextBodyDoesNotLeakParameters() {
+        String html = "<h2>Linked Table</h2>" +
+            "<ac:structured-macro ac:name=\"outer-live-table\">" +
+            "  <ac:parameter ac:name=\"source\">Some Other Page</ac:parameter>" +
+            "  <ac:rich-text-body>" +
+            "    <ac:structured-macro ac:name=\"inner-sort-config\">" +
+            "      <ac:parameter ac:name=\"disableSorting\">false</ac:parameter>" +
+            "      <ac:parameter ac:name=\"enableSparkline\">true</ac:parameter>" +
+            "      <ac:parameter ac:name=\"columnFilter\">Workflow Type</ac:parameter>" +
+            "    </ac:structured-macro>" +
+            "    <p>Fallback text</p>" +
+            "  </ac:rich-text-body>" +
+            "</ac:structured-macro>";
+
+        String markdown = ConfluenceStorageMarkdown.toMarkdown(html);
+
+        assertTrue("Should keep heading", markdown.contains("Linked Table"));
+        assertTrue("Should keep fallback body text", markdown.contains("Fallback text"));
+        assertFalse("Should not leak nested macro parameter values",
+            markdown.contains("disableSorting"));
+        assertFalse("Should not leak nested macro parameter values",
+            markdown.contains("enableSparkline"));
+        assertFalse("Should not leak nested macro parameter values",
+            markdown.contains("columnFilter"));
+        assertFalse("Should not leak concatenated boolean noise",
+            markdown.toLowerCase().contains("falsetrue"));
+    }
 }


### PR DESCRIPTION
## Problem
When converting Confluence `body.storage` to Markdown, unknown structured macros that wrap another macro inside their `ac:rich-text-body` (a pattern used by third-party "live table" macros such as `table-excerpt-include`, `livesearch`, `pivot-table`, `sparkline`) leaked raw macro configuration as text, e.g. `falseSparklinetruetrue...`.

Root cause: `ConfluenceStorageMarkdown.replaceRemainingAcLinksAndImages` iterated `doc.getElementsByTag("ac:structured-macro")` in a single pass. Unwrapping a macro's `ac:rich-text-body` into a plain `<div>` can reveal further nested `ac:structured-macro`/`ac:parameter` elements that were never revisited, so their raw parameter text passed straight through to the Markdown converter.

## Fix
- Macro resolution now iterates to a fixed point (bounded) so newly-revealed nested macros get processed too.
- `ac:parameter` children are stripped from a rich-text-body before it is unwrapped.
- Added a final safety net that removes any stray `ac:parameter` left in the document.

## Tests
Added `testToMarkdown_nestedMacroInsideRichTextBodyDoesNotLeakParameters` (synthetic macro sample, no client-specific content) reproducing the nested-macro leak and asserting the fallback text is kept while parameter noise is gone. All existing `ConfluenceHtmlToMarkdownTest` cases still pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>