### PR TITLE
chore(ai): remove dead methods from JAssistant

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/JAssistant.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/JAssistant.java
@@ -4,14 +4,11 @@
 package com.github.istin.dmtools.ai;
 
 import com.github.istin.dmtools.atlassian.jira.JiraClient;
-import com.github.istin.dmtools.atlassian.jira.model.IssueType;
 import com.github.istin.dmtools.atlassian.jira.model.Ticket;
-import com.github.istin.dmtools.atlassian.jira.utils.IssuesIDsParser;
 import com.github.istin.dmtools.ba.UserStoryGenerator;
 import com.github.istin.dmtools.ba.UserStoryGeneratorParams;
 import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.model.*;
-import com.github.istin.dmtools.common.networking.RestClient;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.common.utils.StringUtils;
@@ -30,7 +27,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class JAssistant {
 
@@ -91,102 +87,6 @@ public class JAssistant {
         this.ai = ai;
         this.promptManager = (PromptManager) promptManager;
         this.conversationObserver = conversationObserver;
-    }
-
-    public String generateCode(String role, TicketContext ticketContext) throws Exception {
-        ITicket ticket = ticketContext.getTicket();
-
-        CodeGeneration codeGeneration = new CodeGeneration(trackerClient.getBasePath(), role, ticketContext);
-        codeGeneration.setExtraTickets(ticketContext.getExtraTickets());
-        if (!IssueType.isBug(ticket.getIssueType())) {
-            List<? extends ITicket> testCases = trackerClient.getTestCases(ticket, "Test Case");
-            codeGeneration.setExistingTickets(testCases);
-        }
-
-        List<IFile> finalResults = new ArrayList<>();
-        for (SourceCode sourceCode : sourceCodes) {
-            extractPotentiallyEffectedFiles(role, ticketContext, sourceCode, codeGeneration, ticket, finalResults);
-        }
-
-        codeGeneration.setFiles(finalResults);
-        String finalAIRequest = promptManager.requestGenerateCodeForTicket(codeGeneration);
-        String finalResponse = ai.chat(
-                CODE_AI_MODEL,
-                finalAIRequest);
-        logger.info("----- FINAL AI RESPONSE ---- ");
-        logger.info(finalResponse);
-        trackerClient.postComment(ticketContext.getTicket().getTicketKey(), "<p>AI Generated Code: </p>" + finalResponse);
-        trackerClient.addLabelIfNotExists(ticketContext.getTicket(), "ai_generated_code");
-        return finalResponse;
-
-    }
-
-    private void extractPotentiallyEffectedFiles(String role, TicketContext ticketContext, SourceCode sourceCode, CodeGeneration codeGeneration, ITicket ticket, List<IFile> finalResults) throws Exception {
-        List<IFile> listOfFiles = sourceCode.getListOfFiles(sourceCode.getDefaultWorkspace(), sourceCode.getDefaultRepository(), sourceCode.getDefaultBranch());
-        List<IFile> filesOnly = listOfFiles.stream().filter(file -> !file.isDir()).collect(Collectors.toList());
-
-        JSONArray filePaths = getListOfEffectedFilesFromFiles(codeGeneration, filesOnly);
-
-        List<ICommit> commitsFromBranch = sourceCode.getCommitsFromBranch(sourceCode.getDefaultWorkspace(), sourceCode.getDefaultRepository(), sourceCode.getDefaultBranch(), null, null);
-        JSONArray filePathsFromCommits = getListOfEffectedFilesFromCommits(sourceCode, sourceCode.getDefaultWorkspace(), sourceCode.getDefaultRepository(), codeGeneration, commitsFromBranch);
-        filePaths.putAll(filePathsFromCommits);
-        for (int i = 0; i < filePaths.length(); i++) {
-            String path = filePaths.getString(i);
-            List<IFile> result = filesOnly.stream().filter(file -> file.getPath().equals(path)).collect(Collectors.toList());
-            if (!result.isEmpty()) {
-                IFile file = result.get(0);
-                file.setFileContent(sourceCode.getFileContent(file.getSelfLink()));
-
-                TicketFilePrompt ticketFilePrompt = new TicketFilePrompt(trackerClient.getBasePath(), role, ticketContext, file);
-                ticketFilePrompt.setExtraTickets(ticketContext.getExtraTickets());
-                String request = promptManager.validatePotentiallyEffectedFile(ticketFilePrompt);
-                boolean isTheFileUsefull = AI.Utils.chatAsBoolean(ai,
-                        CODE_AI_MODEL,
-                        request);
-                if (isTheFileUsefull) {
-                    finalResults.add(file);
-                }
-            }
-        }
-    }
-
-    private JSONArray getListOfEffectedFilesFromFiles(CodeGeneration codeGeneration, List<IFile> filesOnly) throws Exception {
-        codeGeneration.setFiles(filesOnly);
-        String aiRequest = promptManager.checkPotentiallyEffectedFilesForTicket(codeGeneration);
-        JSONArray result = AI.Utils.chatAsJSONArray(ai,
-                CODE_AI_MODEL,
-                aiRequest);
-        logger.info(result);
-        return result;
-    }
-
-    private JSONArray getListOfEffectedFilesFromCommits(SourceCode sourceCode, String workspace, String repository, CodeGeneration codeGeneration, List<ICommit> commits) throws Exception {
-        codeGeneration.setCommits(commits);
-        String aiRequest = promptManager.checkPotentiallyRelatedCommitsToTicket(codeGeneration);
-        JSONArray jsonArray = AI.Utils.chatAsJSONArray(ai,
-                CODE_AI_MODEL,
-                aiRequest);
-        logger.info(jsonArray);
-        Set<String> filesFromCommits = new HashSet<>();
-        for (int i = 0; i < jsonArray.length(); i++) {
-            String commit = jsonArray.getString(i);
-            IDiffStats commitDiffStat = sourceCode.getCommitDiffStat(workspace, repository, commit);
-            List<IChange> changes = commitDiffStat.getChanges();
-            for (IChange change : changes) {
-                filesFromCommits.add(change.getFilePath());
-            }
-        }
-        JSONArray result = new JSONArray();
-        for (String path : filesFromCommits) {
-            result.put(path);
-        }
-        return result;
-    }
-
-    private void trackConversation(String author, String text) {
-        if (conversationObserver != null) {
-            conversationObserver.addMessage(new ConversationObserver.Message(author, text));
-        }
     }
 
     public UserStoryGenerator.Result generateUserStories(TicketContext ticketContext, List<? extends ITicket> listOfLinkedUserStories, String projectCode, String issueType, String acceptanceCriteriaField, String relationship, String outputType, String priorities, String parentField) throws Exception {
@@ -311,39 +211,6 @@ public class JAssistant {
         }
     }
 
-    public @NotNull StringBuilder buildAttachmentsDescription(ITicket ticket) throws Exception {
-        List<? extends IAttachment> attachments = ticket.getAttachments();
-        StringBuilder attachmentsDescription = new StringBuilder();
-        if (!attachments.isEmpty()) {
-            for (IAttachment attachment : attachments) {
-                if (!RestClient.Impl.getFileImageExtension(attachment.getName()).isEmpty()) {
-                    java.io.File pageSnapshot = trackerClient.convertUrlToFile(attachment.getUrl());
-                    String extendedDescription = combineTextAndImage(ticket.getTicketTitle() + "\n" + ticket.getTicketDescription() + "\n" + attachmentsDescription, pageSnapshot);
-                    attachmentsDescription.append(extendedDescription).append("\n");
-                }
-            }
-
-        }
-        return attachmentsDescription;
-    }
-
-    public void generateNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO(String key) throws Exception {
-        ITicket ticket = trackerClient.performTicket(key, trackerClient.getExtendedQueryFields());
-        TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-        ticketContext.prepareContext();
-        String aiRequest = promptManager.requestNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO(new TicketBasedPrompt(trackerClient.getBasePath(), ticketContext));
-        String response = ai.chat(aiRequest);
-        response = ai.chat(promptManager.convertToHTML(new InputPrompt(response)));
-        trackerClient.postComment(key, "<p>JAI Generated Nice Looking Story In Gherkin Style And Potential Questions To PO: </p>" + response);
-    }
-
-    public String checkStoryIsTechnicalOrProduct(ITicket ticket) throws Exception {
-        TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-        ticketContext.prepareContext();
-        String aiRequest = promptManager.checkTaskTechnicalOrProduct(new TicketBasedPrompt(trackerClient.getBasePath(), ticketContext));
-        return ai.chat(aiRequest);
-    }
-
     public String chooseFeatureAreaForStory(ToText inputText, String areas) throws Exception {
         String aiRequest = promptManager.checkStoryAreas(new BAStoryAreaPrompt(trackerClient.getBasePath(), inputText, areas));
         return ai.chat(
@@ -443,47 +310,6 @@ public class JAssistant {
             return null;
         }
     }
-    public void reviewPullRequest(SourceCode sourceCode, String role, String workspace, String repository, String pullRequestId, IssuesIDsParser issuesIDsParser) throws Exception {
-        IPullRequest pullRequest = sourceCode.pullRequest(workspace, repository, pullRequestId);
-        List<String> keys = issuesIDsParser.parseIssues(pullRequest.getTitle(), pullRequest.getSourceBranchName(), pullRequest.getDescription());
-        if (keys.isEmpty()) {
-            sourceCode.addPullRequestComment(workspace, repository, pullRequestId, "Please use Ticket Number in Title, Description or Branch Name");
-            return;
-        }
-        if (keys.size() > 1) {
-            sourceCode.addPullRequestComment(workspace, repository, pullRequestId, "One Pull Request should be related to one ticket.");
-            return;
-        }
-
-        ITicket ticket = trackerClient.performTicket(keys.get(0), trackerClient.getExtendedQueryFields());
-        TicketContext ticketContext = new TicketContext(trackerClient, ticket);
-        ticketContext.prepareContext();
-        PullRequestReview input = new PullRequestReview(trackerClient.getBasePath(), role, ticketContext);
-        input.setTicket(ticket);
-
-        if (!IssueType.isBug(ticket.getIssueType())) {
-            List<? extends ITicket> testCases = trackerClient.getTestCases(ticket, "Test Case");
-            input.setExistingTickets(testCases);
-        }
-
-        input.setRole(role);
-        IBody diff = sourceCode.getDiff(workspace, repository, pullRequestId);
-        input.setDiff(diff.getBody());
-
-        String request;
-        if (!IssueType.isBug(ticket.getIssueType())) {
-            request = promptManager.requestDeveloperStoryPullRequestReview(input);
-        } else {
-            request = promptManager.requestDeveloperBugPullRequestReview(input);
-        }
-        String response = ai.chat(request);
-        logger.info("===== AI Response ======");
-        logger.info(response);
-        logger.info("===== AI Response ======");
-        sourceCode.addPullRequestComment(workspace, repository, pullRequestId, "JAI Review \n\n\n" + response);
-    }
-
-
     public JSONObject createFeatureAreasTree(String inputAreas) throws Exception {
         String prompt = promptManager.createFeatureAreasTree(new InputPrompt(inputAreas));
         return AI.Utils.chatAsJSONObject(ai, prompt);

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/JAssistantCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/JAssistantCoverageTest.java
@@ -5,7 +5,6 @@ package com.github.istin.dmtools.ai;
 
 import com.github.istin.dmtools.atlassian.jira.JiraClient;
 import com.github.istin.dmtools.atlassian.jira.model.Ticket;
-import com.github.istin.dmtools.atlassian.jira.utils.IssuesIDsParser;
 import com.github.istin.dmtools.ba.UserStoryGenerator;
 import com.github.istin.dmtools.ba.UserStoryGeneratorParams;
 import com.github.istin.dmtools.common.code.SourceCode;
@@ -19,7 +18,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,9 +26,8 @@ import static org.mockito.Mockito.*;
 
 /**
  * Additional coverage tests for {@link JAssistant} focusing on branches
- * not exercised by {@link JAssistantTest}: code generation over source
- * files/commits, user story creation/update flows, story estimation,
- * pull request review and attachment description building.
+ * not exercised by {@link JAssistantTest}: user story creation/update
+ * flows, story estimation and similar-ticket validation.
  */
 public class JAssistantCoverageTest {
 
@@ -47,58 +44,6 @@ public class JAssistantCoverageTest {
         aiClientMock = mock(AI.class);
         promptManagerMock = mock(PromptManager.class);
         jAssistant = new JAssistant(trackerClientMock, sourceCodesMock, aiClientMock, promptManagerMock);
-    }
-
-    @Test
-    public void testGenerateCodeWithSourceCodeFilesAndCommits() throws Exception {
-        TicketContext ticketContextMock = mock(TicketContext.class);
-        ITicket ticketMock = mock(ITicket.class);
-        when(ticketContextMock.getTicket()).thenReturn(ticketMock);
-        when(ticketContextMock.getExtraTickets()).thenReturn(new ArrayList<>());
-        when(ticketMock.getIssueType()).thenReturn("Story");
-        when(ticketMock.getTicketKey()).thenReturn("KEY-1");
-        when(trackerClientMock.getBasePath()).thenReturn("basePath");
-        when(trackerClientMock.getTestCases(any(), anyString())).thenReturn(new ArrayList<>());
-
-        SourceCode sourceCodeMock = mock(SourceCode.class);
-        sourceCodesMock.add(sourceCodeMock);
-        when(sourceCodeMock.getDefaultWorkspace()).thenReturn("workspace");
-        when(sourceCodeMock.getDefaultRepository()).thenReturn("repository");
-        when(sourceCodeMock.getDefaultBranch()).thenReturn("branch");
-
-        IFile fileMock = mock(IFile.class);
-        when(fileMock.isDir()).thenReturn(false);
-        when(fileMock.getPath()).thenReturn("src/A.java");
-        when(fileMock.getSelfLink()).thenReturn("selfLink");
-        IFile dirMock = mock(IFile.class);
-        when(dirMock.isDir()).thenReturn(true);
-        when(sourceCodeMock.getListOfFiles(anyString(), anyString(), anyString()))
-                .thenReturn(Arrays.asList(fileMock, dirMock));
-
-        ICommit commitMock = mock(ICommit.class);
-        when(sourceCodeMock.getCommitsFromBranch(anyString(), anyString(), anyString(), any(), any()))
-                .thenReturn(Collections.singletonList(commitMock));
-        IDiffStats diffStatsMock = mock(IDiffStats.class);
-        IChange changeMock = mock(IChange.class);
-        when(changeMock.getFilePath()).thenReturn("src/A.java");
-        when(diffStatsMock.getChanges()).thenReturn(Collections.singletonList(changeMock));
-        when(sourceCodeMock.getCommitDiffStat(anyString(), anyString(), anyString())).thenReturn(diffStatsMock);
-        when(sourceCodeMock.getFileContent(anyString())).thenReturn("file content");
-
-        when(promptManagerMock.checkPotentiallyEffectedFilesForTicket(any())).thenReturn("AI Request");
-        when(promptManagerMock.checkPotentiallyRelatedCommitsToTicket(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(any(), anyString(), (File) any()))
-                .thenReturn("[\"src/A.java\"]", "[\"commit1\"]");
-        when(promptManagerMock.validatePotentiallyEffectedFile(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(any(), anyString())).thenReturn("true", "AI Final Response");
-        when(promptManagerMock.requestGenerateCodeForTicket(any())).thenReturn("Final AI Request");
-
-        String result = jAssistant.generateCode("role", ticketContextMock);
-
-        assertEquals("AI Final Response", result);
-        verify(fileMock, times(2)).setFileContent("file content");
-        verify(trackerClientMock).postComment(eq("KEY-1"), contains("AI Generated Code: "));
-        verify(trackerClientMock).addLabelIfNotExists(ticketMock, "ai_generated_code");
     }
 
     @Test
@@ -303,146 +248,6 @@ public class JAssistantCoverageTest {
         assertEquals(1, result.size());
         assertSame(similarTicketMock, result.get(0));
         verify(promptManagerMock, never()).validateSimilarStory(any());
-    }
-
-    @Test
-    public void testReviewPullRequestWithoutTicketKeys() throws Exception {
-        SourceCode sourceCodeMock = mock(SourceCode.class);
-        IPullRequest pullRequestMock = mock(IPullRequest.class);
-        when(pullRequestMock.getTitle()).thenReturn("Some title");
-        when(pullRequestMock.getSourceBranchName()).thenReturn("feature/branch");
-        when(pullRequestMock.getDescription()).thenReturn("description");
-        when(sourceCodeMock.pullRequest(anyString(), anyString(), anyString())).thenReturn(pullRequestMock);
-        IssuesIDsParser issuesIDsParserMock = mock(IssuesIDsParser.class);
-        when(issuesIDsParserMock.parseIssues(anyString(), anyString(), anyString()))
-                .thenReturn(new ArrayList<>());
-
-        jAssistant.reviewPullRequest(sourceCodeMock, "role", "workspace", "repository", "1", issuesIDsParserMock);
-
-        verify(sourceCodeMock).addPullRequestComment("workspace", "repository", "1",
-                "Please use Ticket Number in Title, Description or Branch Name");
-        verify(trackerClientMock, never()).performTicket(anyString(), any());
-    }
-
-    @Test
-    public void testReviewPullRequestWithMultipleTicketKeys() throws Exception {
-        SourceCode sourceCodeMock = mock(SourceCode.class);
-        IPullRequest pullRequestMock = mock(IPullRequest.class);
-        when(pullRequestMock.getTitle()).thenReturn("DMC-1 DMC-2 title");
-        when(pullRequestMock.getSourceBranchName()).thenReturn("feature/branch");
-        when(pullRequestMock.getDescription()).thenReturn("description");
-        when(sourceCodeMock.pullRequest(anyString(), anyString(), anyString())).thenReturn(pullRequestMock);
-        IssuesIDsParser issuesIDsParserMock = mock(IssuesIDsParser.class);
-        when(issuesIDsParserMock.parseIssues(anyString(), anyString(), anyString()))
-                .thenReturn(Arrays.asList("DMC-1", "DMC-2"));
-
-        jAssistant.reviewPullRequest(sourceCodeMock, "role", "workspace", "repository", "1", issuesIDsParserMock);
-
-        verify(sourceCodeMock).addPullRequestComment("workspace", "repository", "1",
-                "One Pull Request should be related to one ticket.");
-        verify(trackerClientMock, never()).performTicket(anyString(), any());
-    }
-
-    @Test
-    public void testReviewPullRequestForStory() throws Exception {
-        SourceCode sourceCodeMock = mock(SourceCode.class);
-        IPullRequest pullRequestMock = mock(IPullRequest.class);
-        when(pullRequestMock.getTitle()).thenReturn("DMC-1 title");
-        when(pullRequestMock.getSourceBranchName()).thenReturn("feature/DMC-1");
-        when(pullRequestMock.getDescription()).thenReturn("description");
-        when(sourceCodeMock.pullRequest(anyString(), anyString(), anyString())).thenReturn(pullRequestMock);
-        IssuesIDsParser issuesIDsParserMock = mock(IssuesIDsParser.class);
-        when(issuesIDsParserMock.parseIssues(anyString(), anyString(), anyString()))
-                .thenReturn(Collections.singletonList("DMC-1"));
-
-        ITicket ticketMock = mock(ITicket.class);
-        when(ticketMock.toText()).thenReturn("");
-        when(ticketMock.getIssueType()).thenReturn("Story");
-        when(trackerClientMock.performTicket(eq("DMC-1"), any())).thenReturn(ticketMock);
-        when(trackerClientMock.getTestCases(any(), anyString())).thenReturn(new ArrayList<>());
-        IBody bodyMock = mock(IBody.class);
-        when(bodyMock.getBody()).thenReturn("diff body");
-        when(sourceCodeMock.getDiff(anyString(), anyString(), anyString())).thenReturn(bodyMock);
-        when(promptManagerMock.requestDeveloperStoryPullRequestReview(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString())).thenReturn("Review response");
-
-        jAssistant.reviewPullRequest(sourceCodeMock, "role", "workspace", "repository", "1", issuesIDsParserMock);
-
-        verify(promptManagerMock).requestDeveloperStoryPullRequestReview(any());
-        verify(promptManagerMock, never()).requestDeveloperBugPullRequestReview(any());
-        verify(sourceCodeMock).addPullRequestComment(eq("workspace"), eq("repository"), eq("1"),
-                contains("JAI Review"));
-    }
-
-    @Test
-    public void testReviewPullRequestForBug() throws Exception {
-        SourceCode sourceCodeMock = mock(SourceCode.class);
-        IPullRequest pullRequestMock = mock(IPullRequest.class);
-        when(pullRequestMock.getTitle()).thenReturn("DMC-1 title");
-        when(pullRequestMock.getSourceBranchName()).thenReturn("bugfix/DMC-1");
-        when(pullRequestMock.getDescription()).thenReturn("description");
-        when(sourceCodeMock.pullRequest(anyString(), anyString(), anyString())).thenReturn(pullRequestMock);
-        IssuesIDsParser issuesIDsParserMock = mock(IssuesIDsParser.class);
-        when(issuesIDsParserMock.parseIssues(anyString(), anyString(), anyString()))
-                .thenReturn(Collections.singletonList("DMC-1"));
-
-        ITicket ticketMock = mock(ITicket.class);
-        when(ticketMock.toText()).thenReturn("");
-        when(ticketMock.getIssueType()).thenReturn("Bug");
-        when(trackerClientMock.performTicket(eq("DMC-1"), any())).thenReturn(ticketMock);
-        IBody bodyMock = mock(IBody.class);
-        when(bodyMock.getBody()).thenReturn("diff body");
-        when(sourceCodeMock.getDiff(anyString(), anyString(), anyString())).thenReturn(bodyMock);
-        when(promptManagerMock.requestDeveloperBugPullRequestReview(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString())).thenReturn("Review response");
-
-        jAssistant.reviewPullRequest(sourceCodeMock, "role", "workspace", "repository", "1", issuesIDsParserMock);
-
-        verify(trackerClientMock, never()).getTestCases(any(), anyString());
-        verify(promptManagerMock).requestDeveloperBugPullRequestReview(any());
-        verify(sourceCodeMock).addPullRequestComment(eq("workspace"), eq("repository"), eq("1"),
-                contains("JAI Review"));
-    }
-
-    @Test
-    public void testBuildAttachmentsDescriptionWithImage() throws Exception {
-        ITicket ticketMock = mock(ITicket.class);
-        IAttachment attachmentMock = mock(IAttachment.class);
-        when(attachmentMock.getName()).thenReturn("snapshot.png");
-        when(attachmentMock.getUrl()).thenReturn("http://example.com/snapshot.png");
-        doReturn(Collections.singletonList(attachmentMock)).when(ticketMock).getAttachments();
-        when(ticketMock.getTicketTitle()).thenReturn("Title");
-        when(ticketMock.getTicketDescription()).thenReturn("Description");
-        when(trackerClientMock.convertUrlToFile(anyString())).thenReturn(new File("snapshot.png"));
-        when(promptManagerMock.combineTextAndImage(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString(), anyString(), (File) any())).thenReturn("extended description");
-
-        StringBuilder result = jAssistant.buildAttachmentsDescription(ticketMock);
-
-        assertTrue(result.toString().contains("extended description"));
-    }
-
-    @Test
-    public void testBuildAttachmentsDescriptionWithNonImageAttachment() throws Exception {
-        ITicket ticketMock = mock(ITicket.class);
-        IAttachment attachmentMock = mock(IAttachment.class);
-        when(attachmentMock.getName()).thenReturn("document.pdf");
-        doReturn(Collections.singletonList(attachmentMock)).when(ticketMock).getAttachments();
-
-        StringBuilder result = jAssistant.buildAttachmentsDescription(ticketMock);
-
-        assertEquals(0, result.length());
-        verify(trackerClientMock, never()).convertUrlToFile(anyString());
-    }
-
-    @Test
-    public void testBuildAttachmentsDescriptionWithoutAttachments() throws Exception {
-        ITicket ticketMock = mock(ITicket.class);
-        when(ticketMock.getAttachments()).thenReturn(new ArrayList<>());
-
-        StringBuilder result = jAssistant.buildAttachmentsDescription(ticketMock);
-
-        assertEquals(0, result.length());
     }
 
     @Test

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/JAssistantTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/JAssistantTest.java
@@ -38,46 +38,6 @@ public class JAssistantTest {
     }
 
     @Test
-    public void testGenerateCode() throws Exception {
-        TicketContext ticketContextMock = mock(TicketContext.class);
-        ITicket ticketMock = mock(ITicket.class);
-        when(ticketContextMock.getTicket()).thenReturn(ticketMock);
-        when(ticketMock.getIssueType()).thenReturn("Story");
-        when(trackerClientMock.getBasePath()).thenReturn("basePath");
-        when(promptManagerMock.requestGenerateCodeForTicket(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString(), anyString())).thenReturn("AI Response");
-
-        jAssistant.generateCode("role", ticketContextMock);
-
-        verify(trackerClientMock).addLabelIfNotExists(any(), eq("ai_generated_code"));
-    }
-
-    @Test
-    public void testGenerateNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO() throws Exception {
-        ITicket ticketMock = mock(ITicket.class);
-        when(trackerClientMock.performTicket(anyString(), any())).thenReturn(ticketMock);
-        when(promptManagerMock.requestNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString())).thenReturn("AI Response");
-        when(ticketMock.toText()).thenReturn("");
-        jAssistant.generateNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO("TICKET-1");
-
-        verify(trackerClientMock).postComment(anyString(), contains("JAI Generated Nice Looking Story In Gherkin Style And Potential Questions To PO: "));
-    }
-
-    @Test
-    public void testCheckStoryIsTechnicalOrProduct() throws Exception {
-        ITicket ticketMock = mock(ITicket.class);
-        when(trackerClientMock.performTicket(anyString(), any())).thenReturn(ticketMock);
-        when(promptManagerMock.checkTaskTechnicalOrProduct(any())).thenReturn("AI Request");
-        when(aiClientMock.chat(anyString())).thenReturn("Technical");
-        when(ticketMock.toText()).thenReturn("");
-
-        String result = jAssistant.checkStoryIsTechnicalOrProduct(ticketMock);
-
-        assertEquals("Technical", result);
-    }
-
-    @Test
     public void testChooseFeatureAreaForStory() throws Exception {
         ToText inputTextMock = mock(ToText.class);
         when(promptManagerMock.checkStoryAreas(any())).thenReturn("AI Request");


### PR DESCRIPTION
Follow-up to #360. These methods have **zero references repo-wide** (checked Java, JS, JSON, MD) — leftovers from the removed legacy job flows:

- `generateCode` (+ orphaned private helpers `extractPotentiallyEffectedFiles`, `getListOfEffectedFilesFromFiles/FromCommits`)
- `buildAttachmentsDescription`
- `generateNiceLookingStoryInGherkinStyleAndPotentialQuestionsToPO`
- `checkStoryIsTechnicalOrProduct`
- `reviewPullRequest`
- `trackConversation` (private, never invoked)

Corresponding tests removed (11 methods). JAssistant itself stays — it's a shared helper for 9 surviving classes.

Verified: full dmtools-core suite green (7,117 tests, 0 failures), repo-wide grep for the removed names comes back empty. Net: **-411 lines**.