### PR TITLE
fix(auto-update): avoid cancelled runs and update only triggering PR on PR events

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -13,25 +13,27 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: auto-update-prs
-  cancel-in-progress: true
+  # Serialize updates but never cancel an in-progress run.
+  # Push to main updates all PRs; pull_request updates only the triggering PR.
+  group: auto-update-prs-${{ github.event_name == 'push' && 'push' || github.event.pull_request.number }}
+  cancel-in-progress: false
 
 jobs:
   update-prs:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Update open PRs that are behind main
+      - name: Update all open PRs that are behind main (push to main)
+        if: github.event_name == 'push'
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          # After a push to main or when a PR is changed, GitHub invalidates cached
-          # mergeability for all open PRs and recomputes asynchronously — returning
-          # "UNKNOWN" until ready. Retry until no PRs are stuck in UNKNOWN (up to ~90s)
-          # so the MERGEABLE filter doesn't miss them.
+          # After a push to main, GitHub invalidates cached mergeability for all open PRs
+          # and recomputes asynchronously — returning "UNKNOWN" until ready. Retry until
+          # no PRs are stuck in UNKNOWN (up to ~90s) so the MERGEABLE filter doesn't miss them.
           for attempt in $(seq 1 6); do
             unknown=$(gh pr list --repo ${{ github.repository }} --state open --base main \
               --json number,mergeable \
@@ -59,3 +61,13 @@ jobs:
             gh pr update-branch "$pr" --repo ${{ github.repository }} \
               || echo "PR #$pr skipped (already up to date or conflict)"
           done
+
+      - name: Update triggering PR if it is behind main
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "Attempting to update PR #$PR_NUMBER..."
+          gh pr update-branch "$PR_NUMBER" --repo ${{ github.repository }} \
+            || echo "PR #$PR_NUMBER skipped (already up to date or conflict)"


### PR DESCRIPTION
Fixes the situation where dependabot PRs get stuck showing `Update branch` and are not auto-merged.

### Problem
After merging the dependabot auto-merge workflow, many PRs triggered `auto-update-prs.yml` simultaneously via the new `pull_request` events. The workflow used a single global concurrency group with `cancel-in-progress: true`, so most runs were cancelled. The one surviving run often ran before the latest `main` state was visible, leaving PRs permanently `BEHIND`.

Additionally, every `pull_request` event tried to update **all** open PRs, creating unnecessary noise and contention.

### Changes
1. **Concurrency**: use separate groups for `push` to `main` and per-PR `pull_request` events, and set `cancel-in-progress: false` so in-progress updates are never killed.
2. **Push to main**: keeps the existing behavior of updating all open mergeable PRs.
3. **Pull request event**: now updates only the triggering PR, reducing noise.
4. **Timeout**: increased from 5 to 10 minutes to give bulk updates more headroom.

### Why this unblocks auto-merge
When one dependabot PR merges, the push to `main` reliably updates all remaining PRs. Each update re-triggers checks and the dependabot auto-merge workflow. With cancellation removed, these updates actually complete instead of being discarded.

### Important prerequisite
For GitHub native auto-merge to wait for checks before merging, the `main` branch should have **required status checks** configured in branch protection. Currently this repository does not have branch protection enabled on `main`, which can cause auto-merge to behave inconsistently.