### PR TITLE
fix: use PAT for dependabot auto-merge and add scheduled fallback

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -10,6 +10,10 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+  schedule:
+    # Fallback: auto-merge commits made via PAT still may not trigger push events
+    # in some edge cases. Poll every 5 minutes (offset to avoid the :00/:30 herd).
+    - cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *'
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -28,4 +28,6 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT so that the subsequent auto-merge commit triggers push events
+          # (merges performed via GITHUB_TOKEN do not trigger further workflows).
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Fixes the remaining issue where dependabot PRs stay in `BEHIND` state after another dependabot PR is auto-merged.

### Root cause
When `dependabot-auto-merge.yml` used `GITHUB_TOKEN`, GitHub performed the actual merge as `app/github-actions`. Pushes made by GitHub Actions using the default token do **not** trigger new `push` events, so `auto-update-prs.yml` never ran after a dependabot PR was merged. The remaining PRs therefore stayed `BEHIND` with the `Update branch` button visible.

### Changes
1. **`.github/workflows/dependabot-auto-merge.yml`** — switched from `GITHUB_TOKEN` to `PAT_TOKEN` when enabling auto-merge. This should make the subsequent auto-merge commit emit a regular `push` event that triggers `auto-update-prs.yml`.
2. **`.github/workflows/auto-update-prs.yml`** — added a scheduled trigger every 5 minutes as a safety net, so even if a push event is missed, PRs are brought up to date shortly after.

### After merge
- Merging one dependabot PR should reliably update the remaining open PRs.
- The scheduled fallback will catch any edge cases where the push event is still not emitted.

Relates to #387 and #388.