### PR TITLE
ci: add dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -1,9 +1,15 @@
-name: Auto-update open PRs when main changes
+name: Auto-update open PRs when main or PRs change
 
 on:
   push:
     branches:
       - main
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
   workflow_dispatch: {}
 
 concurrency:
@@ -22,9 +28,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          # After a push to main, GitHub invalidates cached mergeability for all open PRs
-          # and recomputes asynchronously — returning "UNKNOWN" until ready. Retry until
-          # no PRs are stuck in UNKNOWN (up to ~90s) so the MERGEABLE filter doesn't miss them.
+          # After a push to main or when a PR is changed, GitHub invalidates cached
+          # mergeability for all open PRs and recomputes asynchronously — returning
+          # "UNKNOWN" until ready. Retry until no PRs are stuck in UNKNOWN (up to ~90s)
+          # so the MERGEABLE filter doesn't miss them.
           for attempt in $(seq 1 6); do
             unknown=$(gh pr list --repo ${{ github.repository }} --state open --base main \
               --json number,mergeable \

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge for Dependabot PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that enables GitHub native auto-merge for pull requests opened by Dependabot targeting `main`, and extends the existing auto-update workflow to keep PR branches up to date when PRs are created or updated.

### Changes
1. **New workflow** `.github/workflows/dependabot-auto-merge.yml`:
   - Triggers on `pull_request` events (opened, synchronize, reopened, ready_for_review).
   - Filters PRs by author (`dependabot[bot]`), base branch (`main`), and non-draft state.
   - Enables native auto-merge with squash strategy via `gh pr merge --auto --squash`.
   - GitHub waits for all required status checks to pass before merging.

2. **Updated workflow** `.github/workflows/auto-update-prs.yml`:
   - Now also triggers on `pull_request` events, so newly opened or updated PR branches are brought up to date with `main` automatically.
   - Keeps the existing behavior of updating all open mergeable PRs.

### How the two workflows work together
- When a dependabot PR is opened, `dependabot-auto-merge.yml` enables native auto-merge.
- If the PR branch is behind `main`, `auto-update-prs.yml` rebases/updates it.
- After the update, required checks run again and GitHub auto-merge completes the merge.

### Prerequisites
- **Allow auto-merge** must be enabled in the repository settings.
- Required status checks must be configured for the `main` branch.

Relates to dependabot pull requests at https://github.com/epam/dm.ai/pulls.