### PR TITLE
feat(confluence): recover live/aggregated tables via body.export_view

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -258,7 +258,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         String format
 ) throws IOException {
         // Construct the path using the content ID and expand needed fields
-        GenericRequest content = new GenericRequest(this, path("content/" + contentId + "?expand=body.storage,ancestors,version"));
+        GenericRequest content = new GenericRequest(this, path("content/" + contentId + "?expand=body.storage,body.export_view,ancestors,version"));
 
         // Execute the request
         String response = execute(content);
@@ -294,7 +294,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         @MCPParam(name = "format", description = "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.", required = false, example = "md")
         String format
     ) throws IOException {
-        GenericRequest content = new GenericRequest(this, path("content?expand=body.storage,ancestors,version"));
+        GenericRequest content = new GenericRequest(this, path("content?expand=body.storage,body.export_view,ancestors,version"));
         content.param("title", title);
         if (space != null && !space.isEmpty()) {
             content.param("spaceKey", space);
@@ -637,7 +637,7 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         @MCPParam(name = "format", description = "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.", required = false, example = "md")
         String format
     ) throws IOException {
-        return applyFormat(new ContentResult(execute(new GenericRequest(this, path("content/" + contentId + "/child/page?limit=100&expand=body.storage,ancestors,version")))).getContents(), format);
+        return applyFormat(new ContentResult(execute(new GenericRequest(this, path("content/" + contentId + "/child/page?limit=100&expand=body.storage,body.export_view,ancestors,version")))).getContents(), format);
     }
 
     /**
@@ -988,11 +988,31 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
      * @return Markdown or extracted YAML
      */
     private static String convertStorageToMarkdown(String storageValue) {
+        return convertStorageToMarkdown(storageValue, null);
+    }
+
+    /**
+     * Converts Confluence storage format HTML to Markdown, using the page's rendered
+     * {@code body.export_view} HTML (when available) to recover content from "live"
+     * macros (e.g. third-party table filter/aggregation macros) whose actual output
+     * only exists once Confluence renders the page — {@code body.storage} only holds
+     * their configuration parameters.
+     * If the content uses the Confluence YAML macro format, the YAML payload is
+     * extracted instead (matching the behaviour in {@link InstructionProcessor}).
+     *
+     * @param storageValue raw Confluence storage format HTML
+     * @param exportViewValue rendered Confluence HTML ({@code body.export_view.value}), may be null
+     * @return Markdown or extracted YAML
+     */
+    private static String convertStorageToMarkdown(String storageValue, String exportViewValue) {
         if (storageValue == null || storageValue.isBlank()) {
             return storageValue;
         }
         if (StringUtils.isConfluenceYamlFormat(storageValue)) {
             return StringUtils.extractYamlContentFromConfluence(storageValue);
+        }
+        if (exportViewValue != null && !exportViewValue.isBlank()) {
+            return ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageValue, exportViewValue);
         }
         return ConfluenceStorageMarkdown.toMarkdown(storageValue);
     }
@@ -1000,7 +1020,10 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
     /**
      * Applies the requested output format to a single Confluence content object.
      * For format "md"/"markdown" the {@code body.storage.value} is replaced with
-     * Markdown and the representation is updated to "markdown".
+     * Markdown and the representation is updated to "markdown". When the response
+     * also contains {@code body.export_view} (rendered HTML with macros resolved),
+     * it is used to recover "live" tables (see {@link #convertStorageToMarkdown(String, String)})
+     * and then dropped from the returned JSON to avoid doubling the payload size.
      *
      * @param content the content to transform (mutated in place)
      * @param format the requested format
@@ -1018,8 +1041,17 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         if (value == null || value.isBlank()) {
             return content;
         }
-        String markdown = convertStorageToMarkdown(value);
         JSONObject body = content.getJSONObject().optJSONObject("body");
+        String exportViewValue = null;
+        if (body != null) {
+            JSONObject exportViewObj = body.optJSONObject("export_view");
+            if (exportViewObj != null) {
+                exportViewValue = exportViewObj.optString("value", null);
+            }
+            // Drop the (large, now redundant) rendered HTML from the response.
+            body.remove("export_view");
+        }
+        String markdown = convertStorageToMarkdown(value, exportViewValue);
         if (body != null) {
             JSONObject storageObj = body.optJSONObject("storage");
             if (storageObj != null) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceStorageMarkdown.java
@@ -12,6 +12,8 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -113,6 +115,200 @@ public final class ConfluenceStorageMarkdown {
         } catch (Exception e) {
             logger.warn("Confluence HTML→Markdown conversion failed, returning raw HTML: {}", e.getMessage(), e);
             return confluenceHtml;
+        }
+    }
+
+    /**
+     * Structured macros whose Markdown output is already complete/meaningful from
+     * {@code body.storage} alone (their content lives in the storage document itself,
+     * or we already render them into a sensible placeholder). Anything NOT in this set
+     * is treated as a candidate for {@link #toMarkdownWithRenderedFallback} — most
+     * commonly third-party "live"/aggregated-table macros (e.g. table-excerpt-include,
+     * livesearch, pivot-table, sparkline, content-report-table, multiexcerpt-include,
+     * jiraissues, ...) whose actual output is computed by Confluence only when the page
+     * is rendered, and is therefore absent from {@code body.storage}.
+     */
+    private static final java.util.Set<String> SAFE_LOCAL_MACROS = java.util.Set.of(
+        "toc", "code", "info", "note", "warning", "tip", "panel",
+        "expand", "status", "children", "childpages", "anchor", "excerpt"
+    );
+
+    /**
+     * Converts Confluence Storage Format HTML to Markdown, using the page's rendered
+     * {@code body.export_view} HTML as a fallback source for sections whose storage
+     * representation only contains a "live"/aggregated-table macro's configuration
+     * (i.e. no usable content) instead of real data.
+     *
+     * <p>Confluence macros that aggregate or transclude data from elsewhere (a common
+     * pattern for third-party "table filter/chart" style macros) only compute their
+     * actual output when the page is rendered server-side; {@code body.storage} only
+     * stores the macro's configuration parameters. {@code body.export_view} is
+     * Confluence's own rendered HTML for the page, with every macro already resolved
+     * into real markup (including such live tables).
+     *
+     * <p>Matching between the two documents is done by aligning top-level heading
+     * sections (by heading text, falling back to positional order for unmatched
+     * headings). For any storage section that contains an unresolved/unknown
+     * structured macro and whose matching export_view section contains an actual
+     * {@code <table>}, the storage section's content is replaced by the export_view
+     * section's content before the normal Markdown conversion pipeline runs. All other
+     * sections are left untouched, so existing behavior (ac:link/ac:image resolution
+     * to clean titles/filenames, etc.) is unaffected.
+     *
+     * @param storageHtml raw Confluence Storage Format (XHTML) string ({@code body.storage.value})
+     * @param exportViewHtml rendered Confluence HTML ({@code body.export_view.value}), may be null/blank
+     * @return Markdown text
+     */
+    public static String toMarkdownWithRenderedFallback(String storageHtml, String exportViewHtml) {
+        if (exportViewHtml == null || exportViewHtml.isBlank()) {
+            return toMarkdown(storageHtml);
+        }
+        if (storageHtml == null || storageHtml.isBlank()) {
+            return toMarkdown(exportViewHtml);
+        }
+        try {
+            String merged = mergeUnresolvedSectionsWithRenderedContent(storageHtml, exportViewHtml);
+            return toMarkdown(merged);
+        } catch (Exception e) {
+            logger.warn("Storage/export_view merge failed, falling back to storage-only Markdown: {}", e.getMessage(), e);
+            return toMarkdown(storageHtml);
+        }
+    }
+
+    private static String mergeUnresolvedSectionsWithRenderedContent(String storageHtml, String exportViewHtml) {
+        Document storageDoc = parseFragment(storageHtml);
+        Document exportDoc = parseFragment(exportViewHtml);
+
+        List<Section> storageSections = buildSections(storageDoc);
+        List<Section> exportSections = buildSections(exportDoc);
+
+        java.util.Map<String, java.util.ArrayDeque<Section>> exportByHeading = new java.util.HashMap<>();
+        List<Section> exportHeadingSectionsInOrder = new ArrayList<>();
+        for (Section section : exportSections) {
+            if (section.headingElement == null) {
+                continue;
+            }
+            exportHeadingSectionsInOrder.add(section);
+            exportByHeading
+                .computeIfAbsent(section.headingText, k -> new java.util.ArrayDeque<>())
+                .add(section);
+        }
+
+        int headingOrdinal = 0;
+        for (Section storageSection : storageSections) {
+            if (storageSection.headingElement == null) {
+                continue; // Preamble content before the first heading is left untouched.
+            }
+            int ordinal = headingOrdinal++;
+            if (!needsRenderedFallback(storageSection.bodyElements)) {
+                continue;
+            }
+
+            Section matched = pollMatchingSection(storageSection.headingText, exportByHeading, ordinal, exportHeadingSectionsInOrder);
+            if (matched == null || !containsTable(matched.bodyElements)) {
+                continue;
+            }
+            replaceSectionBody(storageSection, matched);
+        }
+
+        return bodyHtml(storageDoc);
+    }
+
+    private static Section pollMatchingSection(
+            String headingText,
+            java.util.Map<String, java.util.ArrayDeque<Section>> byText,
+            int ordinal,
+            List<Section> ordinalList
+    ) {
+        java.util.ArrayDeque<Section> queue = byText.get(headingText);
+        if (queue != null && !queue.isEmpty()) {
+            return queue.poll();
+        }
+        if (ordinal < ordinalList.size()) {
+            return ordinalList.get(ordinal);
+        }
+        return null;
+    }
+
+    private static boolean needsRenderedFallback(List<Element> bodyElements) {
+        for (Element el : bodyElements) {
+            for (Element macro : el.getElementsByTag("ac:structured-macro")) {
+                if (!SAFE_LOCAL_MACROS.contains(macro.attr("ac:name").toLowerCase())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsTable(List<Element> bodyElements) {
+        for (Element el : bodyElements) {
+            if (!el.getElementsByTag("table").isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void replaceSectionBody(Section storageSection, Section replacementSection) {
+        StringBuilder replacementHtml = new StringBuilder();
+        for (Element el : replacementSection.bodyElements) {
+            replacementHtml.append(el.outerHtml());
+        }
+        if (replacementHtml.length() == 0) {
+            return;
+        }
+        if (!storageSection.bodyElements.isEmpty()) {
+            storageSection.bodyElements.get(0).before(replacementHtml.toString());
+            for (Element el : storageSection.bodyElements) {
+                el.remove();
+            }
+        } else {
+            storageSection.headingElement.after(replacementHtml.toString());
+        }
+    }
+
+    /**
+     * Splits a document's top-level body elements into sections, one per heading
+     * ({@code h1}-{@code h6}), plus a leading "preamble" section (heading == null)
+     * for any content before the first heading.
+     */
+    private static List<Section> buildSections(Document doc) {
+        List<Section> sections = new ArrayList<>();
+        Section preamble = new Section(null, null);
+        sections.add(preamble);
+        Section current = preamble;
+        if (doc.body() == null) {
+            return sections;
+        }
+        for (Element el : doc.body().children()) {
+            if (isHeading(el)) {
+                current = new Section(normalizeHeadingText(el.text()), el);
+                sections.add(current);
+            } else {
+                current.bodyElements.add(el);
+            }
+        }
+        return sections;
+    }
+
+    private static boolean isHeading(Element el) {
+        return el.tagName().matches("h[1-6]");
+    }
+
+    private static String normalizeHeadingText(String text) {
+        return text == null ? "" : text.trim().replaceAll("\\s+", " ").toLowerCase();
+    }
+
+    /** A heading (or the preamble, when {@code headingElement == null}) and its direct body elements. */
+    private static final class Section {
+        final String headingText;
+        final Element headingElement;
+        final List<Element> bodyElements = new ArrayList<>();
+
+        Section(String headingText, Element headingElement) {
+            this.headingText = headingText;
+            this.headingElement = headingElement;
         }
     }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
@@ -327,4 +327,79 @@ public class ConfluenceHtmlToMarkdownTest {
         assertFalse("Should not leak concatenated boolean noise",
             markdown.toLowerCase().contains("falsetrue"));
     }
+
+    // --- toMarkdownWithRenderedFallback: recovering "live" tables via body.export_view ---
+    //
+    // Third-party "live table" macros (table filter/aggregation-style: transclusion,
+    // pivot, sparkline, live search, etc.) only store their configuration in
+    // body.storage; the actual rows only exist once Confluence renders the page
+    // (body.export_view). These tests use a synthetic macro name/structure — not tied
+    // to any specific real-world page or plugin — to verify the generic recovery logic.
+
+    @Test
+    public void testToMarkdownWithRenderedFallback_recoversTableFromExportView() {
+        String storageHtml =
+            "<h2>Overview</h2>" +
+            "<p>Some description.</p>" +
+            "<h2>Linked Table</h2>" +
+            "<ac:structured-macro ac:name=\"live-table-include\" ac:schema-version=\"2\">" +
+            "  <ac:parameter ac:name=\"name\">Source Table Name</ac:parameter>" +
+            "  <ac:parameter ac:name=\"disableSorting\">false</ac:parameter>" +
+            "</ac:structured-macro>" +
+            "<h2>Next Section</h2>" +
+            "<p>Trailing content</p>";
+
+        String exportViewHtml =
+            "<h2>Overview</h2>" +
+            "<p>Some description.</p>" +
+            "<h2>Linked Table</h2>" +
+            "<table><tbody>" +
+            "<tr><th>Col A</th><th>Col B</th></tr>" +
+            "<tr><td>1</td><td>2</td></tr>" +
+            "</tbody></table>" +
+            "<h2>Next Section</h2>" +
+            "<p>Trailing content</p>";
+
+        String markdown = ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageHtml, exportViewHtml);
+
+        assertTrue("Should keep unrelated headings/paragraphs", markdown.contains("Overview"));
+        assertTrue("Should keep unrelated headings/paragraphs", markdown.contains("Some description."));
+        assertTrue("Should keep unrelated headings/paragraphs", markdown.contains("Next Section"));
+        assertTrue("Should keep unrelated headings/paragraphs", markdown.contains("Trailing content"));
+        assertTrue("Should recover the live table's header cell", markdown.contains("Col A"));
+        assertTrue("Should recover the live table's header cell", markdown.contains("Col B"));
+        assertTrue("Should recover the live table's data row", markdown.contains("1"));
+        assertTrue("Should recover the live table's data row", markdown.contains("2"));
+        assertFalse("Should not leak the macro's own parameter values",
+            markdown.contains("Source Table Name"));
+        assertFalse("Should not leak the macro's own parameter values",
+            markdown.contains("disableSorting"));
+    }
+
+    @Test
+    public void testToMarkdownWithRenderedFallback_leavesResolvedSectionsUntouched() {
+        // Section without any unresolved macro: even though export_view has different
+        // wording, the storage-format text must win (minimal-risk behavior — only
+        // sections that actually need it get swapped).
+        String storageHtml = "<h2>Section</h2><p>Original storage text.</p>";
+        String exportViewHtml = "<h2>Section</h2><p>Different rendered text.</p>";
+
+        String markdown = ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageHtml, exportViewHtml);
+
+        assertTrue("Should keep the storage-format text", markdown.contains("Original storage text."));
+        assertFalse("Should not use export_view text for already-resolved sections",
+            markdown.contains("Different rendered text."));
+    }
+
+    @Test
+    public void testToMarkdownWithRenderedFallback_fallsBackToStorageOnlyWhenExportViewMissing() {
+        String storageHtml = "<h2>Section</h2><p>Only storage available.</p>";
+
+        String withNull = ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageHtml, null);
+        String withBlank = ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageHtml, "  ");
+        String plain = ConfluenceStorageMarkdown.toMarkdown(storageHtml);
+
+        assertEquals(plain, withNull);
+        assertEquals(plain, withBlank);
+    }
 }


### PR DESCRIPTION
## Problem
Confluence pages that use aggregating/transcluding macros (e.g. server-rendered aggregator tables, transclusions, Jira issue tables) render fine to a human viewer, but converting `body.storage` alone to Markdown only produces the macro's *configuration* — the actual rows are computed by Confluence only when the page is rendered, and are absent from `body.storage`.

## Fix
`body.export_view` is Confluence's own server-rendered HTML for the page with macros already resolved. This PR:
- Requests `body.export_view` alongside `body.storage` in `contentById`, `content(title, space)`, and `getChildrenOfContentById`.
- Adds `ConfluenceStorageMarkdown.toMarkdownWithRenderedFallback(storageHtml, exportViewHtml)`: aligns top-level heading sections between the two documents (by heading text, falling back to positional order), and for any storage section containing an unresolved/unknown structured macro whose matching export_view section has a real `<table>`, swaps in the rendered section before running the normal Markdown pipeline. Sections that don't need recovery are left completely untouched — existing `ac:link`/`ac:image` → clean-title/filename resolution is unaffected for the common case.
- `applyFormat()` uses `body.export_view` when present for the merge, then strips it from the returned JSON so the response payload isn't doubled.

## Scope / limitation
This recovers macros that Confluence resolves **server-side**. Some third-party "live table" apps render entirely **client-side** (populate a stub `<div>` via the app's own browser JavaScript after page load) — those are not recoverable through either `body.storage` or `body.export_view` via the REST API, and are out of scope for this change.

## Tests
Added synthetic, non-client-specific cases to `ConfluenceHtmlToMarkdownTest`:
- `testToMarkdownWithRenderedFallback_recoversTableFromExportView`
- `testToMarkdownWithRenderedFallback_leavesResolvedSectionsUntouched`
- `testToMarkdownWithRenderedFallback_fallsBackToStorageOnlyWhenExportViewMissing`

All existing `dmtools-core` Confluence unit tests pass. Manually verified end-to-end via `dmtools` CLI (local build) against a real Confluence page — confirmed `body.export_view` is now requested/consumed and stripped from the response, and previously-leaked macro parameter noise (see #347) is no longer present.

Depends on / pairs well with #347 (nested macro parameter leak fix) but is independent and can be merged separately.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>