### PR TITLE
chore(dmtools-core): default JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES=true and JIRA_EXTRA_FIELDS_PROJECT=TS

### DIFF
--- a/dmtools-core/PROPERTIES.md
+++ b/dmtools-core/PROPERTIES.md
@@ -158,7 +158,8 @@ export AI_RETRY_DELAY_STEP="20000"
 - `JIRA_LOGGING_ENABLED`: Boolean flag for request logging
 - `JIRA_CLEAR_CACHE`: Boolean flag for cache management
 - `JIRA_EXTRA_FIELDS`: Comma-separated list of additional fields to fetch
-- `JIRA_EXTRA_FIELDS_PROJECT`: Project-specific extra fields
+- `JIRA_EXTRA_FIELDS_PROJECT`: Project-specific extra fields (defaults to `TS` when unset)
+- `JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES`: Rename `customfield_XXXX` keys to their human-readable names (defaults to `true` when unset)
 
 ### Confluence Integration
 - `CONFLUENCE_LOGIN_PASS_TOKEN`: Confluence API Token

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -342,15 +342,11 @@ public class PropertyReader {
   }
 
   public boolean isJiraTransformCustomFieldsToNames() {
-    String value = getValue("JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES");
-    if (value == null) {
-      return false;
-    }
-    return Boolean.parseBoolean(value);
+    return Boolean.parseBoolean(getValue("JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES", "true"));
   }
 
   public String getJiraExtraFieldsProject() {
-    return getValue(JIRA_EXTRA_FIELDS_PROJECT);
+    return getValue(JIRA_EXTRA_FIELDS_PROJECT, "TS");
   }
 
     public int getJiraMaxSearchResults() {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderCoverageTest.java
@@ -244,7 +244,7 @@ class PropertyReaderCoverageTest {
     }
 
     @Test
-    @DisplayName("Jira boolean flags default to false when unset")
+    @DisplayName("Jira boolean flags fall back to defaults when unset")
     void testJiraBooleanFlagsDefaults() {
         // Empty-string overrides shadow any real environment variables and behave as "unset"
         Map<String, String> values = new HashMap<>();
@@ -256,7 +256,8 @@ class PropertyReaderCoverageTest {
         assertFalse(propertyReader.isJiraWaitBeforePerform());
         assertFalse(propertyReader.isJiraLoggingEnabled());
         assertFalse(propertyReader.isJiraClearCache());
-        assertFalse(propertyReader.isJiraTransformCustomFieldsToNames());
+        // JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES defaults to true when unset
+        assertTrue(propertyReader.isJiraTransformCustomFieldsToNames());
     }
 
     @Test


### PR DESCRIPTION
## What

Changes the out-of-the-box defaults in `PropertyReader` to match the production configuration:

- `JIRA_TRANSFORM_CUSTOM_FIELDS_TO_NAMES`: default `false` → **`true`** when unset
- `JIRA_EXTRA_FIELDS_PROJECT`: default `null` → **`TS`** when unset

Explicitly set values still win — this only affects environments where the variables are not configured.

## Changes

- `PropertyReader.java`: use `getValue(key, default)` for both properties
- `PropertyReaderCoverageTest.java`: updated the unset-defaults test to expect `true` for the transform flag
- `PROPERTIES.md`: documented both defaults

## Verification

`./gradlew :dmtools-core:test` — BUILD SUCCESSFUL