### PR TITLE
fix(teams): make contentType explicit parameter in sendChatMessage

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/teams-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/teams-tools.md
@@ -52,9 +52,9 @@ const result = teams_chats(...);
 | `teams_myself_messages_raw` | Get messages from your personal self chat (notes to yourself) with full raw data | `limit` (number, optional) |
 | `teams_recent_chats` | Get recent chats sorted by last activity showing chat/contact names, last message with author, and date. Shows 'new: true' for unread messages. Filter by type: 'oneOnOne' for 1-on-1 chats, 'group' for group chats, 'meeting' for meeting chats, or 'all' (default). Only shows chats with activity in the last 90 days. | `limit` (number, optional)<br>`chatType` (string, optional) |
 | `teams_search_user_drive_files` | Search for files in a user's OneDrive (e.g., meeting transcripts/recordings). Returns list of files with download URLs. | `userId` (string, **required**)<br>`searchQuery` (string, **required**) |
-| `teams_send_message` | Send a message to a chat by name or participant name (finds chat, then sends message) | `chatName` (string, **required**)<br>`content` (string, **required**) |
-| `teams_send_message_by_id` | Send a message to a chat by ID (returns raw JSON) | `chatId` (string, **required**)<br>`content` (string, **required**) |
-| `teams_send_myself_message` | Send a message to your personal self chat (notes to yourself) | `content` (string, **required**) |
+| `teams_send_message` | Send a message to a chat by name or participant name (finds chat, then sends message) | `chatName` (string, **required**)<br>`content` (string, **required**)<br>`contentType` (string, optional) |
+| `teams_send_message_by_id` | Send a message to a chat by ID (returns raw JSON) | `chatId` (string, **required**)<br>`content` (string, **required**)<br>`contentType` (string, optional) |
+| `teams_send_myself_message` | Send a message to your personal self chat (notes to yourself) | `content` (string, **required**)<br>`contentType` (string, optional) |
 | `teams_test` | Test Microsoft Teams connectivity by fetching the current user's profile | None |
 
 ## Detailed Parameter Information
@@ -707,14 +707,20 @@ Send a message to a chat by name or participant name (finds chat, then sends mes
 - **`content`** (string) 🔴 Required
   - Message content (plain text or HTML)
 
+- **`contentType`** (string) ⚪ Optional
+  - Message content type: `"text"` or `"html"`. Defaults to `"text"` when omitted.
+  - Use `"html"` to render `content` as formatted HTML in Teams.
+
 **Example:**
 ```bash
-dmtools teams_send_message "value" "value"
+dmtools teams_send_message "Project" "Hello team"
+dmtools teams_send_message "Project" "<b>Bold update</b>" "html"
 ```
 
 ```javascript
 // In JavaScript agent
 const result = teams_send_message("chatName", "content");
+const htmlResult = teams_send_message("chatName", "<b>HTML content</b>", "html");
 ```
 
 ---
@@ -731,14 +737,20 @@ Send a message to a chat by ID (returns raw JSON)
 - **`content`** (string) 🔴 Required
   - Message content (plain text or HTML)
 
+- **`contentType`** (string) ⚪ Optional
+  - Message content type: `"text"` or `"html"`. Defaults to `"text"` when omitted.
+  - Use `"html"` to render `content` as formatted HTML in Teams.
+
 **Example:**
 ```bash
-dmtools teams_send_message_by_id "value" "value"
+dmtools teams_send_message_by_id "19:abc@thread.v2" "Hello team"
+dmtools teams_send_message_by_id "19:abc@thread.v2" "<b>Bold update</b>" "html"
 ```
 
 ```javascript
 // In JavaScript agent
 const result = teams_send_message_by_id("chatId", "content");
+const htmlResult = teams_send_message_by_id("chatId", "<b>HTML content</b>", "html");
 ```
 
 ---
@@ -752,14 +764,20 @@ Send a message to your personal self chat (notes to yourself)
 - **`content`** (string) 🔴 Required
   - Message content (plain text or HTML)
 
+- **`contentType`** (string) ⚪ Optional
+  - Message content type: `"text"` or `"html"`. Defaults to `"text"` when omitted.
+  - Use `"html"` to render `content` as formatted HTML in Teams.
+
 **Example:**
 ```bash
-dmtools teams_send_myself_message "value"
+dmtools teams_send_myself_message "Buy milk"
+dmtools teams_send_myself_message "<b>Reminder</b>: buy milk" "html"
 ```
 
 ```javascript
 // In JavaScript agent
 const result = teams_send_myself_message("content");
+const htmlResult = teams_send_myself_message("<b>HTML content</b>", "html");
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/teams/TeamsClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/microsoft/teams/TeamsClient.java
@@ -842,9 +842,26 @@ public class TeamsClient extends MicrosoftGraphRestClient {
     
     /**
      * Sends a message to a chat by ID.
-     * 
+     * Defaults to plain text content type.
+     *
      * @param chatId The chat ID
      * @param content Message content (plain text or HTML)
+     * @return The created message
+     * @throws IOException if request fails
+     */
+    public ChatMessage sendChatMessage(
+            String chatId,
+            String content) throws IOException {
+
+        return sendChatMessage(chatId, content, "text");
+    }
+
+    /**
+     * Sends a message to a chat by ID.
+     *
+     * @param chatId The chat ID
+     * @param content Message content (plain text or HTML)
+     * @param contentType Message content type: "text" or "html". Defaults to "text" if null or empty.
      * @return The created message
      * @throws IOException if request fails
      */
@@ -856,16 +873,34 @@ public class TeamsClient extends MicrosoftGraphRestClient {
     )
     public ChatMessage sendChatMessage(
             @MCPParam(name = "chatId", description = "The chat ID", required = true) String chatId,
-            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content) throws IOException {
-        
-        return sendChatMessageWithType(chatId, content, "text");
+            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content,
+            @MCPParam(name = "contentType", description = "Message content type: 'text' or 'html'", required = false, example = "text") String contentType) throws IOException {
+
+        return sendChatMessageWithType(chatId, content, normalizeContentType(contentType));
     }
-    
+
     /**
      * Sends a message to a chat by name.
-     * 
+     * Defaults to plain text content type.
+     *
      * @param chatName The chat name to search for
      * @param content Message content (plain text or HTML)
+     * @return The created message, or null if chat not found
+     * @throws IOException if request fails
+     */
+    public String sendChatMessageByName(
+            String chatName,
+            String content) throws IOException {
+
+        return sendChatMessageByName(chatName, content, "text");
+    }
+
+    /**
+     * Sends a message to a chat by name.
+     *
+     * @param chatName The chat name to search for
+     * @param content Message content (plain text or HTML)
+     * @param contentType Message content type: "text" or "html". Defaults to "text" if null or empty.
      * @return The created message, or null if chat not found
      * @throws IOException if request fails
      */
@@ -877,8 +912,9 @@ public class TeamsClient extends MicrosoftGraphRestClient {
     )
     public String sendChatMessageByName(
             @MCPParam(name = "chatName", description = "The chat topic or participant name", required = true) String chatName,
-            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content) throws IOException {
-        
+            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content,
+            @MCPParam(name = "contentType", description = "Message content type: 'text' or 'html'", required = false, example = "text") String contentType) throws IOException {
+
         Chat chat = findChatByName(chatName);
         if (chat == null) {
             logger.error("Cannot send message: chat '{}' not found", chatName);
@@ -887,40 +923,54 @@ public class TeamsClient extends MicrosoftGraphRestClient {
             error.put("error", "Chat not found: " + chatName);
             return error.toString(2);
         }
-        
-        ChatMessage message = sendChatMessage(chat.getId(), content);
-        
+
+        ChatMessage message = sendChatMessage(chat.getId(), content, contentType);
+
         JSONObject result = new JSONObject();
         result.put("success", true);
         result.put("chatName", chat.getTopic() != null ? chat.getTopic() : "1-on-1 chat");
         result.put("chatId", chat.getId());
         result.put("messageId", message.getId());
         result.put("createdDateTime", message.getCreatedDateTime());
-        
+
         logger.info("Sent message to chat: {}", chatName);
         return result.toString(2);
     }
-    
+
     /**
      * Sends a message with specific content type.
      */
     private ChatMessage sendChatMessageWithType(String chatId, String content, String contentType) throws IOException {
         String url = path(String.format("/me/chats/%s/messages", chatId));
-        
+
         JSONObject messageBody = new JSONObject();
         JSONObject body = new JSONObject();
         body.put("content", content);
         body.put("contentType", contentType);
         messageBody.put("body", body);
-        
+
         GenericRequest request = new GenericRequest(this, url);
         request.setBody(messageBody.toString());
-        
+
         String response = post(request);
         ChatMessage message = new ChatMessage(response);
-        
+
         logger.info("Message sent to chat {}: {} chars", chatId, content.length());
         return message;
+    }
+
+    /**
+     * Normalizes the content type parameter.
+     * Defaults to "text" when null or empty.
+     *
+     * @param contentType The requested content type
+     * @return "text" if contentType is null or empty, otherwise the trimmed contentType
+     */
+    private String normalizeContentType(String contentType) {
+        if (contentType == null || contentType.trim().isEmpty()) {
+            return "text";
+        }
+        return contentType.trim();
     }
     
     // ========== Self Chat Operations (Personal Notes) ==========
@@ -982,8 +1032,24 @@ public class TeamsClient extends MicrosoftGraphRestClient {
     /**
      * Sends a message to your self chat (personal notes).
      * The self chat is a special chat with ID "48:notes" where you can send messages to yourself.
-     * 
+     * Defaults to plain text content type.
+     *
      * @param content Message content (plain text or HTML)
+     * @return JSON string with result (success/error) and message details
+     * @throws IOException if request fails
+     */
+    public String sendSelfChatMessage(
+            String content) throws IOException {
+
+        return sendSelfChatMessage(content, "text");
+    }
+
+    /**
+     * Sends a message to your self chat (personal notes).
+     * The self chat is a special chat with ID "48:notes" where you can send messages to yourself.
+     *
+     * @param content Message content (plain text or HTML)
+     * @param contentType Message content type: "text" or "html". Defaults to "text" if null or empty.
      * @return JSON string with result (success/error) and message details
      * @throws IOException if request fails
      */
@@ -994,17 +1060,18 @@ public class TeamsClient extends MicrosoftGraphRestClient {
         category = "communication"
     )
     public String sendSelfChatMessage(
-            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content) throws IOException {
-        
-        ChatMessage message = sendChatMessage(SELF_CHAT_ID, content);
-        
+            @MCPParam(name = "content", description = "Message content (plain text or HTML)", required = true) String content,
+            @MCPParam(name = "contentType", description = "Message content type: 'text' or 'html'", required = false, example = "text") String contentType) throws IOException {
+
+        ChatMessage message = sendChatMessage(SELF_CHAT_ID, content, contentType);
+
         JSONObject result = new JSONObject();
         result.put("success", true);
         result.put("chatName", "Self Chat (Personal Notes)");
         result.put("chatId", SELF_CHAT_ID);
         result.put("messageId", message.getId());
         result.put("createdDateTime", message.getCreatedDateTime());
-        
+
         logger.info("Sent message to self chat (personal notes)");
         return result.toString(2);
     }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/teams/TeamsClientUnitTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/microsoft/teams/TeamsClientUnitTest.java
@@ -668,6 +668,43 @@ class TeamsClientUnitTest {
     }
 
     @Test
+    void sendChatMessage_withHtmlContentType_postsHtmlBody() throws IOException {
+        onPost(messageJson("msg-sent", "2026-07-10T10:00:00Z", "<b>hello</b>"));
+
+        ChatMessage message = client.sendChatMessage("chat-1", "<b>hello</b>", "html");
+
+        assertEquals("msg-sent", message.getId());
+        assertEquals(1, postedRequests.size());
+        JSONObject body = new JSONObject(postedRequests.get(0).getBody());
+        assertEquals("html", body.getJSONObject("body").getString("contentType"));
+        assertEquals("<b>hello</b>", body.getJSONObject("body").getString("content"));
+    }
+
+    @Test
+    void sendChatMessage_withNullContentType_defaultsToText() throws IOException {
+        onPost(messageJson("msg-sent", "2026-07-10T10:00:00Z", "hello"));
+
+        ChatMessage message = client.sendChatMessage("chat-1", "hello", null);
+
+        assertEquals("msg-sent", message.getId());
+        assertEquals(1, postedRequests.size());
+        JSONObject body = new JSONObject(postedRequests.get(0).getBody());
+        assertEquals("text", body.getJSONObject("body").getString("contentType"));
+    }
+
+    @Test
+    void sendChatMessage_withEmptyContentType_defaultsToText() throws IOException {
+        onPost(messageJson("msg-sent", "2026-07-10T10:00:00Z", "hello"));
+
+        ChatMessage message = client.sendChatMessage("chat-1", "hello", "   ");
+
+        assertEquals("msg-sent", message.getId());
+        assertEquals(1, postedRequests.size());
+        JSONObject body = new JSONObject(postedRequests.get(0).getBody());
+        assertEquals("text", body.getJSONObject("body").getString("contentType"));
+    }
+
+    @Test
     void sendChatMessageByName_chatNotFound() throws IOException {
         on("/me/chats", page());
 
@@ -706,6 +743,20 @@ class TeamsClientUnitTest {
     }
 
     @Test
+    void sendChatMessageByName_withHtmlContentType_postsHtmlBody() throws IOException {
+        on("/me/chats", page(chatJson("chat-1", "Project", "group")));
+        onPost(messageJson("msg-sent", "2026-07-10T10:00:00Z", "<b>hello</b>"));
+
+        String result = client.sendChatMessageByName("project", "<b>hello</b>", "html");
+
+        JSONObject json = new JSONObject(result);
+        assertTrue(json.getBoolean("success"));
+        JSONObject body = new JSONObject(postedRequests.get(0).getBody());
+        assertEquals("html", body.getJSONObject("body").getString("contentType"));
+        assertEquals("<b>hello</b>", body.getJSONObject("body").getString("content"));
+    }
+
+    @Test
     void getSelfChatMessages_usesSelfChatId() throws IOException {
         on("/me/chats/48:notes/messages", page(messageJson("note-1", "2026-07-10T10:00:00Z", "note")));
 
@@ -737,6 +788,20 @@ class TeamsClientUnitTest {
         assertEquals("Self Chat (Personal Notes)", json.getString("chatName"));
         assertEquals("48:notes", json.getString("chatId"));
         assertEquals("note-sent", json.getString("messageId"));
+    }
+
+    @Test
+    void sendSelfChatMessage_withHtmlContentType_postsHtmlBody() throws IOException {
+        onPost(messageJson("note-sent", "2026-07-10T10:00:00Z", "<b>remember this</b>"));
+
+        String result = client.sendSelfChatMessage("<b>remember this</b>", "html");
+
+        JSONObject json = new JSONObject(result);
+        assertTrue(json.getBoolean("success"));
+        JSONObject body = new JSONObject(postedRequests.get(0).getBody());
+        assertEquals("html", body.getJSONObject("body").getString("contentType"));
+        assertEquals("<b>remember this</b>", body.getJSONObject("body").getString("content"));
+        assertTrue(postedRequests.get(0).url().contains("/me/chats/48:notes/messages"));
     }
 
     // ==================== File download ====================


### PR DESCRIPTION
Adds optional `contentType` parameter (`text` or `html`, defaults to `text`) to Teams send message MCP tools:

- `teams_send_message_by_id` (`sendChatMessage`)
- `teams_send_message` (`sendChatMessageByName`)
- `teams_send_myself_message` (`sendSelfChatMessage`)

Backward-compatible overloads without `contentType` are preserved, so existing callers continue to work. When `contentType=html` is passed, Microsoft Teams renders the message as formatted HTML instead of showing raw tags.

Closes #397