### PR TITLE
fix(dial): normalize base path join to avoid missing slash

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/dial/DialAIClient.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/dial/DialAIClient.java
@@ -95,7 +95,16 @@ public class DialAIClient extends AbstractRestClient implements AI {
 
     @Override
     public String path(String path) {
-        return getBasePath() + path;// + "?api-version=" + API_VERSION;
+        String base = getBasePath() == null ? "" : getBasePath();
+        if (path == null) {
+            path = "";
+        }
+        if (base.endsWith("/") && path.startsWith("/")) {
+            path = path.substring(1);
+        } else if (!base.isEmpty() && !base.endsWith("/") && !path.startsWith("/")) {
+            base += "/";
+        }
+        return base + path;
     }
 
     @Override

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/dial/DialAIClientCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/dial/DialAIClientCoverageTest.java
@@ -173,7 +173,7 @@ public class DialAIClientCoverageTest {
 
         ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
         verify(spy).post(captor.capture());
-        assertEquals(BASE_PATH + "openai/deployments/" + MODEL + "/chat/completions",
+        assertEquals(BASE_PATH + "/openai/deployments/" + MODEL + "/chat/completions",
                 captor.getValue().url());
         String body = captor.getValue().getBody();
         assertTrue(body.contains("\"temperature\":0.1"));

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/ai/dial/DialAIClientTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/ai/dial/DialAIClientTest.java
@@ -3,10 +3,12 @@
 
 package com.github.istin.dmtools.ai.dial;
 
+import com.github.istin.dmtools.common.config.ApplicationConfiguration;
 import com.github.istin.dmtools.common.networking.GenericRequest;
 import okhttp3.Request;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
 
@@ -33,7 +35,58 @@ public class DialAIClientTest {
     @Test
     public void testPath() {
         String path = "test/path";
-        assertEquals(BASE_PATH + path, dialAIClient.path(path));
+        assertEquals(BASE_PATH + "/" + path, dialAIClient.path(path));
+    }
+
+    @Test
+    public void testPathWithTrailingSlashBase() throws IOException {
+        DialAIClient client = new DialAIClient(BASE_PATH + "/", AUTHORIZATION, MODEL);
+        assertEquals(BASE_PATH + "/test/path", client.path("test/path"));
+    }
+
+    @Test
+    public void testPathWithLeadingSlashPath() {
+        assertEquals(BASE_PATH + "/test/path", dialAIClient.path("/test/path"));
+    }
+
+    @Test
+    public void testChatUrlWhenBasePathHasNoTrailingSlash() throws Exception {
+        ApplicationConfiguration config = mock(ApplicationConfiguration.class);
+        when(config.getDialBathPath()).thenReturn("https://api.dial.com");
+        when(config.getDialApiKey()).thenReturn(AUTHORIZATION);
+        when(config.getDialModel()).thenReturn(MODEL);
+        when(config.getDialApiVersion()).thenReturn(null);
+
+        BasicDialAI client = new BasicDialAI(null, config);
+        DialAIClient spy = spy(client);
+        doReturn("{\"choices\":[]}").when(spy).post(any(GenericRequest.class));
+
+        spy.chat("Hi");
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(spy).post(captor.capture());
+        assertEquals("https://api.dial.com/openai/deployments/" + MODEL + "/chat/completions",
+                captor.getValue().url());
+    }
+
+    @Test
+    public void testChatUrlWhenBasePathHasTrailingSlash() throws Exception {
+        ApplicationConfiguration config = mock(ApplicationConfiguration.class);
+        when(config.getDialBathPath()).thenReturn("https://api.dial.com/");
+        when(config.getDialApiKey()).thenReturn(AUTHORIZATION);
+        when(config.getDialModel()).thenReturn(MODEL);
+        when(config.getDialApiVersion()).thenReturn(null);
+
+        BasicDialAI client = new BasicDialAI(null, config);
+        DialAIClient spy = spy(client);
+        doReturn("{\"choices\":[]}").when(spy).post(any(GenericRequest.class));
+
+        spy.chat("Hi");
+
+        ArgumentCaptor<GenericRequest> captor = ArgumentCaptor.forClass(GenericRequest.class);
+        verify(spy).post(captor.capture());
+        assertEquals("https://api.dial.com/openai/deployments/" + MODEL + "/chat/completions",
+                captor.getValue().url());
     }
 
     @Test


### PR DESCRIPTION
## Problem

When `DIAL_BASE_PATH` is configured without a trailing slash (e.g. `https://api.dial.com`), `DialAIClient` builds request URLs like:

```
https://api.dial.comopenai/deployments/.../chat/completions
```

instead of:

```
https://api.dial.com/openai/deployments/.../chat/completions
```

## Fix

- `DialAIClient.path()` now inserts a single `/` between the base path and the endpoint path when neither already provides one.
- It also strips a leading slash from the path when the base path already ends with one, avoiding double slashes.

## Tests

- Updated `DialAIClientTest` and `DialAIClientCoverageTest` which previously encoded the old buggy concatenation.
- Added tests for base paths with and without a trailing slash, including mocked `ApplicationConfiguration` chat scenarios using `https://api.dial.com`.

```
./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.ai.dial.*"
```

Result: BUILD SUCCESSFUL.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
