### PR TITLE
fix(install): prevent silent exit when GitHub API fallback fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1565,7 +1565,7 @@ download_checksum_file() {
 
     # Try GitHub API direct URL
     local api_asset_url
-    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-checksums.sha256")
+    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-checksums.sha256") || true
     if [ -n "$api_asset_url" ]; then
         if download_file "$api_asset_url" "$checksum_path" "DMTools checksums (from API)" "false" >/dev/null 2>&1; then
             echo "$checksum_path"
@@ -1634,7 +1634,7 @@ download_dmtools_jar() {
     # the redirect-based release URL is slow or blocked)
     info "Standard release URL failed or checksum mismatch. Trying GitHub API direct asset URL..."
     local api_asset_url
-    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-${version}-all.jar")
+    api_asset_url=$(get_asset_url_from_api "$version" "dmtools-${version}-all.jar") || true
     if [ -n "$api_asset_url" ]; then
         info "Got API asset URL: $api_asset_url"
     else
@@ -1688,7 +1688,7 @@ download_dmtools_shell_script() {
     # Method 2: Try GitHub API to get direct asset URL (avoids expired blob URLs)
     warn "Redirect-based download failed, trying GitHub API for direct asset URL..."
     local api_asset_url
-    api_asset_url=$(get_asset_url_from_api "$version" "dmtools.sh")
+    api_asset_url=$(get_asset_url_from_api "$version" "dmtools.sh") || true
     
     if [ -n "$api_asset_url" ]; then
         if download_file "$api_asset_url" "$SCRIPT_PATH" "DMTools shell script (from API)" "true"; then


### PR DESCRIPTION
## Problem

When the primary GitHub release URL download succeeds but checksum verification fails (for example after resuming a partial/corrupted download), the installer falls back to the GitHub API direct asset URL. In the captured log the fallback call printed:

```
Standard release URL failed or checksum mismatch. Trying GitHub API direct asset URL...
Getting asset URL from GitHub API...
```

and then the script returned to the shell without any further message.

## Root cause

The script runs with `set -e`. Three callers capture the output of `get_asset_url_from_api()` via command substitution:

```bash
api_asset_url=
```

When the API call fails (network error, rate limit, empty response, etc.) the function returns `1`, which makes the assignment command exit non-zero, and `set -e` aborts the whole installer immediately.

## Fix

Append `|| true` to each of the three command substitutions so the installer continues and handles an empty `api_asset_url` gracefully:

- `download_checksum_file()`
- `download_dmtools_jar()`
- `download_dmtools_shell_script()`

## Verification

```bash
bash -n install.sh  # OK
```

Also tested the `set -e` behavior in isolation:

```bash
bash -c 'set -e; f() { return 1; }; x= || true; echo continued'
# prints: continued
```