### PR TITLE
Gate JavaScriptExecutor's full postJSAction result logging behind DMTOOLS_JS_LOG_TOOL_CALLS

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JavaScriptExecutor.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JavaScriptExecutor.java
@@ -9,6 +9,7 @@ import com.github.istin.dmtools.common.code.SourceCode;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
 import com.github.istin.dmtools.ai.AI;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.google.gson.Gson;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -106,7 +107,12 @@ public class JavaScriptExecutor {
             }
             Object result = jsBridge.executeJavaScript(jsCode, jsParamsJson);
             
-            logger.info("JavaScript executed successfully: {}", result);
+            if (new PropertyReader().isJsToolCallLoggingEnabled()) {
+                logger.info("JavaScript executed successfully: {}", result);
+            } else {
+                logger.info("JavaScript executed successfully (result type: {}, set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full result)",
+                        result != null ? result.getClass().getSimpleName() : "null");
+            }
             return result;
             
         } catch (Exception e) {


### PR DESCRIPTION
## Problem

Follow-up to #392 / #393. `JavaScriptExecutor.execute()` — the code path used for `preJSAction`, `postJSAction`, `timerJSAction`, and `preCliJSAction` in Teammate/Expert jobs — unconditionally logs the full JS action return value:

```java
logger.info("JavaScript executed successfully: {}", result);
```

Unlike the spots fixed in #392/#393, this one is at **INFO** level, so it fires on **every run regardless of log level** — no DEBUG needed. The return value of a `postJSAction` agent can be arbitrarily large (e.g. an agent that includes diff text, file content, or other large payloads in its result object), which can flood CI logs the same way the other spots did.

## Fix

Full result is now only logged when `PropertyReader.isJsToolCallLoggingEnabled()` (`DMTOOLS_JS_LOG_TOOL_CALLS=true`) is set. Otherwise, only the result's type name is logged, e.g.:

```
JavaScript executed successfully (result type: JSONObject, set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full result)
```

## Scope note

Audited other JS/tool-call logging spots in `JobJavaScriptBridge`, `FileTools`, `CliCommandExecutor`, `CliExecutionHelper`, and `JSRunner` — no other unconditional full-content dumps found (the rest already log only lengths/byte counts, or are already gated by #392/#393, or are behind logger.debug which the ops pipeline doesn't enable outside this one INFO-level spot).

## Testing

- `./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.job.JavaScriptExecutor*"` — all pass.
