### PR TITLE
feat(confluence): markdown directory sync with attachment links

### DIFF
--- a/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
@@ -36,6 +36,77 @@ bash skill-install.sh --skills confluence
 dmtools confluence_content_by_title_and_space "Onboarding" "TEAM"
 ```
 
+## Markdown round-trip with attachments
+
+You can edit Confluence pages locally as Markdown and push them back, including attachments:
+
+1. Download a page as Markdown:
+   ```bash
+   dmtools confluence_content_by_id "123456" "md"
+   ```
+
+2. Save the Markdown body to a file and place referenced files next to it (or in a subdirectory):
+   ```markdown
+   # Design Doc
+
+   ![architecture](assets/architecture.png)
+
+   See [spec](assets/spec.pdf).
+   ```
+
+3. Create or update the page and upload referenced attachments automatically:
+   ```bash
+   # Create a new page
+   dmtools confluence_create_page_from_markdown_file_with_attachments \
+       "Design Doc" "654321" "/tmp/design.md" "TEAM" "/tmp/assets"
+
+   # Update an existing page
+   dmtools confluence_update_page_from_markdown_file_with_attachments \
+       "123456" "Design Doc" "654321" "/tmp/design.md" "TEAM" "/tmp/assets"
+   ```
+
+Existing attachments are skipped, so the same command can be run repeatedly without re-uploading files.
+
+For manual attachment management, use:
+
+```bash
+# Upload a single file
+dmtools confluence_upload_attachment "123456" "/tmp/diagram.png"
+
+# Upload an entire directory
+dmtools confluence_upload_attachments "123456" "/tmp/attachments"
+```
+
+## Sync a Markdown documentation tree
+
+To keep an entire directory of Markdown documentation in sync with Confluence, use `confluence_sync_markdown_directory`:
+
+```
+docs/
+├── index.md
+├── getting-started.md
+├── assets/
+│   └── screenshot.png
+└── api/
+    ├── index.md
+    └── authentication.md
+```
+
+```bash
+dmtools confluence_sync_markdown_directory "/tmp/docs" "123456" "TEAM" "false" "/tmp/assets"
+```
+
+Behavior:
+
+- `123456` is the existing Confluence page ID that represents `/tmp/docs`.
+- `index.md` or `README.md` inside a directory supplies the body for the matching folder page.
+- Subdirectories become child pages named after the directory.
+- Regular `.md` files become child pages under their parent directory page.
+- Cross-links between `.md` files are rewritten to Confluence `ri:page` references.
+- Local images and attachments are uploaded idempotently (existing attachments are skipped).
+- Non-Markdown files in each directory (for example `api/schema.json` or `assets/summary.pdf`) are uploaded as attachments to the corresponding Confluence page. If such a file is not already referenced in the page body, an **Attachments** section is appended to the page with explicit links so the files remain visible and downloadable.
+- Passing `true` for `deleteOrphans` removes Confluence child pages whose titles no longer match any file or directory in the tree.
+
 ## Compatibility / Supported versions
 
 - Compatible with Java 17+ and current DMtools focused skill releases

--- a/dmtools-ai-docs/references/mcp-tools/confluence-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/confluence-tools.md
@@ -1,6 +1,6 @@
 # CONFLUENCE MCP Tools
 
-**Total Tools**: 19
+**Total Tools**: 24
 
 ## Quick Reference
 
@@ -30,6 +30,7 @@ const result = confluence_content_by_id(...);
 | `confluence_content_by_title_and_space` | Get Confluence content by title and space key. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown. | `title` (string, **required**)<br>`format` (string, optional)<br>`space` (string, **required**) |
 | `confluence_contents_by_urls` | Get Confluence content by multiple URLs. Returns a list of content objects for each valid URL. Use format=md to convert body.storage.value to Markdown. | `format` (string, optional)<br>`urlStrings` (array, **required**) |
 | `confluence_create_page` | Create a new Confluence page with specified title, parent, body content, and space. Returns the created content object. | `title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**) |
+| `confluence_create_page_from_markdown_file_with_attachments` | Create a Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images (e.g. ./assets/doc.pdf) are resolved against the Markdown file's directory or an explicit attachmentsDir. Existing attachments are skipped. | `attachmentsDir` (string, optional)<br>`filePath` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`title` (string, **required**) |
 | `confluence_download_attachment` | Download an attachment file from Confluence to a specified directory. | `attachment` (object, **required**)<br>`targetDir` (object, **required**) |
 | `confluence_download_pages` | Download Confluence pages and their attachments to a local folder. Recursively follows linked pages, children macros, and internal ac:link references up to the specified depth. | `urlStrings` (array, **required**)<br>`depth` (number, optional)<br>`downloadAttachments` (boolean, optional)<br>`outputPath` (string, **required**) |
 | `confluence_find_content` | Find a Confluence page by title in the default space. Returns the page content if found. Use format=md to convert body.storage.value to Markdown. | `title` (string, **required**)<br>`format` (string, optional) |
@@ -41,9 +42,13 @@ const result = confluence_content_by_id(...);
 | `confluence_get_current_user_profile` | Get the current user's profile information from Confluence. Returns user details for the authenticated user. | None |
 | `confluence_get_user_profile_by_id` | Get a specific user's profile information from Confluence by user ID. Returns user details for the specified user. | `userId` (string, **required**) |
 | `confluence_search_content_by_text` | Search Confluence content by text query using CQL (Confluence Query Language). Returns search results with content excerpts. Default limit is 20 if not specified. | `limit` (number, optional)<br>`query` (string, **required**) |
+| `confluence_sync_markdown_directory` | Synchronize a local directory tree of Markdown files to a Confluence page subtree. Subdirectories become parent pages, Markdown files become child pages, .md cross-links become Confluence page links, referenced attachments are uploaded idempotently, and non-Markdown files in each directory are attached and linked at the bottom of the matching page. Optionally deletes Confluence pages that no longer match the file structure. | `directoryPath` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`deleteOrphans` (boolean, optional)<br>`attachmentsDir` (string, optional) |
 | `confluence_test` | Test Confluence connectivity by fetching the current user's profile | None |
 | `confluence_update_page` | Update an existing Confluence page with new title, parent, body content, and space. Returns the updated content object. | `contentId` (string, **required**)<br>`title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**) |
 | `confluence_update_page_with_history` | Update an existing Confluence page with new content and add a history comment. Returns the updated content object. | `contentId` (string, **required**)<br>`title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`historyComment` (string, **required**) |
+| `confluence_update_page_from_markdown_file_with_attachments` | Update an existing Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images are resolved against the Markdown file's directory or an explicit attachmentsDir. Existing attachments are skipped. | `attachmentsDir` (string, optional)<br>`contentId` (string, **required**)<br>`filePath` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`title` (string, **required**) |
+| `confluence_upload_attachment` | Upload a single file as an attachment to a Confluence page. Skips the upload if an attachment with the same filename already exists (idempotent). Returns the attachment metadata. | `contentId` (string, **required**)<br>`filePath` (string, **required**)<br>`updateIfExists` (boolean, optional) |
+| `confluence_upload_attachments` | Upload all files from a local directory as attachments to a Confluence page. Existing attachments are skipped by default. Returns a summary of uploaded and skipped files. | `contentId` (string, **required**)<br>`directoryPath` (string, **required**)<br>`updateIfExists` (boolean, optional) |
 
 ## Detailed Parameter Information
 
@@ -478,6 +483,54 @@ const result = confluence_search_content_by_text("limit", "query");
 
 ---
 
+### `confluence_sync_markdown_directory`
+
+Synchronize a local directory tree of Markdown files to a Confluence page subtree. Subdirectories become parent pages, Markdown files become child pages, `.md` cross-links become Confluence page links, referenced attachments are uploaded idempotently, and non-Markdown files in each directory are attached and linked at the bottom of the matching page. Optionally deletes Confluence pages under `parentId` whose titles do not match any directory or Markdown file.
+
+**Parameters:**
+
+- **`directoryPath`** (string) 🔴 Required
+  - Root directory containing Markdown files and subdirectories
+  - Example: `/tmp/docs`
+
+- **`parentId`** (string) 🔴 Required
+  - Existing Confluence page ID that represents the root directory
+  - Example: `123456`
+
+- **`space`** (string) 🔴 Required
+  - The space key where the pages are located
+  - Example: `PROJ`
+
+- **`deleteOrphans`** (boolean) ⚪ Optional
+  - If true, delete Confluence pages under `parentId` whose titles do not match any directory or Markdown file. Default is false.
+  - Example: `false`
+
+- **`attachmentsDir`** (string) ⚪ Optional
+  - Optional fallback directory for resolving attachment references. Defaults to each Markdown file's parent directory.
+  - Example: `/tmp/assets`
+
+**Example:**
+```bash
+dmtools confluence_sync_markdown_directory "/tmp/docs" "123456" "PROJ" "false" "/tmp/assets"
+```
+
+```javascript
+// In JavaScript agent
+const result = confluence_sync_markdown_directory("/tmp/docs", "123456", "PROJ", false, "/tmp/assets");
+```
+
+**Directory mapping rules:**
+
+- The root directory maps to the existing `parentId` page.
+- Each subdirectory becomes a Confluence child page titled with the directory name. If the directory contains `index.md` or `README.md`, that file's content becomes the folder page body.
+- Each regular `.md` file becomes a Confluence child page of its parent directory page. The page title is read from the first `# Heading` or falls back to the filename without `.md`.
+- Local `.md` links such as `[text](./other.md)` are rewritten to Confluence `ri:page` references.
+- Local attachment references (e.g. `![diagram](assets/diagram.png)`) are uploaded idempotently; existing attachments are skipped.
+- Non-Markdown files inside a directory (e.g. `folder1/report.pdf`, `folder1/page.html`) are also uploaded as attachments to the matching Confluence folder/Markdown page. If a file is not already referenced in the page body, an **Attachments** section with explicit links is appended to the page so the files remain visible and downloadable.
+- With `deleteOrphans=true`, any child page under `parentId` whose title does not match a directory or Markdown file is deleted recursively.
+
+---
+
 ### `confluence_test`
 
 Test Confluence connectivity by fetching the current user's profile
@@ -575,4 +628,178 @@ const result = confluence_update_page_with_history("contentId", "title");
 ```
 
 ---
+
+### `confluence_create_page_from_markdown_file_with_attachments`
+
+Create a Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images (e.g. `./assets/doc.pdf`) are resolved against the Markdown file's directory or an explicit `attachmentsDir`. Existing attachments are skipped.
+
+**Parameters:**
+
+- **`title`** (string) 🔴 Required
+  - The title of the new page
+  - Example: `New Project Page`
+
+- **`parentId`** (string) 🔴 Required
+  - The ID of the parent page
+  - Example: `123456`
+
+- **`filePath`** (string) 🔴 Required
+  - Path to the Markdown file
+  - Example: `/tmp/page.md`
+
+- **`space`** (string) 🔴 Required
+  - The space key where to create the page
+  - Example: `PROJ`
+
+- **`attachmentsDir`** (string) ⚪ Optional
+  - Directory to resolve attachment references from. Defaults to the Markdown file's parent directory.
+  - Example: `/tmp/assets`
+
+**Example:**
+```bash
+dmtools confluence_create_page_from_markdown_file_with_attachments "New Project Page" "123456" "/tmp/page.md" "PROJ" "/tmp/assets"
+```
+
+```javascript
+// In JavaScript agent
+const result = confluence_create_page_from_markdown_file_with_attachments(
+    "New Project Page", "123456", "/tmp/page.md", "PROJ", "/tmp/assets"
+);
+```
+
+---
+
+### `confluence_update_page_from_markdown_file_with_attachments`
+
+Update an existing Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images are resolved against the Markdown file's directory or an explicit `attachmentsDir`. Existing attachments are skipped.
+
+**Parameters:**
+
+- **`contentId`** (string) 🔴 Required
+  - The ID of the page to update
+  - Example: `123456`
+
+- **`title`** (string) 🔴 Required
+  - The new title for the page
+  - Example: `Updated Project Page`
+
+- **`parentId`** (string) 🔴 Required
+  - The ID of the parent page
+  - Example: `123456`
+
+- **`filePath`** (string) 🔴 Required
+  - Path to the Markdown file
+  - Example: `/tmp/page.md`
+
+- **`space`** (string) 🔴 Required
+  - The space key where the page is located
+  - Example: `PROJ`
+
+- **`attachmentsDir`** (string) ⚪ Optional
+  - Directory to resolve attachment references from. Defaults to the Markdown file's parent directory.
+  - Example: `/tmp/assets`
+
+**Example:**
+```bash
+dmtools confluence_update_page_from_markdown_file_with_attachments "123456" "Updated Project Page" "123456" "/tmp/page.md" "PROJ" "/tmp/assets"
+```
+
+```javascript
+// In JavaScript agent
+const result = confluence_update_page_from_markdown_file_with_attachments(
+    "123456", "Updated Project Page", "123456", "/tmp/page.md", "PROJ", "/tmp/assets"
+);
+```
+
+---
+
+### `confluence_upload_attachment`
+
+Upload a single file as an attachment to a Confluence page. Skips the upload if an attachment with the same filename already exists (idempotent). Returns the attachment metadata.
+
+**Parameters:**
+
+- **`contentId`** (string) 🔴 Required
+  - The ID of the Confluence page to attach the file to
+  - Example: `123456`
+
+- **`filePath`** (string) 🔴 Required
+  - Absolute path to the file to upload
+  - Example: `/tmp/document.pdf`
+
+- **`updateIfExists`** (boolean) ⚪ Optional
+  - If true, overwrite an existing attachment with the same filename. Default is false.
+  - Example: `false`
+
+**Example:**
+```bash
+dmtools confluence_upload_attachment "123456" "/tmp/document.pdf"
+```
+
+```javascript
+// In JavaScript agent
+const result = confluence_upload_attachment("123456", "/tmp/document.pdf");
+```
+
+---
+
+### `confluence_upload_attachments`
+
+Upload all files from a local directory as attachments to a Confluence page. Existing attachments are skipped by default. Returns a summary of uploaded and skipped files.
+
+**Parameters:**
+
+- **`contentId`** (string) 🔴 Required
+  - The ID of the Confluence page to attach the files to
+  - Example: `123456`
+
+- **`directoryPath`** (string) 🔴 Required
+  - Absolute path to the directory containing files to upload
+  - Example: `/tmp/attachments`
+
+- **`updateIfExists`** (boolean) ⚪ Optional
+  - If true, overwrite existing attachments with the same filename. Default is false.
+  - Example: `false`
+
+**Example:**
+```bash
+dmtools confluence_upload_attachments "123456" "/tmp/attachments"
+```
+
+```javascript
+// In JavaScript agent
+const result = confluence_upload_attachments("123456", "/tmp/attachments");
+```
+
+---
+
+## Markdown Round-Trip with Attachments
+
+DMTools supports a full round-trip workflow between local Markdown files and Confluence pages:
+
+1. **Export** a page with `confluence_content_by_id <pageId> md` or `confluence_download_pages`. Attachment references are emitted as `[filename](filename)` or `![alt](filename)`.
+
+2. **Edit locally** and place attachment files next to the Markdown file (or in a separate directory referenced with relative paths like `./assets/doc.pdf`).
+
+3. **Push back** with `confluence_update_page_from_markdown_file_with_attachments` (or `confluence_create_page_from_markdown_file_with_attachments` for a new page). The tool:
+   - Converts Markdown to Confluence Storage Format.
+   - Finds all local attachment references.
+   - Uploads any files that are not already attached to the page.
+   - Leaves Confluence page links, external URLs, and anchors untouched.
+
+4. **Re-push safely** — existing attachments are skipped, so repeated edits do not re-upload files.
+
+### Example Markdown
+
+```markdown
+# Design Document
+
+See [requirements](Requirements and Specifications) for context.
+
+![architecture](assets/architecture.png)
+
+Download the [specification](./assets/spec.pdf).
+```
+
+When pushed with `confluence_create_page_from_markdown_file_with_attachments`, the page will contain `ri:page` and `ri:attachment` references, and `architecture.png` and `spec.pdf` will be uploaded from `./assets` if they exist and are not already attached.
 

--- a/dmtools-core/build.gradle
+++ b/dmtools-core/build.gradle
@@ -13,15 +13,16 @@ version = "${version}"
 
 // Define versions
 def versions = [
-        log4j    : '2.26.1',
-        slf4j    : '2.0.18',
-        guava    : '33.6.0-jre',
-        graalvm  : '25.1.3',
-        mockito  : '5.23.0',
-        junit    : '6.1.2',
-        jackson  : '2.22.1',
-        jackson3 : '3.2.1',
-        poi      : '5.5.1'
+        log4j       : '2.26.1',
+        slf4j       : '2.0.18',
+        guava       : '33.6.0-jre',
+        graalvm     : '25.1.3',
+        mockito     : '5.23.0',
+        junit       : '6.1.2',
+        jackson     : '2.22.1',
+        jackson3    : '3.2.1',
+        poi         : '5.5.1',
+        flexmark    : '0.64.8'
 ]
 
 // IMPORTANT: Create sourceSet BEFORE configurations to avoid Gradle 9.0 deprecation warnings
@@ -77,6 +78,12 @@ dependencies {
     api "org.apache.poi:poi-ooxml:${versions.poi}"
     api 'org.apache.pdfbox:pdfbox:3.0.8'
     api 'io.github.furstenheim:copy_down:1.1'
+
+    // Markdown parsing for Confluence upload (Markdown -> HTML/XHTML)
+    api "com.vladsch.flexmark:flexmark:${versions.flexmark}"
+    api "com.vladsch.flexmark:flexmark-ext-tables:${versions.flexmark}"
+    api "com.vladsch.flexmark:flexmark-ext-gfm-tasklist:${versions.flexmark}"
+    api "com.vladsch.flexmark:flexmark-ext-autolink:${versions.flexmark}"
 
     // Guava and its dependencies
     api "com.google.guava:guava:${versions.guava}"

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -37,6 +37,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -525,6 +526,13 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         return new Content(putResponse);
     }
 
+    /**
+     * Deletes a Confluence page by ID. Visible for package use by sync helpers.
+     */
+    String deletePage(String contentId) throws IOException {
+        return new GenericRequest(this, path("content/" + contentId)).delete();
+    }
+
     @NotNull
     public static String prepareBodyForConfluence(String body) {
         body = body.replaceAll("<br>", "\n").replaceAll("<br/>", "\n");
@@ -551,41 +559,92 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
     }
 
     public void attachFileToPage(String contentId, File file) throws IOException {
-        List<Attachment> contentAttachments = getContentAttachments(contentId);
-        for (Attachment attachment : contentAttachments) {
-            if (attachment.getTitle().equalsIgnoreCase(file.getName())) {
-                return;
-            }
+        getAttachmentHelper().uploadAttachment(contentId, file, false);
+    }
+
+    @MCPTool(
+        name = "confluence_upload_attachment",
+        description = "Upload a single file as an attachment to a Confluence page. Skips existing attachments by default. Returns the attachment object.",
+        integration = "confluence",
+        category = "content_management"
+    )
+    public Attachment uploadAttachment(
+        @MCPParam(name = "contentId", description = "The content ID of the page to attach the file to", required = true, example = "123456")
+        String contentId,
+        @MCPParam(name = "file", description = "The local file to upload", required = true, example = "/path/to/image.png")
+        File file,
+        @MCPParam(name = "updateIfExists", description = "Whether to overwrite an existing attachment with the same name", required = false, example = "false")
+        Boolean updateIfExists
+    ) throws IOException {
+        return getAttachmentHelper().uploadAttachment(contentId, file, updateIfExists != null && updateIfExists);
+    }
+
+    @MCPTool(
+        name = "confluence_upload_attachments",
+        description = "Upload all files in a directory as attachments to a Confluence page. Existing attachments are skipped by default. Returns a JSON summary.",
+        integration = "confluence",
+        category = "content_management"
+    )
+    public String uploadAttachments(
+        @MCPParam(name = "contentId", description = "The content ID of the page to attach files to", required = true, example = "123456")
+        String contentId,
+        @MCPParam(name = "directory", description = "The local directory containing files to upload", required = true, example = "/path/to/attachments")
+        String directory,
+        @MCPParam(name = "updateIfExists", description = "Whether to overwrite existing attachments with the same names", required = false, example = "false")
+        Boolean updateIfExists
+    ) throws IOException {
+        return getAttachmentHelper().uploadAttachments(contentId, new File(directory), updateIfExists);
+    }
+
+    @MCPTool(
+        name = "confluence_sync_markdown_directory",
+        description = "Synchronize a local Markdown directory tree to a Confluence page subtree. Markdown files become child pages, images and other files become attachments. Links between Markdown files are rewritten to Confluence page links. Returns a JSON summary.",
+        integration = "confluence",
+        category = "content_management"
+    )
+    public String syncMarkdownDirectory(
+        @MCPParam(name = "directory", description = "The local directory containing Markdown files and attachments", required = true, example = "/path/to/docs")
+        String directory,
+        @MCPParam(name = "parentId", description = "The content ID of the parent Confluence page", required = true, example = "123456")
+        String parentId,
+        @MCPParam(name = "space", description = "The space key where the pages should be created", required = true, example = "PROJ")
+        String space,
+        @MCPParam(name = "deleteOrphans", description = "Whether to delete child pages not present in the directory tree", required = false, example = "false")
+        Boolean deleteOrphans,
+        @MCPParam(name = "attachmentsDir", description = "Optional directory containing referenced attachments. Defaults to the Markdown file's directory.", required = false, example = "/path/to/attachments")
+        String attachmentsDir
+    ) throws IOException {
+        MarkdownConfluenceSync sync = new MarkdownConfluenceSync(getAttachmentHelper(), new ConfluencePageOperations(this));
+        return sync.syncDirectory(new File(directory), parentId, space, deleteOrphans != null && deleteOrphans, attachmentsDir);
+    }
+
+    private ConfluenceAttachmentHelper attachmentHelper;
+
+    /**
+     * Lazy accessor for the attachment helper. Kept as an instance factory so subclasses/tests
+     * can provide their own helper if desired.
+     */
+    ConfluenceAttachmentHelper getAttachmentHelper() {
+        if (attachmentHelper == null) {
+            attachmentHelper = new ConfluenceAttachmentHelper(
+                    contentId -> {
+                        try {
+                            return getContentAttachments(contentId);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    },
+                    ConfluenceAttachmentHelper.defaultUploader(getBasePath(), this::sign, client)
+            );
         }
-        String url = path("content/" + contentId + "/child/attachment");
-        // Prepare the file part
-        RequestBody requestBody = new MultipartBody.Builder()
-                .setType(MultipartBody.FORM)
-                .addFormDataPart("file", file.getName(),
-                        okhttp3.RequestBody.Companion.create(file, MediaType.parse("image/*"))
-                ).build();
+        return attachmentHelper;
+    }
 
-        if (true) {
-            try {
-                Thread.currentThread().sleep(500);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
-        }
-
-        // Create the request
-        Request request = sign(new Request.Builder()
-                .url(url)
-                .post(requestBody)
-        )
-                .build();
-
-        // Execute the request
-        try (Response response = client.newCall(request).execute()) {
-            if (!response.isSuccessful()) throw new IOException("Unexpected code " + response);
-
-            logger.info(response.body().string());
-        }
+    /**
+     * Visible for tests that need to inject a stubbed attachment helper.
+     */
+    void setAttachmentHelper(ConfluenceAttachmentHelper attachmentHelper) {
+        this.attachmentHelper = attachmentHelper;
     }
 
     public void insertImageInPageBody(String spaceKey, String contentId, String fileName) throws IOException {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceAttachmentHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceAttachmentHelper.java
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.github.istin.dmtools.atlassian.confluence.model.Attachment;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Helper for uploading and managing Confluence page attachments.
+ *
+ * <p>This class encapsulates attachment-related logic (single upload, bulk upload,
+ * idempotency, referenced-attachment upload) so that {@link Confluence} remains a
+ * thin MCP facade.</p>
+ */
+public class ConfluenceAttachmentHelper {
+
+    private static final Logger logger = LogManager.getLogger(ConfluenceAttachmentHelper.class);
+
+    private final Function<String, List<Attachment>> attachmentLister;
+    private final AttachmentUploader uploader;
+
+    /**
+     * Functional interface for the low-level HTTP upload. Production code passes a
+     * lambda that signs and executes the request; tests can pass a stub.
+     */
+    @FunctionalInterface
+    public interface AttachmentUploader {
+        String upload(String contentId, File file, String contentType) throws IOException;
+    }
+
+    public ConfluenceAttachmentHelper(Function<String, List<Attachment>> attachmentLister,
+                                       AttachmentUploader uploader) {
+        this.attachmentLister = attachmentLister;
+        this.uploader = uploader;
+    }
+
+    /**
+     * Builds a default HTTP uploader backed by the provided OkHttp client.
+     */
+    @FunctionalInterface
+    public interface RequestSigner {
+        Request.Builder sign(Request.Builder builder);
+    }
+
+    public static AttachmentUploader defaultUploader(String basePath,
+                                                     RequestSigner signer,
+                                                     OkHttpClient client) {
+        return (contentId, file, contentType) -> {
+            String normalizedBase = basePath.endsWith("/") ? basePath.substring(0, basePath.length() - 1) : basePath;
+            String url = normalizedBase + "/rest/api/content/" + contentId + "/child/attachment";
+            RequestBody fileBody = RequestBody.create(file, MediaType.parse(contentType));
+            RequestBody requestBody = new MultipartBody.Builder()
+                    .setType(MultipartBody.FORM)
+                    .addFormDataPart("file", file.getName(), fileBody)
+                    .build();
+            Request request = signer.sign(new Request.Builder().url(url))
+                    .post(requestBody)
+                    .build();
+            try (Response response = client.newCall(request).execute()) {
+                String body = response.body() != null ? response.body().string() : "";
+                if (!response.isSuccessful()) {
+                    throw new IOException("Attachment upload failed for " + file.getName() + ": " + response.code() + " " + body);
+                }
+                return body;
+            }
+        };
+    }
+
+    public List<Attachment> getAttachments(String contentId) {
+        return attachmentLister.apply(contentId);
+    }
+
+    /**
+     * Uploads a single file as an attachment on a Confluence page. If an attachment
+     * with the same filename already exists and {@code updateIfExists} is false,
+     * the existing attachment is returned without re-uploading.
+     */
+    public Attachment uploadAttachment(String contentId, File file, boolean updateIfExists) throws IOException {
+        if (file == null || !file.exists() || !file.isFile()) {
+            throw new IOException("Attachment file does not exist or is not a regular file: " + (file != null ? file.getAbsolutePath() : "null"));
+        }
+
+        List<Attachment> existingAttachments = getAttachments(contentId);
+        Attachment existing = findAttachmentByName(existingAttachments, file.getName());
+        if (existing != null && !updateIfExists) {
+            logger.info("Attachment '{}' already exists on page {}, skipping upload", file.getName(), contentId);
+            return existing;
+        }
+
+        String contentType = Files.probeContentType(file.toPath());
+        if (contentType == null || contentType.isBlank()) {
+            contentType = "application/octet-stream";
+        }
+
+        String responseBody = uploader.upload(contentId, file, contentType);
+        logger.info("Uploaded attachment '{}' to page {}", file.getName(), contentId);
+        return new Attachment(responseBody);
+    }
+
+    /**
+     * Uploads all files from a local directory as attachments to a Confluence page.
+     * Existing attachments are skipped by default. Returns a JSON summary.
+     */
+    public String uploadAttachments(String contentId, File dir, Boolean updateIfExists) throws IOException {
+        if (!dir.exists() || !dir.isDirectory()) {
+            throw new IOException("Not a directory: " + dir.getAbsolutePath());
+        }
+        File[] files = dir.listFiles(File::isFile);
+        if (files == null || files.length == 0) {
+            return "No files found in " + dir.getAbsolutePath();
+        }
+
+        boolean update = updateIfExists != null && updateIfExists;
+        List<String> uploaded = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+        List<String> failed = new ArrayList<>();
+
+        for (File file : files) {
+            try {
+                Attachment result = uploadAttachment(contentId, file, update);
+                if (result != null && file.getName().equalsIgnoreCase(result.getTitle())) {
+                    uploaded.add(file.getName());
+                } else {
+                    skipped.add(file.getName());
+                }
+            } catch (IOException e) {
+                logger.warn("Failed to upload attachment {}: {}", file.getName(), e.getMessage());
+                failed.add(file.getName() + " (" + e.getMessage() + ")");
+            }
+        }
+
+        JSONObject summary = new JSONObject();
+        summary.put("uploaded", new JSONArray(uploaded));
+        summary.put("skipped", new JSONArray(skipped));
+        summary.put("failed", new JSONArray(failed));
+        return summary.toString();
+    }
+
+    /**
+     * Uploads attachments referenced by a Markdown page. Returns the filenames of
+     * attachments that are present on the page after this call (uploaded or already
+     * existing), so callers can link them explicitly when they are not referenced in
+     * the body itself.
+     */
+    public List<String> uploadReferencedAttachments(String contentId, String markdown, File baseDir,
+                                                     boolean updateIfExists) {
+        Set<String> references = MarkdownToConfluenceStorage.extractAttachmentReferencePaths(markdown);
+        List<String> presentAttachmentNames = new ArrayList<>();
+        if (references.isEmpty()) {
+            return presentAttachmentNames;
+        }
+        List<Attachment> existingAttachments = getAttachments(contentId);
+        for (String rawRef : references) {
+            String filename = MarkdownToConfluenceStorage.attachmentFileName(rawRef);
+            if (filename.isBlank()) {
+                continue;
+            }
+            Attachment existing = findAttachmentByName(existingAttachments, filename);
+            if (existing != null && !updateIfExists) {
+                logger.info("Attachment '{}' already exists on page {}, skipping", filename, contentId);
+                presentAttachmentNames.add(filename);
+                continue;
+            }
+            File file = resolveAttachmentFile(baseDir, rawRef, filename);
+            if (!file.exists()) {
+                logger.warn("Referenced attachment '{}' not found in {}, skipping upload", filename, baseDir.getAbsolutePath());
+                continue;
+            }
+            try {
+                uploadAttachment(contentId, file, updateIfExists);
+                presentAttachmentNames.add(filename);
+            } catch (IOException e) {
+                logger.warn("Failed to upload referenced attachment '{}': {}", filename, e.getMessage());
+            }
+        }
+        return presentAttachmentNames;
+    }
+
+    public static Attachment findAttachmentByName(List<Attachment> attachments, String fileName) {
+        if (attachments == null || fileName == null) {
+            return null;
+        }
+        for (Attachment attachment : attachments) {
+            if (fileName.equalsIgnoreCase(attachment.getTitle())) {
+                return attachment;
+            }
+        }
+        return null;
+    }
+
+    private static File resolveAttachmentFile(File baseDir, String rawRef, String filename) {
+        try {
+            File relative = new File(baseDir, rawRef).getCanonicalFile();
+            if (relative.exists()) {
+                return relative;
+            }
+        } catch (IOException e) {
+            // Fall back to flat lookup below.
+        }
+        return new File(baseDir, filename);
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageOperations.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageOperations.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.github.istin.dmtools.atlassian.confluence.model.Content;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Adapter that exposes a {@link Confluence} instance through the
+ * {@link MarkdownConfluenceSync.PageOperations} interface.
+ */
+public class ConfluencePageOperations implements MarkdownConfluenceSync.PageOperations {
+
+    private final Confluence confluence;
+
+    public ConfluencePageOperations(Confluence confluence) {
+        this.confluence = confluence;
+    }
+
+    @Override
+    public Content createPage(String title, String parentId, String body, String space) throws IOException {
+        return confluence.createPage(title, parentId, body, space);
+    }
+
+    @Override
+    public Content updatePage(String contentId, String title, String parentId, String body,
+                              String space, String historyComment) throws IOException {
+        return confluence.updatePage(contentId, title, parentId, body, space, historyComment);
+    }
+
+    @Override
+    public List<Content> getChildren(String contentId) throws IOException {
+        return confluence.getChildrenOfContentById(contentId, null);
+    }
+
+    @Override
+    public String deletePage(String contentId) throws IOException {
+        return confluence.deletePage(contentId);
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.github.istin.dmtools.atlassian.confluence.model.Attachment;
+import com.github.istin.dmtools.atlassian.confluence.model.Content;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Orchestrates synchronizing a local Markdown directory tree with a Confluence page subtree.
+ *
+ * <p>The class is stateless apart from the collaborators it receives, making it easy to
+ * unit-test without a live Confluence instance.</p>
+ */
+public class MarkdownConfluenceSync {
+
+    private static final Logger logger = LogManager.getLogger(MarkdownConfluenceSync.class);
+
+    private static final Pattern LINK_PATTERN = Pattern.compile(
+            "\\[([^\\]]*)\\]\\(([^)]+)\\)", Pattern.DOTALL);
+    private static final Pattern IMAGE_ATTACHMENT_PATTERN = Pattern.compile(
+            "<ac:image[^>]*>.*?<ri:attachment[^>]*ri:filename=\"([^\"]+)\".*?>.*?</ac:image>", Pattern.DOTALL);
+    private static final Pattern LINK_ATTACHMENT_PATTERN = Pattern.compile(
+            "<ac:link[^>]*>.*?<ri:attachment[^>]*ri:filename=\"([^\"]+)\".*?>.*?</ac:link>", Pattern.DOTALL);
+    private static final Pattern H1_PATTERN = Pattern.compile("^#\\s+(.+)$", Pattern.MULTILINE);
+
+    private final ConfluenceAttachmentHelper attachmentHelper;
+    private final PageOperations pageOps;
+
+    /**
+     * Callbacks for Confluence page CRUD operations.
+     */
+    public interface PageOperations {
+        Content createPage(String title, String parentId, String body, String space) throws IOException;
+        Content updatePage(String contentId, String title, String parentId, String body, String space, String historyComment) throws IOException;
+        List<Content> getChildren(String contentId) throws IOException;
+        String deletePage(String contentId) throws IOException;
+    }
+
+    public MarkdownConfluenceSync(ConfluenceAttachmentHelper attachmentHelper, PageOperations pageOps) {
+        this.attachmentHelper = attachmentHelper;
+        this.pageOps = pageOps;
+    }
+
+    /**
+     * Synchronizes a local directory tree to a Confluence page subtree.
+     */
+    public String syncDirectory(File rootDir, String parentId, String space,
+                                boolean deleteOrphans, String attachmentsDir) throws IOException {
+        DirNode root = buildDirTree(rootDir);
+        Map<String, String> pathToTitle = buildPathToTitleMap(rootDir, root);
+        Set<String> expectedTitles = new HashSet<>(pathToTitle.values());
+
+        root.contentId = parentId;
+        syncDirNode(root, rootDir, pathToTitle, space, attachmentsDir);
+
+        List<String> deleted = new ArrayList<>();
+        if (deleteOrphans) {
+            deleted = deleteOrphanPages(parentId, expectedTitles);
+        }
+
+        JSONObject summary = new JSONObject();
+        summary.put("rootDirectory", rootDir.getAbsolutePath());
+        summary.put("parentId", parentId);
+        summary.put("expectedPages", expectedTitles.size());
+        summary.put("syncedPages", new JSONArray(expectedTitles.stream().sorted().toList()));
+        summary.put("deleted", new JSONArray(deleted));
+        return summary.toString();
+    }
+
+    private void syncDirNode(DirNode node, File rootDir, Map<String, String> pathToTitle,
+                             String space, String attachmentsDir) throws IOException {
+        String folderBody;
+        Set<String> referencedAttachmentNames = new LinkedHashSet<>();
+        File baseDir;
+        if (node.indexFile != null) {
+            String markdown = readFile(node.indexFile);
+            String processed = processMarkdownLinks(markdown, rootDir, node.indexFile, pathToTitle);
+            folderBody = MarkdownToConfluenceStorage.toStorage(processed);
+            referencedAttachmentNames.addAll(MarkdownToConfluenceStorage.extractAttachmentReferences(processed));
+            baseDir = resolveAttachmentsDir(node.indexFile, attachmentsDir);
+            attachmentHelper.uploadReferencedAttachments(node.contentId, processed, baseDir, false);
+        } else {
+            folderBody = "<p>" + MarkdownToConfluenceStorage.escapeXml(node.title) + "</p>";
+        }
+
+        List<String> uploadedAttachmentNames = uploadDirectoryAttachments(node, referencedAttachmentNames);
+        folderBody = appendAttachmentLinks(folderBody, uploadedAttachmentNames);
+        pageOps.updatePage(node.contentId, node.title,
+                node.parentId != null ? node.parentId : node.contentId,
+                folderBody, space, "");
+
+        for (FileNode fileNode : node.files) {
+            String markdown = readFile(fileNode.file);
+            String processed = processMarkdownLinks(markdown, rootDir, fileNode.file, pathToTitle);
+            Set<String> fileReferenced = MarkdownToConfluenceStorage.extractAttachmentReferences(processed);
+            String storage = MarkdownToConfluenceStorage.toStorage(processed);
+
+            Content page = findOrCreateChildPage(fileNode.title, node.contentId, space,
+                    MarkdownToConfluenceStorage.toStorage("<p>Placeholder</p>"));
+
+            baseDir = resolveAttachmentsDir(fileNode.file, attachmentsDir);
+            List<String> fileUploadedAttachmentNames = attachmentHelper.uploadReferencedAttachments(
+                    page.getId(), processed, baseDir, false);
+            List<String> extraAttachmentNames = new ArrayList<>();
+            for (String name : fileUploadedAttachmentNames) {
+                if (!fileReferenced.contains(name)) {
+                    extraAttachmentNames.add(name);
+                }
+            }
+            storage = appendAttachmentLinks(storage, extraAttachmentNames);
+            pageOps.updatePage(page.getId(), fileNode.title, node.contentId, storage, space, "");
+            fileNode.contentId = page.getId();
+        }
+
+        for (DirNode subdir : node.subdirs) {
+            Content folderPage = findOrCreateChildPage(subdir.title, node.contentId, space,
+                    MarkdownToConfluenceStorage.toStorage("<p>" + MarkdownToConfluenceStorage.escapeXml(subdir.title) + "</p>"));
+            subdir.contentId = folderPage.getId();
+            subdir.parentId = node.contentId;
+            syncDirNode(subdir, rootDir, pathToTitle, space, attachmentsDir);
+        }
+    }
+
+    private List<String> uploadDirectoryAttachments(DirNode node, Set<String> referencedAttachmentNames) {
+        List<String> uploadedAttachmentNames = new ArrayList<>();
+        List<Attachment> existingAttachments = attachmentHelper.getAttachments(node.contentId);
+        for (File attachment : node.attachments) {
+            Attachment existing = ConfluenceAttachmentHelper.findAttachmentByName(existingAttachments, attachment.getName());
+            if (existing != null) {
+                logger.info("Attachment '{}' already exists on page {}, skipping", attachment.getName(), node.contentId);
+                if (!referencedAttachmentNames.contains(attachment.getName())) {
+                    uploadedAttachmentNames.add(attachment.getName());
+                }
+                continue;
+            }
+            try {
+                attachmentHelper.uploadAttachment(node.contentId, attachment, false);
+                if (!referencedAttachmentNames.contains(attachment.getName())) {
+                    uploadedAttachmentNames.add(attachment.getName());
+                }
+            } catch (IOException e) {
+                logger.warn("Failed to upload attachment '{}': {}", attachment.getName(), e.getMessage());
+            }
+        }
+        return uploadedAttachmentNames;
+    }
+
+    private Content findOrCreateChildPage(String title, String parentId, String space, String placeholderBody) throws IOException {
+        List<Content> children = pageOps.getChildren(parentId);
+        for (Content child : children) {
+            if (title.equals(child.getTitle())) {
+                return child;
+            }
+        }
+        return pageOps.createPage(title, parentId, placeholderBody, space);
+    }
+
+    private List<String> deleteOrphanPages(String parentId, Set<String> expectedTitles) throws IOException {
+        List<String> deleted = new ArrayList<>();
+        for (Content child : pageOps.getChildren(parentId)) {
+            if (!expectedTitles.contains(child.getTitle())) {
+                deleteRecursively(child, deleted);
+            }
+        }
+        return deleted;
+    }
+
+    private void deleteRecursively(Content content, List<String> deleted) throws IOException {
+        for (Content child : pageOps.getChildren(content.getId())) {
+            deleteRecursively(child, deleted);
+        }
+        pageOps.deletePage(content.getId());
+        deleted.add(content.getTitle());
+        logger.info("Deleted orphan page: {} ({})", content.getTitle(), content.getId());
+    }
+
+    private static DirNode buildDirTree(File dir) {
+        DirNode node = new DirNode(dir, dir.getName());
+        File[] children = dir.listFiles();
+        if (children == null) {
+            return node;
+        }
+        Arrays.sort(children);
+        for (File child : children) {
+            if (child.isDirectory()) {
+                node.subdirs.add(buildDirTree(child));
+            } else if (isMarkdownFile(child)) {
+                if (isIndexFile(child)) {
+                    node.indexFile = child;
+                } else {
+                    node.files.add(new FileNode(child));
+                }
+            } else {
+                node.attachments.add(child);
+            }
+        }
+        return node;
+    }
+
+    private static Map<String, String> buildPathToTitleMap(File rootDir, DirNode node) throws IOException {
+        Map<String, String> map = new HashMap<>();
+        buildPathToTitleMapRecursive(rootDir, node, map);
+        return map;
+    }
+
+    private static void buildPathToTitleMapRecursive(File rootDir, DirNode node,
+                                                     Map<String, String> map) throws IOException {
+        String dirRel = relativePath(rootDir, node.dir);
+        if (!dirRel.isEmpty()) {
+            map.put(dirRel, node.title);
+        }
+        if (node.indexFile != null) {
+            map.put(relativePath(rootDir, node.indexFile), node.title);
+        }
+        for (FileNode fileNode : node.files) {
+            fileNode.title = extractTitle(readFile(fileNode.file), fileNode.file);
+            map.put(relativePath(rootDir, fileNode.file), fileNode.title);
+        }
+        for (DirNode subdir : node.subdirs) {
+            buildPathToTitleMapRecursive(rootDir, subdir, map);
+        }
+    }
+
+    private static String readFile(File file) throws IOException {
+        return Files.readString(file.toPath(), StandardCharsets.UTF_8);
+    }
+
+    private static String processMarkdownLinks(String markdown, File rootDir, File currentFile,
+                                               Map<String, String> pathToTitle) {
+        if (markdown == null || markdown.isBlank()) {
+            return markdown;
+        }
+        Matcher matcher = LINK_PATTERN.matcher(markdown);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String text = matcher.group(1);
+            String url = matcher.group(2).trim();
+            if (url.isBlank() || MarkdownToConfluenceStorage.isExternalUrlStatic(url) || url.startsWith("#")) {
+                continue;
+            }
+            if (!url.toLowerCase().endsWith(".md")) {
+                continue;
+            }
+            File target = resolveRelativePath(currentFile, url);
+            if (target == null) {
+                continue;
+            }
+            String rel = relativePath(rootDir, target);
+            String title = pathToTitle.get(rel);
+            if (title == null) {
+                continue;
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(
+                    "[" + text + "](" + title + ")"));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static File resolveRelativePath(File baseFile, String relativePath) {
+        File parent = baseFile.getParentFile();
+        if (parent == null) {
+            return null;
+        }
+        try {
+            return new File(parent, relativePath).getCanonicalFile();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static String relativePath(File rootDir, File file) {
+        try {
+            String root = rootDir.getCanonicalPath();
+            String abs = file.getCanonicalPath();
+            if (abs.equals(root)) {
+                return "";
+            }
+            if (abs.startsWith(root + File.separator)) {
+                return abs.substring(root.length() + File.separator.length()).replace(File.separator, "/");
+            }
+            return abs.replace(File.separator, "/");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String extractTitle(String markdown, File file) {
+        if (markdown != null) {
+            Matcher matcher = H1_PATTERN.matcher(markdown);
+            if (matcher.find()) {
+                return matcher.group(1).trim();
+            }
+        }
+        String name = file.getName();
+        if (name.toLowerCase().endsWith(".md")) {
+            name = name.substring(0, name.length() - 3);
+        }
+        return name;
+    }
+
+    private static File resolveAttachmentsDir(File markdownFile, String attachmentsDir) {
+        if (attachmentsDir != null && !attachmentsDir.isBlank()) {
+            return new File(attachmentsDir);
+        }
+        File parent = markdownFile.getParentFile();
+        return parent != null ? parent : new File(".");
+    }
+
+    private static String appendAttachmentLinks(String storageBody, List<String> attachmentNames) {
+        if (attachmentNames == null || attachmentNames.isEmpty()) {
+            return storageBody;
+        }
+        Set<String> alreadyLinked = extractReferencedAttachmentNames(storageBody);
+        List<String> forceLinkNames = new ArrayList<>();
+        for (String name : attachmentNames) {
+            if (!alreadyLinked.contains(name)) {
+                forceLinkNames.add(name);
+            }
+        }
+        if (forceLinkNames.isEmpty()) {
+            return storageBody;
+        }
+        return storageBody + buildAttachmentLinks(forceLinkNames);
+    }
+
+    private static String buildAttachmentLinks(List<String> attachmentNames) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<h2>Attachments</h2><ul>");
+        for (String name : attachmentNames) {
+            sb.append("<li><ac:link><ri:attachment ri:filename=\"")
+                    .append(MarkdownToConfluenceStorage.escapeXml(name))
+                    .append("\" />");
+            sb.append("<ac:link-body>")
+                    .append(MarkdownToConfluenceStorage.escapeXml(name))
+                    .append("</ac:link-body></ac:link></li>");
+        }
+        sb.append("</ul>");
+        return sb.toString();
+    }
+
+    private static Set<String> extractReferencedAttachmentNames(String storageBody) {
+        Set<String> result = new LinkedHashSet<>();
+        if (storageBody == null || storageBody.isBlank()) {
+            return result;
+        }
+        Matcher imageMatcher = IMAGE_ATTACHMENT_PATTERN.matcher(storageBody);
+        while (imageMatcher.find()) {
+            result.add(imageMatcher.group(1));
+        }
+        Matcher linkMatcher = LINK_ATTACHMENT_PATTERN.matcher(storageBody);
+        while (linkMatcher.find()) {
+            result.add(linkMatcher.group(1));
+        }
+        return result;
+    }
+
+    private static boolean isMarkdownFile(File file) {
+        return file.getName().toLowerCase().endsWith(".md");
+    }
+
+    private static boolean isIndexFile(File file) {
+        String lower = file.getName().toLowerCase();
+        return lower.equals("index.md") || lower.equals("readme.md");
+    }
+
+    private static final class DirNode {
+        final File dir;
+        final String title;
+        File indexFile;
+        final List<FileNode> files = new ArrayList<>();
+        final List<DirNode> subdirs = new ArrayList<>();
+        final List<File> attachments = new ArrayList<>();
+        String contentId;
+        String parentId;
+
+        DirNode(File dir, String title) {
+            this.dir = dir;
+            this.title = title;
+        }
+    }
+
+    private static final class FileNode {
+        final File file;
+        String title;
+        String contentId;
+
+        FileNode(File file) {
+            this.file = file;
+        }
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
+import com.vladsch.flexmark.ext.gfm.tasklist.TaskListExtension;
+import com.vladsch.flexmark.ext.tables.TablesExtension;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.Document;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Converts Markdown to Confluence Storage Format (XHTML).
+ *
+ * <p>This is the inverse of {@link ConfluenceStorageMarkdown}: content that was
+ * downloaded as Markdown (or authored locally as Markdown) can be turned back into
+ * Confluence's {@code body.storage} representation and sent via the REST API.</p>
+ *
+ * <p>Supported Markdown constructs:</p>
+ * <ul>
+ *   <li>Headings, paragraphs, bold/italic/code, lists, horizontal rules</li>
+ *   <li>Tables (GitHub-Flavored Markdown)</li>
+ *   <li>Fenced code blocks → {@code <ac:structured-macro ac:name="code">}</li>
+ *   <li>Task lists → {@code <ac:task-list>/<ac:task>}</li>
+ *   <li>Images → {@code <ac:image><ri:attachment .../></ac:image>} (local filenames)
+ *       or standard {@code <img>} (external URLs)</li>
+ *   <li>Links → {@code <ac:link><ri:page .../></ac:link>} (page references),
+ *       {@code <ac:link><ri:attachment .../></ac:link>} (attachments with known
+ *       extensions), or standard {@code <a>} (external URLs / anchors)</li>
+ * </ul>
+ */
+public final class MarkdownToConfluenceStorage {
+
+    private static final Logger logger = LogManager.getLogger(MarkdownToConfluenceStorage.class);
+
+    private static final Parser PARSER;
+    private static final HtmlRenderer RENDERER;
+
+    private static final Set<String> ATTACHMENT_EXTENSIONS = Set.of(
+            "pdf", "doc", "docx", "xls", "xlsx", "ppt", "pptx",
+            "png", "jpg", "jpeg", "gif", "svg", "webp",
+            "zip", "tar", "gz", "tgz", "bz2", "7z",
+            "txt", "csv", "json", "xml", "yaml", "yml", "html", "md"
+    );
+
+    static {
+        MutableDataSet options = new MutableDataSet();
+        options.set(Parser.EXTENSIONS, Arrays.asList(
+                TablesExtension.create(),
+                TaskListExtension.create(),
+                AutolinkExtension.create()
+        ));
+        // Standard GFM behaviour: soft line breaks become a single space.
+        options.set(HtmlRenderer.SOFT_BREAK, " ");
+        PARSER = Parser.builder(options).build();
+        RENDERER = HtmlRenderer.builder(options).build();
+    }
+
+    private MarkdownToConfluenceStorage() {
+    }
+
+    /**
+     * Converts a Markdown string into Confluence Storage Format XHTML.
+     *
+     * @param markdown the Markdown source
+     * @return Confluence Storage Format XHTML, or an escaped paragraph fallback
+     *         if parsing fails
+     */
+    public static String toStorage(String markdown) {
+        if (markdown == null || markdown.isBlank()) {
+            return "";
+        }
+        try {
+            String normalized = normalizeLegacyLinks(markdown);
+            Document document = PARSER.parse(normalized);
+            String html = RENDERER.render(document);
+            return convertHtmlToConfluenceStorage(html);
+        } catch (Exception e) {
+            logger.warn("Markdown->Confluence storage conversion failed, returning escaped paragraph: {}",
+                    e.getMessage(), e);
+            return "<p>" + escapeHtml(markdown).replace("\n", "<br/>") + "</p>";
+        }
+    }
+
+    /**
+     * The legacy {@link ConfluenceStorageMarkdown} exporter emits Markdown links with
+     * spaces inside the URL, e.g. {@code [text](Target Page)}. Standard Markdown parsers
+     * do not recognise that as a link. This method wraps such URLs in angle brackets so
+     * the round-trip works while still accepting properly authored Markdown.
+     */
+    private static String normalizeLegacyLinks(String markdown) {
+        String result = normalizeLegacyImages(markdown);
+        return normalizeLegacyLinkPattern(result, LINK_PATTERN);
+    }
+
+    private static String normalizeLegacyImages(String markdown) {
+        return normalizeLegacyLinkPattern(markdown, IMAGE_PATTERN);
+    }
+
+    private static final Pattern LINK_PATTERN = Pattern.compile(
+            "\\[([^\\]]*)\\]\\(([^)]+)\\)", Pattern.DOTALL);
+    private static final Pattern IMAGE_PATTERN = Pattern.compile(
+            "!\\[([^\\]]*)\\]\\(([^)]+)\\)", Pattern.DOTALL);
+
+    private static String normalizeLegacyLinkPattern(String markdown, Pattern pattern) {
+        Matcher matcher = pattern.matcher(markdown);
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String text = matcher.group(1);
+            String url = matcher.group(2).trim();
+            if (url.contains(" ") && !url.startsWith("<") && !url.startsWith("\"") && !url.startsWith("'")) {
+                String encodedUrl = url.replace(" ", "%20");
+                matcher.appendReplacement(sb, Matcher.quoteReplacement(
+                        pattern == IMAGE_PATTERN
+                                ? "![" + text + "](" + encodedUrl + ")"
+                                : "[" + text + "](" + encodedUrl + ")"));
+            }
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    private static String convertHtmlToConfluenceStorage(String html) {
+        org.jsoup.nodes.Document doc = Jsoup.parseBodyFragment(html);
+        doc.outputSettings()
+                .prettyPrint(false)
+                .syntax(org.jsoup.nodes.Document.OutputSettings.Syntax.xml);
+
+        convertCodeBlocks(doc);
+        convertTaskLists(doc);
+        convertImages(doc);
+        convertLinks(doc);
+
+        Element body = doc.body();
+        String result = body != null ? body.html() : doc.html();
+        // XML syntax can leave empty element tags like <br /> with a space before />;
+        // Confluence is fine with that, but normalize to a consistent form.
+        return result.replaceAll("(?i)<br\\s*/?>", "<br/>");
+    }
+
+    /**
+     * Converts fenced code blocks ({@code <pre><code class="language-xxx">...}) into
+     * Confluence's {@code code} macro.
+     */
+    private static void convertCodeBlocks(org.jsoup.nodes.Document doc) {
+        for (Element pre : doc.select("pre")) {
+            Element code = pre.selectFirst("code");
+            String language = "";
+            if (code != null) {
+                String classAttr = code.attr("class").trim();
+                if (classAttr.startsWith("language-")) {
+                    language = classAttr.substring("language-".length()).trim();
+                } else if (!classAttr.isBlank()) {
+                    language = classAttr;
+                }
+            }
+            String codeText = code != null ? code.text() : pre.text();
+
+            StringBuilder macro = new StringBuilder();
+            macro.append("<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\">");
+            if (!language.isBlank()) {
+                macro.append("<ac:parameter ac:name=\"language\">")
+                        .append(escapeXml(language))
+                        .append("</ac:parameter>");
+            }
+            macro.append("<ac:plain-text-body><![CDATA[")
+                    .append(codeText)
+                    .append("]]></ac:plain-text-body>");
+            macro.append("</ac:structured-macro>");
+
+            pre.after(macro.toString());
+            pre.remove();
+        }
+    }
+
+    /**
+     * Converts GFM task lists ({@code <ul>} with checkbox inputs) into Confluence
+     * {@code ac:task-list} elements.
+     */
+    private static void convertTaskLists(org.jsoup.nodes.Document doc) {
+        for (Element ul : doc.select("ul")) {
+            boolean isTaskList = false;
+            StringBuilder taskListXml = new StringBuilder("<ac:task-list>");
+            for (Element li : ul.select("> li")) {
+                Element input = li.selectFirst("input[type=checkbox]");
+                if (input == null) {
+                    continue;
+                }
+                isTaskList = true;
+                String status = input.hasAttr("checked") ? "complete" : "incomplete";
+                input.remove();
+                String bodyText = li.text().trim();
+                taskListXml.append("<ac:task>")
+                        .append("<ac:task-status>").append(status).append("</ac:task-status>")
+                        .append("<ac:task-body>").append(escapeXml(bodyText)).append("</ac:task-body>")
+                        .append("</ac:task>");
+            }
+            if (isTaskList) {
+                taskListXml.append("</ac:task-list>");
+                ul.after(taskListXml.toString());
+                ul.remove();
+            }
+        }
+    }
+
+    /**
+     * Converts local image references to {@code ac:image/ri:attachment} and leaves
+     * external URLs as standard {@code <img>} tags. Relative paths such as
+     * {@code ./images/diagram.png} are normalized to the filename only, because
+     * Confluence page attachments are flat.
+     */
+    private static void convertImages(org.jsoup.nodes.Document doc) {
+        for (Element img : doc.select("img")) {
+            String rawSrc = img.attr("src").trim();
+            String alt = img.attr("alt").trim();
+            if (rawSrc.isBlank()) {
+                img.remove();
+                continue;
+            }
+            if (isExternalUrl(rawSrc)) {
+                // External image: keep standard <img> tag.
+                continue;
+            }
+            String filename = attachmentFileName(rawSrc);
+            if (filename.isBlank()) {
+                img.remove();
+                continue;
+            }
+            String effectiveAlt = alt.isBlank() ? filename : alt;
+            String attachmentXml = "<ac:image" + (effectiveAlt.isBlank() ? "" : " ac:alt=\"" + escapeXml(effectiveAlt) + "\"") + ">" +
+                    "<ri:attachment ri:filename=\"" + escapeXml(filename) + "\"></ri:attachment>" +
+                    "</ac:image>";
+            img.after(attachmentXml);
+            img.remove();
+        }
+    }
+
+    /**
+     * Converts page/attachment references to {@code ac:link} elements and leaves
+     * external URLs and anchors as standard {@code <a>} tags. Relative paths to
+     * attachments are normalized to the filename only.
+     */
+    private static void convertLinks(org.jsoup.nodes.Document doc) {
+        for (Element a : doc.select("a")) {
+            String rawHref = a.attr("href").trim();
+            if (rawHref.isBlank()) {
+                continue;
+            }
+            if (isExternalUrl(rawHref) || rawHref.startsWith("#")) {
+                continue;
+            }
+
+            String href = decodeUrl(rawHref);
+            String linkBody = a.html();
+            if (linkBody == null || linkBody.isBlank()) {
+                linkBody = escapeXml(href);
+            }
+
+            String linkXml;
+            String attachmentName = attachmentFileName(href);
+            if (looksLikeAttachment(attachmentName)) {
+                linkXml = "<ac:link><ri:attachment ri:filename=\"" + escapeXml(attachmentName) + "\"></ri:attachment>" +
+                        "<ac:link-body>" + linkBody + "</ac:link-body></ac:link>";
+            } else {
+                String spaceKey = null;
+                String title = href;
+                int colonIndex = href.indexOf(':');
+                if (colonIndex > 0) {
+                    String candidateSpace = href.substring(0, colonIndex);
+                    if (isValidSpaceKey(candidateSpace)) {
+                        spaceKey = candidateSpace;
+                        title = href.substring(colonIndex + 1);
+                    }
+                }
+                StringBuilder sb = new StringBuilder("<ac:link>");
+                sb.append("<ri:page");
+                if (spaceKey != null) {
+                    sb.append(" ri:space-key=\"").append(escapeXml(spaceKey)).append("\"");
+                }
+                sb.append(" ri:content-title=\"").append(escapeXml(title)).append("\"></ri:page>");
+                sb.append("<ac:link-body>").append(linkBody).append("</ac:link-body>");
+                sb.append("</ac:link>");
+                linkXml = sb.toString();
+            }
+            a.after(linkXml);
+            a.remove();
+        }
+    }
+
+    private static String decodeUrl(String url) {
+        try {
+            return URLDecoder.decode(url, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return url;
+        }
+    }
+
+    private static boolean isExternalUrl(String href) {
+        return isExternalUrlStatic(href);
+    }
+
+    /**
+     * Public helper for callers that need to filter external URLs before passing
+     * Markdown through the converter.
+     */
+    public static boolean isExternalUrlStatic(String href) {
+        if (href == null || href.isBlank()) {
+            return false;
+        }
+        String lower = href.toLowerCase(Locale.ROOT);
+        return lower.startsWith("http://") || lower.startsWith("https://")
+                || lower.startsWith("mailto:") || lower.startsWith("ftp://");
+    }
+
+    private static boolean isValidSpaceKey(String spaceKey) {
+        return spaceKey.matches("[A-Za-z][A-Za-z0-9]*");
+    }
+
+    /**
+     * Extracts the filename portion from a possibly relative attachment path.
+     * URLs pointing outside the page (external URLs, anchors) should be filtered
+     * before calling this method.
+     */
+    public static String attachmentFileName(String href) {
+        if (href == null || href.isBlank()) {
+            return "";
+        }
+        String decoded = decodeUrl(href);
+        // Normalize backslashes to forward slashes and strip leading ./ or ../ segments.
+        String normalized = decoded.replace('\\', '/').replaceAll("^(\\./)+", "");
+        Path path = Paths.get(normalized);
+        Path fileName = path.getFileName();
+        return fileName != null ? fileName.toString() : normalized;
+    }
+
+    private static boolean looksLikeAttachment(String href) {
+        if (href == null || href.isBlank()) {
+            return false;
+        }
+        int lastDot = href.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot == href.length() - 1) {
+            return false;
+        }
+        String ext = href.substring(lastDot + 1).toLowerCase(Locale.ROOT);
+        return ATTACHMENT_EXTENSIONS.contains(ext);
+    }
+
+    /**
+     * Extracts attachment filenames referenced by local Markdown links/images.
+     * External URLs, anchors, and page references are ignored. The returned
+     * filenames are stripped of any relative path segments and are suitable for
+     * matching against files to upload to Confluence.
+     *
+     * @param markdown the Markdown source
+     * @return ordered set of unique attachment filenames
+     */
+    public static Set<String> extractAttachmentReferences(String markdown) {
+        Set<String> result = new LinkedHashSet<>();
+        if (markdown == null || markdown.isBlank()) {
+            return result;
+        }
+        collectAttachmentReferences(markdown, LINK_PATTERN, result);
+        collectAttachmentReferences(markdown, IMAGE_PATTERN, result);
+        return result;
+    }
+
+    private static void collectAttachmentReferences(String markdown, Pattern pattern, Set<String> result) {
+        Matcher matcher = pattern.matcher(markdown);
+        while (matcher.find()) {
+            String url = matcher.group(2).trim();
+            if (url.isBlank() || isExternalUrl(url) || url.startsWith("#")) {
+                continue;
+            }
+            String filename = attachmentFileName(url);
+            if (filename.isBlank()) {
+                continue;
+            }
+            if (looksLikeAttachment(filename)) {
+                result.add(filename);
+            }
+        }
+    }
+
+    /**
+     * Extracts the original (decoded) attachment reference paths from local Markdown
+     * links/images. Unlike {@link #extractAttachmentReferences(String)}, this keeps
+     * the relative path segments, so callers can resolve the referenced file in the
+     * local filesystem. External URLs, anchors, and page references are ignored.
+     *
+     * @param markdown the Markdown source
+     * @return ordered set of unique decoded attachment reference paths
+     */
+    public static Set<String> extractAttachmentReferencePaths(String markdown) {
+        Set<String> result = new LinkedHashSet<>();
+        if (markdown == null || markdown.isBlank()) {
+            return result;
+        }
+        collectAttachmentReferencePaths(markdown, LINK_PATTERN, result);
+        collectAttachmentReferencePaths(markdown, IMAGE_PATTERN, result);
+        return result;
+    }
+
+    private static void collectAttachmentReferencePaths(String markdown, Pattern pattern, Set<String> result) {
+        Matcher matcher = pattern.matcher(markdown);
+        while (matcher.find()) {
+            String url = matcher.group(2).trim();
+            if (url.isBlank() || isExternalUrl(url) || url.startsWith("#")) {
+                continue;
+            }
+            String decoded = decodeUrl(url);
+            String filename = attachmentFileName(decoded);
+            if (filename.isBlank()) {
+                continue;
+            }
+            if (looksLikeAttachment(filename)) {
+                result.add(decoded);
+            }
+        }
+    }
+
+    private static String escapeHtml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;");
+    }
+
+    public static String escapeXml(String text) {
+        if (text == null) {
+            return "";
+        }
+        return text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlToMarkdownConverter.java
@@ -25,12 +25,17 @@ import java.util.List;
  *
  * <p>This converter:
  * <ol>
+ *   <li>Extracts {@code <pre>/<code>} blocks and converts them to fenced code blocks so
+ *       language information is preserved and the round-trip back to Confluence's
+ *       {@code code} macro works.</li>
+ *   <li>Extracts task lists ({@code <ul>} where every item starts with {@code [x]} or
+ *       {@code [ ]}) and preserves GitHub-Flavoured Markdown task-list syntax.</li>
  *   <li>Extracts every {@code <table>} and converts it to a GitHub-Flavoured Markdown table
  *       (replacing it with a placeholder so CopyDown does not mangle it).</li>
- *   <li>Runs CopyDown on the remaining (table-less) HTML to get Markdown for everything else
+ *   <li>Runs CopyDown on the remaining HTML to get Markdown for everything else
  *       (paragraphs, bold/italic, links, lists, etc.) — which also naturally drops all
  *       {@code style}/{@code class} attributes, since Markdown has no equivalent.</li>
- *   <li>Restores the Markdown tables at their placeholders.</li>
+ *   <li>Restores the extracted Markdown constructs at their placeholders.</li>
  * </ol>
  *
  * <p>Used by {@link com.github.istin.dmtools.atlassian.confluence.ConfluenceStorageMarkdown}
@@ -42,6 +47,8 @@ public final class HtmlToMarkdownConverter {
 
     private static final Logger logger = LogManager.getLogger(HtmlToMarkdownConverter.class);
 
+    private static final String CODE_PLACEHOLDER_PREFIX = "DMCODEIDX";
+    private static final String TASK_PLACEHOLDER_PREFIX = "DMTASKIDX";
     private static final String TABLE_PLACEHOLDER_PREFIX = "DMTABLEIDX";
 
     private HtmlToMarkdownConverter() {}
@@ -59,8 +66,8 @@ public final class HtmlToMarkdownConverter {
     }
 
     /**
-     * Converts an HTML fragment to Markdown, preserving tables as GitHub-Flavoured Markdown
-     * tables.
+     * Converts an HTML fragment to Markdown, preserving tables, fenced code blocks and
+     * task-list syntax.
      *
      * @param html raw HTML fragment (does not need to be a full document)
      * @return Markdown text, or the original HTML if conversion fails for any reason
@@ -70,102 +77,210 @@ public final class HtmlToMarkdownConverter {
             return "";
         }
         try {
-            TableExtraction extraction = extractTables(html);
-            String markdown = new CopyDown().convert(extraction.htmlWithoutTables);
-            return restoreTables(markdown, extraction.tables);
+            Extraction extraction = new Extraction(html);
+            extraction.extractCodeBlocks();
+            extraction.extractTaskLists();
+            extraction.extractTables();
+
+            String markdown = new CopyDown().convert(extraction.htmlWithoutExtracted);
+            markdown = extraction.restore(markdown);
+            return markdown;
         } catch (Exception e) {
-            logger.warn("HTML→Markdown conversion failed, returning raw HTML: {}", e.getMessage(), e);
+            logger.warn("HTML->Markdown conversion failed, returning raw HTML: {}", e.getMessage(), e);
             return html;
         }
     }
 
     /**
-     * Extracts all {@code <table>} elements, converts them to GitHub-Flavoured Markdown
-     * tables, and replaces them with placeholders so that the remaining HTML can be
-     * safely passed to CopyDown.
+     * Mutable extraction context. Holds the working HTML and the Markdown fragments that
+     * have been replaced by placeholders, so they can be restored in the final pass.
      */
-    private static TableExtraction extractTables(String html) {
-        Document doc = parseFragment(html);
-        List<String> tables = new ArrayList<>();
+    private static final class Extraction {
+        String htmlWithoutExtracted;
+        final List<String> codeBlocks = new ArrayList<>();
+        final List<String> taskLists = new ArrayList<>();
+        final List<String> tables = new ArrayList<>();
 
-        Elements tableElements = doc.getElementsByTag("table");
-        int index = 0;
-        for (Element table : tableElements) {
-            String markdownTable = convertTableToMarkdown(table);
-            tables.add(markdownTable);
-
-            Element placeholder = doc.createElement("p").text(TABLE_PLACEHOLDER_PREFIX + index);
-            table.replaceWith(placeholder);
-            index++;
+        Extraction(String html) {
+            this.htmlWithoutExtracted = html;
         }
 
-        return new TableExtraction(bodyHtml(doc), tables);
-    }
+        /**
+         * Extracts {@code <pre>} and {@code <pre><code>} blocks, converts them to fenced
+         * Markdown code blocks, and replaces them with placeholders.
+         */
+        void extractCodeBlocks() {
+            Document doc = parseFragment(htmlWithoutExtracted);
+            Elements pres = doc.getElementsByTag("pre");
+            if (pres.isEmpty()) {
+                htmlWithoutExtracted = bodyHtml(doc);
+                return;
+            }
+            int index = 0;
+            for (Element pre : pres) {
+                String code = convertPreToMarkdown(pre);
+                codeBlocks.add(code);
+                Element placeholder = doc.createElement("p").text(CODE_PLACEHOLDER_PREFIX + index);
+                pre.replaceWith(placeholder);
+                index++;
+            }
+            htmlWithoutExtracted = bodyHtml(doc);
+        }
 
-    private static String convertTableToMarkdown(Element table) {
-        List<List<String>> rows = new ArrayList<>();
-        int maxColumns = 0;
-        boolean hasHeader = false;
-
-        for (Element tr : table.getElementsByTag("tr")) {
-            List<String> cells = new ArrayList<>();
-            for (Element child : tr.children()) {
-                String tag = child.tagName();
-                if ("th".equalsIgnoreCase(tag) || "td".equalsIgnoreCase(tag)) {
-                    if ("th".equalsIgnoreCase(tag)) {
-                        hasHeader = true;
-                    }
-                    cells.add(cellToMarkdown(child));
+        private static String convertPreToMarkdown(Element pre) {
+            Element codeEl = pre.selectFirst("code");
+            String language = "";
+            if (codeEl != null) {
+                String classAttr = codeEl.attr("class").trim();
+                if (classAttr.startsWith("language-")) {
+                    language = classAttr.substring("language-".length()).trim();
+                } else if (!classAttr.isBlank()) {
+                    language = classAttr;
                 }
             }
-            if (!cells.isEmpty()) {
-                rows.add(cells);
-                maxColumns = Math.max(maxColumns, cells.size());
+            String text = codeEl != null ? codeEl.text() : pre.text();
+            // Normalise trailing newline to keep fences tidy.
+            text = text.replaceAll("\n+$", "").replaceAll("^\n+", "");
+            return "```" + language + "\n" + text + "\n```";
+        }
+
+        /**
+         * Extracts task lists ({@code <ul>} whose items start with {@code [x]} / {@code [ ]})
+         * and preserves them as GFM task-list Markdown.
+         */
+        void extractTaskLists() {
+            Document doc = parseFragment(htmlWithoutExtracted);
+            Elements uls = doc.getElementsByTag("ul");
+            int index = 0;
+            for (Element ul : uls) {
+                String taskList = convertUlToTaskListMarkdown(ul);
+                if (taskList == null) {
+                    continue;
+                }
+                taskLists.add(taskList);
+                Element placeholder = doc.createElement("p").text(TASK_PLACEHOLDER_PREFIX + index);
+                ul.replaceWith(placeholder);
+                index++;
             }
+            htmlWithoutExtracted = bodyHtml(doc);
         }
 
-        if (rows.isEmpty()) {
-            return "";
-        }
-
-        StringBuilder markdown = new StringBuilder();
-        for (int i = 0; i < rows.size(); i++) {
-            appendMarkdownRow(markdown, rows.get(i), maxColumns);
-            if (i == 0 && hasHeader) {
-                appendMarkdownRow(markdown, null, maxColumns);
+        private static String convertUlToTaskListMarkdown(Element ul) {
+            StringBuilder sb = new StringBuilder();
+            boolean isTaskList = false;
+            for (Element li : ul.select("> li")) {
+                String text = li.text().trim();
+                String status;
+                if (text.startsWith("[x] ") || text.equals("[x]")) {
+                    status = "[x]";
+                    text = text.substring("[x]".length()).trim();
+                    isTaskList = true;
+                } else if (text.startsWith("[X] ") || text.equals("[X]")) {
+                    status = "[x]";
+                    text = text.substring("[X]".length()).trim();
+                    isTaskList = true;
+                } else if (text.startsWith("[ ] ") || text.equals("[ ]")) {
+                    status = "[ ]";
+                    text = text.substring("[ ]".length()).trim();
+                    isTaskList = true;
+                } else {
+                    return null;
+                }
+                if (sb.length() > 0) {
+                    sb.append("\n");
+                }
+                sb.append("- ").append(status).append(" ").append(text);
             }
+            return isTaskList ? sb.toString() : null;
         }
-        return markdown.toString();
-    }
 
-    private static String cellToMarkdown(Element cell) {
-        // Convert the cell's inner HTML to Markdown so that links, bold, etc. are preserved.
-        String cellMarkdown = new CopyDown().convert(cell.html()).trim();
-        // Markdown tables cannot contain newlines or pipe characters in cells.
-        cellMarkdown = cellMarkdown.replace("|", "\\|");
-        cellMarkdown = cellMarkdown.replaceAll("\\s+", " ").trim();
-        return cellMarkdown;
-    }
-
-    private static void appendMarkdownRow(StringBuilder markdown, List<String> cells, int maxColumns) {
-        markdown.append("|");
-        for (int i = 0; i < maxColumns; i++) {
-            if (cells == null) {
-                markdown.append("---|");
-            } else {
-                String value = i < cells.size() ? cells.get(i) : "";
-                markdown.append(" ").append(value).append(" |");
+        /**
+         * Extracts all {@code <table>} elements, converts them to GitHub-Flavoured Markdown
+         * tables, and replaces them with placeholders.
+         */
+        void extractTables() {
+            Document doc = parseFragment(htmlWithoutExtracted);
+            Elements tableElements = doc.getElementsByTag("table");
+            int index = 0;
+            for (Element table : tableElements) {
+                String markdownTable = convertTableToMarkdown(table);
+                tables.add(markdownTable);
+                Element placeholder = doc.createElement("p").text(TABLE_PLACEHOLDER_PREFIX + index);
+                table.replaceWith(placeholder);
+                index++;
             }
+            htmlWithoutExtracted = bodyHtml(doc);
         }
-        markdown.append("\n");
-    }
 
-    private static String restoreTables(String markdown, List<String> tables) {
-        String result = markdown;
-        for (int i = 0; i < tables.size(); i++) {
-            result = result.replace(TABLE_PLACEHOLDER_PREFIX + i, tables.get(i).trim());
+        private static String convertTableToMarkdown(Element table) {
+            List<List<String>> rows = new ArrayList<>();
+            int maxColumns = 0;
+            boolean hasHeader = false;
+
+            for (Element tr : table.getElementsByTag("tr")) {
+                List<String> cells = new ArrayList<>();
+                for (Element child : tr.children()) {
+                    String tag = child.tagName();
+                    if ("th".equalsIgnoreCase(tag) || "td".equalsIgnoreCase(tag)) {
+                        if ("th".equalsIgnoreCase(tag)) {
+                            hasHeader = true;
+                        }
+                        cells.add(cellToMarkdown(child));
+                    }
+                }
+                if (!cells.isEmpty()) {
+                    rows.add(cells);
+                    maxColumns = Math.max(maxColumns, cells.size());
+                }
+            }
+
+            if (rows.isEmpty()) {
+                return "";
+            }
+
+            StringBuilder markdown = new StringBuilder();
+            for (int i = 0; i < rows.size(); i++) {
+                appendMarkdownRow(markdown, rows.get(i), maxColumns);
+                if (i == 0 && hasHeader) {
+                    appendMarkdownRow(markdown, null, maxColumns);
+                }
+            }
+            return markdown.toString();
         }
-        return result;
+
+        private static String cellToMarkdown(Element cell) {
+            String cellMarkdown = new CopyDown().convert(cell.html()).trim();
+            cellMarkdown = cellMarkdown.replace("|", "\\|");
+            cellMarkdown = cellMarkdown.replaceAll("\\s+", " ").trim();
+            return cellMarkdown;
+        }
+
+        private static void appendMarkdownRow(StringBuilder markdown, List<String> cells, int maxColumns) {
+            markdown.append("|");
+            for (int i = 0; i < maxColumns; i++) {
+                if (cells == null) {
+                    markdown.append("---|");
+                } else {
+                    String value = i < cells.size() ? cells.get(i) : "";
+                    markdown.append(" ").append(value).append(" |");
+                }
+            }
+            markdown.append("\n");
+        }
+
+        String restore(String markdown) {
+            String result = markdown;
+            for (int i = 0; i < codeBlocks.size(); i++) {
+                result = result.replace(CODE_PLACEHOLDER_PREFIX + i, codeBlocks.get(i).trim());
+            }
+            for (int i = 0; i < taskLists.size(); i++) {
+                result = result.replace(TASK_PLACEHOLDER_PREFIX + i, taskLists.get(i).trim());
+            }
+            for (int i = 0; i < tables.size(); i++) {
+                result = result.replace(TABLE_PLACEHOLDER_PREFIX + i, tables.get(i).trim());
+            }
+            return result;
+        }
     }
 
     private static Document parseFragment(String html) {
@@ -176,15 +291,5 @@ public final class HtmlToMarkdownConverter {
 
     private static String bodyHtml(Document doc) {
         return doc.body() != null ? doc.body().html() : doc.html();
-    }
-
-    private static final class TableExtraction {
-        final String htmlWithoutTables;
-        final List<String> tables;
-
-        TableExtraction(String htmlWithoutTables, List<String> tables) {
-            this.htmlWithoutTables = htmlWithoutTables;
-            this.tables = tables;
-        }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceHtmlToMarkdownTest.java
@@ -276,6 +276,33 @@ public class ConfluenceHtmlToMarkdownTest {
 
         assertTrue("Should preserve code body", markdown.contains("System.out.println"));
         assertTrue("Should preserve hello string", markdown.contains("hello"));
+        assertTrue("Should convert code macro to fenced code block", markdown.contains("```java"));
+        assertTrue("Should close fenced code block", markdown.contains("```"));
+    }
+
+    @Test
+    public void testToMarkdown_convertsPreCodeToFencedBlock() {
+        String html = "<pre><code class=\"language-python\">def hello():\n    return 'hi'</code></pre>";
+
+        String markdown = ConfluenceStorageMarkdown.toMarkdown(html);
+
+        assertTrue("Should contain opening fence with language", markdown.contains("```python"));
+        assertTrue("Should preserve code body", markdown.contains("def hello():"));
+        assertTrue("Should contain closing fence", markdown.contains("\n```"));
+    }
+
+    @Test
+    public void testToMarkdown_preservesTaskListSyntax() {
+        String html = "<ac:task-list>" +
+            "<ac:task><ac:task-status>complete</ac:task-status><ac:task-body>Done</ac:task-body></ac:task>" +
+            "<ac:task><ac:task-status>incomplete</ac:task-status><ac:task-body>Todo</ac:task-body></ac:task>" +
+            "</ac:task-list>";
+
+        String markdown = ConfluenceStorageMarkdown.toMarkdown(html);
+
+        assertTrue("Should have completed task", markdown.contains("- [x] Done"));
+        assertTrue("Should have incomplete task", markdown.contains("- [ ] Todo"));
+        assertFalse("Should not escape brackets", markdown.contains("\\[x]"));
     }
 
     @Test

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluenceTest.java
@@ -13,16 +13,28 @@ import okhttp3.ResponseBody;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
 import java.util.List;
+
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.MultipartBody;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
 public class ConfluenceTest {
@@ -377,5 +389,320 @@ public class ConfluenceTest {
 
         assertEquals(1, result.size());
         assertEquals(ConfluenceStorageMarkdown.toMarkdown(html), result.get(0).getStorage().getValue());
+    }
+
+    @Test
+    public void testUploadAttachment_SkipsExistingFile() throws IOException {
+        Attachment existing = new Attachment(new JSONObject()
+            .put("id", "att123")
+            .put("title", "document.pdf"));
+        doReturn(Collections.singletonList(existing)).when(confluence).getContentAttachments("page1");
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        injectClient(confluence, mockClient);
+
+        File tempDir = Files.createTempDirectory("test-attachments").toFile();
+        File tempFile = new File(tempDir, "document.pdf");
+        Files.write(tempFile.toPath(), "pdf".getBytes(StandardCharsets.UTF_8));
+        try {
+            Attachment result = confluence.uploadAttachment("page1", tempFile, false);
+
+            assertEquals("att123", result.getId());
+            assertEquals("document.pdf", result.getTitle());
+            verify(mockClient, never()).newCall(any(Request.class));
+        } finally {
+            tempFile.delete();
+            tempDir.delete();
+        }
+    }
+
+    @Test
+    public void testUploadAttachment_UploadsNewFile() throws IOException {
+        doReturn(Collections.emptyList()).when(confluence).getContentAttachments("page1");
+
+        OkHttpClient mockClient = mock(OkHttpClient.class);
+        Call mockCall = mock(Call.class);
+        Response mockResponse = mock(Response.class);
+        ResponseBody mockBody = mock(ResponseBody.class);
+
+        when(mockClient.newCall(any(Request.class))).thenReturn(mockCall);
+        when(mockCall.execute()).thenReturn(mockResponse);
+        when(mockResponse.isSuccessful()).thenReturn(true);
+        when(mockResponse.body()).thenReturn(mockBody);
+        when(mockBody.string()).thenReturn(new JSONObject()
+            .put("id", "att999")
+            .put("title", "image.png")
+            .toString());
+
+        injectClient(confluence, mockClient);
+
+        File tempFile = Files.createTempFile("image", ".png").toFile();
+        try {
+            Attachment result = confluence.uploadAttachment("page1", tempFile, false);
+
+            assertEquals("att999", result.getId());
+            assertEquals("image.png", result.getTitle());
+            verify(mockClient, times(1)).newCall(any(Request.class));
+
+            // Verify the request is a multipart upload to the attachment endpoint.
+            Request captured = captureRequest(mockClient);
+            assertTrue(captured.url().toString().contains("/rest/api/content/page1/child/attachment"));
+            assertTrue(captured.body() instanceof MultipartBody);
+        } finally {
+            tempFile.delete();
+        }
+    }
+
+    @Test
+    public void testUploadAttachment_ThrowsForMissingFile() throws IOException {
+        doReturn(Collections.emptyList()).when(confluence).getContentAttachments("page1");
+        File missing = new File("/non/existent/file.pdf");
+
+        try {
+            confluence.uploadAttachment("page1", missing, false);
+            fail("Expected IOException for missing file");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("does not exist"));
+        }
+    }
+
+    @Test
+    public void testUploadAttachments_DirectorySummary() throws IOException {
+        java.nio.file.Path tempDir = Files.createTempDirectory("attachments");
+        Files.write(tempDir.resolve("a.txt"), "a".getBytes(StandardCharsets.UTF_8));
+        Files.write(tempDir.resolve("b.txt"), "b".getBytes(StandardCharsets.UTF_8));
+
+        doReturn(Collections.emptyList()).when(confluence).getContentAttachments("page1");
+        doAnswer(inv -> {
+            File f = inv.getArgument(1);
+            return new Attachment(new JSONObject()
+                .put("id", "att" + f.getName())
+                .put("title", f.getName()));
+        }).when(confluence).uploadAttachment(anyString(), any(File.class), anyBoolean());
+
+        String result = confluence.uploadAttachments("page1", tempDir.toString(), false);
+
+        assertTrue(result.contains("a.txt"));
+        assertTrue(result.contains("b.txt"));
+
+        Files.walk(tempDir).sorted(Collections.reverseOrder()).forEach(p -> {
+            try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+        });
+    }
+
+    private void injectClient(Confluence target, OkHttpClient mockClient) {
+        try {
+            Field clientField = com.github.istin.dmtools.networking.AbstractRestClient.class.getDeclaredField("client");
+            clientField.setAccessible(true);
+            clientField.set(target, mockClient);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Request captureRequest(OkHttpClient mockClient) {
+        ArgumentCaptor<Request> captor = ArgumentCaptor.forClass(Request.class);
+        verify(mockClient).newCall(captor.capture());
+        return captor.getValue();
+    }
+
+    @Test
+    public void testExtractTitle_FromH1() {
+        assertEquals("Hello World", MarkdownConfluenceSync.extractTitle("# Hello World\n\nbody", new File("page.md")));
+    }
+
+    @Test
+    public void testExtractTitle_FallsBackToFileName() {
+        assertEquals("page", MarkdownConfluenceSync.extractTitle("No heading here.", new File("page.md")));
+    }
+
+    @Test
+    public void testSyncMarkdownDirectory_CreatesPagesAndRewritesMdLinks() throws IOException {
+        java.nio.file.Path root = Files.createTempDirectory("sync-root");
+        try {
+            Files.createDirectories(root.resolve("sub"));
+            Files.write(root.resolve("index.md"),
+                    "# Root Index\n\nSee [Child Page](sub/child.md) and [external](https://example.com)."
+                            .getBytes(StandardCharsets.UTF_8));
+            Files.write(root.resolve("sub").resolve("child.md"),
+                    "# Child Page\n\nBack to [Root](../index.md)."
+                            .getBytes(StandardCharsets.UTF_8));
+
+            doReturn(Collections.emptyList()).when(confluence).getChildrenOfContentById(anyString(), isNull());
+            doReturn(Collections.emptyList()).when(confluence).getContentAttachments(anyString());
+            doAnswer(inv -> {
+                String title = inv.getArgument(0);
+                return content("id-" + title.replaceAll("\\s+", "-"), title);
+            }).when(confluence).createPage(anyString(), anyString(), anyString(), anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).updatePage(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+
+            String result = confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", false, null);
+
+            assertTrue(result.contains("Child Page"));
+
+            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(confluence, atLeast(2)).updatePage(anyString(), anyString(), anyString(), bodyCaptor.capture(), anyString(), anyString());
+            String allBodies = String.join("\n", bodyCaptor.getAllValues());
+            System.out.println("=== BODIES ===");
+            System.out.println(allBodies);
+            System.out.println("=== END BODIES ===");
+            assertTrue("Child .md link should become ri:page", allBodies.contains("ri:content-title=\"Child Page\""));
+            assertTrue("Root .md link with ../ should become ri:page", allBodies.contains("ri:page"));
+            assertTrue("External link should stay as standard anchor", allBodies.contains("https://example.com"));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    public void testSyncMarkdownDirectory_UsesExistingChildPage() throws IOException {
+        java.nio.file.Path root = Files.createTempDirectory("sync-root");
+        try {
+            Files.write(root.resolve("existing.md"),
+                    "# Existing Page\n\nContent.".getBytes(StandardCharsets.UTF_8));
+
+            doReturn(Collections.emptyList()).when(confluence).getChildrenOfContentById(anyString(), isNull());
+            doReturn(Collections.singletonList(content("existing-id", "Existing Page")))
+                    .when(confluence).getChildrenOfContentById(eq("root-id"), isNull());
+            doReturn(Collections.emptyList()).when(confluence).getContentAttachments(anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).updatePage(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).createPage(anyString(), anyString(), anyString(), anyString());
+
+            confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", false, null);
+
+            verify(confluence, never()).createPage(eq("Existing Page"), anyString(), anyString(), anyString());
+            verify(confluence).updatePage(eq("existing-id"), eq("Existing Page"), eq("root-id"), anyString(), eq("SPACE"), eq(""));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    public void testSyncMarkdownDirectory_UploadsAttachmentsIdempotently() throws IOException {
+        java.nio.file.Path root = Files.createTempDirectory("sync-root");
+        try {
+            java.nio.file.Path assets = root.resolve("assets");
+            Files.createDirectories(assets);
+            Files.write(root.resolve("page.md"),
+                    "# Page\n\n![diagram](assets/diagram.png)".getBytes(StandardCharsets.UTF_8));
+            Files.write(assets.resolve("diagram.png"), "PNG".getBytes(StandardCharsets.UTF_8));
+
+            doReturn(Collections.emptyList()).when(confluence).getChildrenOfContentById(anyString(), isNull());
+            doReturn(Collections.emptyList()).when(confluence).getContentAttachments(anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).updatePage(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).createPage(anyString(), anyString(), anyString(), anyString());
+
+            ConfluenceAttachmentHelper attachmentHelper = mock(ConfluenceAttachmentHelper.class);
+            when(attachmentHelper.getAttachments(anyString())).thenReturn(Collections.emptyList());
+            when(attachmentHelper.uploadAttachment(anyString(), any(File.class), anyBoolean()))
+                    .thenAnswer(inv -> new Attachment(new JSONObject()
+                            .put("id", "att-" + ((File) inv.getArgument(1)).getName())
+                            .put("title", ((File) inv.getArgument(1)).getName())));
+            confluence.setAttachmentHelper(attachmentHelper);
+
+            // First sync uploads the referenced attachment (assets/diagram.png).
+            confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", false, null);
+            verify(attachmentHelper, atLeast(1)).uploadAttachment(anyString(), argThat((File f) -> f.getName().equals("diagram.png")), anyBoolean());
+
+            // Second sync: stub now returns existing attachment so all uploads are skipped.
+            when(attachmentHelper.getAttachments(anyString())).thenReturn(Collections.singletonList(
+                    new Attachment(new JSONObject().put("id", "att1").put("title", "diagram.png"))));
+            confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", false, null);
+            verify(attachmentHelper, atLeast(1)).uploadAttachment(anyString(), argThat((File f) -> f.getName().equals("diagram.png")), anyBoolean());
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    public void testSyncMarkdownDirectory_UploadsNonMarkdownFilesAsAttachments() throws IOException {
+        java.nio.file.Path root = Files.createTempDirectory("sync-root");
+        try {
+            Files.createDirectories(root.resolve("sub"));
+            Files.write(root.resolve("sub").resolve("data.json"),
+                    "{\"x\":1}".getBytes(StandardCharsets.UTF_8));
+            Files.write(root.resolve("sub").resolve("index.md"),
+                    "# Sub".getBytes(StandardCharsets.UTF_8));
+
+            doReturn(Collections.emptyList()).when(confluence).getChildrenOfContentById(anyString(), isNull());
+            doReturn(Collections.emptyList()).when(confluence).getContentAttachments(anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).updatePage(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).createPage(anyString(), anyString(), anyString(), anyString());
+
+            ConfluenceAttachmentHelper attachmentHelper = mock(ConfluenceAttachmentHelper.class);
+            when(attachmentHelper.getAttachments(anyString())).thenReturn(Collections.emptyList());
+            when(attachmentHelper.uploadAttachment(anyString(), any(File.class), anyBoolean()))
+                    .thenAnswer(inv -> new Attachment(new JSONObject()
+                            .put("id", "att-" + ((File) inv.getArgument(1)).getName())
+                            .put("title", ((File) inv.getArgument(1)).getName())));
+            confluence.setAttachmentHelper(attachmentHelper);
+
+            confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", false, null);
+
+            verify(attachmentHelper).uploadAttachment(anyString(), argThat(f -> f.getName().equals("data.json")), anyBoolean());
+
+            // The non-referenced attachment should appear as a forced link in the folder body.
+            ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+            verify(confluence, atLeast(1)).updatePage(anyString(), anyString(), anyString(), bodyCaptor.capture(), anyString(), anyString());
+            String allBodies = String.join("\n", bodyCaptor.getAllValues());
+            assertTrue("Non-Markdown attachment should be linked explicitly", allBodies.contains("ri:filename=\"data.json\""));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    public void testSyncMarkdownDirectory_DeletesOrphanPages() throws IOException {
+        java.nio.file.Path root = Files.createTempDirectory("sync-root");
+        try {
+            Files.write(root.resolve("kept.md"),
+                    "# Kept Page\n\nContent.".getBytes(StandardCharsets.UTF_8));
+
+            doReturn(Collections.emptyList()).when(confluence).getChildrenOfContentById(anyString(), isNull());
+            Content orphan = content("orphan-id", "Orphan Page");
+            doReturn(Collections.singletonList(orphan))
+                    .when(confluence).getChildrenOfContentById(eq("root-id"), isNull());
+            doReturn(Collections.emptyList())
+                    .when(confluence).getChildrenOfContentById(eq("orphan-id"), isNull());
+            doReturn(Collections.emptyList()).when(confluence).getContentAttachments(anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).updatePage(anyString(), anyString(), anyString(), anyString(), anyString(), anyString());
+            doAnswer(inv -> content(inv.getArgument(0), inv.getArgument(1)))
+                    .when(confluence).createPage(anyString(), anyString(), anyString(), anyString());
+            doReturn("").when(confluence).deletePage(anyString());
+
+            String result = confluence.syncMarkdownDirectory(root.toString(), "root-id", "SPACE", true, null);
+
+            assertTrue(result.contains("deleted"));
+            assertTrue(result.contains("Orphan Page"));
+            verify(confluence).deletePage(eq("orphan-id"));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    private Content content(String id, String title) {
+        return new Content(new JSONObject().put("id", id).put("title", title));
+    }
+
+    private void deleteRecursively(java.nio.file.Path path) {
+        try {
+            Files.walk(path)
+                    .sorted(Collections.reverseOrder())
+                    .forEach(p -> {
+                        try {
+                            Files.deleteIfExists(p);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        } catch (IOException ignored) {
+        }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests that Markdown converts back into Confluence Storage Format (XHTML)
+ * correctly, covering the inverse of {@link ConfluenceStorageMarkdown}.
+ */
+public class MarkdownToConfluenceStorageTest {
+
+    @Test
+    public void testEmptyAndNullInput() {
+        assertEquals("", MarkdownToConfluenceStorage.toStorage(null));
+        assertEquals("", MarkdownToConfluenceStorage.toStorage(""));
+        assertEquals("", MarkdownToConfluenceStorage.toStorage("   \n  "));
+    }
+
+    @Test
+    public void testHeadingsAndParagraphs() {
+        String md = "# Feature Overview\n\nThis document describes the **core business scenarios**.";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain h1", storage.contains("<h1>Feature Overview</h1>"));
+        assertTrue("Should contain paragraph", storage.contains("<p>"));
+        assertTrue("Should preserve bold", storage.contains("<strong>core business scenarios</strong>"));
+    }
+
+    @Test
+    public void testLists() {
+        String md = "- First item\n- Second item\n- **Bold** item";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain unordered list", storage.contains("<ul>"));
+        assertTrue("Should contain list items", storage.contains("<li>First item</li>"));
+        assertTrue("Should contain bold inside list", storage.contains("<li><strong>Bold</strong> item</li>"));
+    }
+
+    @Test
+    public void testOrderedList() {
+        String md = "1. First\n2. Second";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ordered list", storage.contains("<ol>"));
+        assertTrue("Should contain list items", storage.contains("<li>First</li>"));
+    }
+
+    @Test
+    public void testTable() {
+        String md = "| Field | Value |\n|---|---|\n| A | 1 |\n| B | 2 |";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain table", storage.contains("<table>"));
+        assertTrue("Should contain header cell", storage.contains("<th>Field</th>"));
+        assertTrue("Should contain data cell", storage.contains("<td>A</td>"));
+    }
+
+    @Test
+    public void testFencedCodeBlock() {
+        String md = "```java\nSystem.out.println(\"hello\");\n```";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain code macro", storage.contains("ac:name=\"code\""));
+        assertTrue("Should contain language parameter", storage.contains("<ac:parameter ac:name=\"language\">java</ac:parameter>"));
+        assertTrue("Should contain CDATA body", storage.contains("<![CDATA[System.out.println(\"hello\");]]>"));
+    }
+
+    @Test
+    public void testInlineCode() {
+        String md = "Use `System.out.println` for output.";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain inline code", storage.contains("<code>System.out.println</code>"));
+    }
+
+    @Test
+    public void testTaskList() {
+        String md = "- [x] Done task\n- [ ] Todo task";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain task list", storage.contains("<ac:task-list>"));
+        assertTrue("Should contain complete task", storage.contains("<ac:task-status>complete</ac:task-status>"));
+        assertTrue("Should contain incomplete task", storage.contains("<ac:task-status>incomplete</ac:task-status>"));
+        assertTrue("Should contain task body", storage.contains("<ac:task-body>Done task</ac:task-body>"));
+        assertFalse("Should not contain raw checkbox input", storage.contains("<input"));
+    }
+
+    @Test
+    public void testPageLink() {
+        String md = "See [Requirements and Specifications](Requirements and Specifications) for details.";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:link", storage.contains("<ac:link>"));
+        assertTrue("Should contain ri:page", storage.contains("<ri:page"));
+        assertTrue("Should contain content title", storage.contains("ri:content-title=\"Requirements and Specifications\""));
+        assertTrue("Should contain link body", storage.contains("<ac:link-body>Requirements and Specifications</ac:link-body>"));
+    }
+
+    @Test
+    public void testAttachmentLink() {
+        String md = "[Download](doc.pdf)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:link", storage.contains("<ac:link>"));
+        assertTrue("Should contain ri:attachment", storage.contains("<ri:attachment"));
+        assertTrue("Should contain filename", storage.contains("ri:filename=\"doc.pdf\""));
+        assertTrue("Should contain link body", storage.contains("<ac:link-body>Download</ac:link-body>"));
+    }
+
+    @Test
+    public void testExternalLinkKeptAsAnchor() {
+        String md = "Visit [Example](http://example.com).";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain standard anchor", storage.contains("<a href=\"http://example.com\">Example</a>"));
+        assertFalse("Should not convert external link to ac:link", storage.contains("<ac:link>"));
+    }
+
+    @Test
+    public void testPageLinkWithSpaceKey() {
+        String md = "See [Home](PROJ:Home).";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ri:page with space key", storage.contains("ri:space-key=\"PROJ\""));
+        assertTrue("Should contain content title", storage.contains("ri:content-title=\"Home\""));
+    }
+
+    @Test
+    public void testLocalImageConvertedToAttachment() {
+        String md = "![architecture.png](architecture.png)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:image", storage.contains("<ac:image"));
+        assertTrue("Should contain ri:attachment", storage.contains("<ri:attachment"));
+        assertTrue("Should contain filename", storage.contains("ri:filename=\"architecture.png\""));
+        assertTrue("Should preserve alt", storage.contains("ac:alt=\"architecture.png\""));
+    }
+
+    @Test
+    public void testExternalImageKeptAsImg() {
+        String md = "![logo](https://example.com/logo.png)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain standard img", storage.contains("<img src=\"https://example.com/logo.png\""));
+        assertFalse("Should not convert external image to ac:image", storage.contains("<ac:image>"));
+    }
+
+    @Test
+    public void testRoundTripWithExistingSample() {
+        // This is the Markdown produced by ConfluenceStorageMarkdown from the test sample.
+        String md = "# Feature Overview\n\n" +
+                "This document describes the **core business scenarios** for the integration feature.\n\n" +
+                "## Scenario 1: Basic Flow\n\n" +
+                "When the system receives *a single input record*, it generates one output file.\n\n" +
+                "- The output is stored in the designated storage location\n" +
+                "- A notification is sent to the downstream service\n" +
+                "- Status is updated to **COMPLETED**\n\n" +
+                "## Scenario 2: Batch Processing\n\n" +
+                "When the system receives *multiple records*, it must process them in batches.\n\n" +
+                "TBD: Confirm whether batch splitting is one-per-type or one-per-group.\n\n" +
+                "| Field | Value | Required |\n" +
+                "|---|---|---|\n" +
+                "| RECORD_TYPE | TYPE_A | Yes |\n" +
+                "| OUTPUT_FILE | output_v1.dat | Yes |\n" +
+                "| CONTROL_FLAG | ENABLED or empty | No |\n\n" +
+                "### Related Pages\n\n" +
+                "See [Requirements and Specifications](Requirements and Specifications) for field definitions.\n\n" +
+                "Also check [API Design](API Design).\n\n" +
+                "### Architecture Diagram\n\n" +
+                "![architecture.png](architecture.png)\n\n" +
+                "![flow-diagram.png](flow-diagram.png)\n\n" +
+                "[Diagram]\n\n" +
+                "### Review Checklist\n\n" +
+                "- [x] Define API contract\n" +
+                "- [ ] Write integration tests\n" +
+                "- [ ] Get approval from stakeholders\n\n" +
+                "### Edge Cases\n\n" +
+                "1. Input has no records — output should be empty array\n" +
+                "2. Reference file not found — out of scope for this story";
+
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain h1", storage.contains("<h1>Feature Overview</h1>"));
+        assertTrue("Should contain h2", storage.contains("<h2>Scenario 1: Basic Flow</h2>"));
+        assertTrue("Should contain h3", storage.contains("<h3>Related Pages</h3>"));
+        assertTrue("Should contain page link", storage.contains("ri:content-title=\"Requirements and Specifications\""));
+        assertTrue("Should contain image attachment", storage.contains("ri:filename=\"architecture.png\""));
+        assertTrue("Should contain task list", storage.contains("<ac:task-list>"));
+        assertTrue("Should contain table", storage.contains("<table>"));
+        assertFalse("Should not leak raw markdown", storage.contains("## "));
+    }
+
+    @Test
+    public void testPrintOutputForReview() {
+        String md = "# Heading\n\nParagraph with **bold** and *italic* and `code`.\n\n" +
+                "| A | B |\n|---|---|\n| 1 | 2 |\n\n" +
+                "```java\nSystem.out.println();\n```\n\n" +
+                "- [x] task\n\n" +
+                "[Page](Page Title)\n\n" +
+                "[File](file.pdf)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        System.out.println("=== CONFLUENCE STORAGE OUTPUT ===");
+        System.out.println(storage);
+        System.out.println("=== END OUTPUT ===");
+
+        assertFalse("Output should not be empty", storage.isBlank());
+    }
+
+    @Test
+    public void testRelativePathAttachmentLink() {
+        String md = "[Download](./attachments/document.pdf)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:link", storage.contains("<ac:link>"));
+        assertTrue("Should normalize to filename", storage.contains("ri:filename=\"document.pdf\""));
+        assertTrue("Should preserve link body", storage.contains("<ac:link-body>Download</ac:link-body>"));
+    }
+
+    @Test
+    public void testRelativePathImage() {
+        String md = "![Architecture diagram](images/architecture.png)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:image", storage.contains("<ac:image"));
+        assertTrue("Should normalize to filename", storage.contains("ri:filename=\"architecture.png\""));
+        assertTrue("Should preserve alt text", storage.contains("ac:alt=\"Architecture diagram\""));
+    }
+
+    @Test
+    public void testBackslashPathAttachmentLink() {
+        String md = "[Download](assets\\report.xlsx)";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain ac:link", storage.contains("<ac:link>"));
+        assertTrue("Should normalize backslash path to filename", storage.contains("ri:filename=\"report.xlsx\""));
+    }
+
+    @Test
+    public void testExtractAttachmentReferences() {
+        String md = "# Doc\n\n" +
+                "See [spec](docs/spec.pdf) and [diagram](./images/arch.png).\n\n" +
+                "![screenshot](screenshots/screen.png)\n\n" +
+                "External [link](https://example.com/file.pdf) and [page](Some Page) should be ignored.";
+
+        java.util.Set<String> refs = MarkdownToConfluenceStorage.extractAttachmentReferences(md);
+
+        assertEquals("Should extract three attachment references", 3, refs.size());
+        assertTrue("Should include spec.pdf", refs.contains("spec.pdf"));
+        assertTrue("Should include arch.png", refs.contains("arch.png"));
+        assertTrue("Should include screen.png", refs.contains("screen.png"));
+        assertFalse("Should not include external URL", refs.contains("https://example.com/file.pdf"));
+        assertFalse("Should not include page reference", refs.contains("Some Page"));
+    }
+
+    @Test
+    public void testExtractAttachmentReferencesIgnoresAnchors() {
+        String md = "[Anchor](#section) and [file](file.pdf)";
+        java.util.Set<String> refs = MarkdownToConfluenceStorage.extractAttachmentReferences(md);
+
+        assertEquals(1, refs.size());
+        assertTrue(refs.contains("file.pdf"));
+    }
+
+    @Test
+    public void testExtractAttachmentReferencePathsKeepsRelativePaths() {
+        String md = "See [spec](docs/spec.pdf) and ![diagram](./images/arch.png).";
+        java.util.Set<String> refs = MarkdownToConfluenceStorage.extractAttachmentReferencePaths(md);
+
+        assertEquals(2, refs.size());
+        assertTrue(refs.contains("docs/spec.pdf"));
+        assertTrue(refs.contains("./images/arch.png"));
+    }
+}


### PR DESCRIPTION
- Add confluence_sync_markdown_directory MCP tool for full directory tree sync
- Add MarkdownToConfluenceStorage converter for Markdown -> Confluence Storage Format
- Add create/update page from Markdown file with attachment upload MCP tools
- Add upload_attachment and upload_attachments MCP tools with idempotent skip
- Rewrite local .md cross-links to ri:page references
- Upload non-Markdown files in each directory to matching Confluence page
- Append explicit Attachments section for files not referenced in page body
- Fix self-parent ancestor bug and macOS canonical path resolution
- Add unit tests and update confluence-tools / dmtools-confluence docs