### PR TITLE
Gate remaining JobJavaScriptBridge debug logs that dump full tool args

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
@@ -284,11 +284,14 @@ public class JobJavaScriptBridge {
      * Execute MCP tool from JavaScript
      */
     public Object executeToolFromJS(String toolName, Object jsArgs) {
+        boolean verboseToolLogging = isToolCallArgsLoggingEnabled();
         try {
             // Convert JavaScript object to Map
             Map<String, Object> argsMap = new HashMap<>();
             if (jsArgs != null) {
-                logger.debug("Converting JS args for tool {}: {} (type: {})", toolName, jsArgs, jsArgs.getClass().getName());
+                if (verboseToolLogging) {
+                    logger.debug("Converting JS args for tool {}: {} (type: {})", toolName, jsArgs, jsArgs.getClass().getName());
+                }
                 
                 Value argsValue = Value.asValue(jsArgs);
                 logger.debug("JS args as Value: hasMembers={}, isHostObject={}", argsValue.hasMembers(), argsValue.isHostObject());
@@ -335,7 +338,9 @@ public class JobJavaScriptBridge {
                             // Otherwise, it's just a regular string - keep it as-is
                         }
                         argsMap.put(key, memberValue);
-                        logger.debug("Converted JS arg: {} = {} (type: {})", key, memberValue, memberValue != null ? memberValue.getClass().getName() : "null");
+                        if (verboseToolLogging) {
+                            logger.debug("Converted JS arg: {} = {} (type: {})", key, memberValue, memberValue != null ? memberValue.getClass().getName() : "null");
+                        }
                     }
                 } else if (argsValue.isHostObject()) {
                     // Handle case where JS object is passed as host object
@@ -376,12 +381,16 @@ public class JobJavaScriptBridge {
                             }
                         }
                         argsMap.putAll(hostMap);
-                        logger.debug("Used host object as Map: {}", argsMap);
+                        if (verboseToolLogging) {
+                            logger.debug("Used host object as Map: {}", argsMap);
+                        }
                     }
                 }
             }
             
-            logger.debug("Final args map for tool {}: {}", toolName, argsMap);
+            if (verboseToolLogging) {
+                logger.debug("Final args map for tool {}: {}", toolName, argsMap);
+            }
             
             // Get tool schema to check parameter types
             Map<String, Object> toolSchema = getToolSchema(toolName);


### PR DESCRIPTION
## Problem

PR #392 hid the JS-generated `console.log('Calling tool X with args:', ...)` behind `DMTOOLS_JS_LOG_TOOL_CALLS`. However, `executeToolFromJS()` has four more **unconditional** `logger.debug()` calls (Java-side, not JS) that also dump full argument content whenever log4j's DEBUG level is enabled for the run:

```java
logger.debug("Converting JS args for tool {}: {} (type: {})", toolName, jsArgs, ...);   // dumps jsArgs.toString()
logger.debug("Converted JS arg: {} = {} (type: {})", key, memberValue, ...);              // dumps each member value
logger.debug("Used host object as Map: {}", argsMap);                                     // dumps the whole args map
logger.debug("Final args map for tool {}: {}", toolName, argsMap);                        // dumps the whole args map
```

In a real GitLab CI pipeline (log level DEBUG), this produced a **1.1MB single log line** for a `file_write` call whose content was a full Jenkins failure log — even with `DMTOOLS_JS_LOG_TOOL_CALLS` unset, since these are separate from the JS-side console.log fixed in #392.

## Fix

Gate all four log statements behind the same `PropertyReader.isJsToolCallLoggingEnabled()` flag (`DMTOOLS_JS_LOG_TOOL_CALLS=true`), so enabling DEBUG log level alone no longer causes full tool-argument dumps — it now requires the explicit opt-in flag, consistent with #392.

## Testing

- `./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.job.JobJavaScriptBridge*"` — all pass.

Follow-up to #392.
