### PR TITLE
fix(confluence): preserve real parent + title when syncMarkdownDirectory updates an existing root page

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageOperations.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageOperations.java
@@ -40,4 +40,9 @@ public class ConfluencePageOperations implements MarkdownConfluenceSync.PageOper
     public String deletePage(String contentId) throws IOException {
         return confluence.deletePage(contentId);
     }
+
+    @Override
+    public Content getContent(String contentId) throws IOException {
+        return confluence.contentById(contentId, null);
+    }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
@@ -55,6 +55,13 @@ public class MarkdownConfluenceSync {
         Content updatePage(String contentId, String title, String parentId, String body, String space, String historyComment) throws IOException;
         List<Content> getChildren(String contentId) throws IOException;
         String deletePage(String contentId) throws IOException;
+        /**
+         * Fetches a page's current metadata, including its ancestors — used only to look up
+         * the ROOT target page's existing real parent before updating it (see
+         * {@link #syncDirectory}). Not needed for any other node in the tree, since every
+         * other node's parentId is set explicitly as it is created during the sync walk.
+         */
+        Content getContent(String contentId) throws IOException;
     }
 
     public MarkdownConfluenceSync(ConfluenceAttachmentHelper attachmentHelper, PageOperations pageOps) {
@@ -72,6 +79,18 @@ public class MarkdownConfluenceSync {
         Set<String> expectedTitles = new HashSet<>(pathToTitle.values());
 
         root.contentId = parentId;
+        // The root node's own page (parentId) is an EXISTING page being updated in place
+        // (its body becomes rootDir's index.md) — unlike every other node in the tree,
+        // it was never "created" during this sync walk, so nothing ever set its
+        // parentId. Without this lookup, syncDirNode's fallback (node.parentId != null
+        // ? node.parentId : node.contentId) would pass the page's OWN id as its ancestor
+        // on update, which Confluence rejects with "Can not set page as its own parent."
+        // Fetch its actual current parent so the update preserves it unchanged.
+        try {
+            root.parentId = pageOps.getContent(parentId).getParentId();
+        } catch (IOException e) {
+            logger.warn("syncDirectory: failed to look up existing parent of root page {} — proceeding without it: {}", parentId, e.getMessage());
+        }
         syncDirNode(root, rootDir, pathToTitle, space, attachmentsDir);
 
         List<String> deleted = new ArrayList<>();

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
@@ -81,15 +81,33 @@ public class MarkdownConfluenceSync {
         root.contentId = parentId;
         // The root node's own page (parentId) is an EXISTING page being updated in place
         // (its body becomes rootDir's index.md) — unlike every other node in the tree,
-        // it was never "created" during this sync walk, so nothing ever set its
-        // parentId. Without this lookup, syncDirNode's fallback (node.parentId != null
-        // ? node.parentId : node.contentId) would pass the page's OWN id as its ancestor
-        // on update, which Confluence rejects with "Can not set page as its own parent."
-        // Fetch its actual current parent so the update preserves it unchanged.
+        // it was never "created" during this sync walk, so nothing ever set its title
+        // or parentId; buildDirTree defaults every node's title to its directory's
+        // basename, which is correct for a brand-new page representing a subdirectory,
+        // but WRONG for the root: it would silently rename the caller's existing target
+        // page (e.g. "TICKET-123 Summary") to the local root folder's basename (e.g.
+        // "discovery") on every single sync — and since Confluence enforces per-space
+        // title uniqueness, that rename can even fail outright with "A page with this
+        // title already exists" if some unrelated page in the space happens to already
+        // have that literal folder name as its title.
+        //
+        // Similarly, its parentId fallback (node.parentId != null ? node.parentId :
+        // node.contentId) would pass the page's OWN id as its ancestor on update, which
+        // Confluence rejects with "Can not set page as its own parent."
+        //
+        // Fetch the root page's actual current title + parent ONCE so the update
+        // preserves both unchanged, instead of falling back to a directory-name pseudo
+        // creation. Non-fatal if this lookup fails — falls back to the old behavior
+        // (self-parent, directory-name title) rather than aborting the whole sync.
         try {
-            root.parentId = pageOps.getContent(parentId).getParentId();
+            Content existingRoot = pageOps.getContent(parentId);
+            root.parentId = existingRoot.getParentId();
+            String existingTitle = existingRoot.getTitle();
+            if (existingTitle != null && !existingTitle.isEmpty()) {
+                root.title = existingTitle;
+            }
         } catch (IOException e) {
-            logger.warn("syncDirectory: failed to look up existing parent of root page {} — proceeding without it: {}", parentId, e.getMessage());
+            logger.warn("syncDirectory: failed to look up existing title/parent of root page {} — proceeding without them: {}", parentId, e.getMessage());
         }
         syncDirNode(root, rootDir, pathToTitle, space, attachmentsDir);
 
@@ -406,7 +424,7 @@ public class MarkdownConfluenceSync {
 
     private static final class DirNode {
         final File dir;
-        final String title;
+        String title;
         File indexFile;
         final List<FileNode> files = new ArrayList<>();
         final List<DirNode> subdirs = new ArrayList<>();

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.github.istin.dmtools.atlassian.confluence.model.Attachment;
+import com.github.istin.dmtools.atlassian.confluence.model.Content;
+import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Regression coverage for {@link MarkdownConfluenceSync#syncDirectory}, in particular the
+ * root-node "own parent" bug: updating an existing target root page must preserve its real
+ * current ancestor instead of falling back to the page's own ID.
+ */
+public class MarkdownConfluenceSyncTest {
+
+    /**
+     * Minimal in-memory fake of {@link MarkdownConfluenceSync.PageOperations} that records
+     * every updatePage/createPage call and lets a test pre-seed an existing page's ancestor.
+     */
+    private static class FakePageOperations implements MarkdownConfluenceSync.PageOperations {
+        final Map<String, String> parentsById = new HashMap<>();
+        final List<String[]> updateCalls = new ArrayList<>(); // {contentId, parentId, body}
+        int nextId = 1000;
+
+        @Override
+        public Content createPage(String title, String parentId, String body, String space) {
+            String id = String.valueOf(nextId++);
+            parentsById.put(id, parentId);
+            return contentFor(id, title, parentId);
+        }
+
+        @Override
+        public Content updatePage(String contentId, String title, String parentId, String body, String space, String historyComment) {
+            updateCalls.add(new String[]{contentId, parentId, body});
+            parentsById.put(contentId, parentId);
+            return contentFor(contentId, title, parentId);
+        }
+
+        @Override
+        public List<Content> getChildren(String contentId) {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public String deletePage(String contentId) {
+            return "deleted";
+        }
+
+        @Override
+        public Content getContent(String contentId) throws IOException {
+            String parentId = parentsById.get(contentId);
+            return contentFor(contentId, "existing", parentId);
+        }
+
+        private Content contentFor(String id, String title, String parentId) {
+            JSONObject json = new JSONObject();
+            json.put("id", id);
+            json.put("title", title);
+            if (parentId != null) {
+                JSONObject ancestor = new JSONObject().put("id", parentId);
+                json.put("ancestors", new org.json.JSONArray().put(ancestor));
+            }
+            return new Content(json);
+        }
+    }
+
+    private static class NoopAttachmentHelper extends ConfluenceAttachmentHelper {
+        NoopAttachmentHelper() {
+            super(contentId -> new ArrayList<Attachment>(), (contentId, file, updateIfExists) -> null);
+        }
+    }
+
+    @Test
+    public void syncDirectory_updatesRootPage_preservingItsRealExistingParent() throws IOException {
+        File tempDir = File.createTempFile("md-sync-test", "");
+        tempDir.delete();
+        tempDir.mkdirs();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            // The root page ("555") already exists in Confluence under a real grandparent
+            // ("999") — e.g. our discovery agent's ticket page nested under a project's
+            // "Discovery" parent page. Before the fix, syncDirectory never looked this up,
+            // so the update call below would have sent parentId="555" (itself).
+            pageOps.parentsById.put("555", "999");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertEquals("exactly one updatePage call for the root page", 1, pageOps.updateCalls.size());
+            String[] call = pageOps.updateCalls.get(0);
+            assertEquals("555", call[0]);
+            assertEquals("update must preserve the real existing parent (999), not self-reference (555)",
+                    "999", call[1]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_rootPageWithNoExistingParent_fallsBackGracefully() throws IOException {
+        File tempDir = File.createTempFile("md-sync-test", "");
+        tempDir.delete();
+        tempDir.mkdirs();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            // Root page "555" has no known ancestor (e.g. a Confluence space's homepage) —
+            // getParentId() legitimately returns null here; the sync must still complete
+            // without throwing, falling back to the pre-fix self-reference behavior.
+            pageOps.parentsById.put("555", null);
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertEquals(1, pageOps.updateCalls.size());
+            assertEquals("555", pageOps.updateCalls.get(0)[0]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_parentLookupFailure_isNonFatal() throws IOException {
+        File tempDir = File.createTempFile("md-sync-test", "");
+        tempDir.delete();
+        tempDir.mkdirs();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations() {
+                @Override
+                public Content getContent(String contentId) throws IOException {
+                    throw new IOException("Confluence unavailable");
+                }
+            };
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            // Must not throw — a failed parent lookup should not abort the whole sync.
+            String summary = sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertNotNull(summary);
+            assertEquals(1, pageOps.updateCalls.size());
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_childFile_becomesChildPageOfRoot() throws IOException {
+        File tempDir = File.createTempFile("md-sync-test", "");
+        tempDir.delete();
+        tempDir.mkdirs();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+            FileUtils.write(new File(tempDir, "prd.md"), "# PRD\ncontent", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.parentsById.put("555", "999");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            // 1 update for the root page body + 1 createPage + 1 updatePage for prd.md's
+            // placeholder-then-real-content flow.
+            assertEquals(2, pageOps.updateCalls.size());
+            String[] rootUpdate = pageOps.updateCalls.get(0);
+            assertEquals("555", rootUpdate[0]);
+            assertEquals("999", rootUpdate[1]);
+
+            String[] childUpdate = pageOps.updateCalls.get(1);
+            assertEquals("child page's parent must be the root page (555), not the grandparent",
+                    "555", childUpdate[1]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
@@ -18,35 +18,42 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
- * Regression coverage for {@link MarkdownConfluenceSync#syncDirectory}, in particular the
- * root-node "own parent" bug: updating an existing target root page must preserve its real
- * current ancestor instead of falling back to the page's own ID.
+ * Regression coverage for {@link MarkdownConfluenceSync#syncDirectory}, in particular two
+ * root-node bugs found while updating an already-existing target page across repeated syncs:
+ * (1) the update sent the page's own ID as its ancestor ("Can not set page as its own
+ * parent"), and (2) the update silently renamed the page to the local root directory's
+ * basename instead of preserving its real title (which can even fail outright with
+ * "A page with this title already exists" if some unrelated page in the space happens to
+ * share that literal folder name).
  */
 public class MarkdownConfluenceSyncTest {
 
     /**
      * Minimal in-memory fake of {@link MarkdownConfluenceSync.PageOperations} that records
-     * every updatePage/createPage call and lets a test pre-seed an existing page's ancestor.
+     * every updatePage/createPage call and lets a test pre-seed an existing page's title
+     * and ancestor.
      */
     private static class FakePageOperations implements MarkdownConfluenceSync.PageOperations {
         final Map<String, String> parentsById = new HashMap<>();
-        final List<String[]> updateCalls = new ArrayList<>(); // {contentId, parentId, body}
+        final Map<String, String> titlesById = new HashMap<>();
+        final List<String[]> updateCalls = new ArrayList<>(); // {contentId, title, parentId, body}
         int nextId = 1000;
 
         @Override
         public Content createPage(String title, String parentId, String body, String space) {
             String id = String.valueOf(nextId++);
             parentsById.put(id, parentId);
+            titlesById.put(id, title);
             return contentFor(id, title, parentId);
         }
 
         @Override
         public Content updatePage(String contentId, String title, String parentId, String body, String space, String historyComment) {
-            updateCalls.add(new String[]{contentId, parentId, body});
+            updateCalls.add(new String[]{contentId, title, parentId, body});
             parentsById.put(contentId, parentId);
+            titlesById.put(contentId, title);
             return contentFor(contentId, title, parentId);
         }
 
@@ -63,7 +70,8 @@ public class MarkdownConfluenceSyncTest {
         @Override
         public Content getContent(String contentId) throws IOException {
             String parentId = parentsById.get(contentId);
-            return contentFor(contentId, "existing", parentId);
+            String title = titlesById.containsKey(contentId) ? titlesById.get(contentId) : "existing";
+            return contentFor(contentId, title, parentId);
         }
 
         private Content contentFor(String id, String title, String parentId) {
@@ -84,11 +92,16 @@ public class MarkdownConfluenceSyncTest {
         }
     }
 
-    @Test
-    public void syncDirectory_updatesRootPage_preservingItsRealExistingParent() throws IOException {
+    private File newTempDir() throws IOException {
         File tempDir = File.createTempFile("md-sync-test", "");
         tempDir.delete();
         tempDir.mkdirs();
+        return tempDir;
+    }
+
+    @Test
+    public void syncDirectory_updatesRootPage_preservingItsRealExistingParent() throws IOException {
+        File tempDir = newTempDir();
         try {
             FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
 
@@ -98,6 +111,7 @@ public class MarkdownConfluenceSyncTest {
             // "Discovery" parent page. Before the fix, syncDirectory never looked this up,
             // so the update call below would have sent parentId="555" (itself).
             pageOps.parentsById.put("555", "999");
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
 
             MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
             sync.syncDirectory(tempDir, "555", "SPACE", false, null);
@@ -106,17 +120,39 @@ public class MarkdownConfluenceSyncTest {
             String[] call = pageOps.updateCalls.get(0);
             assertEquals("555", call[0]);
             assertEquals("update must preserve the real existing parent (999), not self-reference (555)",
-                    "999", call[1]);
+                    "999", call[2]);
         } finally {
             FileUtils.deleteDirectory(tempDir);
         }
     }
 
     @Test
-    public void syncDirectory_rootPageWithNoExistingParent_fallsBackGracefully() throws IOException {
-        File tempDir = File.createTempFile("md-sync-test", "");
-        tempDir.delete();
-        tempDir.mkdirs();
+    public void syncDirectory_updatesRootPage_preservingItsRealExistingTitle() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            // tempDir's basename (e.g. "md-sync-test1234567890") is NOT the desired page
+            // title — the root page's REAL existing title ("TICKET-123 Some feature") must
+            // be preserved, not overwritten with the local directory's basename.
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.parentsById.put("555", "999");
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            String[] call = pageOps.updateCalls.get(0);
+            assertEquals("update must preserve the real existing title, not the local directory's basename",
+                    "TICKET-123 Some feature", call[1]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_rootPageWithNoExistingParentOrTitle_fallsBackGracefully() throws IOException {
+        File tempDir = newTempDir();
         try {
             FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
 
@@ -125,12 +161,16 @@ public class MarkdownConfluenceSyncTest {
             // getParentId() legitimately returns null here; the sync must still complete
             // without throwing, falling back to the pre-fix self-reference behavior.
             pageOps.parentsById.put("555", null);
+            pageOps.titlesById.put("555", "");
 
             MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
             sync.syncDirectory(tempDir, "555", "SPACE", false, null);
 
             assertEquals(1, pageOps.updateCalls.size());
             assertEquals("555", pageOps.updateCalls.get(0)[0]);
+            // Empty existing title falls back to the directory-basename default (pre-fix
+            // behavior) rather than sending an empty title.
+            assertEquals(tempDir.getName(), pageOps.updateCalls.get(0)[1]);
         } finally {
             FileUtils.deleteDirectory(tempDir);
         }
@@ -138,9 +178,7 @@ public class MarkdownConfluenceSyncTest {
 
     @Test
     public void syncDirectory_parentLookupFailure_isNonFatal() throws IOException {
-        File tempDir = File.createTempFile("md-sync-test", "");
-        tempDir.delete();
-        tempDir.mkdirs();
+        File tempDir = newTempDir();
         try {
             FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
 
@@ -152,7 +190,7 @@ public class MarkdownConfluenceSyncTest {
             };
 
             MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
-            // Must not throw — a failed parent lookup should not abort the whole sync.
+            // Must not throw — a failed parent/title lookup should not abort the whole sync.
             String summary = sync.syncDirectory(tempDir, "555", "SPACE", false, null);
 
             assertNotNull(summary);
@@ -164,15 +202,14 @@ public class MarkdownConfluenceSyncTest {
 
     @Test
     public void syncDirectory_childFile_becomesChildPageOfRoot() throws IOException {
-        File tempDir = File.createTempFile("md-sync-test", "");
-        tempDir.delete();
-        tempDir.mkdirs();
+        File tempDir = newTempDir();
         try {
             FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
             FileUtils.write(new File(tempDir, "prd.md"), "# PRD\ncontent", "UTF-8");
 
             FakePageOperations pageOps = new FakePageOperations();
             pageOps.parentsById.put("555", "999");
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
 
             MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
             sync.syncDirectory(tempDir, "555", "SPACE", false, null);
@@ -182,11 +219,12 @@ public class MarkdownConfluenceSyncTest {
             assertEquals(2, pageOps.updateCalls.size());
             String[] rootUpdate = pageOps.updateCalls.get(0);
             assertEquals("555", rootUpdate[0]);
-            assertEquals("999", rootUpdate[1]);
+            assertEquals("TICKET-123 Some feature", rootUpdate[1]);
+            assertEquals("999", rootUpdate[2]);
 
             String[] childUpdate = pageOps.updateCalls.get(1);
             assertEquals("child page's parent must be the root page (555), not the grandparent",
-                    "555", childUpdate[1]);
+                    "555", childUpdate[2]);
         } finally {
             FileUtils.deleteDirectory(tempDir);
         }


### PR DESCRIPTION
## Bugs

`confluence_sync_markdown_directory`'s root node (the directory's `index.md`,
mapped to the `parentId` content ID passed in) is an **existing page being
updated in place**. Two bugs surfaced testing this end-to-end against a real
Confluence Cloud space:

1. **"Can not set page as its own parent"** — `syncDirectory` never set
   `root.parentId`, so `syncDirNode`'s fallback
   (`node.parentId != null ? node.parentId : node.contentId`) sent the page's
   own ID as its ancestor on update. 400 Bad Request.

2. **"A page with this title already exists"** — `buildDirTree` sets every
   node's title (including root) to its directory's basename. For the root
   node that's wrong: it silently renamed the caller's already-correctly-
   titled target page (e.g. `"TICKET-123 Summary"`) to the local root
   folder's basename (e.g. `"discovery"`) on every sync. Confluence enforces
   per-space title uniqueness, so this can fail outright if any unrelated
   page in the space happens to share that literal folder name.

Both break the sync for **any** root page that isn't a brand-new,
never-before-created page — i.e. every realistic repeat/iteration use of
this tool, since the whole point is to keep updating the same page across
runs.

Found while building a new agent (`dmtools-agents` `discovery.json`) that
publishes a Markdown folder to a per-ticket Confluence page nested under a
fixed parent page — a second "publish again after a re-run" attempt against
a real site hit both errors back-to-back (fixing #1 immediately surfaced #2).

## Fix

- Added `PageOperations.getContent(contentId)` (implemented via the existing
  `confluence_content_by_id` call, which already expands `ancestors`).
- Before syncing, `syncDirectory` fetches the root page's actual current
  parent **and** title via this single call, and uses both — so the update
  preserves the real, unchanged ancestor and title instead of self-
  referencing / renaming to the folder's basename.
- Falls back gracefully (logs a warning, proceeds without them) if the lookup
  fails, the page has no parent (e.g. a space homepage), or has no title yet
  — matching the pre-fix behavior in those edge cases rather than aborting
  the whole sync.

## Tests

- `MarkdownConfluenceSyncTest.java` (this class had **zero** direct unit test
  coverage before) with an in-memory fake `PageOperations` covering:
  - preserving a real existing parent on update,
  - preserving a real existing title on update,
  - graceful fallback when the root page has no known parent/title,
  - resilience to a failed parent/title-lookup call (non-fatal),
  - a child-page-gets-root-as-parent sanity check.
- Re-ran the existing `ConfluenceTest` suite (Mockito-spy-based, exercises the
  MCP tool surface end-to-end) — all still pass; the new lookup call safely
  no-ops there via the same fallback path since `ancestors`/`title` aren't
  stubbed in those tests.

```
./gradlew :dmtools-core:test --tests "...MarkdownConfluenceSyncTest" --tests "...ConfluenceTest"
BUILD SUCCESSFUL
```
