### PR TITLE
fix(skills): stop adding .dmtools/ to gitignore

### DIFF
--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -78,7 +78,6 @@ grep -q "dmtools.env\|dmtools-local.env" .gitignore 2>/dev/null || echo "Not in 
 # DMtools configuration (contains secrets)
 dmtools.env
 dmtools-local.env
-.dmtools/
 ```
 
 ### Configuration Template
@@ -169,7 +168,7 @@ Create `dmtools.env` in project root (see template in FIRST-TIME SETUP section)
 
 #### 3. Add to .gitignore
 ```bash
-echo -e "\n# DMtools configuration\ndmtools.env\ndmtools-local.env\n.dmtools/" >> .gitignore
+echo -e "\n# DMtools configuration\ndmtools.env\ndmtools-local.env" >> .gitignore
 ```
 
 #### 4. Get API Tokens

--- a/dmtools-ai-docs/SKILL.scl.md
+++ b/dmtools-ai-docs/SKILL.scl.md
@@ -223,7 +223,7 @@ C|setup|when user mentions DMtools or asks to use it perform setup checks immedi
 C|setup|if dmtools missing => offer/install using z
 C|setup|if aa missing => ask ea + ask eb + do ec + do ed
 C|security|aa contains secrets => never commit
-C|gitignore|required_lines:dmtools.env,dmtools-local.env,.dmtools/
+C|gitignore|required_lines:dmtools.env,dmtools-local.env
 C|defaults|recommended_ai_provider:ad
 C|gemini|note:free_tier_15_req_min
 C|json_config|name field is immutable Java class name, not friendly label

--- a/dmtools-ai-docs/SKILL.ultra.md
+++ b/dmtools-ai-docs/SKILL.ultra.md
@@ -18,7 +18,7 @@ SETUP={
 MISS{
   !dmtools=>offer/install;
   !env=>ask{integrations,ai_provider}->mk(dmtools.env);
-  !gitignore=>+{"dmtools.env","dmtools-local.env",".dmtools/"}
+  !gitignore=>+{"dmtools.env","dmtools-local.env"}
 }
 
 SKILLS{focused:DMTOOLS_SKILLS=jira,github}

--- a/dmtools-ai-docs/setup-dmtools.sh
+++ b/dmtools-ai-docs/setup-dmtools.sh
@@ -114,7 +114,6 @@ if [ -f ".gitignore" ]; then
 # DMtools configuration (contains secrets)
 dmtools.env
 dmtools-local.env
-.dmtools/
 EOF
         echo -e "${GREEN}✓${NC} Added DMtools files to .gitignore"
     fi
@@ -125,7 +124,6 @@ else
 # DMtools configuration (contains secrets)
 dmtools.env
 dmtools-local.env
-.dmtools/
 EOF
     echo -e "${GREEN}✓${NC} Created .gitignore with DMtools files"
 fi


### PR DESCRIPTION
## Problem

The `dmtools` skill and `setup-dmtools.sh` add `.dmtools/` to the project's `.gitignore` next to the secret env files. This is wrong: `.dmtools/` holds shared product/instructions knowledge (`config.js`, `instructions/`, `kb/`) that should be committed and shared with the team, not ignored.

Only `dmtools.env` and `dmtools-local.env` contain secrets and must stay ignored.

## Fix

Remove `.dmtools/` from the gitignore additions in:

- `dmtools-ai-docs/SKILL.md`
- `dmtools-ai-docs/SKILL.scl.md`
- `dmtools-ai-docs/SKILL.ultra.md`
- `dmtools-ai-docs/setup-dmtools.sh`

`dmtools.env` and `dmtools-local.env` remain in the gitignore list.

## Related discussion

The issue also raised open questions about `kb/repositories.md` (Quick Reference section describing the target repo vs. the repo where Factory runs) and how to separate per-repository data such as `domain_knowledge` and `REPOS_PROJECT_KEY` when multiple repos are involved. Those are tracked separately — this PR only fixes the incorrect `.dmtools/` ignore rule.