### PR TITLE
test(docs): ensure every @MCPTool is documented

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/bitbucket-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/bitbucket-tools.md
@@ -1,0 +1,9 @@
+# Bitbucket MCP Tools
+
+**Total Tools**: 1
+
+## Available Tools
+
+| Tool Name | Description | Category |
+|-----------|-------------|----------|
+| `bitbucket_test` | Test Bitbucket connectivity by fetching the current user's profile. | system |

--- a/dmtools-ai-docs/references/mcp-tools/bitrise-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/bitrise-tools.md
@@ -1,11 +1,12 @@
 # Bitrise MCP Tools
 
-**Total Tools**: 23
+**Total Tools**: 24
 
 ## Available Tools
 
 | Tool Name | Description | Category |
 |-----------|-------------|----------|
+| `bitrise_test` | Test Bitrise connectivity by fetching the current user's profile. | system |
 | `bitrise_list_apps` | List all Bitrise apps accessible with the current token. Returns app slugs, titles, project types and repo URLs. | apps |
 | `bitrise_get_app` | Get details of a specific Bitrise app by its slug. | apps |
 | `bitrise_list_builds` | List builds for a Bitrise app. Optionally filter by workflow, branch or status. Status codes: not_started, in_progress, success, failed, aborted. | builds |

--- a/dmtools-ai-docs/references/mcp-tools/rally-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/rally-tools.md
@@ -1,0 +1,9 @@
+# Rally MCP Tools
+
+**Total Tools**: 1
+
+## Available Tools
+
+| Tool Name | Description | Category |
+|-----------|-------------|----------|
+| `rally_test` | Test Rally connectivity by fetching the current user's profile. | system |

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/mcp/McpToolsDocumentationTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/mcp/McpToolsDocumentationTest.java
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.mcp;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Ensures every MCP tool declared via {@code @MCPTool} has a corresponding entry in the
+ * end-user documentation under {@code dmtools-ai-docs/references/mcp-tools}.
+ */
+class McpToolsDocumentationTest {
+
+    private static final Pattern TOOL_NAME_PATTERN =
+            Pattern.compile("@MCPTool\\s*\\(\\s*name\\s*=\\s*\"([^\"]+)\"");
+
+    private static final Pattern WORD_BOUNDARY = Pattern.compile("\\b");
+
+    @Test
+    void everyMcpToolIsDocumented() throws IOException {
+        Path moduleRoot = Paths.get("").toAbsolutePath();
+        Path sourceRoot = moduleRoot.resolve("src/main/java");
+        Path docsRoot = moduleRoot.getParent().resolve("dmtools-ai-docs/references/mcp-tools");
+
+        if (!Files.exists(sourceRoot)) {
+            fail("Source root not found: " + sourceRoot);
+        }
+        if (!Files.exists(docsRoot)) {
+            fail("Documentation root not found: " + docsRoot);
+        }
+
+        Set<String> toolNames = collectToolNames(sourceRoot);
+        assertTrue(!toolNames.isEmpty(), "No @MCPTool annotated methods found; check source scanning logic.");
+
+        String allDocs = concatenateDocs(docsRoot);
+
+        Set<String> undocumented = toolNames.stream()
+                .filter(name -> !isDocumented(allDocs, name))
+                .collect(Collectors.toSet());
+
+        if (!undocumented.isEmpty()) {
+            List<String> sorted = undocumented.stream().sorted().toList();
+            fail("Missing documentation for MCP tools: " + String.join(", ", sorted)
+                    + ". Please add them to dmtools-ai-docs/references/mcp-tools/*.md");
+        }
+    }
+
+    private Set<String> collectToolNames(Path sourceRoot) throws IOException {
+        Set<String> names = new HashSet<>();
+        try (Stream<Path> walk = Files.walk(sourceRoot)) {
+            List<Path> javaFiles = walk
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .toList();
+            for (Path file : javaFiles) {
+                String content = Files.readString(file, StandardCharsets.UTF_8);
+                Matcher matcher = TOOL_NAME_PATTERN.matcher(content);
+                while (matcher.find()) {
+                    names.add(matcher.group(1));
+                }
+            }
+        }
+        return names;
+    }
+
+    private String concatenateDocs(Path docsRoot) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (Stream<Path> walk = Files.walk(docsRoot)) {
+            List<Path> mdFiles = walk
+                    .filter(p -> p.toString().endsWith(".md"))
+                    .toList();
+            for (Path file : mdFiles) {
+                sb.append(Files.readString(file, StandardCharsets.UTF_8)).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    private boolean isDocumented(String docs, String toolName) {
+        return docs.contains("`" + toolName + "`")
+                || docs.contains(toolName);
+    }
+}


### PR DESCRIPTION
Adds a unit test that scans all @MCPTool annotated methods in dmtools-core and fails if any tool name is missing from dmtools-ai-docs/references/mcp-tools documentation. Also documents the previously missing bitbucket_test, bitrise_test, and rally_test tools.