### PR TITLE
ci(coverage): self-hosted coverage badges, drop Codecov + trust badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,13 @@
 name: Coverage
 
 # Dedicated coverage workflow. It runs the dmtools-core unit tests, generates the
-# JaCoCo report, and uploads it to Codecov. It is intentionally a standalone
-# workflow (not part of build-and-test.yml) so that it runs in parallel with the
-# release pipeline and can never block a release.
+# JaCoCo report, and publishes a self-hosted coverage badge (no external service).
+# It is intentionally a standalone workflow (not part of build-and-test.yml) so it
+# runs in parallel with the release pipeline and can never block a release.
+#
+# The badge SVG is committed straight back to `main`. Pushes made with the default
+# GITHUB_TOKEN do not trigger new workflow runs (and the message carries [skip ci]),
+# so this cannot loop.
 
 on:
   push:
@@ -13,11 +17,11 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: read
+  contents: write  # needed to commit the coverage badge back to main
 
 jobs:
   coverage:
-    name: JaCoCo coverage -> Codecov
+    name: JaCoCo coverage badge
     runs-on: ubuntu-latest
 
     steps:
@@ -41,11 +45,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v7
-        # Never fail the build because of a coverage upload problem.
-        continue-on-error: true
+      - name: Generate coverage badges
+        id: jacoco
+        uses: cicirello/jacoco-badge-generator@v2
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: dmtools-core/build/reports/jacoco/test/jacocoTestReport.xml
-          fail_ci_if_error: false
+          jacoco-csv-file: dmtools-core/build/reports/jacoco/test/jacocoTestReport.csv
+          generate-branches-badge: true
+
+      - name: Log coverage percentage
+        run: |
+          echo "coverage = ${{ steps.jacoco.outputs.coverage }}"
+          echo "branch coverage = ${{ steps.jacoco.outputs.branches }}"
+
+      - name: Commit coverage badge to main (if changed)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          if [[ -n $(git status --porcelain .github/badges) ]]; then
+            git config --global user.name 'github-actions[bot]'
+            git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add .github/badges
+            git commit -m "chore(badges): update coverage badge [skip ci]"
+            git push origin HEAD:main
+          else
+            echo "Coverage badge unchanged; nothing to commit."
+          fi

--- a/README.md
+++ b/README.md
@@ -10,7 +10,18 @@ Enterprise dark-factory orchestrator for automating delivery workflows across tr
 >
 > PowerShell: https://github.com/epam/dm.ai/releases/latest/download/install.ps1
 
-[![Latest Release](https://img.shields.io/github/v/release/epam/dm.ai?label=latest%20version)](https://github.com/epam/dm.ai/releases/latest) [![codecov](https://codecov.io/gh/epam/dm.ai/branch/main/graph/badge.svg)](https://codecov.io/gh/epam/dm.ai) [![](https://jitpack.io/v/epam/dm.ai.svg)](https://jitpack.io/#epam/dm.ai)
+[![Latest Release](https://img.shields.io/github/v/release/epam/dm.ai?label=latest%20version)](https://github.com/epam/dm.ai/releases/latest)
+[![Coverage](.github/badges/jacoco.svg)](https://github.com/epam/dm.ai/actions/workflows/coverage.yml)
+[![Branches](.github/badges/branches.svg)](https://github.com/epam/dm.ai/actions/workflows/coverage.yml)
+[![License](https://img.shields.io/github/license/epam/dm.ai)](LICENSE)
+[![JitPack](https://jitpack.io/v/epam/dm.ai.svg)](https://jitpack.io/#epam/dm.ai)
+
+[![GitHub stars](https://img.shields.io/github/stars/epam/dm.ai)](https://github.com/epam/dm.ai/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/epam/dm.ai)](https://github.com/epam/dm.ai/network/members)
+[![Contributors](https://img.shields.io/github/contributors/epam/dm.ai)](https://github.com/epam/dm.ai/graphs/contributors)
+[![Downloads](https://img.shields.io/github/downloads/epam/dm.ai/total)](https://github.com/epam/dm.ai/releases)
+[![Last commit](https://img.shields.io/github/last-commit/epam/dm.ai)](https://github.com/epam/dm.ai/commits/main)
+[![Java](https://img.shields.io/badge/Java-17%2B-blue)](https://adoptium.net/)
 
 > DMTools is orchestration layer for enterprise dark factories. It is designed for self-hosted and enterprise environments where teams need repeatable AI-assisted workflows instead of one-off scripts or server-first demos.
 
@@ -203,3 +214,13 @@ set DMTOOLS_VERSION=v1.7.179 && curl -fsSL https://github.com/epam/dm.ai/release
 ```
 
 See the [installation guide](dmtools-ai-docs/references/installation/README.md) for local development installation details.
+
+## Star History
+
+<a href="https://star-history.com/#epam/dm.ai&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=epam/dm.ai&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=epam/dm.ai&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=epam/dm.ai&type=Date" />
+  </picture>
+</a>

--- a/dmtools-core/build.gradle
+++ b/dmtools-core/build.gradle
@@ -204,6 +204,7 @@ jacocoTestReport {
     reports {
         xml.required.set(true)
         html.required.set(true)
+        csv.required.set(true)
     }
 }
 


### PR DESCRIPTION
## Why

Codecov upload kept failing with `{"message":"Repository not found"}` and needed token + GitHub App setup. For a public repo where we mainly want a coverage badge, an external service is unnecessary — the CI already produces the JaCoCo report. This removes the Codecov dependency entirely.

## What changed

**`.github/workflows/coverage.yml`**
- Dropped the `codecov/codecov-action` step.
- Added [`cicirello/jacoco-badge-generator`](https://github.com/cicirello/jacoco-badge-generator) which parses the JaCoCo CSV and generates **coverage** + **branches** SVG badges (no external calls).
- Commits the badges straight to `main` (`.github/badges/`) when they change. Pushes via `GITHUB_TOKEN` don't re-trigger workflows, and the message carries `[skip ci]`, so there's no loop. Commit step only runs on `push: main` (never on PRs/forks).
- Still a standalone workflow → runs in parallel with releases and can't block them.

**`dmtools-core/build.gradle`**
- Enabled the JaCoCo **CSV** report (`csv.required.set(true)`) that the badge generator parses.

**`README.md`**
- Replaced the Codecov badge with the self-hosted **coverage** and **branches** badges (link to the coverage workflow).
- Added trust badges: **License**, **Stars**, **Forks**, **Contributors**, **Downloads**, **Last commit**, **Java 17+**.
- Added a **Star History** chart.

## Notes

- The coverage/branches badges show a broken image until the first coverage run on `main` completes and commits `.github/badges/*.svg` (i.e. right after this merges + the first push).
- No secrets required anymore; `CODECOV_TOKEN` can be removed from the repo if it was only used for this.
- Verified `coverage.yml` parses as valid YAML.