### PR TITLE
feat(landing): support custom domain dmtools.epam.com

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -20,9 +20,15 @@ const REPO_URL = 'https://github.com/epam/dm.ai';
  * Splitting it into origin and path matters for a project page: the site lives
  * under /<repo>/, and every generated asset link has to carry that prefix or
  * it resolves against the user page root and 404s.
+ *
+ * When a custom domain is configured (e.g. dmtools.epam.com), the site serves
+ * from the domain root, so the base path must be '/'.
  */
 const SITE_URL = process.env.SITE_URL || 'http://localhost:4321';
-const { origin, pathname } = new URL(SITE_URL.endsWith('/') ? SITE_URL : `${SITE_URL}/`);
+const siteUrl = new URL(SITE_URL.endsWith('/') ? SITE_URL : `${SITE_URL}/`);
+const origin = siteUrl.origin;
+// Project pages live under /<repo>/; custom domains serve from the root.
+const pathname = origin.endsWith('github.io') ? siteUrl.pathname : '/';
 
 export default defineConfig({
   site: origin,


### PR DESCRIPTION
## Change\n\nMake the Astro base path adaptive so the landing can be served from a custom domain root (`dmtools.epam.com`) as well as from the existing GitHub Pages project path (`epam.github.io/dm.ai`).\n\n- GitHub Pages project page origin (`*.github.io`) keeps `base: /dm.ai/`.\n- Any other origin (custom domain) uses `base: /`.\n\n## Verification\n\n- `SITE_URL=https://dmtools.epam.com/ npm run build` produces root-relative asset links and `og:url` pointing to `https://dmtools.epam.com/`.\n- `SITE_URL=https://epam.github.io/dm.ai npm run build` still produces `/dm.ai/` prefixed links and correct `og:url`.\n\n## Required DNS setup\n\nAsk the team that owns the `epam.com` domain to add this DNS record:\n\n```\nName:  dmtools.epam.com\nType:  CNAME\nValue: epam.github.io\nTTL:   300\n```\n\nAfter the DNS record is live, a repository admin must set the custom domain in the repository:\n\n1. Open https://github.com/epam/dm.ai/settings/pages\n2. Under "Custom domain", enter `dmtools.epam.com` and click Save.\n3. Wait for the DNS check to pass and for GitHub to create the `CNAME` file.\n4. Re-run the deploy workflow if it does not start automatically.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>