### PR TITLE
feat: persist full CLI/agent output on truncation, decoupled from DMTOOLS_JS_LOG_TOOL_CALLS

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -236,6 +236,11 @@ public class CommandLineUtils {
 
         // Drain stdout/stderr in real-time so the process doesn't block on a full pipe
         boolean verboseCommandOutputLogging = new PropertyReader().isJsToolCallLoggingEnabled();
+        // Path a full, untruncated transcript would be written to IF this command's
+        // output ends up exceeding the logging cap (computed upfront, from the same
+        // timestamp/uniqueId used for the temp script, so the truncation notice can
+        // point at it immediately instead of only after the fact).
+        Path fullOutputLogFile = resolveFullOutputLogFile(timestamp, uniqueId);
         StringBuilder output = new StringBuilder();
         int lineCount = 0;
         int loggedLineCount = 0;
@@ -254,7 +259,12 @@ public class CommandLineUtils {
                     logger.info(line);
                     loggedLineCount++;
                 } else if (!truncationNoticeLogged) {
-                    logger.info("... output truncated after {} line(s); set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output ...", maxLinesToLog);
+                    if (fullOutputLogFile != null) {
+                        logger.info("... output truncated after {} line(s); full output will be saved to {} ...",
+                                maxLinesToLog, fullOutputLogFile);
+                    } else {
+                        logger.info("... output truncated after {} line(s); set DMTOOLS_JS_LOG_TOOL_CALLS=true to log full output ...", maxLinesToLog);
+                    }
                     truncationNoticeLogged = true;
                 }
 
@@ -282,12 +292,59 @@ public class CommandLineUtils {
         }
         logger.debug("Process exited with code: {}", exitCode);
 
+        // Persist the complete transcript whenever the console logging was actually
+        // capped, regardless of exit code, so a failing/CI run is never left blind
+        // even before the exception below is thrown/handled by the caller.
+        if (truncationNoticeLogged && fullOutputLogFile != null) {
+            persistFullOutput(fullOutputLogFile, command, workingDirectory, output.toString(), lineCount, exitCode);
+        }
+
         // Propagate non-zero exit codes so callers are not silently misled.
         if (exitCode != 0) {
             throw new IOException("Command failed (exit code " + exitCode + "): " + command + "\nOutput:\n" + output.toString().trim());
         }
 
         return output.toString().trim();
+    }
+
+    /**
+     * Resolves (without creating) the path a full command-output transcript would be
+     * written to, or null if full-output persistence is disabled
+     * (DMTOOLS_CLI_LOG_DIR set to an empty string).
+     */
+    private static Path resolveFullOutputLogFile(String timestamp, String uniqueId) {
+        String logDirProperty = new PropertyReader().getCliFullOutputLogDir();
+        if (logDirProperty == null || logDirProperty.isBlank()) {
+            return null;
+        }
+        return Paths.get(logDirProperty).resolve(timestamp + "-" + uniqueId + ".log");
+    }
+
+    /**
+     * Writes the complete, untruncated output of a command to disk. Only called
+     * when the console logging was actually capped (see maxLinesToLog), so trivial
+     * commands whose full output already fit on the console never produce a file.
+     * Best-effort: failures to write are logged and swallowed, never propagated,
+     * so a read-only filesystem or full disk can't turn a successful command into
+     * a failure.
+     */
+    private static void persistFullOutput(Path logFile, String command, File workingDirectory,
+                                           String fullOutput, int lineCount, int exitCode) {
+        try {
+            Path parent = logFile.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            String header = "Command: " + SecurityUtils.maskCommand(command) + System.lineSeparator()
+                    + "Working directory: " + (workingDirectory != null ? workingDirectory.getAbsolutePath() : System.getProperty("user.dir")) + System.lineSeparator()
+                    + "Exit code: " + exitCode + System.lineSeparator()
+                    + "Total output lines: " + lineCount + System.lineSeparator()
+                    + "----" + System.lineSeparator();
+            Files.writeString(logFile, header + fullOutput);
+            logger.info("Full output ({} line(s)) written to: {}", lineCount, logFile.toAbsolutePath());
+        } catch (IOException e) {
+            logger.warn("Failed to persist full command output to {}: {}", logFile, e.getMessage());
+        }
     }
 
     static void removeExcludedEnvironmentVariables(Map<String, String> environment,

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -438,6 +438,29 @@ public class PropertyReader {
     return Boolean.parseBoolean(value) || "1".equals(value);
   }
 
+  /**
+   * Directory where {@link CommandLineUtils#runCommand} persists the complete,
+   * untruncated output of any command whose console logging was capped (see
+   * DEFAULT_MAX_LOGGED_OUTPUT_LINES / maxLinesToLog). This is intentionally
+   * DECOUPLED from DMTOOLS_JS_LOG_TOOL_CALLS: that flag also enables verbose
+   * per-call JS/MCP tool argument dumping (JobJavaScriptBridge), which can
+   * include large payloads (e.g. full file_write contents) and is unwanted
+   * noise when the only goal is recovering a capped CLI subprocess transcript
+   * (e.g. a nested `dmtools run ...` invoked via cli_execute_command).
+   * <p>
+   * Full-output persistence only fires when a command's output actually
+   * exceeds the logging cap — short/trivial commands (e.g. `git status`,
+   * `git checkout`) never produce a file, so normal agent runs with many
+   * small shell calls (pre/post JS actions, git plumbing, etc.) don't get
+   * cluttered with log files.
+   * <p>
+   * Set to an empty string to disable persisting these files entirely.
+   * Defaults to ".dmtools-logs/cli" (relative to the process working directory).
+   */
+  public String getCliFullOutputLogDir() {
+    return getValue("DMTOOLS_CLI_LOG_DIR", ".dmtools-logs/cli");
+  }
+
   public boolean isXrayCacheGetRequestsEnabled() {
     String value = getValue("XRAY_CACHE_GET_REQUESTS_ENABLED");
     if (value == null) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
@@ -312,4 +312,84 @@ class CommandLineUtilsTest {
             assertTrue(result.contains("B"));
         }
     }
+
+    @Test
+    void testRunCommand_TruncatedOutput_PersistsFullOutputToConfiguredDir() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("full-output-logs");
+        try {
+            PropertyReader.setOverrides(Map.of("DMTOOLS_CLI_LOG_DIR", logDir.toString()));
+
+            Path testFile = tempDir.resolve("five-lines.txt");
+            Files.writeString(testFile, "L1\nL2\nL3\nL4\nL5\n");
+
+            // maxLinesToLog=2 guarantees truncation (5 lines produced) without needing
+            // DMTOOLS_JS_LOG_TOOL_CALLS, which is the whole point of this decoupling.
+            String result = CommandLineUtils.runCommand(
+                    "cat " + testFile.toAbsolutePath(), null, Map.of(), null, false, null, 2);
+
+            // Full output is still returned to the caller regardless of the cap.
+            assertTrue(result.contains("L1") && result.contains("L5"));
+
+            assertTrue(Files.isDirectory(logDir), "Log dir should have been created");
+            try (var files = Files.list(logDir)) {
+                java.util.List<Path> written = files.toList();
+                assertEquals(1, written.size(), "Exactly one full-output log file should be written");
+                String content = Files.readString(written.get(0));
+                assertTrue(content.contains("L1") && content.contains("L5"),
+                        "Persisted file should contain the full untruncated output");
+                assertTrue(content.contains("Exit code: 0"));
+            }
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testRunCommand_UntruncatedOutput_DoesNotWriteLogFile() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("full-output-logs-2");
+        try {
+            PropertyReader.setOverrides(Map.of("DMTOOLS_CLI_LOG_DIR", logDir.toString()));
+
+            // Trivial command (single line) well within the default/any reasonable cap —
+            // this mirrors pre/post JS action shell calls (git status, git checkout, etc.)
+            // that must NOT clutter the log directory.
+            CommandLineUtils.runCommand("echo only-one-line");
+
+            assertFalse(Files.exists(logDir), "No log file/dir should be created when nothing was truncated");
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testRunCommand_TruncatedOutput_LogDirDisabled_DoesNotWriteFile() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("full-output-logs-3");
+        try {
+            // Empty string explicitly disables full-output persistence.
+            PropertyReader.setOverrides(Map.of("DMTOOLS_CLI_LOG_DIR", ""));
+
+            Path testFile = tempDir.resolve("three-lines.txt");
+            Files.writeString(testFile, "A\nB\nC\n");
+
+            String result = CommandLineUtils.runCommand(
+                    "cat " + testFile.toAbsolutePath(), null, Map.of(), null, false, null, 1);
+
+            assertTrue(result.contains("A") && result.contains("C"));
+            assertFalse(Files.exists(logDir), "No log file should be written when DMTOOLS_CLI_LOG_DIR is empty");
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`DMTOOLS_JS_LOG_TOOL_CALLS` currently gates two unrelated concerns at once:

1. `CommandLineUtils.runCommand()` — whether console INFO logging of a spawned process's stdout is capped at `maxLinesToLog` (default 50) or unlimited. This matters most for nested `dmtools run ...` invocations shelled out via `cli_execute_command` (e.g. the `pr_rework_redirect.json` pattern), whose real CLI-agent transcript is otherwise invisible beyond 50 lines.
2. `JobJavaScriptBridge` — whether every generated JS→Java MCP tool wrapper logs `console.log('Calling tool X with args:', JSON.stringify(args))` on every call, which can include large payloads (e.g. full `file_write` contents).

Turning the flag on to fix (1) unavoidably also turns on (2), flooding CI logs with noise/large payloads that have nothing to do with wanting to see a capped subprocess's real output. This was the root cause of a real "blind CI" incident while diagnosing an unresolved MR review (GENSGENP-53009 / gens-igt !7860): the nested `dmtools --debug run repo-agents/gens-igt/pr_rework.json` process produced 8280 lines / 880KB of real output, but the console only showed 50 lines, with no way to recover the rest after the fact.

## Fix

Decouple these two concerns:

- `DMTOOLS_JS_LOG_TOOL_CALLS` keeps controlling only the JS/MCP tool-call arg dumping (unchanged).
- New: whenever a command's output actually exceeds `maxLinesToLog` (i.e. truncation would occur), `CommandLineUtils.runCommand()` now **always** persists the complete, untruncated transcript to a file under `DMTOOLS_CLI_LOG_DIR` (default `.dmtools-logs/cli`), independent of `DMTOOLS_JS_LOG_TOOL_CALLS`. The truncation notice now points at the exact file path.
- Persistence only fires on actual truncation — trivial commands (`git status`, `git checkout`, etc., the bulk of pre/post JS action shell calls) never produce a file, so normal runs aren't cluttered with log files.
- Best-effort: file-write failures are logged and swallowed, never fail the command itself (handles read-only FS / full disk gracefully).
- Set `DMTOOLS_CLI_LOG_DIR=""` (empty string) to disable persistence entirely.

## Testing

- `./gradlew :dmtools-core:test --tests CommandLineUtilsTest --tests PropertyReaderTest` — 30/30 and 43/43 passing.
- New tests added: persists full output on truncation, no-op when output isn't truncated, no-op when `DMTOOLS_CLI_LOG_DIR` is explicitly disabled.

## Related

Companion change in `dmtools-agents` (`feature/persist-full-cli-transcripts`) applies the same "persist instead of delete" fix to `run-agent.sh`'s provider scripts (claude/codemie/copilot/cursor/kimi), which previously `tee`'d their full agent transcript to a `mktemp` file and deleted it right after a single grep — meaning the top-level CLI agent's own conversation was never recoverable either. Both write under the same `.dmtools-logs/cli` root so a single CI artifact glob (`.dmtools-logs/**`, `when: always`) picks up everything.