### PR TITLE
ci(coverage): use PAT_TOKEN for badge PR so its CI actually runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,11 +5,12 @@ name: Coverage
 # It is intentionally a standalone workflow (not part of build-and-test.yml) so it
 # runs in parallel with the release pipeline and can never block a release.
 #
-# The badge SVGs land on `main` via a small bot PR with auto-merge: the
-# "Protect main" ruleset requires the "Java unit tests" status check, so a
-# direct push from a workflow is rejected. The PR gets the required check
-# from unit-tests.yml, then GitHub auto-merges it (squash). Bot-created squash
-# merges do not fire the push trigger, so this cannot loop.
+# The badge SVGs land on `main` via a small auto-merge PR: the "Protect main"
+# ruleset requires the "Java unit tests" status check, so a direct push from a
+# workflow is rejected. The PR gets the required check from unit-tests.yml,
+# then GitHub auto-merges it (squash). The publish step uses PAT_TOKEN because
+# events triggered by the default GITHUB_TOKEN do not start new workflow runs,
+# so this cannot loop.
 #
 # Use `workflow_dispatch` to refresh the badge manually, e.g. after an
 # auto-merged PR (bot squash merges do not fire the push trigger).
@@ -69,7 +70,11 @@ jobs:
       - name: Publish coverage badge to main via auto-merge PR (if changed)
         if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT_TOKEN (not GITHUB_TOKEN) on purpose: events triggered by the
+          # default GITHUB_TOKEN do not start new workflow runs, so a bot-pushed
+          # branch / bot-created PR would never get the required "Java unit
+          # tests" check and auto-merge would stall forever.
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           if [[ -z $(git status --porcelain .github/badges) ]]; then
             echo "Coverage badge unchanged; nothing to do."
@@ -77,15 +82,15 @@ jobs:
           fi
 
           # Direct pushes to main are rejected by the "Protect main" ruleset
-          # (required check "Java unit tests"), so publish through a bot PR and
-          # let GitHub auto-merge it once the required check passes.
+          # (required check "Java unit tests"), so publish through a PR and let
+          # GitHub auto-merge it once the required check passes.
           BRANCH="bot/coverage-badges-${{ github.run_id }}"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git checkout -b "$BRANCH"
           git add .github/badges
           git commit -m "chore(badges): update coverage badge"
-          git push origin "$BRANCH"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$BRANCH"
 
           PR_URL=$(gh pr create \
             --base main \


### PR DESCRIPTION
The badge PR (#357) created with the default GITHUB_TOKEN never got any checks: events triggered by GITHUB_TOKEN do not start new workflow runs, so the required "Java unit tests" check would never appear and auto-merge stalled.

Switch the badge-publish step to `secrets.PAT_TOKEN` (same pattern as merge-trigger.yml): the PAT-backed branch push and PR creation trigger unit-tests.yml normally, the required check passes, and GitHub auto-merges the badge PR.