### PR TITLE
docs(skill): expose CliAgent in SKILL.md and CHANGELOG

### DIFF
--- a/dmtools-ai-docs/CHANGELOG.md
+++ b/dmtools-ai-docs/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### Added
 
+- **New job: `CliAgent`** — lightweight CLI-agent orchestration that runs cursor-agent / claude / copilot-style tools without requiring an `inputJql` or tracker ticket. Supports setup/cache/reset hooks, `preCliJSAction`, `cliOutputLineJSAction`, `cliExecutionErrorJSAction`, `timerJSAction`, and smart input-context building from a ticket or JQL when integrations are available.
 - **Structured `cliPrompts` with named sections** — `cliPrompts` now supports a mixed array of plain strings and named section objects (`{"id": "...", "prompts": ["..."], "mergeStrategy": "append|prepend|replace"}`). This allows:
   - grouping related prompts (e.g., `input`, `output`, `template`) while preserving order
   - partial overrides when inheriting configs: sections with the same `id` are merged according to `mergeStrategy`, unnamed strings keep their position, and new items are appended to the end
   - full backward compatibility: plain string arrays are still accepted and treated as unnamed prompts
-- Updated `references/agents/teammate-configs.md` and `references/jobs/README.md` with structured `cliPrompts` documentation and inheritance examples
+- Updated `references/agents/teammate-configs.md`, `references/jobs/README.md`, and `SKILL.md` with `CliAgent` and structured `cliPrompts` documentation and inheritance examples
 
 ## [skill-v1.0.30] - 2026-07-04
 

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: dmtools
-description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 96+ MCP tools for Jira, Azure DevOps, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows, or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator jobs.
+description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 96+ MCP tools for Jira, Azure DevOps, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
 license: Apache-2.0
 compatibility:
   - Java 17+
   - macOS, Linux, Windows (WSL)
 metadata:
-  version: skill-v1.0.23
+  version: skill-v1.0.31
   author: DMtools Team
   repository: https://github.com/epam/dm.ai
   documentation: https://github.com/epam/dm.ai/tree/main/dmtools-ai-docs
@@ -147,7 +147,7 @@ Use this skill when:
 - Generating analytics reports (ReportGenerator, ReportVisualizer)
 - Troubleshooting DMtools issues
 - Working with dmtools.env configuration
-- Creating AI teammate configurations
+- Creating AI teammate configurations (Teammate/CliAgent)
 - Setting up CI/CD run tracing (`ciRunUrl`) for ticket traceability
 
 ## Quick Reference
@@ -252,8 +252,9 @@ function action(params) {
 | | [Azure DevOps](references/configuration/integrations/ado.md) | PAT setup and 23+ tools |
 | | [Gemini AI](references/configuration/ai-providers/gemini.md) | Free tier configuration (15 req/min) |
 | | [Other AI Providers](references/configuration/ai-providers/) | OpenAI, Claude, DIAL, Ollama |
-| **Jobs** | [Jobs Reference](references/jobs/README.md) | Complete guide to all 23 jobs |
+| **Jobs** | [Jobs Reference](references/jobs/README.md) | Complete guide to all 24 jobs |
 | | [Teammate](references/jobs/README.md#teammate) | Flexible AI assistant with custom instructions |
+| | [CliAgent](references/jobs/README.md#cliagent) | Lightweight CLI-agent orchestration without a tracker ticket |
 | | [Expert](references/jobs/README.md#expert) | Domain expert Q&A based on project context |
 | | [TestCasesGenerator](references/jobs/README.md#testcasesgenerator) | Automated test case generation |
 | | [InstructionsGenerator](references/jobs/README.md#instructionsgenerator) | Build reusable implementation instructions from tracker tickets |

--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dmtools
-description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 96+ MCP tools for Jira, Azure DevOps, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
+description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 328+ MCP tools for Jira, Azure DevOps, GitHub, GitLab, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
 license: Apache-2.0
 compatibility:
   - Java 17+
@@ -14,7 +14,7 @@ metadata:
 
 # DMtools Development Assistant
 
-DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 96+ MCP tools for reusable delivery automation.
+DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 328+ MCP tools for reusable delivery automation.
 
 ## 🔧 FIRST-TIME SETUP (DO THIS PROACTIVELY)
 
@@ -180,7 +180,7 @@ See [Installation Guide](references/installation/README.md#️-configuration-set
 
 ### Common Commands
 ```bash
-dmtools list                          # List all 96+ MCP tools
+dmtools list                          # List all 328+ MCP tools
 dmtools jira_get_ticket PROJ-123      # Get Jira ticket
 dmtools run agents/config.json        # Run configuration
 dmtools run agents/config.json --ciRunUrl "https://ci.example.com/runs/42"  # With CI tracing
@@ -189,27 +189,30 @@ dmtools run agents/config.json "${ENCODED_CONFIG}" --inputJql "key=PROJ-1"  # Wi
 
 ## Core Capabilities
 
-### 152+ MCP Tools Available
+### 328+ MCP Tools Available
 
 **Complete Reference**: [references/mcp-tools/README.md](references/mcp-tools/README.md) - Auto-generated from actual DMtools build
 
-Current breakdown (16 integrations):
-- **Jira** (52 tools): Ticket management, search, comments, Xray test management
-- **Teams** (30 tools): Messages, chats, files, transcripts, meetings
-- **Confluence** (17 tools): Page management, search, content access, attachments
-- **ADO** (31 tools): Azure DevOps work items, queries, comments, attachments, pull requests, code review threads
-- **Figma** (12 tools): Design extraction, icons, layers, styles, components
-- **AI Providers** (12 tools):
-  - Gemini (2): Chat, multimodal
-  - OpenAI (2): Chat, vision models with files
-  - Anthropic (2): Claude chat
-  - Bedrock (2): AWS Claude
-  - DIAL (2): Enterprise AI
-  - Ollama (2): Local models
+Current breakdown (20 integrations):
+- **Jira** (58 tools): Ticket management, search, comments, fields
+- **Jira Xray** (11 tools): Xray test management
+- **Teams** (28 tools): Messages, chats, files, transcripts, meetings
+- **Teams Auth** (3 tools): Teams authentication flows
+- **Confluence** (22 tools): Page management, search, content access, attachments
+- **ADO** (38 tools): Azure DevOps work items, queries, comments, attachments, pull requests, code review threads
+- **GitHub** (35 tools): Pull requests, issues, comments, workflows
+- **GitLab** (30 tools): Merge requests, issues, CI/CD pipelines
+- **Bitbucket** (1 tool): Pull request operations
+- **Figma** (22 tools): Design extraction, icons, layers, styles, components
+- **AI Providers** (15 tools): Chat, vision, and file inputs across Gemini, OpenAI, Anthropic, Bedrock, DIAL, Ollama, and Vertex
 - **Knowledge Base** (5 tools): Document search, indexing, RAG
 - **File** (4 tools): File operations, read/write
 - **Mermaid** (3 tools): Diagram generation
 - **SharePoint** (2 tools): Document management
+- **Bitrise** (24 tools): Mobile CI/CD builds and artifacts
+- **Jenkins** (7 tools): CI/CD job and build information
+- **TestRail** (16 tools): Test case and test run management
+- **Rally** (1 tool): Work item lookups
 - **CLI** (1 tool): Command execution
 
 **Example tools**:
@@ -248,11 +251,11 @@ function action(params) {
 | **Configuration** | [Configuration Overview](references/configuration/README.md) | Environment variables and hierarchy |
 | | [CLI Output Formats](references/configuration/cli-output-formats.md) | `json` / `toon` / `mini` — token savings up to 70% |
 | | [JSON Configuration Rules](references/configuration/json-config-rules.md) | **⚠️ CRITICAL**: Rules for job configurations |
-| | [Jira Setup](references/configuration/integrations/jira.md) | API tokens and 52 tools |
-| | [Azure DevOps](references/configuration/integrations/ado.md) | PAT setup and 23+ tools |
+| | [Jira Setup](references/configuration/integrations/jira.md) | API tokens and 58 tools |
+| | [Azure DevOps](references/configuration/integrations/ado.md) | PAT setup and 38+ tools |
 | | [Gemini AI](references/configuration/ai-providers/gemini.md) | Free tier configuration (15 req/min) |
 | | [Other AI Providers](references/configuration/ai-providers/) | OpenAI, Claude, DIAL, Ollama |
-| **Jobs** | [Jobs Reference](references/jobs/README.md) | Complete guide to all 24 jobs |
+| **Jobs** | [Jobs Reference](references/jobs/README.md) | Complete guide to all 23 jobs |
 | | [Teammate](references/jobs/README.md#teammate) | Flexible AI assistant with custom instructions |
 | | [CliAgent](references/jobs/README.md#cliagent) | Lightweight CLI-agent orchestration without a tracker ticket |
 | | [Expert](references/jobs/README.md#expert) | Domain expert Q&A based on project context |
@@ -266,11 +269,11 @@ function action(params) {
 | | [ReportVisualizer](references/jobs/README.md#reportvisualizer) | Render an existing report JSON as interactive HTML |
 | | [KBProcessingJob](references/jobs/README.md#kbprocessingjob) | Process source material into knowledge-base artifacts |
 | **Agents** | [Agent Best Practices](references/agents/best-practices.md) | **⚠️ CRITICAL**: Patterns and lessons learned |
-| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 152+ MCP tools |
+| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 328+ MCP tools |
 | | [Teammate Configs](references/agents/teammate-configs.md) | JSON-based AI workflows (CLI safety v1.7.133+) |
 | | [CLI Integration](references/agents/cli-integration.md) | Cursor, Claude, Copilot, Gemini CLI agents |
 | **Testing** | [Test Generation](references/test-generation/xray-manual.md) | Xray test case creation |
-| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 152+ tools (16 integrations) |
+| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 328+ tools (20 integrations) |
 | **CI/CD** | [GitHub Actions](references/workflows/github-actions-teammate.md) | Automated ticket processing + CI run tracing |
 
 ## ⚠️ CRITICAL: JSON Configuration "name" Field

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -1,6 +1,6 @@
 # DMtools Jobs Reference
 
-Complete reference for all 24 available jobs in DMtools. Jobs are specialized workflows that orchestrate MCP tools, AI agents, and data processing.
+Complete reference for all 23 available jobs in DMtools. Jobs are specialized workflows that orchestrate MCP tools, AI agents, and data processing.
 
 > **Deprecation notice:** `CodeGenerator` is no longer a supported development workflow. The CLI entry remains as a compatibility shim for one release, logs a deprecation warning, and performs no generation. Migrate to `Teammate`-driven development flows or other supported jobs before `v1.8.0`.
 

--- a/dmtools-ai-docs/references/jobs/README.md
+++ b/dmtools-ai-docs/references/jobs/README.md
@@ -1,6 +1,6 @@
 # DMtools Jobs Reference
 
-Complete reference for all 23 available jobs in DMtools. Jobs are specialized workflows that orchestrate MCP tools, AI agents, and data processing.
+Complete reference for all 24 available jobs in DMtools. Jobs are specialized workflows that orchestrate MCP tools, AI agents, and data processing.
 
 > **Deprecation notice:** `CodeGenerator` is no longer a supported development workflow. The CLI entry remains as a compatibility shim for one release, logs a deprecation warning, and performs no generation. Migrate to `Teammate`-driven development flows or other supported jobs before `v1.8.0`.
 
@@ -74,6 +74,7 @@ The `"name"` field is a **technical identifier** that maps to a Java class in DM
 
 ### AI Assistants
 - **[Teammate](#teammate)** - Flexible AI teammate with custom instructions
+- **[CliAgent](#cliagent)** - Lightweight CLI-agent orchestration without a tracker ticket
 - **[Expert](#expert)** - Domain expert for answering questions
 
 ### Utilities

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobRunner.java
@@ -134,6 +134,7 @@ public class JobRunner {
                             new com.github.istin.dmtools.reporting.ReportVisualizerJob(),
                             new Expert(),
                             new Teammate(),
+                            new CliAgent(),
                             new SourceCodeTrackerSyncJob(),
                             new SourceCodeCommitTrackerSyncJob(),
                             new UserStoryGenerator(),

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/docs/DocsCountsConsistencyTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/docs/DocsCountsConsistencyTest.java
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.docs;
+
+import com.github.istin.dmtools.job.Job;
+import com.github.istin.dmtools.job.JobRunner;
+import com.github.istin.dmtools.mcp.MCPToolDefinition;
+import com.github.istin.dmtools.mcp.generated.MCPToolRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Ensures hard-coded counts in the skill documentation match the actual code:
+ * job counts, MCP tool totals, integration counts and per-integration tool counts.
+ */
+class DocsCountsConsistencyTest {
+
+    private static final Path MODULE_ROOT = Paths.get("").toAbsolutePath();
+    private static final Path SKILL_MD = MODULE_ROOT.getParent().resolve("dmtools-ai-docs/SKILL.md");
+    private static final Path JOBS_README = MODULE_ROOT.getParent().resolve("dmtools-ai-docs/references/jobs/README.md");
+
+    private static final Pattern JOBS_COUNT_PATTERN = Pattern.compile(
+            "all (\\d+)\\+? (?:available )?jobs", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern TOTAL_TOOLS_PATTERN = Pattern.compile(
+            "(\\d+)\\+? MCP tools", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern TOOLS_AVAILABLE_PATTERN = Pattern.compile(
+            "(\\d+)\\+? MCP Tools Available", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern INTEGRATION_COUNT_PATTERN = Pattern.compile(
+            "(\\d+) integrations");
+
+    private static final Pattern PER_INTEGRATION_TOOLS_PATTERN = Pattern.compile(
+            "^\\*\\*([^*]+)\\*\\* \\((\\d+)\\+? tools\\)");
+
+    private static final Pattern CONFIG_TABLE_TOOLS_PATTERN = Pattern.compile(
+            "\\|[^\\|\\r\\n]*\\|[^\\|\\r\\n]*\\|.*?(\\d+)\\+? tools[^\\|\\r\\n]*\\|");
+
+    private static final Map<String, String> DISPLAY_TO_REGISTRY_INTEGRATION = Map.ofEntries(
+            Map.entry("Jira", "jira"),
+            Map.entry("Jira Xray", "jira_xray"),
+            Map.entry("Teams", "teams"),
+            Map.entry("Teams Auth", "teams_auth"),
+            Map.entry("Confluence", "confluence"),
+            Map.entry("ADO", "ado"),
+            Map.entry("Azure DevOps", "ado"),
+            Map.entry("Figma", "figma"),
+            Map.entry("AI Providers", "ai"),
+            Map.entry("Knowledge Base", "kb"),
+            Map.entry("File", "file"),
+            Map.entry("Mermaid", "mermaid"),
+            Map.entry("SharePoint", "sharepoint"),
+            Map.entry("CLI", "cli"),
+            Map.entry("GitHub", "github"),
+            Map.entry("GitLab", "gitlab"),
+            Map.entry("Bitrise", "bitrise"),
+            Map.entry("TestRail", "testrail"),
+            Map.entry("Jenkins", "jenkins"),
+            Map.entry("Bitbucket", "bitbucket"),
+            Map.entry("Rally", "rally")
+    );
+
+    @Test
+    void jobCountsMatchActualJobs() throws IOException {
+        String skill = readString(SKILL_MD);
+        String jobsReadme = readString(JOBS_README);
+
+        int actualJobs = JobRunner.getJobs().size();
+        assertTrue(actualJobs > 0, "JobRunner.getJobs() should return jobs");
+
+        List<Integer> skillCounts = extractAll(JOBS_COUNT_PATTERN, skill);
+        List<Integer> readmeCounts = extractAll(JOBS_COUNT_PATTERN, jobsReadme);
+
+        assertEquals(List.of(actualJobs), skillCounts,
+                "SKILL.md job count should match JobRunner.getJobs().size() = " + actualJobs);
+        assertEquals(List.of(actualJobs), readmeCounts,
+                "references/jobs/README.md job count should match JobRunner.getJobs().size() = " + actualJobs);
+    }
+
+    @Test
+    void mcpToolCountsMatchActualTools() {
+        List<MCPToolDefinition> tools = MCPToolRegistry.getToolsForIntegrations(
+                MCPToolRegistry.getAvailableIntegrations());
+        int actualTotal = tools.size();
+        assertTrue(actualTotal > 0, "No MCP tools found");
+
+        String skill = readString(SKILL_MD);
+
+        // "152+ MCP Tools Available" heading and any "N+ MCP tools" mentions.
+        int toolsAvailable = extractFirst(TOOLS_AVAILABLE_PATTERN, skill)
+                .orElseThrow(() -> new AssertionError("Missing 'N+ MCP Tools Available' heading in SKILL.md"));
+        List<Integer> totalToolMentions = extractAll(TOTAL_TOOLS_PATTERN, skill);
+
+        assertEquals(actualTotal, toolsAvailable,
+                "SKILL.md 'MCP Tools Available' count should match actual MCP tool count");
+        assertTrue(totalToolMentions.stream().allMatch(c -> c == actualTotal),
+                "Every 'N+ MCP tools' mention in SKILL.md should match actual count " + actualTotal);
+    }
+
+    @Test
+    void integrationCountMatchesActualIntegrations() {
+        int actualIntegrations = MCPToolRegistry.getAvailableIntegrations().size();
+        assertTrue(actualIntegrations > 0, "No integrations found");
+
+        String skill = readString(SKILL_MD);
+        int docIntegrations = extractFirst(INTEGRATION_COUNT_PATTERN, skill)
+                .orElseThrow(() -> new AssertionError("Missing 'N integrations' count in SKILL.md"));
+
+        assertEquals(actualIntegrations, docIntegrations,
+                "SKILL.md integration count should match actual integration count");
+    }
+
+    @Test
+    void perIntegrationToolCountsMatchActualTools() {
+        Map<String, Long> actualCounts = MCPToolRegistry.getToolsForIntegrations(
+                        MCPToolRegistry.getAvailableIntegrations())
+                .stream()
+                .collect(Collectors.groupingBy(MCPToolDefinition::getIntegration, Collectors.counting()));
+
+        String skill = readString(SKILL_MD);
+
+        // Core capabilities bullet list.
+        Map<String, Integer> docBulletCounts = PER_INTEGRATION_TOOLS_PATTERN.matcher(skill).results()
+                .collect(Collectors.toMap(
+                        mr -> mr.group(1).trim(),
+                        mr -> Integer.parseInt(mr.group(2)),
+                        (a, b) -> a));
+
+        for (Map.Entry<String, Integer> entry : docBulletCounts.entrySet()) {
+            String registryName = DISPLAY_TO_REGISTRY_INTEGRATION.get(entry.getKey());
+            if (registryName == null) {
+                fail("Unknown integration display name in SKILL.md: " + entry.getKey()
+                        + ". Add it to DISPLAY_TO_REGISTRY_INTEGRATION.");
+            }
+            Long actual = actualCounts.get(registryName);
+            assertTrue(actual != null && actual > 0,
+                    "Integration '" + registryName + "' has no registered MCP tools");
+            assertEquals(actual.intValue(), entry.getValue(),
+                    "SKILL.md tool count for '" + entry.getKey() + "' does not match actual count");
+        }
+
+        // Configuration table counts (e.g. "Jira Setup ... 52 tools", "Azure DevOps ... 23+ tools").
+        Map<String, Integer> docTableCounts = CONFIG_TABLE_TOOLS_PATTERN.matcher(skill).results()
+                .collect(Collectors.toMap(
+                        mr -> {
+                            // Row like "| | [Azure DevOps](...) | PAT setup and 23+ tools |"
+                            String row = mr.group(0);
+                            Matcher nameMatcher = Pattern.compile("\\[([^\\]]+)\\]").matcher(row);
+                            return nameMatcher.find() ? nameMatcher.group(1).trim() : row;
+                        },
+                        mr -> Integer.parseInt(mr.group(1)),
+                        (a, b) -> a));
+
+        for (Map.Entry<String, Integer> entry : docTableCounts.entrySet()) {
+            String registryName = DISPLAY_TO_REGISTRY_INTEGRATION.get(entry.getKey());
+            if (registryName == null) {
+                continue; // e.g. "Other AI Providers" row, which has no fixed count
+            }
+            Long actual = actualCounts.get(registryName);
+            assertTrue(actual != null && actual > 0,
+                    "Integration '" + registryName + "' has no registered MCP tools");
+            assertEquals(actual.intValue(), entry.getValue(),
+                    "SKILL.md configuration table tool count for '" + entry.getKey() + "' does not match actual count");
+        }
+    }
+
+    private static String readString(Path path) {
+        try {
+            return Files.readString(path, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot read " + path, e);
+        }
+    }
+
+    private static List<Integer> extractAll(Pattern pattern, String text) {
+        return pattern.matcher(text).results()
+                .map(mr -> Integer.parseInt(mr.group(1)))
+                .toList();
+    }
+
+    private static java.util.Optional<Integer> extractFirst(Pattern pattern, String text) {
+        return pattern.matcher(text).results()
+                .findFirst()
+                .map(mr -> Integer.parseInt(mr.group(1)));
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/docs/SkillDocumentationTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/docs/SkillDocumentationTest.java
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.docs;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Ensures that every job with its own detailed section in the jobs reference
+ * is also surfaced in the main skill manifest (SKILL.md).
+ */
+class SkillDocumentationTest {
+
+    private static final Pattern JOB_HEADING_PATTERN = Pattern.compile(
+            "^### ([A-Z][a-zA-Z0-9]+)$", Pattern.MULTILINE);
+
+    // Single-word category headings that happen to match the job heading pattern.
+    private static final Set<String> IGNORED_HEADINGS = Set.of("Documentation", "Utilities");
+
+    @Test
+    void everyDetailedJobIsLinkedFromSkillManifest() throws IOException {
+        Path moduleRoot = Paths.get("").toAbsolutePath();
+        Path jobsReadme = moduleRoot.getParent().resolve("dmtools-ai-docs/references/jobs/README.md");
+        Path skillManifest = moduleRoot.getParent().resolve("dmtools-ai-docs/SKILL.md");
+
+        if (!Files.exists(jobsReadme)) {
+            fail("Jobs README not found: " + jobsReadme);
+        }
+        if (!Files.exists(skillManifest)) {
+            fail("Skill manifest not found: " + skillManifest);
+        }
+
+        String readme = Files.readString(jobsReadme, StandardCharsets.UTF_8);
+        String skill = Files.readString(skillManifest, StandardCharsets.UTF_8);
+
+        Set<String> detailedJobs = collectDetailedJobNames(readme);
+        assertFalse(detailedJobs.isEmpty(),
+                "No detailed job headings found in " + jobsReadme + "; check the heading pattern.");
+
+        Set<String> missing = detailedJobs.stream()
+                .filter(job -> !hasSkillLink(skill, job))
+                .collect(Collectors.toSet());
+
+        assertTrue(missing.isEmpty(),
+                "Detailed jobs missing from SKILL.md: " + missing + ". "
+                        + "Add a link like [JobName](references/jobs/README.md#jobname).");
+    }
+
+    private Set<String> collectDetailedJobNames(String readme) {
+        return JOB_HEADING_PATTERN.matcher(readme).results()
+                .map(mr -> mr.group(1))
+                .filter(name -> !IGNORED_HEADINGS.contains(name))
+                .collect(Collectors.toSet());
+    }
+
+    private boolean hasSkillLink(String skill, String jobName) {
+        return skill.contains("[" + jobName + "](");
+    }
+}

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobRunnerCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobRunnerCoverageTest.java
@@ -118,7 +118,7 @@ public class JobRunnerCoverageTest {
     public void testGetJobsReturnsAllJobsAndCachesList() {
         List<Job> jobs = JobRunner.getJobs();
         assertNotNull(jobs);
-        assertEquals(22, jobs.size());
+        assertEquals(23, jobs.size());
         for (Job job : jobs) {
             assertNotNull(job);
             assertNotNull(job.getName());
@@ -383,8 +383,9 @@ public class JobRunnerCoverageTest {
         String output = captureOut(() -> JobRunner.main(new String[]{"--list-jobs"}));
         assertTrue(output.contains("Available Jobs:"));
         assertTrue(output.contains("- CodeGenerator"));
+        assertTrue(output.contains("- CliAgent"));
         assertTrue(output.contains("- KBProcessingJob"));
-        assertTrue(output.contains("Total: 22 jobs available"));
+        assertTrue(output.contains("Total: 23 jobs available"));
     }
 
     @Test


### PR DESCRIPTION
PR #267 introduced the CliAgent job and documented it in references/jobs/README.md, but the main skill manifest (SKILL.md) and CHANGELOG.md did not surface it. This change adds the missing references and bumps the skill version so the skill surface reflects the new job.