### PR TITLE
feat(landing): enhance Google Analytics tracking

### DIFF
--- a/landing/src/components/Analytics.astro
+++ b/landing/src/components/Analytics.astro
@@ -11,6 +11,7 @@
  * variable rather than a secret.
  */
 const gaId = process.env.GA_MEASUREMENT_ID;
+const consentMode = (process.env.GA_CONSENT_MODE || 'denied').toLowerCase();
 ---
 
 {gaId && (
@@ -22,6 +23,18 @@ const gaId = process.env.GA_MEASUREMENT_ID;
     <script is:inline set:html={`window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-    gtag('config', ${JSON.stringify(gaId)});`} />
+    gtag('consent', 'default', {
+      ad_storage: '${consentMode}',
+      analytics_storage: 'granted',
+      ad_user_data: '${consentMode}',
+      ad_personalization: '${consentMode}'
+    });
+    gtag('config', ${JSON.stringify(gaId)}, {
+      send_page_view: true,
+      allow_google_signals: false,
+      cookie_flags: 'SameSite=None;Secure',
+      cookie_expires: 63072000,
+      custom_map: { dimension1: 'theme', metric1: 'scroll_depth' }
+    });`} />
   </>
 )}

--- a/landing/src/components/CopyButton.astro
+++ b/landing/src/components/CopyButton.astro
@@ -14,6 +14,7 @@ const { target, label, class: extraClass } = Astro.props;
   class:list={['cmd__copy', extraClass]}
   type="button"
   data-copy={target}
+  data-copy-target={target}
   aria-label={label}
 >
   <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true">

--- a/landing/src/sections/Hero.astro
+++ b/landing/src/sections/Hero.astro
@@ -86,8 +86,43 @@ const playerUrl = `${filmEmbedUrl}?autoplay=1&rel=0`;
       iframe.focus();
     };
 
-    playButton.addEventListener('click', playFilm);
-    watchButton?.addEventListener('click', playFilm);
+    playButton.addEventListener('click', () => {
+      playFilm();
+      if (typeof gtag === 'function') {
+        gtag('event', 'play_film', { event_category: 'engagement', event_label: 'hero' });
+      }
+    });
+    watchButton?.addEventListener('click', () => {
+      playFilm();
+      if (typeof gtag === 'function') {
+        gtag('event', 'play_film', { event_category: 'engagement', event_label: 'hero_button' });
+      }
+    });
   }
 
+  // Scroll-depth tracking for the landing page.
+  if (typeof window !== 'undefined') {
+    const markers = [25, 50, 75, 90];
+    const sent = new Set<number>();
+    const sendDepth = () => {
+      const scroll = window.scrollY + window.innerHeight;
+      const height = document.documentElement.scrollHeight;
+      if (!height) return;
+      const depth = Math.round((scroll / height) * 100);
+      markers.forEach((m) => {
+        if (depth >= m && !sent.has(m)) {
+          sent.add(m);
+          if (typeof gtag === 'function') {
+            gtag('event', 'scroll_depth', {
+              event_category: 'engagement',
+              event_label: String(m),
+              value: m,
+            });
+          }
+        }
+      });
+    };
+    window.addEventListener('scroll', sendDepth, { passive: true });
+    sendDepth();
+  }
 </script>

--- a/landing/src/sections/Install.astro
+++ b/landing/src/sections/Install.astro
@@ -82,7 +82,15 @@ import { installTabs, verifyCommand, DOCS } from '../data/content';
     };
 
     tabs.forEach((tab) => {
-      tab.addEventListener('click', () => select(tab));
+      tab.addEventListener('click', () => {
+        select(tab);
+        if (typeof gtag === 'function') {
+          gtag('event', 'install_tab_switch', {
+            event_category: 'engagement',
+            event_label: tab.dataset.panel,
+          });
+        }
+      });
 
       tab.addEventListener('keydown', (event) => {
         if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
@@ -94,4 +102,17 @@ import { installTabs, verifyCommand, DOCS } from '../data/content';
       });
     });
   }
+
+  // Track copies of install/verify commands.
+  document.querySelectorAll<HTMLButtonElement>('[data-copy-target]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const target = btn.dataset.copyTarget;
+      if (target && typeof gtag === 'function') {
+        gtag('event', 'copy_command', {
+          event_category: 'engagement',
+          event_label: target,
+        });
+      }
+    });
+  });
 </script>

--- a/landing/src/sections/Nav.astro
+++ b/landing/src/sections/Nav.astro
@@ -80,8 +80,12 @@ const docsLink = navLinks.find((link) => link.label === 'Docs');
 
     labelToggle();
     toggle.addEventListener('click', () => {
-      applyTheme(root.dataset.theme === 'night' ? 'snow' : 'night');
+      const next = root.dataset.theme === 'night' ? 'snow' : 'night';
+      applyTheme(next);
       labelToggle();
+      if (typeof gtag === 'function') {
+        gtag('event', 'theme_switch', { event_category: 'engagement', event_label: next });
+      }
     });
   }
 


### PR DESCRIPTION
## What\n\nExpand Google Analytics coverage on the landing page while we wait for the `dmtools.epam.com` custom domain to be provisioned. The same GA property will keep collecting data after the domain change, so no migration is needed.\n\n## Changes\n\n- `Analytics.astro`\n  - Add GA4 consent defaults (analytics storage granted, ad signals denied).\n  - Set secure, cross-domain cookie flags.\n  - Register custom dimensions/metrics for theme and scroll depth.\n\n- `Nav.astro`\n  - Track `theme_switch` events.\n\n- `Hero.astro`\n  - Track `play_film` events from both the poster play button and the "Watch the film" CTA.\n  - Track scroll depth at 25%, 50%, 75%, 90%.\n\n- `Install.astro` + `CopyButton.astro`\n  - Track `install_tab_switch` per platform.\n  - Track `copy_command` events for install and verify commands.\n\n## Verification\n\n- `npm run build` completes and generates all 64 pages.\n- Built HTML contains the updated gtag block when `GA_MEASUREMENT_ID` is set.\n\n## Deployment note\n\nMake sure the repository variable `GA_MEASUREMENT_ID` is set (Settings → Variables → Actions). If it is unset, the site ships without tracking, same as before.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>