### PR TITLE
fix(ci): add missing permissions to release-ai-skill publish-npm job

### DIFF
--- a/.github/workflows/release-ai-skill.yml
+++ b/.github/workflows/release-ai-skill.yml
@@ -197,6 +197,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-release
     if: github.event.inputs.prerelease != 'true'
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Problem\n\nCodeQL alert "Workflow does not contain permissions" (actions/missing-workflow-permissions) is also reported for the `publish-npm` job in `.github/workflows/release-ai-skill.yml`.\n\n## Change\n\nAdd explicit least-privilege permissions to the `publish-npm` job:\n\n- `contents: read` – to check out the repository\n- `packages: write` – to publish the NPM package\n\n## Verification\n\nWorkflow YAML passes validation.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>