### PR TITLE
feat(jenkins): fix queueUrl capture + add queue-item polling and trigger-and-wait

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/jenkins-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/jenkins-tools.md
@@ -1,6 +1,6 @@
 # Jenkins MCP Tools
 
-**Total Tools**: 5
+**Total Tools**: 7
 
 ## Available Tools
 
@@ -10,5 +10,7 @@
 | `jenkins_list_builds` | List recent builds for a Jenkins job. Provide the job path as folder/job-name. | builds |
 | `jenkins_get_job_info` | Get details of a specific Jenkins build by job path and build number. | builds |
 | `jenkins_get_build_log` | Get the raw console log text of a specific Jenkins build. | builds |
-| `jenkins_trigger_job` | Trigger a Jenkins job. Provide parameters as a JSON object to use buildWithParameters. | builds |
+| `jenkins_trigger_job` | Trigger a Jenkins job. Provide parameters as a JSON object to use buildWithParameters. Returns 'queueUrl' — the Jenkins queue item URL (from the response's Location header) — which can be resolved to a build number via jenkins_get_queue_item. Prefer jenkins_trigger_job_and_wait when the caller needs to block until the build finishes. | builds |
+| `jenkins_get_queue_item` | Check the status of a Jenkins queue item — the 'queueUrl' returned by jenkins_trigger_job. While the job is queued/blocked (e.g. waiting for an executor or an upstream lock) there is no build number yet; once Jenkins starts executing it, the response includes 'buildNumber'/'buildUrl'. Returns 'cancelled': true if the queued item was cancelled instead of executed. | builds |
+| `jenkins_trigger_job_and_wait` | Trigger a Jenkins job and block until the resulting build finishes (or a timeout elapses). Internally resolves the queue item to a build number (falling back to build-number polling if no queue URL is available), then polls the build until it is no longer 'building'. Use this instead of jenkins_trigger_job + manual polling when the caller needs a synchronous result — e.g. before continuing a git workflow that depends on the triggered job's outcome (such as a branch-creation job that must finish before the branch can be checked out). | builds |
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/jenkins/Jenkins.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/jenkins/Jenkins.java
@@ -10,6 +10,8 @@ import com.github.istin.dmtools.mcp.MCPParam;
 import com.github.istin.dmtools.mcp.MCPTool;
 import com.github.istin.dmtools.networking.AbstractRestClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
@@ -31,6 +33,8 @@ import java.util.Map;
  *   <li>Listing and inspecting builds</li>
  *   <li>Reading build console logs</li>
  *   <li>Triggering parameterized and non-parameterized jobs</li>
+ *   <li>Resolving a triggered job's queue item to its build number</li>
+ *   <li>Triggering a job and blocking until it finishes (queue + build polling)</li>
  * </ul>
  *
  * <p>Configure via environment variables:
@@ -170,10 +174,14 @@ public abstract class Jenkins extends AbstractRestClient {
             String jobPath,
             @MCPParam(name = "buildNumber", description = "Build number", required = true)
             Integer buildNumber) throws IOException {
+        return fetchBuildInfoJson(jobPath, buildNumber).toMap();
+    }
+
+    private JSONObject fetchBuildInfoJson(String jobPath, int buildNumber) throws IOException {
         GenericRequest req = new GenericRequest(this,
                 path(toApiJobPath(jobPath) + buildNumber + "/api/json"));
         String response = execute(req);
-        return new JSONObject(response).toMap();
+        return new JSONObject(response);
     }
 
     @MCPTool(
@@ -194,7 +202,7 @@ public abstract class Jenkins extends AbstractRestClient {
 
     @MCPTool(
             name = "jenkins_trigger_job",
-            description = "Trigger a Jenkins job. Provide parameters as a JSON object to use buildWithParameters.",
+            description = "Trigger a Jenkins job. Provide parameters as a JSON object to use buildWithParameters. Returns 'queueUrl' — the Jenkins queue item URL (from the response's Location header) — which can be resolved to a build number via jenkins_get_queue_item. Prefer jenkins_trigger_job_and_wait when the caller needs to block until the build finishes.",
             integration = "jenkins",
             category = "builds"
     )
@@ -218,15 +226,179 @@ public abstract class Jenkins extends AbstractRestClient {
             } else {
                 req = new GenericRequest(this, path(toApiJobPath(jobPath) + "build"));
             }
-            req.setBody("");
-            String response = post(req);
-            result.put("success", true);
-            result.put("queueUrl", response != null && !response.isEmpty() ? response : null);
+
+            // Jenkins' build/buildWithParameters endpoints return an empty body and put the
+            // actual queue item location in the "Location" response header — post(GenericRequest)
+            // only returns the body, so we make the raw call ourselves (via the overridable
+            // executeRawRequest seam below, so tests can stub the HTTP layer) to read that header.
+            Request.Builder builder = new Request.Builder()
+                    .url(req.url())
+                    .header("User-Agent", "DMTools")
+                    .post(RequestBody.create("", JSON));
+            sign(builder);
+
+            try (Response response = executeRawRequest(builder.build())) {
+                if (response.isSuccessful() || response.code() == 302) {
+                    result.put("success", true);
+                    result.put("queueUrl", response.header("Location"));
+                } else {
+                    result.put("success", false);
+                    result.put("message", "Failed to trigger Jenkins job: HTTP " + response.code());
+                }
+            }
         } catch (Exception e) {
             result.put("success", false);
             result.put("message", "Failed to trigger Jenkins job: " + e.getMessage());
             logger.warn("Failed to trigger Jenkins job", e);
         }
         return result;
+    }
+
+    /**
+     * Executes a raw OkHttp request and returns the response (headers included), bypassing
+     * {@link #post(GenericRequest)} which only exposes the response body. Overridable/spy-able
+     * seam so unit tests can stub the HTTP layer without a real Jenkins instance.
+     */
+    protected Response executeRawRequest(Request request) throws IOException {
+        return client.newCall(request).execute();
+    }
+
+    @MCPTool(
+            name = "jenkins_get_queue_item",
+            description = "Check the status of a Jenkins queue item — the 'queueUrl' returned by jenkins_trigger_job. While the job is queued/blocked (e.g. waiting for an executor or an upstream lock) there is no build number yet; once Jenkins starts executing it, the response includes 'buildNumber'/'buildUrl'. Returns 'cancelled': true if the queued item was cancelled instead of executed.",
+            integration = "jenkins",
+            category = "builds"
+    )
+    public Map<String, Object> getQueueItem(
+            @MCPParam(name = "queueUrl", description = "Queue item URL returned by jenkins_trigger_job's 'queueUrl' field, e.g. https://jenkins.example.com/queue/item/12345/", required = true)
+            String queueUrl) throws IOException {
+        Map<String, Object> result = new HashMap<>();
+        if (queueUrl == null || queueUrl.trim().isEmpty()) {
+            result.put("success", false);
+            result.put("message", "queueUrl is required");
+            return result;
+        }
+        String normalized = queueUrl.trim();
+        if (!normalized.endsWith("/")) {
+            normalized = normalized + "/";
+        }
+        GenericRequest req = new GenericRequest(this, normalized + "api/json");
+        String response = execute(req);
+        JSONObject json = new JSONObject(response);
+
+        result.put("success", true);
+        result.put("cancelled", json.optBoolean("cancelled", false));
+        result.put("blocked", json.optBoolean("blocked", false));
+        if (json.has("why")) {
+            result.put("why", json.optString("why", null));
+        }
+        JSONObject executable = json.optJSONObject("executable");
+        if (executable != null) {
+            result.put("buildNumber", executable.optInt("number"));
+            result.put("buildUrl", executable.optString("url", null));
+        }
+        return result;
+    }
+
+    @MCPTool(
+            name = "jenkins_trigger_job_and_wait",
+            description = "Trigger a Jenkins job and block until the resulting build finishes (or a timeout elapses). Internally resolves the queue item to a build number (falling back to build-number polling if no queue URL is available), then polls the build until it is no longer 'building'. Use this instead of jenkins_trigger_job + manual polling when the caller needs a synchronous result — e.g. before continuing a git workflow that depends on the triggered job's outcome (such as a branch-creation job that must finish before the branch can be checked out).",
+            integration = "jenkins",
+            category = "builds"
+    )
+    public Map<String, Object> triggerJobAndWait(
+            @MCPParam(name = "jobPath", description = "Jenkins job path, e.g. folder/job-name", required = true)
+            String jobPath,
+            @MCPParam(name = "parametersJson", description = "JSON object of parameter names to values, e.g. {\"BRANCH\":\"main\"}", required = false)
+            String parametersJson,
+            @MCPParam(name = "pollIntervalSeconds", description = "Seconds to wait between status checks. Default: 10", required = false)
+            Integer pollIntervalSeconds,
+            @MCPParam(name = "timeoutSeconds", description = "Maximum seconds to wait before giving up. Default: 600 (10 minutes)", required = false)
+            Integer timeoutSeconds) throws IOException {
+        Map<String, Object> result = new HashMap<>();
+        int interval = (pollIntervalSeconds != null && pollIntervalSeconds >= 0) ? pollIntervalSeconds : 10;
+        int timeout = (timeoutSeconds != null && timeoutSeconds > 0) ? timeoutSeconds : 600;
+        long deadline = System.currentTimeMillis() + (timeout * 1000L);
+
+        Map<String, Object> triggerResult = triggerJob(jobPath, parametersJson);
+        if (!Boolean.TRUE.equals(triggerResult.get("success"))) {
+            result.put("success", false);
+            result.put("message", triggerResult.containsKey("message") ? triggerResult.get("message") : "Failed to trigger Jenkins job");
+            return result;
+        }
+
+        String queueUrl = (String) triggerResult.get("queueUrl");
+        Integer buildNumber = null;
+
+        if (queueUrl != null && !queueUrl.trim().isEmpty()) {
+            while (System.currentTimeMillis() < deadline) {
+                Map<String, Object> queueItem = getQueueItem(queueUrl);
+                if (Boolean.TRUE.equals(queueItem.get("cancelled"))) {
+                    result.put("success", false);
+                    result.put("message", "Jenkins queue item was cancelled before it started building");
+                    result.put("queueUrl", queueUrl);
+                    return result;
+                }
+                Object bn = queueItem.get("buildNumber");
+                if (bn instanceof Integer && (Integer) bn > 0) {
+                    buildNumber = (Integer) bn;
+                    break;
+                }
+                sleepSeconds(interval);
+            }
+            if (buildNumber == null) {
+                result.put("success", false);
+                result.put("message", "Timed out waiting for Jenkins to start the queued build");
+                result.put("queueUrl", queueUrl);
+                return result;
+            }
+        } else {
+            // No queueUrl (e.g. an older Jenkins/proxy that doesn't surface the Location
+            // header) — fall back to diffing the latest build number before/after triggering.
+            // Best-effort: can race with a concurrent trigger of the same job by someone else.
+            logger.warn("jenkins_trigger_job_and_wait: no queueUrl returned for {} — falling back to build-number polling (racy under concurrent use)", jobPath);
+            List<JenkinsBuild> before = listBuilds(jobPath, 1);
+            int beforeNumber = before.isEmpty() ? 0 : before.get(0).getNumber();
+            while (System.currentTimeMillis() < deadline && buildNumber == null) {
+                sleepSeconds(interval);
+                List<JenkinsBuild> builds = listBuilds(jobPath, 1);
+                if (!builds.isEmpty() && builds.get(0).getNumber() > beforeNumber) {
+                    buildNumber = builds.get(0).getNumber();
+                }
+            }
+            if (buildNumber == null) {
+                result.put("success", false);
+                result.put("message", "Timed out waiting for a new build to appear");
+                return result;
+            }
+        }
+
+        while (System.currentTimeMillis() < deadline) {
+            JSONObject buildInfo = fetchBuildInfoJson(jobPath, buildNumber);
+            if (!buildInfo.optBoolean("building", false)) {
+                String buildResult = buildInfo.optString("result", null);
+                result.put("success", "SUCCESS".equals(buildResult));
+                result.put("buildNumber", buildNumber);
+                result.put("result", buildResult);
+                result.put("buildUrl", buildInfo.optString("url", null));
+                result.put("timedOut", false);
+                return result;
+            }
+            sleepSeconds(interval);
+        }
+
+        result.put("success", false);
+        result.put("message", "Timed out waiting for build #" + buildNumber + " to finish");
+        result.put("buildNumber", buildNumber);
+        result.put("timedOut", true);
+        return result;
+    }
+
+    private static void sleepSeconds(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/jenkins/JenkinsClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/jenkins/JenkinsClientTest.java
@@ -5,6 +5,10 @@ package com.github.istin.dmtools.jenkins;
 
 import com.github.istin.dmtools.common.networking.GenericRequest;
 import com.github.istin.dmtools.jenkins.model.JenkinsBuild;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +49,21 @@ class JenkinsClientTest {
     }
 
     private StubJenkins jenkins;
+
+    /** Builds a real (non-mocked) okhttp3.Response so triggerJob()'s header reading works as-is. */
+    private static Response fakeResponse(int code, String locationHeader) {
+        Request request = new Request.Builder().url("http://localhost:8080/job/folder/job/job-name/build").build();
+        Response.Builder builder = new Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(code)
+                .message(code < 300 ? "OK" : "Found")
+                .body(ResponseBody.create(new byte[0], null));
+        if (locationHeader != null) {
+            builder.header("Location", locationHeader);
+        }
+        return builder.build();
+    }
 
     @BeforeEach
     void setUp() throws IOException {
@@ -141,27 +160,120 @@ class JenkinsClientTest {
 
     @Test
     void jenkins_trigger_job_withParameters_usesBuildWithParametersAndQueryParams() throws IOException {
-        doReturn("").when(jenkins).post(any(GenericRequest.class));
+        doReturn(fakeResponse(201, "http://localhost:8080/queue/item/42/")).when(jenkins).executeRawRequest(any(Request.class));
 
         Map<String, Object> result = jenkins.triggerJob(JOB_PATH, "{\"BRANCH\":\"main\",\"ENV\":\"prod\"}");
 
         assertTrue((Boolean) result.get("success"));
-        verify(jenkins).post(argThat((GenericRequest req) ->
-                req.url().contains("/job/folder/job/job-name/buildWithParameters") &&
-                req.url().contains("BRANCH=main") &&
-                req.url().contains("ENV=prod")));
+        assertEquals("http://localhost:8080/queue/item/42/", result.get("queueUrl"));
+        verify(jenkins).executeRawRequest(argThat((Request req) ->
+                req.url().toString().contains("/job/folder/job/job-name/buildWithParameters") &&
+                req.url().toString().contains("BRANCH=main") &&
+                req.url().toString().contains("ENV=prod")));
     }
 
     @Test
     void jenkins_trigger_job_withoutParameters_usesBuild() throws IOException {
-        doReturn("").when(jenkins).post(any(GenericRequest.class));
+        doReturn(fakeResponse(201, "http://localhost:8080/queue/item/7/")).when(jenkins).executeRawRequest(any(Request.class));
 
         Map<String, Object> result = jenkins.triggerJob(JOB_PATH, null);
 
         assertTrue((Boolean) result.get("success"));
-        verify(jenkins).post(argThat((GenericRequest req) ->
-                req.url().contains("/job/folder/job/job-name/build") &&
-                !req.url().contains("buildWithParameters")));
+        assertEquals("http://localhost:8080/queue/item/7/", result.get("queueUrl"));
+        verify(jenkins).executeRawRequest(argThat((Request req) ->
+                req.url().toString().contains("/job/folder/job/job-name/build") &&
+                !req.url().toString().contains("buildWithParameters")));
+    }
+
+    @Test
+    void jenkins_trigger_job_returnsFailure_onNon2xxResponse() throws IOException {
+        doReturn(fakeResponse(404, null)).when(jenkins).executeRawRequest(any(Request.class));
+
+        Map<String, Object> result = jenkins.triggerJob(JOB_PATH, null);
+
+        assertFalse((Boolean) result.get("success"));
+        assertTrue(((String) result.get("message")).contains("404"));
+    }
+
+    @Test
+    void jenkins_get_queue_item_returnsBuildNumber_onceExecuting() throws IOException {
+        JSONObject queueJson = new JSONObject()
+                .put("cancelled", false)
+                .put("blocked", false)
+                .put("executable", new JSONObject().put("number", 99).put("url", "http://localhost:8080/job/folder/job/job-name/99/"));
+        doReturn(queueJson.toString()).when(jenkins).execute(any(GenericRequest.class));
+
+        Map<String, Object> result = jenkins.getQueueItem("http://localhost:8080/queue/item/42/");
+
+        assertTrue((Boolean) result.get("success"));
+        assertEquals(99, result.get("buildNumber"));
+        assertEquals("http://localhost:8080/job/folder/job/job-name/99/", result.get("buildUrl"));
+        assertEquals(false, result.get("cancelled"));
+        verify(jenkins).execute(argThat((GenericRequest req) ->
+                req.url().equals("http://localhost:8080/queue/item/42/api/json")));
+    }
+
+    @Test
+    void jenkins_get_queue_item_reportsCancelled() throws IOException {
+        JSONObject queueJson = new JSONObject().put("cancelled", true);
+        doReturn(queueJson.toString()).when(jenkins).execute(any(GenericRequest.class));
+
+        Map<String, Object> result = jenkins.getQueueItem("http://localhost:8080/queue/item/42");
+
+        assertTrue((Boolean) result.get("success"));
+        assertEquals(true, result.get("cancelled"));
+        assertNull(result.get("buildNumber"));
+    }
+
+    @Test
+    void jenkins_get_queue_item_requiresQueueUrl() throws IOException {
+        Map<String, Object> result = jenkins.getQueueItem("");
+
+        assertFalse((Boolean) result.get("success"));
+        verify(jenkins, never()).execute(any(GenericRequest.class));
+    }
+
+    @Test
+    void jenkins_trigger_job_and_wait_resolvesQueueThenPollsUntilFinished() throws IOException {
+        doReturn(fakeResponse(201, "http://localhost:8080/queue/item/1/")).when(jenkins).executeRawRequest(any(Request.class));
+
+        JSONObject queuedNotYetBuilding = new JSONObject().put("cancelled", false);
+        JSONObject queuedNowBuilding = new JSONObject()
+                .put("cancelled", false)
+                .put("executable", new JSONObject().put("number", 5).put("url", "http://localhost:8080/job/folder/job/job-name/5/"));
+        JSONObject buildStillRunning = new JSONObject().put("building", true);
+        JSONObject buildFinished = new JSONObject().put("building", false).put("result", "SUCCESS").put("url", "http://localhost:8080/job/folder/job/job-name/5/");
+
+        doReturn(queuedNotYetBuilding.toString(), queuedNowBuilding.toString(), buildStillRunning.toString(), buildFinished.toString())
+                .when(jenkins).execute(any(GenericRequest.class));
+
+        Map<String, Object> result = jenkins.triggerJobAndWait(JOB_PATH, null, 0, 5);
+
+        assertTrue((Boolean) result.get("success"));
+        assertEquals(5, result.get("buildNumber"));
+        assertEquals("SUCCESS", result.get("result"));
+        assertEquals(false, result.get("timedOut"));
+    }
+
+    @Test
+    void jenkins_trigger_job_and_wait_failsWhenQueueItemCancelled() throws IOException {
+        doReturn(fakeResponse(201, "http://localhost:8080/queue/item/1/")).when(jenkins).executeRawRequest(any(Request.class));
+        doReturn(new JSONObject().put("cancelled", true).toString()).when(jenkins).execute(any(GenericRequest.class));
+
+        Map<String, Object> result = jenkins.triggerJobAndWait(JOB_PATH, null, 0, 5);
+
+        assertFalse((Boolean) result.get("success"));
+        assertTrue(((String) result.get("message")).toLowerCase().contains("cancelled"));
+    }
+
+    @Test
+    void jenkins_trigger_job_and_wait_failsWhenTriggerItselfFails() throws IOException {
+        doReturn(fakeResponse(500, null)).when(jenkins).executeRawRequest(any(Request.class));
+
+        Map<String, Object> result = jenkins.triggerJobAndWait(JOB_PATH, null, 0, 5);
+
+        assertFalse((Boolean) result.get("success"));
+        verify(jenkins, never()).execute(any(GenericRequest.class));
     }
 
     @Test


### PR DESCRIPTION
`jenkins_trigger_job`'s `queueUrl` was effectively always empty: Jenkins' `build`/`buildWithParameters` endpoints return an empty body and put the actual queue item location in the `Location` response header, but `post(GenericRequest)` only ever returns the response body. `triggerJob()` now makes the raw HTTP call itself (via a new overridable `executeRawRequest()` seam, so it stays unit-testable) and reads the `Location` header directly.

Two new generic, provider-agnostic tools build on top of that fix:

- **`jenkins_get_queue_item(queueUrl)`** — resolves a queue item to its build number once Jenkins starts executing it (or reports `cancelled`/`blocked`).
- **`jenkins_trigger_job_and_wait(jobPath, parametersJson, pollIntervalSeconds, timeoutSeconds)`** — triggers a job and blocks until the resulting build finishes, internally resolving the queue item to a build number (falling back to before/after build-number diffing if a Jenkins/proxy setup doesn't surface the `Location` header) and polling until the build stops `building`.

**Why**: some CI/CD-orchestration jobs (e.g. a Jenkins job that creates a branch via privileged credentials that bypass a repo's branch-protection ruleset) are a hard prerequisite for a caller's next step — the caller can't usefully continue until the job actually finishes and its result is known. Today that requires hand-rolling a queue/build polling loop from `jenkins_trigger_job` + `jenkins_list_builds` + `jenkins_get_job_info`, which is also racy under concurrent use of the same job by other humans/systems (no reliable way to identify *which* build is "mine"). `jenkins_trigger_job_and_wait` gives callers a single synchronous call instead.

**Testing**: added 7 unit tests (2 rewritten to match the header-capturing implementation, 5 new) covering the fixed `queueUrl` capture, `jenkins_get_queue_item`'s success/cancelled/missing-input paths, and `jenkins_trigger_job_and_wait`'s happy path, cancelled-queue-item failure, and trigger-failure short-circuit. All 19 tests in `JenkinsClientTest` pass, plus the broader `jenkins`/`mcp` test suites (no regressions). `:dmtools-core:compileJava` confirms the annotation processor picks up both new tools (328 total, was 326).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>