### PR TITLE
Add structured CLI error/exit-code signal to CliExecutionResult

### DIFF
--- a/dmtools-ai-docs/references/agents/teammate-configs.md
+++ b/dmtools-ai-docs/references/agents/teammate-configs.md
@@ -277,7 +277,7 @@ This solves the `ConfigurationMerger` limitation: when you override a config wit
 | `cliPrompts` | Array | - | Array of prompts — each entry is extracted via `InstructionProcessor` and all parts are joined with `\n\n` into one combined prompt. Combined with `cliPrompt` if both are set (`cliPrompt` comes first). Supports the same sources as `cliPrompt`. | `["./base.md", "https://confluence.co/...", "Also apply coding standards"]` |
 | `cliCommands` | Array | - | CLI commands to execute | `["./cicd/scripts/run-cursor-agent.sh"]` |
 | `preCliJSAction` | String | - | JS script path executed **after** input folder is created but **before** CLI commands run. Receives `params.inputFolderPath` (absolute path). Use to write extra files into the input folder. Errors in this script are logged but do NOT stop CLI execution. | `"agents/js/extendInputFolder.js"` |
-| `timerJSAction` | String | - | JS script path executed **periodically in a background thread** while CLI commands are running. Receives the same params as `postJSAction` + `params.currentCliOutput` (accumulated stdout so far). Use for side-effects like auto-committing, posting progress, or sending notifications. Errors are logged and never abort CLI execution. | `"agents/js/autoCommit.js"` |
+| `timerJSAction` | String | - | JS script path executed **periodically in a background thread** while CLI commands are running. Receives the same params as `postJSAction` + `params.currentCliOutput` (accumulated stdout so far), plus `params.currentCliHasFatalError` (boolean) and `params.currentCliErrorMessage` (string, may be null) — set as soon as a CLI command fails with a non-zero exit code, so retry logic can distinguish a real, non-retryable failure from a transient interruption. Use for side-effects like auto-committing, posting progress, or sending notifications. Errors are logged and never abort CLI execution. | `"agents/js/autoCommit.js"` |
 | `timerIntervalSeconds` | Integer | `60` | Interval in seconds between `timerJSAction` executions. Timer starts after the first interval elapses. Has no effect when `timerJSAction` is not set or when value is ≤ 0. | `300` |
 | `skipAIProcessing` | Boolean | `false` | Skip AI processing when using CLI agents | `true` |
 | `requireCliOutputFile` | Boolean | `true` | **NEW v1.7.133**: Require `output/response.md` before updating fields (strict mode prevents data loss) | `true` (recommended) |
@@ -576,6 +576,8 @@ A JS script executed **periodically in a background thread** while the CLI comma
 - `params` contains the full Teammate config (`agentParams`, `customParams`, etc.)
 - `ticket` is the current Jira/ADO ticket being processed
 - **Extra**: `params.currentCliOutput` — a string snapshot of the accumulated CLI stdout **up to the moment the timer fires**
+- **Extra**: `params.currentCliHasFatalError` — `true` as soon as a CLI command has failed with a non-zero exit code (e.g. an invalid model ID rejected by the AI provider); `false` otherwise. Use this instead of string-scanning `currentCliOutput` to distinguish a real, non-retryable failure from a transient interruption (no output yet, still running).
+- **Extra**: `params.currentCliErrorMessage` — a concise message describing the last fatal CLI failure, or `null`/empty if none occurred yet.
 
 **Threading model**:
 - Single daemon thread (`ScheduledExecutorService`)

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CliCommandFailedException.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CliCommandFailedException.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.common.utils;
+
+import java.io.IOException;
+
+/**
+ * Thrown by {@link CommandLineUtils#runCommand} when the underlying subprocess exits
+ * with a non-zero exit code. Extends {@link IOException} so existing callers that only
+ * catch {@code IOException}/{@code Exception} continue to behave exactly as before;
+ * callers that need the structured exit code / raw output can catch this specific type.
+ */
+public class CliCommandFailedException extends IOException {
+
+    private final String command;
+    private final int exitCode;
+    private final String output;
+
+    public CliCommandFailedException(String command, int exitCode, String output) {
+        super("Command failed (exit code " + exitCode + "): " + command + "\nOutput:\n" + output.trim());
+        this.command = command;
+        this.exitCode = exitCode;
+        this.output = output;
+    }
+
+    public String getCommand() {
+        return command;
+    }
+
+    public int getExitCode() {
+        return exitCode;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -300,8 +300,11 @@ public class CommandLineUtils {
         }
 
         // Propagate non-zero exit codes so callers are not silently misled.
+        // Thrown as CliCommandFailedException (an IOException subtype) so existing
+        // callers that only catch IOException/Exception see no behavior change, while
+        // callers that need the structured exit code can catch it specifically.
         if (exitCode != 0) {
-            throw new IOException("Command failed (exit code " + exitCode + "): " + command + "\nOutput:\n" + output.toString().trim());
+            throw new CliCommandFailedException(command, exitCode, output.toString());
         }
 
         return output.toString().trim();

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -8,6 +8,7 @@ import com.github.istin.dmtools.common.model.IComment;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.CliCommandFailedException;
 import com.github.istin.dmtools.common.utils.CliExecutionStoppedException;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
 import com.github.istin.dmtools.common.utils.IOUtils;
@@ -436,11 +437,114 @@ public class CliExecutionHelper {
                                             AtomicReference<String> liveOutput, boolean allowAnyCommand,
                                             String[] excludedEnvVariables, String[] excludedEnvRegexes,
                                             Consumer<Exception> errorHandler, Predicate<String> lineStopPredicate) {
+        return executeCliCommandsInternal(cliCommands, workingDirectory, envVariablesFile, liveOutput, allowAnyCommand,
+                excludedEnvVariables, excludedEnvRegexes, errorHandler, lineStopPredicate).getCommandResponses();
+    }
+
+    /**
+     * Internal outcome of a CLI command batch, tracking both the accumulated text
+     * responses and a structured signal for the last fatal (non-zero exit code)
+     * command failure encountered, if any. Used to populate {@link CliExecutionResult}
+     * without changing the public {@code executeCliCommands} return type.
+     */
+    private static class CliCommandsOutcome {
+        private final StringBuilder commandResponses;
+        private final boolean hasFatalError;
+        private final Integer lastExitCode;
+        private final String lastErrorMessage;
+
+        CliCommandsOutcome(StringBuilder commandResponses, boolean hasFatalError,
+                           Integer lastExitCode, String lastErrorMessage) {
+            this.commandResponses = commandResponses;
+            this.hasFatalError = hasFatalError;
+            this.lastExitCode = lastExitCode;
+            this.lastErrorMessage = lastErrorMessage;
+        }
+
+        StringBuilder getCommandResponses() {
+            return commandResponses;
+        }
+
+        boolean hasFatalError() {
+            return hasFatalError;
+        }
+
+        Integer getLastExitCode() {
+            return lastExitCode;
+        }
+
+        String getLastErrorMessage() {
+            return lastErrorMessage;
+        }
+    }
+
+    /**
+     * Immutable snapshot of the last fatal CLI command failure encountered so far,
+     * published live via an {@link AtomicReference} (analogous to {@code liveOutput})
+     * so a concurrent {@code timerJSAction} can react to a fatal error before the CLI
+     * command batch as a whole finishes — see {@code Teammate.runJobImpl}.
+     */
+    public static class LiveCliErrorState {
+        public static final LiveCliErrorState NONE = new LiveCliErrorState(false, null, null);
+
+        private final boolean hasFatalError;
+        private final Integer exitCode;
+        private final String errorMessage;
+
+        public LiveCliErrorState(boolean hasFatalError, Integer exitCode, String errorMessage) {
+            this.hasFatalError = hasFatalError;
+            this.exitCode = exitCode;
+            this.errorMessage = errorMessage;
+        }
+
+        public boolean hasFatalError() {
+            return hasFatalError;
+        }
+
+        public Integer getExitCode() {
+            return exitCode;
+        }
+
+        public String getErrorMessage() {
+            return errorMessage;
+        }
+    }
+
+    /**
+     * Executes CLI commands and collects their responses, additionally tracking a
+     * structured signal for the last fatal (non-zero exit code) command failure.
+     *
+     * <p>Unlike the public {@code executeCliCommands} overloads, callers here get
+     * access to the real subprocess exit code rather than only the free-text error
+     * message embedded in {@code cliResponses} — see {@link CliCommandFailedException}.
+     */
+    private CliCommandsOutcome executeCliCommandsInternal(String[] cliCommands, Path workingDirectory, String envVariablesFile,
+                                            AtomicReference<String> liveOutput, boolean allowAnyCommand,
+                                            String[] excludedEnvVariables, String[] excludedEnvRegexes,
+                                            Consumer<Exception> errorHandler, Predicate<String> lineStopPredicate) {
+        return executeCliCommandsInternal(cliCommands, workingDirectory, envVariablesFile, liveOutput, allowAnyCommand,
+                excludedEnvVariables, excludedEnvRegexes, errorHandler, lineStopPredicate, null);
+    }
+
+    /**
+     * Same as the overload above, additionally publishing a live snapshot of the last fatal
+     * CLI failure to {@code liveErrorState} (if non-null) as soon as it is detected — mirroring
+     * how {@code liveOutput} is updated after every line — so a concurrent {@code timerJSAction}
+     * can observe a fatal error before the whole command batch finishes.
+     */
+    private CliCommandsOutcome executeCliCommandsInternal(String[] cliCommands, Path workingDirectory, String envVariablesFile,
+                                            AtomicReference<String> liveOutput, boolean allowAnyCommand,
+                                            String[] excludedEnvVariables, String[] excludedEnvRegexes,
+                                            Consumer<Exception> errorHandler, Predicate<String> lineStopPredicate,
+                                            AtomicReference<LiveCliErrorState> liveErrorState) {
         StringBuilder cliResponses = new StringBuilder();
+        boolean hasFatalError = false;
+        Integer lastExitCode = null;
+        String lastErrorMessage = null;
 
         if (cliCommands == null || cliCommands.length == 0) {
             logger.info("No CLI commands to execute");
-            return cliResponses;
+            return new CliCommandsOutcome(cliResponses, false, null, null);
         }
 
         // Load environment variables from dmtools.env for CLI tools like cursor-agent
@@ -562,10 +666,23 @@ public class CliExecutionHelper {
                 if (liveOutput != null) {
                     liveOutput.set(cliResponses.toString());
                 }
+
+                // Track a structured fatal-error signal so downstream consumers
+                // (e.g. timerJSAction / postJSAction retry logic) can distinguish a
+                // real, non-retryable CLI failure from a transient interruption
+                // without string-scanning the free-text response above.
+                hasFatalError = true;
+                lastErrorMessage = errorMsg;
+                lastExitCode = (e instanceof CliCommandFailedException)
+                        ? ((CliCommandFailedException) e).getExitCode()
+                        : null;
+                if (liveErrorState != null) {
+                    liveErrorState.set(new LiveCliErrorState(true, lastExitCode, lastErrorMessage));
+                }
             }
         }
-        
-        return cliResponses;
+
+        return new CliCommandsOutcome(cliResponses, hasFatalError, lastExitCode, lastErrorMessage);
     }
 
     private boolean hasEnvironmentExclusions(String[] excludedEnvVariables, String[] excludedEnvRegexes) {
@@ -745,15 +862,43 @@ public class CliExecutionHelper {
                                                            Consumer<Exception> errorHandler,
                                                            Predicate<String> lineStopPredicate,
                                                            OutputFolderPreference outputFolderPreference) {
+        return executeCliCommandsWithResult(cliCommands, workingDirectory, envVariablesFile, timerAction, timerIntervalSeconds,
+                liveCliOutput, allowAnyCommand, excludedEnvVariables, excludedEnvRegexes, errorHandler, lineStopPredicate,
+                outputFolderPreference, null);
+    }
+
+    /**
+     * Same as the overload above, additionally publishing a live snapshot of the last fatal CLI
+     * failure to {@code liveErrorState} (if non-null) as soon as it is detected — mirroring
+     * {@code liveCliOutput} — so a concurrent {@code timerJSAction} can observe and react to a
+     * fatal, non-retryable error (e.g. an invalid model ID rejected by the AI provider) before
+     * the whole CLI command batch finishes, rather than only being able to string-scan the raw
+     * output for error text.
+     *
+     * @param liveErrorState Optional shared AtomicReference updated with a {@link LiveCliErrorState}
+     *                       snapshot as soon as a fatal (non-zero exit code) command failure is detected
+     */
+    public CliExecutionResult executeCliCommandsWithResult(String[] cliCommands, Path workingDirectory,
+                                                           String envVariablesFile,
+                                                           Runnable timerAction, int timerIntervalSeconds,
+                                                           AtomicReference<String> liveCliOutput,
+                                                           boolean allowAnyCommand,
+                                                           String[] excludedEnvVariables,
+                                                           String[] excludedEnvRegexes,
+                                                           Consumer<Exception> errorHandler,
+                                                           Predicate<String> lineStopPredicate,
+                                                           OutputFolderPreference outputFolderPreference,
+                                                           AtomicReference<LiveCliErrorState> liveErrorState) {
         AtomicReference<String> liveOutput = liveCliOutput != null ? liveCliOutput
                 : (timerAction != null ? new AtomicReference<>("") : null);
 
         AtomicReference<CliExecutionResult> resultRef = new AtomicReference<>();
         runWithTimer(timerAction, timerIntervalSeconds, () -> {
-            StringBuilder cliResponses = executeCliCommands(cliCommands, workingDirectory, envVariablesFile, liveOutput,
-                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes, errorHandler, lineStopPredicate);
+            CliCommandsOutcome outcome = executeCliCommandsInternal(cliCommands, workingDirectory, envVariablesFile, liveOutput,
+                    allowAnyCommand, excludedEnvVariables, excludedEnvRegexes, errorHandler, lineStopPredicate, liveErrorState);
             String outputResponse = processOutputResponse(workingDirectory, outputFolderPreference);
-            resultRef.set(new CliExecutionResult(cliResponses, outputResponse));
+            resultRef.set(new CliExecutionResult(outcome.getCommandResponses(), outputResponse,
+                    outcome.hasFatalError(), outcome.getLastExitCode(), outcome.getLastErrorMessage()));
         });
         return resultRef.get();
     }
@@ -1020,15 +1165,30 @@ public class CliExecutionHelper {
     }
 
     /**
-     * Result container for CLI execution that includes both command responses and output response.
+     * Result container for CLI execution that includes both command responses and output response,
+     * plus a structured signal for the last fatal (non-zero exit code) command failure encountered,
+     * if any. This lets callers (e.g. {@code timerJSAction}/{@code postJSAction} retry logic)
+     * distinguish a real, non-retryable CLI failure from a transient interruption without having
+     * to string-scan the free-text {@code commandResponses}.
      */
     public static class CliExecutionResult {
         private final StringBuilder commandResponses;
         private final String outputResponse;
+        private final boolean hasFatalError;
+        private final Integer lastExitCode;
+        private final String lastErrorMessage;
 
         public CliExecutionResult(StringBuilder commandResponses, String outputResponse) {
+            this(commandResponses, outputResponse, false, null, null);
+        }
+
+        public CliExecutionResult(StringBuilder commandResponses, String outputResponse,
+                                   boolean hasFatalError, Integer lastExitCode, String lastErrorMessage) {
             this.commandResponses = commandResponses;
             this.outputResponse = outputResponse;
+            this.hasFatalError = hasFatalError;
+            this.lastExitCode = lastExitCode;
+            this.lastErrorMessage = lastErrorMessage;
         }
 
         public StringBuilder getCommandResponses() {
@@ -1041,6 +1201,32 @@ public class CliExecutionHelper {
 
         public boolean hasOutputResponse() {
             return outputResponse != null && !outputResponse.trim().isEmpty();
+        }
+
+        /**
+         * @return {@code true} if the last CLI command in this batch failed with a non-zero
+         * exit code (a fatal, non-retryable error), as opposed to producing no output due to
+         * a transient interruption.
+         */
+        public boolean hasFatalError() {
+            return hasFatalError;
+        }
+
+        /**
+         * @return the exit code of the failing CLI command, or {@code null} if no command
+         * failed with a known exit code (e.g. a non-{@link com.github.istin.dmtools.common.utils.CliCommandFailedException}
+         * exception was thrown, or no command failed at all).
+         */
+        public Integer getLastExitCode() {
+            return lastExitCode;
+        }
+
+        /**
+         * @return a concise error message describing the last fatal CLI command failure,
+         * or {@code null} if no command failed.
+         */
+        public String getLastErrorMessage() {
+            return lastErrorMessage;
         }
     }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -559,16 +559,21 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             String timerJSAction = expertParams.getTimerJSAction();
             int timerIntervalSeconds = expertParams.getTimerIntervalSeconds();
             AtomicReference<String> liveCliOutput = new AtomicReference<>("");
+            AtomicReference<CliExecutionHelper.LiveCliErrorState> liveCliErrorState =
+                    new AtomicReference<>(CliExecutionHelper.LiveCliErrorState.NONE);
             Runnable timerRunnable = null;
             if (timerJSAction != null && !timerJSAction.trim().isEmpty() && timerIntervalSeconds > 0) {
                 timerRunnable = () -> {
                     try {
+                        CliExecutionHelper.LiveCliErrorState errorState = liveCliErrorState.get();
                         js(timerJSAction)
                             .mcp(trackerClient, ai, confluence, null)
                             .withJobContext(expertParams, ticket, null)
                             .with(TrackerParams.INITIATOR, initiator)
                             .with("systemRequest", systemRequestCommentAlias)
                             .with("currentCliOutput", liveCliOutput.get())
+                            .with("currentCliHasFatalError", errorState.hasFatalError())
+                            .with("currentCliErrorMessage", errorState.getErrorMessage())
                             .execute();
                     } catch (Exception e) {
                         logger.warn("timerJSAction execution failed (continues): {}", e.getMessage());
@@ -636,7 +641,11 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                             liveCliOutput,
                             false,
                             expertParams.getExcludedEnvVariables(),
-                            expertParams.getExcludedEnvRegexes());
+                            expertParams.getExcludedEnvRegexes(),
+                            null,
+                            null,
+                            CliExecutionHelper.OutputFolderPreference.LEGACY_OUTPUT_FIRST,
+                            liveCliErrorState);
                     
                     // Append CLI responses to knownInfo if not empty
                     StringBuilder cliResponses = cliResult.getCommandResponses();
@@ -651,9 +660,16 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     
                 } catch (Exception e) {
                     logger.error("Failed to execute CLI commands for ticket {}: {}", ticket.getKey(), e.getMessage(), e);
-                    // Create error result for consistent handling below
+                    // Create error result for consistent handling below. Also populate the
+                    // structured error fields (and the live signal timerJSAction reads) so a
+                    // hard failure surfaced here is just as visible to JS consumers as one
+                    // detected inside executeCliCommandsWithResult itself.
                     StringBuilder errorResponse = new StringBuilder("CLI Execution Error: ").append(e.getMessage()).append("\n");
-                    cliResult = new CliExecutionHelper.CliExecutionResult(errorResponse, null);
+                    Integer exitCode = (e instanceof com.github.istin.dmtools.common.utils.CliCommandFailedException)
+                            ? ((com.github.istin.dmtools.common.utils.CliCommandFailedException) e).getExitCode()
+                            : null;
+                    cliResult = new CliExecutionHelper.CliExecutionResult(errorResponse, null, true, exitCode, e.getMessage());
+                    liveCliErrorState.set(new CliExecutionHelper.LiveCliErrorState(true, exitCode, e.getMessage()));
                 } finally {
                     // Clean up input context
                     if (inputContextPath != null) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
@@ -76,6 +76,20 @@ class CommandLineUtilsTest {
     }
 
     @Test
+    void testRunCommand_NonZeroExitCode_ThrowsCliCommandFailedExceptionWithStructuredExitCode() {
+        // The thrown exception must be the structured CliCommandFailedException (an IOException
+        // subtype), exposing the real exit code without callers needing to parse the message.
+        String os = System.getProperty("os.name").toLowerCase();
+        if (!os.contains("win")) {
+            CliCommandFailedException ex = assertThrows(CliCommandFailedException.class,
+                    () -> CommandLineUtils.runCommand("false"));
+            assertEquals(1, ex.getExitCode());
+            assertEquals("false", ex.getCommand());
+            assertTrue(ex.getMessage().contains("exit code 1"));
+        }
+    }
+
+    @Test
     void testRunCommand_ExitCode128_ThrowsIOExceptionWithCode() {
         String os = System.getProperty("os.name").toLowerCase();
         if (!os.contains("win")) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/CliExecutionHelperTest.java
@@ -8,6 +8,7 @@ import com.github.istin.dmtools.common.model.IComment;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.CliCommandFailedException;
 import com.github.istin.dmtools.common.utils.CliExecutionStoppedException;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
 import org.apache.commons.io.FileUtils;
@@ -446,6 +447,81 @@ public class CliExecutionHelperTest {
             assertTrue(result.getCommandResponses().toString().contains("test"));
             assertTrue(result.hasOutputResponse());
             assertEquals(outputContent, result.getOutputResponse());
+        }
+    }
+
+    @Test
+    void testExecuteCliCommandsWithResult_Success_NoFatalError() throws IOException {
+        // Arrange - a successful command batch must report no fatal error
+        Path workingDir = Files.createTempDirectory(tempDir, "working");
+        String[] commands = {"echo hello"};
+
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.runCommand(eq("echo hello"), any(File.class), any(Map.class), any(), anyBoolean(), any(), anyInt()))
+                      .thenReturn("hello\nExit Code: 0");
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                      .thenReturn(Map.of());
+
+            // Act
+            CliExecutionHelper.CliExecutionResult result = cliHelper.executeCliCommandsWithResult(commands, workingDir, "dmtools.env");
+
+            // Assert
+            assertNotNull(result);
+            assertFalse(result.hasFatalError());
+            assertNull(result.getLastExitCode());
+            assertNull(result.getLastErrorMessage());
+        }
+    }
+
+    @Test
+    void testExecuteCliCommandsWithResult_FatalError_ExposesExitCodeAndMessage() throws IOException {
+        // Arrange - simulate a subprocess that exits non-zero (e.g. an invalid model ID
+        // rejected by a Bedrock/Claude API call), as thrown by CommandLineUtils.runCommand
+        Path workingDir = Files.createTempDirectory(tempDir, "working");
+        String[] commands = {"claude --model invalid-model"};
+
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.runCommand(eq("claude --model invalid-model"), any(File.class), any(Map.class), any(), anyBoolean(), any(), anyInt()))
+                      .thenThrow(new CliCommandFailedException("claude --model invalid-model", 1,
+                              "API Error: 400 {\"detail\":\"ValidationException: The provided model identifier is invalid.\"}"));
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                      .thenReturn(Map.of());
+
+            // Act
+            CliExecutionHelper.CliExecutionResult result = cliHelper.executeCliCommandsWithResult(commands, workingDir, "dmtools.env");
+
+            // Assert - the structured signal must be available without string-scanning commandResponses
+            assertNotNull(result);
+            assertTrue(result.hasFatalError());
+            assertEquals(1, result.getLastExitCode());
+            assertNotNull(result.getLastErrorMessage());
+            assertTrue(result.getLastErrorMessage().contains("ValidationException"));
+            // The free-text transcript still contains the error too (backward compatible)
+            assertTrue(result.getCommandResponses().toString().contains("Error:"));
+        }
+    }
+
+    @Test
+    void testExecuteCliCommandsWithResult_NonCliCommandFailedException_ExitCodeIsNull() throws IOException {
+        // Arrange - a generic IOException (not CliCommandFailedException) should still be
+        // flagged as a fatal error, but with no known exit code.
+        Path workingDir = Files.createTempDirectory(tempDir, "working");
+        String[] commands = {"some-tool"};
+
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.runCommand(eq("some-tool"), any(File.class), any(Map.class), any(), anyBoolean(), any(), anyInt()))
+                      .thenThrow(new IOException("some-tool: command not found"));
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                      .thenReturn(Map.of());
+
+            // Act
+            CliExecutionHelper.CliExecutionResult result = cliHelper.executeCliCommandsWithResult(commands, workingDir, "dmtools.env");
+
+            // Assert
+            assertNotNull(result);
+            assertTrue(result.hasFatalError());
+            assertNull(result.getLastExitCode());
+            assertNotNull(result.getLastErrorMessage());
         }
     }
     
@@ -1033,6 +1109,38 @@ public class CliExecutionHelperTest {
 
             assertTrue(latch.await(5, TimeUnit.SECONDS), "Timer action should fire within 5 seconds");
             assertTrue(fireCount.get() >= 1, "Timer action should have fired at least once");
+        }
+    }
+
+    @Test
+    void testExecuteCliCommandsWithResult_LiveErrorStatePublishedOnFatalError() throws IOException {
+        // Arrange - a fatal CLI failure must be published to liveErrorState synchronously
+        // (mirroring how liveOutput is updated), so a concurrent timerJSAction reading it
+        // afterwards observes the failure without waiting for the whole batch to finish.
+        Path workingDir = Files.createTempDirectory(tempDir, "working");
+        String[] commands = {"claude --model invalid-model"};
+        java.util.concurrent.atomic.AtomicReference<CliExecutionHelper.LiveCliErrorState> liveErrorState =
+                new java.util.concurrent.atomic.AtomicReference<>(CliExecutionHelper.LiveCliErrorState.NONE);
+
+        try (MockedStatic<CommandLineUtils> mockedUtils = Mockito.mockStatic(CommandLineUtils.class)) {
+            mockedUtils.when(() -> CommandLineUtils.runCommand(eq("claude --model invalid-model"), any(File.class), any(Map.class), any(), anyBoolean(), any(), anyInt()))
+                    .thenThrow(new CliCommandFailedException("claude --model invalid-model", 1, "ValidationException"));
+            mockedUtils.when(() -> CommandLineUtils.loadEnvironmentFromFile("dmtools.env"))
+                    .thenReturn(Map.of());
+
+            // Act - assert that liveErrorState starts as NONE, and is updated after execution
+            assertFalse(liveErrorState.get().hasFatalError());
+
+            CliExecutionHelper.CliExecutionResult result = cliHelper.executeCliCommandsWithResult(
+                    commands, workingDir, "dmtools.env", null, 0, null, false, null, null,
+                    null, null, CliExecutionHelper.OutputFolderPreference.LEGACY_OUTPUT_FIRST, liveErrorState);
+
+            // Assert
+            assertNotNull(result);
+            assertTrue(result.hasFatalError());
+            assertTrue(liveErrorState.get().hasFatalError());
+            assertEquals(1, liveErrorState.get().getExitCode());
+            assertNotNull(liveErrorState.get().getErrorMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes #452.

`CliExecutionResult` previously only exposed free-text command responses and the output response file content — no structured signal existed to distinguish a fatal CLI failure (non-zero exit code) from a transient interruption without string-scanning the raw output. This forced downstream JS consumers (`timerJSAction`/`postJSAction` retry logic) into fragile string-parsing, which caused a real silent-infinite-retry bug in a deployed AI Teammate job (see `IstiN/dmtools-agents#338`).

## Changes
- **`CliCommandFailedException`** (new, extends `IOException`): `CommandLineUtils.runCommand` now throws this instead of a plain `IOException` on non-zero exit, exposing `getExitCode()`/`getCommand()`/`getOutput()`. Existing callers that only catch `IOException`/`Exception` see no behavior change (message format is identical).
- **`CliExecutionHelper`**:
  - Tracks the last fatal command failure (exit code + message) across `executeCliCommands`.
  - `CliExecutionResult` gains `hasFatalError()`, `getLastExitCode()`, `getLastErrorMessage()` (backward compatible — original 2-arg constructor/getters unchanged).
  - New `LiveCliErrorState` published live (mirroring `liveCliOutput`) so a concurrent `timerJSAction` can react to a fatal error before the whole CLI command batch finishes, via a new `executeCliCommandsWithResult` overload.
- **`Teammate.java`**: wires `currentCliHasFatalError` / `currentCliErrorMessage` into the `timerJSAction` JS context alongside the existing `currentCliOutput` (the same runnable is reused for `postJSAction`, so it gets this too). The outer exception fallback path also populates the structured fields.
- **Docs**: updated `dmtools-ai-docs/references/agents/teammate-configs.md` to document the new `timerJSAction` params.
- **Tests**: added coverage in `CliExecutionHelperTest` (fatal error detection, exit code propagation, live-signal publishing) and `CommandLineUtilsTest` (structured exception type/fields).

## Testing
- `./gradlew :dmtools-core:compileJava` — clean.
- `./gradlew :dmtools-core:test` — full suite passes (548 test classes, 0 failures).