### PR TITLE
fix(ci): update action versions and add missing permissions

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
         uses: actions/setup-node@v7
@@ -46,7 +46,7 @@ jobs:
       # repository actually publishes to, and the build needs it.
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       # canonical, og:image, the sitemap, robots.txt and three schema fields all
       # need an absolute URL, and the right one differs per repository — a fork
@@ -75,7 +75,7 @@ jobs:
           npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: landing/dist
 
@@ -89,4 +89,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-ai-skill.yml
+++ b/.github/workflows/release-ai-skill.yml
@@ -252,6 +252,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-and-release]
     if: always()
+    permissions:
+      contents: read
 
     steps:
       - name: Send notification


### PR DESCRIPTION
## Changes\n\n1. **Remove Node 20 deprecation warnings in deploy-landing workflow** by bumping all actions to their latest stable major versions that run on Node 24:\n   - `actions/checkout@v4` → `@v7`\n   - `actions/configure-pages@v5` → `@v6`\n   - `actions/upload-pages-artifact@v3` → `@v5`\n   - `actions/deploy-pages@v4` → `@v5`\n\n2. **Fix CodeQL alert "Workflow does not contain permissions"** in `release-ai-skill.yml` by adding `permissions: contents: read` to the `notify` job.\n\n## Verification\n\nAll modified workflow files pass YAML validation.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>