### PR TITLE
Gate CommandLineUtils per-line stdout logging behind DMTOOLS_JS_LOG_TOOL_CALLS

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cli/CliCommandExecutor.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cli/CliCommandExecutor.java
@@ -48,6 +48,12 @@ public class CliCommandExecutor {
     /** Config key for extra allowed commands (comma-separated). */
     public static final String CLI_ALLOWED_COMMANDS_KEY = "CLI_ALLOWED_COMMANDS";
 
+    // This tool is exposed to JS agents for arbitrary whitelisted commands (git diff, mvn,
+    // curl, etc.), whose output is often large/noisy raw command output rather than
+    // something an operator needs to see line-by-line by default. Cap default INFO logging
+    // to a preview; set DMTOOLS_JS_LOG_TOOL_CALLS=true to see the full output.
+    private static final int DEFAULT_MAX_LOGGED_OUTPUT_LINES = 50;
+
     // Security baseline – never removed regardless of configuration
     private static final String[] BASE_ALLOWED_COMMANDS = {
         "git", "gh", "dmtools", "npm", "yarn", "docker",
@@ -123,7 +129,8 @@ public class CliCommandExecutor {
         
         try {
             // Execute command using CommandLineUtils
-            String output = CommandLineUtils.runCommand(trimmedCommand, resolvedWorkingDir, envVars);
+            String output = CommandLineUtils.runCommand(trimmedCommand, resolvedWorkingDir, envVars, null,
+                    DEFAULT_MAX_LOGGED_OUTPUT_LINES);
             
             logger.debug("Command executed successfully, output length: {} characters", output.length());
             return output;

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -118,11 +118,20 @@ public class CommandLineUtils {
         Process process = processBuilder.start();
 
         // Drain stdout/stderr in real-time so the process doesn't block on a full pipe
+        boolean verboseCommandOutputLogging = new PropertyReader().isJsToolCallLoggingEnabled();
         StringBuilder output = new StringBuilder();
+        int lineCount = 0;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                logger.info(line);
+                lineCount++;
+                // Logging every output line unconditionally at INFO can flood CI logs for
+                // commands with large output (e.g. `git diff`, `mvn test`, `curl` responses).
+                // Full line-by-line output is opt-in via DMTOOLS_JS_LOG_TOOL_CALLS; otherwise
+                // only a line-count summary is logged after the command finishes (below).
+                if (verboseCommandOutputLogging) {
+                    logger.info(line);
+                }
                 output.append(line).append(System.lineSeparator());
                 if (lineConsumer != null) {
                     try {
@@ -135,6 +144,10 @@ public class CommandLineUtils {
         }
 
         int exitCode = process.waitFor();
+        if (!verboseCommandOutputLogging) {
+            logger.debug("Command produced {} line(s) of output ({} chars); set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output",
+                    lineCount, output.length());
+        }
         logger.debug("Process exited with code: {}", exitCode);
 
         // Propagate non-zero exit codes so callers are not silently misled.

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -67,6 +67,11 @@ public class CommandLineUtils {
 
     /**
      * Runs a command-line command with full options and an optional per-line output consumer.
+     * Logs every output line at INFO by default (maxLinesToLog = -1, i.e. no cap) — use this
+     * overload for callers where the live output IS the thing operators want to see (e.g. an
+     * interactive CLI agent session such as run-agent.sh). For callers whose output is often
+     * large/noisy raw command output (e.g. a `git diff` or `mvn` invocation from a JS tool
+     * call), use {@link #runCommand(String, File, Map, Consumer, int)} with a small cap instead.
      *
      * @param command The command to run
      * @param workingDirectory The working directory for the command (null to use current directory)
@@ -78,6 +83,32 @@ public class CommandLineUtils {
      */
     public static String runCommand(String command, File workingDirectory, Map<String, String> additionalEnv,
                                     Consumer<String> lineConsumer)
+            throws IOException, InterruptedException {
+        return runCommand(command, workingDirectory, additionalEnv, lineConsumer, -1);
+    }
+
+    /**
+     * Runs a command-line command with full options, an optional per-line output consumer, and
+     * a cap on how many output lines get logged at INFO level by default.
+     *
+     * @param command The command to run
+     * @param workingDirectory The working directory for the command (null to use current directory)
+     * @param additionalEnv Additional environment variables to set
+     * @param lineConsumer Optional consumer called for each output line as it is produced (null to skip)
+     * @param maxLinesToLog Caps how many output lines are logged at INFO level when
+     *                      DMTOOLS_JS_LOG_TOOL_CALLS is not enabled. Use -1 for "no cap - always
+     *                      log every line" (e.g. an interactive CLI agent session whose live
+     *                      output is the point). Use a small positive value (e.g. 50) for
+     *                      callers whose output is often large/noisy raw command output (e.g.
+     *                      `git diff`, `mvn`) where only a preview is useful by default; the
+     *                      full output is always still returned/available to the caller and to
+     *                      DMTOOLS_JS_LOG_TOOL_CALLS=true regardless of this cap.
+     * @return The output of the command as a string
+     * @throws IOException If an I/O error occurs
+     * @throws InterruptedException If the current thread is interrupted
+     */
+    public static String runCommand(String command, File workingDirectory, Map<String, String> additionalEnv,
+                                    Consumer<String> lineConsumer, int maxLinesToLog)
             throws IOException, InterruptedException {
 
         logger.debug("Running command: {}", SecurityUtils.maskCommand(command));
@@ -121,16 +152,24 @@ public class CommandLineUtils {
         boolean verboseCommandOutputLogging = new PropertyReader().isJsToolCallLoggingEnabled();
         StringBuilder output = new StringBuilder();
         int lineCount = 0;
+        int loggedLineCount = 0;
+        boolean truncationNoticeLogged = false;
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 lineCount++;
                 // Logging every output line unconditionally at INFO can flood CI logs for
                 // commands with large output (e.g. `git diff`, `mvn test`, `curl` responses).
-                // Full line-by-line output is opt-in via DMTOOLS_JS_LOG_TOOL_CALLS; otherwise
-                // only a line-count summary is logged after the command finishes (below).
-                if (verboseCommandOutputLogging) {
+                // maxLinesToLog < 0 means "no cap" (always log, e.g. an interactive CLI agent
+                // session); otherwise once DMTOOLS_JS_LOG_TOOL_CALLS is not set, only the first
+                // maxLinesToLog lines are logged and a single truncation notice follows.
+                boolean withinCap = maxLinesToLog < 0 || loggedLineCount < maxLinesToLog;
+                if (verboseCommandOutputLogging || withinCap) {
                     logger.info(line);
+                    loggedLineCount++;
+                } else if (!truncationNoticeLogged) {
+                    logger.info("... output truncated after {} line(s); set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output ...", maxLinesToLog);
+                    truncationNoticeLogged = true;
                 }
                 output.append(line).append(System.lineSeparator());
                 if (lineConsumer != null) {
@@ -145,8 +184,8 @@ public class CommandLineUtils {
 
         int exitCode = process.waitFor();
         if (!verboseCommandOutputLogging) {
-            logger.debug("Command produced {} line(s) of output ({} chars); set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output",
-                    lineCount, output.length());
+            logger.debug("Command produced {} line(s) of output ({} chars), {} logged; set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output",
+                    lineCount, output.length(), loggedLineCount);
         }
         logger.debug("Process exited with code: {}", exitCode);
 


### PR DESCRIPTION
## Problem
`CommandLineUtils.runCommand()` logs every line of subprocess stdout at INFO,
unconditionally, in real time. This is used by two very different callers:

- `CliExecutionHelper` — runs the actual CLI agent session (run-agent.sh via
  cursor-agent/claude/copilot). This output IS the valuable "agent thinking"
  log content operators want to see.
- `CliCommandExecutor` (`cli_execute_command` MCP tool exposed to JS agents)
  — used for git diff/mvn/curl-style commands, which can dump arbitrarily
  large raw output (e.g. a full `git diff`) and is not meant to be read
  line-by-line as a "session log".

The second case was flooding CI logs and making them hard to read.

## Fix
- Per-line INFO logging is now capped via a new `maxLinesToLog` parameter on
  `CommandLineUtils.runCommand(...)`:
  - `maxLinesToLog < 0` → no cap, log every line (used by
    `CliExecutionHelper`, preserving full agent-session visibility).
  - `maxLinesToLog >= 0` → log up to N lines by default, then emit a single
    truncation notice. Full output is still always returned to the caller.
  - The existing 4-arg overload now delegates to this with `-1`, so no
    existing caller changes behavior unless explicitly opted into a cap.
- `CliCommandExecutor` now passes a 50-line cap for its `cli_execute_command`
  tool, since this is the JS-facing path that was producing the spam.
- The `DMTOOLS_JS_LOG_TOOL_CALLS=true` env flag still overrides the cap and
  logs everything, for debugging.

## Testing
- `CommandLineUtilsTest` — all passing.
- `CliCommandExecutorTest` — all passing.
- `CliExecutionHelperTest` — all passing (confirms agent-session logging is
  unaffected).