### PR TITLE
fix(landing): resolve Dependabot alert #11 by pinning nanoid

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -5268,9 +5268,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/landing/package.json
+++ b/landing/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.8.3"
   },
   "overrides": {
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "nanoid": "^3.3.17"
   }
 }


### PR DESCRIPTION
Adds an npm override to pin nanoid to ^3.3.17 so the transitive dependency used by postcss (via vite / @astrojs/react) picks up the patched version.

- npm audit now reports 0 vulnerabilities in landing/
- npm run build still passes

Resolves https://github.com/epam/dm.ai/security/dependabot/11