### PR TITLE
fix(job): stop corrupting string tool args that merely look like JSON arrays (#360)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/job/JobJavaScriptBridge.java
@@ -287,6 +287,11 @@ public class JobJavaScriptBridge {
         boolean verboseToolLogging = isToolCallArgsLoggingEnabled();
         try {
             // Convert JavaScript object to Map
+            // Fetch the tool schema up front: the string-to-array guessing below is
+            // only allowed for parameters the schema does NOT explicitly declare as
+            // a non-array type (IstiN/dmtools-agents#360).
+            Map<String, Object> toolSchema = getToolSchema(toolName);
+
             Map<String, Object> argsMap = new HashMap<>();
             if (jsArgs != null) {
                 if (verboseToolLogging) {
@@ -317,23 +322,10 @@ public class JobJavaScriptBridge {
                             }
                             memberValue = objList;
                         } else if (memberValue instanceof String) {
-                            String strValue = ((String) memberValue).trim();
-                            // Only try to parse as JSON array if it looks like a valid JSON array
-                            // (starts with [ and ends with ])
-                            if (strValue.startsWith("[") && strValue.endsWith("]") && strValue.length() > 2) {
-                                // Handle case where JavaScript passes array as JSON string
-                                try {
-                                    JSONArray jsonArray = new JSONArray(strValue);
-                                    List<Object> objList = new ArrayList<>();
-                                    for (int i = 0; i < jsonArray.length(); i++) {
-                                        objList.add(jsonArray.get(i));
-                                    }
-                                    memberValue = objList;
-                                    logger.debug("Parsed JSON array string for {}: {} elements", key, objList.size());
-                                } catch (org.json.JSONException e) {
-                                    // If parsing fails, keep original value (it's just a string starting with [)
-                                    logger.debug("Failed to parse as JSON array for {} (keeping as string): {}", key, e.getMessage());
-                                }
+                            List<Object> parsedArray = tryParseArrayStringArg(toolName, key, (String) memberValue, toolSchema);
+                            if (parsedArray != null) {
+                                memberValue = parsedArray;
+                                logger.debug("Parsed JSON array string for {}: {} elements", key, parsedArray.size());
                             }
                             // Otherwise, it's just a regular string - keep it as-is
                         }
@@ -359,23 +351,10 @@ public class JobJavaScriptBridge {
                                 }
                                 hostMap.put(entry.getKey(), objList);
                             } else if (value instanceof String) {
-                                String strValue = ((String) value).trim();
-                                // Only try to parse as JSON array if it looks like a valid JSON array
-                                // (starts with [ and ends with ])
-                                if (strValue.startsWith("[") && strValue.endsWith("]") && strValue.length() > 2) {
-                                    // Handle case where JavaScript passes array as JSON string
-                                    try {
-                                        JSONArray jsonArray = new JSONArray(strValue);
-                                        List<Object> objList = new ArrayList<>();
-                                        for (int i = 0; i < jsonArray.length(); i++) {
-                                            objList.add(jsonArray.get(i));
-                                        }
-                                        hostMap.put(entry.getKey(), objList);
-                                        logger.debug("Parsed JSON array string for {}: {} elements", entry.getKey(), objList.size());
-                                    } catch (org.json.JSONException e) {
-                                        // If parsing fails, keep original value (it's just a string starting with [)
-                                        logger.debug("Failed to parse as JSON array for {} (keeping as string): {}", entry.getKey(), e.getMessage());
-                                    }
+                                List<Object> parsedArray = tryParseArrayStringArg(toolName, entry.getKey(), (String) value, toolSchema);
+                                if (parsedArray != null) {
+                                    hostMap.put(entry.getKey(), parsedArray);
+                                    logger.debug("Parsed JSON array string for {}: {} elements", entry.getKey(), parsedArray.size());
                                 }
                                 // Otherwise, it's just a regular string - keep it as-is
                             }
@@ -392,8 +371,7 @@ public class JobJavaScriptBridge {
                 logger.debug("Final args map for tool {}: {}", toolName, argsMap);
             }
             
-            // Get tool schema to check parameter types
-            Map<String, Object> toolSchema = getToolSchema(toolName);
+            // (tool schema was already fetched above, before argument conversion)
             
             // Convert ArrayList to String[] for MCP tools that expect array parameters
             // But keep as List<String> for parameters that require List (e.g., mermaid_index_generate patterns)
@@ -516,30 +494,100 @@ public class JobJavaScriptBridge {
     private boolean isArrayParameter(Map<String, Object> toolSchema, String paramName) {
         if (toolSchema == null) {
             // If schema not available, check known array parameter names
-            return paramName.equals("fields") || paramName.endsWith("s") && 
+            return paramName.equals("fields") || paramName.endsWith("s") &&
                    (paramName.contains("field") || paramName.contains("id") || paramName.contains("url"));
         }
-        
-        @SuppressWarnings("unchecked")
-        Map<String, Object> inputSchema = (Map<String, Object>) toolSchema.get("inputSchema");
-        if (inputSchema == null) {
-            return false;
-        }
-        
-        @SuppressWarnings("unchecked")
-        Map<String, Object> properties = (Map<String, Object>) inputSchema.get("properties");
-        if (properties == null) {
-            return false;
-        }
-        
-        @SuppressWarnings("unchecked")
-        Map<String, Object> paramSchema = (Map<String, Object>) properties.get(paramName);
+        Map<String, Object> paramSchema = getParamSchema(toolSchema, paramName);
         if (paramSchema == null) {
             return false;
         }
-        
         String type = (String) paramSchema.get("type");
         return "array".equals(type);
+    }
+
+    /**
+     * Returns the schema of a single tool parameter, or {@code null} when the
+     * tool schema does not describe it.
+     */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getParamSchema(Map<String, Object> toolSchema, String paramName) {
+        Map<String, Object> inputSchema = (Map<String, Object>) toolSchema.get("inputSchema");
+        if (inputSchema == null) {
+            return null;
+        }
+        Map<String, Object> properties = (Map<String, Object>) inputSchema.get("properties");
+        if (properties == null) {
+            return null;
+        }
+        return (Map<String, Object>) properties.get(paramName);
+    }
+
+    /**
+     * Attempts to interpret a string argument as a JSON array, returning the
+     * parsed elements, or {@code null} when the value must stay a plain string.
+     *
+     * <p>Guards against IstiN/dmtools-agents#360: org.json's tokenizer is lenient
+     * and can "successfully" parse only a leading fragment of a string that merely
+     * starts with '[' and ends with ']' (e.g. "[label]: {...}\nInitiator:
+     * [~accountid:123]" parses as ["label"], silently discarding the payload).
+     * Two guards apply:
+     * <ul>
+     *   <li>the guess is skipped entirely when the tool schema explicitly declares
+     *   the parameter as a non-array type (e.g. jira_post_comment's string
+     *   'comment'); guessing is preserved for array-typed parameters, parameters
+     *   absent from the schema, and unknown tools (backward compatibility);</li>
+     *   <li>the parse must consume the ENTIRE string — any trailing content after
+     *   the balanced ']' means the value is kept as a plain string.</li>
+     * </ul>
+     */
+    private List<Object> tryParseArrayStringArg(String toolName, String paramName, String rawValue, Map<String, Object> toolSchema) {
+        String strValue = rawValue.trim();
+        if (strValue.length() <= 2 || !strValue.startsWith("[") || !strValue.endsWith("]")) {
+            return null;
+        }
+        if (!isArrayStringParsingAllowed(toolName, paramName, toolSchema)) {
+            return null;
+        }
+        try {
+            org.json.JSONTokener tokener = new org.json.JSONTokener(strValue);
+            JSONArray jsonArray = new JSONArray(tokener);
+            // org.json stops at the first balanced ']' and ignores the rest of the
+            // input — require full consumption so "[a]: {...}" is not misread as ["a"].
+            if (tokener.nextClean() != 0) {
+                return null;
+            }
+            List<Object> objList = new ArrayList<>();
+            for (int i = 0; i < jsonArray.length(); i++) {
+                objList.add(jsonArray.get(i));
+            }
+            return objList;
+        } catch (org.json.JSONException e) {
+            // Not a JSON array — the original string is kept as-is.
+            logger.debug("Failed to parse as JSON array for {} (keeping as string): {}", paramName, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Whether a string argument may be guessed as a JSON array: allowed for
+     * array-typed parameters, parameters missing from the schema and unknown
+     * tools (legacy behavior); denied when the schema explicitly declares the
+     * parameter with a non-array type.
+     */
+    private boolean isArrayStringParsingAllowed(String toolName, String paramName, Map<String, Object> toolSchema) {
+        if (shouldKeepAsList(toolName, paramName)) {
+            return true;
+        }
+        if (toolSchema == null) {
+            return true; // unknown tool — legacy behavior
+        }
+        Map<String, Object> paramSchema = getParamSchema(toolSchema, paramName);
+        if (paramSchema == null) {
+            return true; // parameter not described by the schema — legacy behavior
+        }
+        Object type = paramSchema.get("type");
+        // An explicitly declared non-array type (e.g. "string") must not be guessed.
+        return type == null || "array".equals(type);
     }
 
     /**

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobJavaScriptBridgeTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/job/JobJavaScriptBridgeTest.java
@@ -1005,6 +1005,192 @@ class JobJavaScriptBridgeTest {
             ));
         }
     }
+
+    @Test
+    void testBracketedCommentNotMisparsedAsJsonArray_Issue360() throws Exception {
+        // Regression for IstiN/dmtools-agents#360: a comment shaped as
+        // "[label]: {...json...}\nInitiator: [~accountid:<id>]" starts with '[' and
+        // ends with ']', and org.json's lenient tokenizer parsed only the leading
+        // "[label]" fragment as a JSON array, silently replacing the whole comment
+        // with "[\"label\"]" before it reached jira_post_comment.
+        // jira_post_comment.comment is schema-typed "string", so no array guessing
+        // may happen and the original text must arrive untouched.
+        String jsCode = """
+            function action(params) {
+                var comment = '[some-label]: ' + JSON.stringify({foo: 'bar', list: ['a', 'b']});
+                comment += '\\nInitiator: [~accountid:123]';
+                jira_post_comment('MAPC-123', comment);
+                return { ok: true };
+            }
+            """;
+
+        JSONObject params = new JSONObject();
+
+        try (MockedStatic<MCPToolExecutor> mcpMock = mockStatic(MCPToolExecutor.class)) {
+            mcpMock.when(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                any(Map.class),
+                any(Map.class)
+            )).thenReturn("OK");
+
+            Object result = bridge.executeJavaScript(jsCode, params);
+            assertNotNull(result);
+
+            String expected = "[some-label]: {\"foo\":\"bar\",\"list\":[\"a\",\"b\"]}\nInitiator: [~accountid:123]";
+            mcpMock.verify(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                argThat(args -> expected.equals(args.get("comment"))),
+                any(Map.class)
+            ));
+        }
+    }
+
+    @Test
+    void testMentionOnlyBracketStringNotMisparsed() throws Exception {
+        // "[~accountid:123]" alone also matches the [ ... ] shape and org.json
+        // would read the bareword "~accountid:123" as a single array element.
+        // For a string-typed parameter it must stay exactly as written.
+        String jsCode = """
+            function action(params) {
+                jira_post_comment('MAPC-123', '[~accountid:123]');
+                return { ok: true };
+            }
+            """;
+
+        JSONObject params = new JSONObject();
+
+        try (MockedStatic<MCPToolExecutor> mcpMock = mockStatic(MCPToolExecutor.class)) {
+            mcpMock.when(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                any(Map.class),
+                any(Map.class)
+            )).thenReturn("OK");
+
+            Object result = bridge.executeJavaScript(jsCode, params);
+            assertNotNull(result);
+
+            mcpMock.verify(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                argThat(args -> "[~accountid:123]".equals(args.get("comment"))),
+                any(Map.class)
+            ));
+        }
+    }
+
+    @Test
+    void testValidJsonArrayStringStillParsedForArrayParam() throws Exception {
+        // Backward compatibility: agents passing a JSON array as a string to an
+        // array-typed parameter (ado_get_work_item.fields) keep working — the
+        // string is parsed and converted to String[].
+        String jsCode = """
+            function action(params) {
+                ado_get_work_item('123', '["System.Title","System.State"]');
+                return { ok: true };
+            }
+            """;
+
+        JSONObject params = new JSONObject();
+
+        try (MockedStatic<MCPToolExecutor> mcpMock = mockStatic(MCPToolExecutor.class)) {
+            mcpMock.when(() -> MCPToolExecutor.executeTool(
+                eq("ado_get_work_item"),
+                any(Map.class),
+                any(Map.class)
+            )).thenReturn("OK");
+
+            Object result = bridge.executeJavaScript(jsCode, params);
+            assertNotNull(result);
+
+            mcpMock.verify(() -> MCPToolExecutor.executeTool(
+                eq("ado_get_work_item"),
+                argThat(args -> {
+                    Object fields = args.get("fields");
+                    if (!(fields instanceof String[])) return false;
+                    String[] arr = (String[]) fields;
+                    return arr.length == 2
+                        && "System.Title".equals(arr[0])
+                        && "System.State".equals(arr[1]);
+                }),
+                any(Map.class)
+            ));
+        }
+    }
+
+    @Test
+    void testPartialJsonArrayWithTrailingContentKeptAsString() throws Exception {
+        // Full-consumption guard: even for an array-typed parameter, a string that
+        // has content after the first balanced ']' ("["a"] and ["b"]") must NOT be
+        // truncated to ["a"] — it stays the original string.
+        String jsCode = """
+            function action(params) {
+                ado_get_work_item('123', '["System.Title"] and ["System.State"]');
+                return { ok: true };
+            }
+            """;
+
+        JSONObject params = new JSONObject();
+
+        try (MockedStatic<MCPToolExecutor> mcpMock = mockStatic(MCPToolExecutor.class)) {
+            mcpMock.when(() -> MCPToolExecutor.executeTool(
+                eq("ado_get_work_item"),
+                any(Map.class),
+                any(Map.class)
+            )).thenReturn("OK");
+
+            Object result = bridge.executeJavaScript(jsCode, params);
+            assertNotNull(result);
+
+            mcpMock.verify(() -> MCPToolExecutor.executeTool(
+                eq("ado_get_work_item"),
+                argThat(args -> "[\"System.Title\"] and [\"System.State\"]".equals(args.get("fields"))),
+                any(Map.class)
+            ));
+        }
+    }
+
+    @Test
+    void testJsonArrayStringForUndeclaredParamKeepsLegacyParsing() throws Exception {
+        // jira_post_comment only declares (key, comment); the extra arg travels as
+        // an undeclared parameter via the single-object call form.
+        // Backward compatibility: a parameter that is NOT described by the tool
+        // schema still gets the legacy guess-and-reconstruct treatment, so older
+        // agents relying on it do not break.
+        String jsCode = """
+            function action(params) {
+                var args = {key: 'MAPC-123', comment: 'plain comment', customData: '["x","y"]'};
+                jira_post_comment(args);
+                return { ok: true };
+            }
+            """;
+
+        JSONObject params = new JSONObject();
+
+        try (MockedStatic<MCPToolExecutor> mcpMock = mockStatic(MCPToolExecutor.class)) {
+            mcpMock.when(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                any(Map.class),
+                any(Map.class)
+            )).thenReturn("OK");
+
+            Object result = bridge.executeJavaScript(jsCode, params);
+            assertNotNull(result);
+
+            mcpMock.verify(() -> MCPToolExecutor.executeTool(
+                eq("jira_post_comment"),
+                argThat(args -> {
+                    Object customData = args.get("customData");
+                    if (!(customData instanceof String)) return false;
+                    try {
+                        JSONArray arr = new JSONArray((String) customData);
+                        return arr.length() == 2 && "x".equals(arr.getString(0)) && "y".equals(arr.getString(1));
+                    } catch (org.json.JSONException e) {
+                        return false;
+                    }
+                }),
+                any(Map.class)
+            ));
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Problem

Fixes the root cause of IstiN/dmtools-agents#360 (the JS-side workaround in IstiN/dmtools-agents#361 only guarded one call site).

`JobJavaScriptBridge.executeToolFromJS` speculatively parsed **any** string tool argument that `startsWith("[") && endsWith("]")` as a JSON array. org.json's lenient tokenizer can "succeed" on just a leading fragment (e.g. an unquoted bareword `[some-label]`) and silently discard everything after the first balanced `]`. For parameters schema-typed as plain `string` (like `jira_post_comment`'s `comment`), the bridge then **replaced the original argument** with the reconstructed bogus array — a comment like

```
[some-label]: {"foo":"bar",...}
Initiator: [~accountid:123]
```

reached Jira as `["some-label"]`. Silent data loss: no exception, the tool call still "succeeded".

## Fix

The argument conversion now fetches the tool schema **before** guessing, and both duplicated parse sites share one helper (`tryParseArrayStringArg`) with two guards:

1. **Schema-first**: the array guess is skipped entirely when the schema explicitly declares the parameter with a non-array type. Guessing is preserved for array-typed parameters, parameters absent from the schema, and unknown tools — legacy behavior is unchanged there.
2. **Full-consumption**: even when guessing is allowed, the parse must consume the entire trimmed string (`JSONTokener.nextClean()` must hit EOF after the balanced `]`). `[\"a\"] and [\"b\"]` stays a plain string instead of being truncated to `["a"]`.

## Backward compatibility

- Agents passing JSON-array **strings** to **array-typed** params (e.g. `ado_get_work_item.fields`) — still parsed and converted to `String[]`.
- Agents passing JSON-array strings to **string-typed** params (`bitrise_trigger_build.envVars`, `file_write.content`) — now pass through unchanged; since the original string already *is* valid JSON, consumers see identical content (covered by the existing regression tests, which pass unmodified).
- Undeclared parameters and unknown tools keep the legacy guess-and-reconstruct path.

## Testing

5 new regression tests in `JobJavaScriptBridgeTest`:

- exact #360 repro: `[some-label]: {...}\nInitiator: [~accountid:123]` arrives at `jira_post_comment` byte-identical
- mention-only `[~accountid:123]` string stays untouched
- valid JSON array string → `String[]` for an array-typed param (`ado_get_work_item.fields`)
- `["a"] and ["b"]` for an array-typed param → kept as the original string (full-consumption guard)
- undeclared param `customData: '["x","y"]'` → legacy parse+reconstruct preserved

Full `:dmtools-core` `job` package suite: **293 tests, 0 failures** (including the pre-existing `bitrise_trigger_build`/`file_write` array-string regressions).
