### PR TITLE
fix(auto-update): run bulk update on schedule and workflow_dispatch

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -18,8 +18,8 @@ on:
 
 concurrency:
   # Serialize updates but never cancel an in-progress run.
-  # Push to main updates all PRs; pull_request updates only the triggering PR.
-  group: auto-update-prs-${{ github.event_name == 'push' && 'push' || github.event.pull_request.number }}
+  # Push/schedule/workflow_dispatch update all PRs; pull_request updates only the triggering PR.
+  group: auto-update-prs-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event_name }}
   cancel-in-progress: false
 
 jobs:
@@ -30,8 +30,8 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Update all open PRs that are behind main (push to main)
-        if: github.event_name == 'push'
+      - name: Update all open PRs that are behind main
+        if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |


### PR DESCRIPTION
Fixes the bug where scheduled and manually triggered runs of `auto-update-prs.yml` completed successfully but did not actually update any PRs.

### Problem
After adding the `schedule` trigger in #389, the scheduled runs executed but skipped both steps:
- the bulk-update step was guarded by `if: github.event_name == 'push'`
- the single-PR step was guarded by `if: github.event_name == 'pull_request'`

So `schedule` and `workflow_dispatch` events fell through with no work done, leaving dependabot PRs stuck in `BEHIND`.

### Fix
- Changed the bulk-update step condition to `if: github.event_name != 'pull_request'` so it runs for `push`, `schedule`, and `workflow_dispatch`.
- Updated the concurrency group to distinguish `push`, `schedule`, `workflow_dispatch`, and per-PR `pull_request` runs.

Relates to #387, #388, #389.