### PR TITLE
ci(coverage): run Codecov upload in parallel, off the release path

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -179,19 +179,7 @@ jobs:
             dmtools-core/build/reports/tests/test
             dmtools-core/build/test-results/test
           retention-days: 7
-      
-      - name: Upload coverage reports to Codecov
-        if: success() || steps.gradle.outcome == 'failure'
-        uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: Upload test results to Codecov
-        if: success() || steps.gradle.outcome == 'failure'
-        uses: codecov/test-results-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-      
       - name: Prepare Build Artifacts for Upload
         id: prepare_artifacts
         if: steps.gradle.outcome == 'success'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,51 @@
+name: Coverage
+
+# Dedicated coverage workflow. It runs the dmtools-core unit tests, generates the
+# JaCoCo report, and uploads it to Codecov. It is intentionally a standalone
+# workflow (not part of build-and-test.yml) so that it runs in parallel with the
+# release pipeline and can never block a release.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: JaCoCo coverage -> Codecov
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Configure Git for tests
+        run: |
+          git config --global user.name "dm.ai"
+          git config --global user.email "dm.ai@epam.com"
+
+      - name: Run unit tests and generate JaCoCo report
+        run: ./gradlew :dmtools-core:test :dmtools-core:jacocoTestReport --no-daemon -x integrationTest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v7
+        # Never fail the build because of a coverage upload problem.
+        continue-on-error: true
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: dmtools-core/build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false


### PR DESCRIPTION
## Problem

The Codecov badge on `main` shows **unknown**. Root cause:

- Coverage is uploaded to Codecov only from `build-and-test.yml` (reusable, called by `beta-release.yml` on push to `main`, and by `release.yml` on manual release) and from `fatjar_release.yml`.
- `build-and-test.yml` builds with `-x :dmtools-core:test`, so **tests never run and no JaCoCo report is produced** — Codecov has nothing to upload.
- `fatjar_release.yml` (which does run tests) is **deprecated** and only triggers on `workflow_dispatch`.
- These Codecov steps also sit on the release critical path: `build-and-test` → `package-cli`/`package-skill` → `create-unified-release`.

## Fix

Add a dedicated **`.github/workflows/coverage.yml`** that:

- Triggers on **push to `main`** and on **pull requests**.
- Runs `:dmtools-core:test` + `:dmtools-core:jacocoTestReport`, then uploads the JaCoCo XML to Codecov.
- Is a **standalone workflow**, so it runs **in parallel** with the release pipeline and **can never block a release**: `continue-on-error: true` + `fail_ci_if_error: false`, and no release job depends on it.

Also **remove the dead Codecov steps from `build-and-test.yml`** — they never had a coverage report to upload (tests are excluded there) and were on the release critical path.

## Result

- `main` coverage badge updates on every push to `main`.
- Releases run unaffected: coverage is computed in parallel and a coverage/upload hiccup cannot fail or delay a release.

## Verification

- YAML validated with `yaml.safe_load` for both files.
- Release dependency chain (`build-and-test` → `package-cli`/`package-skill` → `create-unified-release`) no longer includes any Codecov step.

## Note

Upload uses `CODECOV_TOKEN`. For fork PRs that secret is unavailable, so the upload is skipped there (non-blocking); `main` and same-repo PRs upload normally.