### PR TITLE
Hide JS tool-call args console.log behind DMTOOLS_JS_LOG_TOOL_CALLS flag

### DIFF
--- a/dmtools-ai-docs/references/agents/javascript-agents.md
+++ b/dmtools-ai-docs/references/agents/javascript-agents.md
@@ -613,6 +613,28 @@ function action(params) {
 }
 ```
 
+### Verbose MCP Tool-Call Logging (opt-in)
+
+By default, DMtools does **not** log the raw arguments of every MCP tool call your
+agent makes, or the "Exposed MCP tool X to JavaScript" registration listing at
+startup. This is intentional: tool args can include large payloads (e.g. a
+`file_write` call containing an entire file's contents, or a Jenkins console log),
+and logging them unconditionally can turn a CI job's log into a multi-megabyte
+wall of text.
+
+If you need to see exactly what args are passed to each MCP tool call while
+debugging an agent locally, opt in with an environment variable:
+
+```bash
+DMTOOLS_JS_LOG_TOOL_CALLS=true dmtools run agents/js/myScript.js '{}'
+```
+
+This enables, for the duration of that run:
+- `Calling tool <name> with args: <json>` before every MCP tool invocation
+- `Exposed MCP tool <name> to JavaScript` for each tool registered at JS context startup
+
+Leave this unset (or `false`) in CI/production pipelines to keep logs readable.
+
 ### Debug Mode (opt-in verbose output)
 
 Use a `debug` param flag to enable verbose output without cluttering production logs:

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -423,6 +423,21 @@ public class PropertyReader {
     return Boolean.parseBoolean(value);
   }
 
+  /**
+   * Whether generated JS MCP tool wrappers should verbosely log at runtime:
+   * the full call args via console.log(...) on every invocation (JobJavaScriptBridge),
+   * and the "Exposed MCP tool X to JavaScript" registration listing at JS context
+   * startup. Off by default — tool args can include large file contents (e.g. an
+   * entire file_write payload), which floods CI logs; opt in for local debugging.
+   */
+  public boolean isJsToolCallLoggingEnabled() {
+    String value = getValue("DMTOOLS_JS_LOG_TOOL_CALLS");
+    if (value == null) {
+      return false;
+    }
+    return Boolean.parseBoolean(value) || "1".equals(value);
+  }
+
   public boolean isXrayCacheGetRequestsEnabled() {
     String value = getValue("XRAY_CACHE_GET_REQUESTS_ENABLED");
     if (value == null) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
@@ -620,6 +620,16 @@ public class JobJavaScriptBridge {
     }
 
     /**
+     * Whether generated JS tool wrappers should console.log their full args (including
+     * file contents / large logs) on every call. Off by default to keep CI logs readable;
+     * opt in with DMTOOLS_JS_LOG_TOOL_CALLS=true (or "1") for local debugging.
+     */
+    private static boolean isToolCallArgsLoggingEnabled() {
+        String value = System.getenv("DMTOOLS_JS_LOG_TOOL_CALLS");
+        return "true".equalsIgnoreCase(value) || "1".equals(value);
+    }
+
+    /**
      * Expose a single MCP tool to JavaScript context using generated executor
      */
     private void exposeToolToJS(String toolName, Map<String, Object> toolSchema) {
@@ -642,6 +652,12 @@ public class JobJavaScriptBridge {
             }
         }
         
+        // Logging full tool-call args (including file contents, large logs, etc.) can
+        // flood CI output. Off by default; opt in via DMTOOLS_JS_LOG_TOOL_CALLS=true.
+        String toolCallLogStatement = isToolCallArgsLoggingEnabled()
+            ? String.format("console.log('Calling tool %s with args:', JSON.stringify(args));", toolName)
+            : "";
+
         // Create a JavaScript function that calls the generated MCP executor
         String jsFunction = String.format("""
             function %s() {
@@ -659,10 +675,10 @@ public class JobJavaScriptBridge {
                         args.message = arguments[0];
                     }
                 }
-                console.log('Calling tool %s with args:', JSON.stringify(args));
+                %s
                 return executeToolViaJava('%s', args);
             }
-            """, toolName, parameterMappingLogic.toString(), toolName, toolName, toolName);
+            """, toolName, parameterMappingLogic.toString(), toolName, toolCallLogStatement, toolName);
             
         try {
             jsContext.eval("js", jsFunction);

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
@@ -8,6 +8,7 @@ import com.github.istin.dmtools.atlassian.confluence.Confluence;
 import com.github.istin.dmtools.cli.CliCommandExecutor;
 import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.file.FileTools;
 import com.github.istin.dmtools.mcp.generated.MCPSchemaGenerator;
 import com.github.istin.dmtools.mcp.generated.MCPToolExecutor;
@@ -621,12 +622,12 @@ public class JobJavaScriptBridge {
 
     /**
      * Whether generated JS tool wrappers should console.log their full args (including
-     * file contents / large logs) on every call. Off by default to keep CI logs readable;
-     * opt in with DMTOOLS_JS_LOG_TOOL_CALLS=true (or "1") for local debugging.
+     * file contents / large logs) on every call, and whether the per-tool "Exposed MCP
+     * tool X to JavaScript" debug line is emitted at startup. Off by default to keep CI
+     * logs readable; opt in with DMTOOLS_JS_LOG_TOOL_CALLS=true (or "1") for local debugging.
      */
     private static boolean isToolCallArgsLoggingEnabled() {
-        String value = System.getenv("DMTOOLS_JS_LOG_TOOL_CALLS");
-        return "true".equalsIgnoreCase(value) || "1".equals(value);
+        return new PropertyReader().isJsToolCallLoggingEnabled();
     }
 
     /**
@@ -652,9 +653,11 @@ public class JobJavaScriptBridge {
             }
         }
         
-        // Logging full tool-call args (including file contents, large logs, etc.) can
-        // flood CI output. Off by default; opt in via DMTOOLS_JS_LOG_TOOL_CALLS=true.
-        String toolCallLogStatement = isToolCallArgsLoggingEnabled()
+        // Verbose logging of tool-call args and per-tool registration can flood CI
+        // output (e.g. args can include large file contents). Off by default; opt in
+        // via DMTOOLS_JS_LOG_TOOL_CALLS=true.
+        boolean verboseToolLogging = isToolCallArgsLoggingEnabled();
+        String toolCallLogStatement = verboseToolLogging
             ? String.format("console.log('Calling tool %s with args:', JSON.stringify(args));", toolName)
             : "";
 
@@ -682,7 +685,9 @@ public class JobJavaScriptBridge {
             
         try {
             jsContext.eval("js", jsFunction);
-            logger.debug("Exposed MCP tool {} to JavaScript", toolName);
+            if (verboseToolLogging) {
+                logger.debug("Exposed MCP tool {} to JavaScript", toolName);
+            }
         } catch (Exception e) {
             logger.error("Failed to expose tool {} to JavaScript", toolName, e);
         }


### PR DESCRIPTION
## Problem

Every generated JS MCP tool wrapper (in `JobJavaScriptBridge.exposeToolToJS`) unconditionally logs its full arguments via:

```js
console.log('Calling tool %s with args:', JSON.stringify(args));
```

For tools like `file_write`, this dumps the *entire* file content (e.g. full Jenkins console logs written to `ci_failures_full.log`) into the job's stdout/log stream — observed as a single **1.1MB log line** in a real CI run, making the surrounding log unreadable and bloating CI log storage.

In addition, the per-tool `Exposed MCP tool X to JavaScript` debug line is logged once for every registered tool (~300+ lines) every time a JS context starts, adding further noise whenever DEBUG logging is enabled.

## Fix

- Added `PropertyReader.isJsToolCallLoggingEnabled()`, following the project's existing pattern for boolean env-driven flags (e.g. `isCacheEnabled()`), backed by a new env var:

  ```bash
  DMTOOLS_JS_LOG_TOOL_CALLS=true   # or "1"
  ```

- `JobJavaScriptBridge` now reads this flag via `PropertyReader` (no more raw `System.getenv`) and gates **both**:
  - the per-call `console.log('Calling tool ...')` args dump (built into the generated JS wrapper — omitted entirely when off, no per-call overhead)
  - the per-tool `Exposed MCP tool X to JavaScript` startup debug listing
- Off by default — CI/production logs stay readable. Opt in for local debugging.
- Documented the new env var in `dmtools-ai-docs/references/agents/javascript-agents.md`.

## Testing

- `./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.job.JobJavaScriptBridge*" --tests "com.github.istin.dmtools.common.utils.PropertyReader*"` — all pass.
