### PR TITLE
fix(cli): apply per-job envVariables overrides in CliCommandExecutor

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cli/CliCommandExecutor.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cli/CliCommandExecutor.java
@@ -316,7 +316,15 @@ public class CliCommandExecutor {
         } else {
             logger.debug("No dmtools.env file found in working directory: {}. Continuing with system environment.", workingDirectory.getAbsolutePath());
         }
-        
+
+        // Per-job envVariables (agent JSON) take highest precedence — also for commands run
+        // from JS actions via cli_execute_command (quality gates, git ops, etc.), not just the
+        // main CLI agent subprocess (CliExecutionHelper already applies them there).
+        Map<String, String> jobOverrides = PropertyReader.getOverrides();
+        if (!jobOverrides.isEmpty()) {
+            envVars.putAll(jobOverrides);
+        }
+
         return envVars;
     }
     

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/cli/CliCommandExecutorTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/cli/CliCommandExecutorTest.java
@@ -13,6 +13,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -207,6 +209,48 @@ public class CliCommandExecutorTest {
         assertNotNull("Result should not be null", result);
         assertTrue("Result should contain 'git version'", 
                 result.toLowerCase().contains("git version"));
+    }
+
+    @Test
+    public void testExecuteCommand_JobEnvOverrides_AppliedToSubprocess() throws IOException, InterruptedException {
+        // Regression test: per-job envVariables (PropertyReader thread-local overrides, set by
+        // JobRunner from the agent JSON "envVariables" param) must reach commands executed via
+        // cli_execute_command — not only the main CLI agent subprocess (CliExecutionHelper).
+        File tempDir = tempFolder.newFolder("test-job-overrides");
+        // dmtools.env sets the same var to a different value — the job override must win.
+        File envFile = new File(tempDir, "dmtools.env");
+        Files.writeString(envFile.toPath(), "DMTOOLS_TEST_OVERRIDE_VAR=from_env_file\n");
+
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("CLI_ALLOWED_COMMANDS", "bash");
+        overrides.put("DMTOOLS_TEST_OVERRIDE_VAR", "from_job_override");
+        PropertyReader.setOverrides(overrides);
+        try {
+            String result = executor.executeCommand("bash -c 'echo $DMTOOLS_TEST_OVERRIDE_VAR'", tempDir.getAbsolutePath());
+            assertTrue("Job envVariables override must be visible to the subprocess and win over dmtools.env; got: " + result,
+                    result.contains("from_job_override"));
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    public void testExecuteCommand_NoJobEnvOverrides_BehaviorUnchanged() throws IOException, InterruptedException {
+        // With no overrides set, the dmtools.env value must be used as before.
+        File tempDir = tempFolder.newFolder("test-no-overrides");
+        File envFile = new File(tempDir, "dmtools.env");
+        Files.writeString(envFile.toPath(), "DMTOOLS_TEST_OVERRIDE_VAR=from_env_file\n");
+
+        Map<String, String> overrides = new HashMap<>();
+        overrides.put("CLI_ALLOWED_COMMANDS", "bash");
+        PropertyReader.setOverrides(overrides);
+        try {
+            String result = executor.executeCommand("bash -c 'echo $DMTOOLS_TEST_OVERRIDE_VAR'", tempDir.getAbsolutePath());
+            assertTrue("Without a job override, dmtools.env value must be used; got: " + result,
+                    result.contains("from_env_file"));
+        } finally {
+            PropertyReader.clearOverrides();
+        }
     }
 
     // ============================================================================


### PR DESCRIPTION
## Problem
Per-job `envVariables` (agent JSON param) were propagated **only** to the main CLI agent subprocess: `CliExecutionHelper` merges `PropertyReader` thread-local overrides into that environment (log line: `Merging N per-job envVariables override(s) into subprocess environment`).

Commands executed from JS actions via `cli_execute_command` — quality gates, git operations, setup commands — go through `CliCommandExecutor`, which built its subprocess env from defaults + `dmtools.env` only, **silently ignoring the job overrides**.

### Real-world impact
An agent config declared `"envVariables": {"CI": "false"}` to match the target project's own CI behavior (their Jenkins/Docker build never sets `CI`). The CLI agent subprocess correctly got `CI=false`, but the quality gate `npm run build` still inherited the orchestrating GitLab pipeline's `CI=true`. CRA's `scripts/build.js` treats warnings as errors when `CI` is truthy, so the gate failed on pre-existing Less deprecation warnings that the project's real pipeline never sees — forcing a workaround commit into the feature branch.

## Fix
Apply `PropertyReader.getOverrides()` last in `CliCommandExecutor.loadEnvironmentVariables()`, giving per-job `envVariables` the highest precedence for every command the executor runs — consistent with `CliExecutionHelper` behavior.

## Testing
Two new tests in `CliCommandExecutorTest`:
- `testExecuteCommand_JobEnvOverrides_AppliedToSubprocess` — job override is visible to the subprocess and wins over the same key in `dmtools.env`
- `testExecuteCommand_NoJobEnvOverrides_BehaviorUnchanged` — without overrides, `dmtools.env` value is used as before

`./gradlew :dmtools-core:test --tests "com.github.istin.dmtools.cli.CliCommandExecutorTest"` — all pass.