### PR TITLE
feat(cli): add DMTOOLS_CLI_LOG_FILTER for selective CLI output tee

### DIFF
--- a/dmtools-ai-docs/references/configuration/README.md
+++ b/dmtools-ai-docs/references/configuration/README.md
@@ -72,6 +72,36 @@ GEMINI_API_KEY=your_personal_key
 | `PROMPT_CHUNK_MAX_SINGLE_FILE_SIZE_MB` | Max file size for context | No | `4` |
 | `DMTOOLS_DEBUG` | Enable debug logging | No | `true` |
 
+### CLI Logging and Transcripts
+
+When DMTools runs in normal CLI mode, most Java-side logging is suppressed to keep output clean. Use these variables to control CLI command output visibility and persistence.
+
+| Variable | Description | Required | Example |
+|----------|-------------|----------|---------|
+| `DMTOOLS_CLI_LOG_FILTER` | Comma-separated substrings; matching CLI commands tee output to console and file | No | `run-agent,cursor-agent` |
+| `DMTOOLS_CLI_LOG_DIR` | Directory for full CLI output transcripts | No | `.dmtools-logs/cli` |
+| `DMTOOLS_JS_LOG_TOOL_CALLS` | Verbose logging of JS/MCP tool calls and args | No | `true` |
+
+#### Selective CLI output with `DMTOOLS_CLI_LOG_FILTER`
+
+Use this variable to make specific long-running CLI commands visible without enabling all debug logging.
+
+```bash
+# Tee run-agent.sh output to console and file
+DMTOOLS_CLI_LOG_FILTER=run-agent ./dmtools.sh run agents/story_development.json
+
+# Match multiple command patterns
+DMTOOLS_CLI_LOG_FILTER=run-agent,cursor-agent,dmtools run ./dmtools.sh run agents/pr_review.json
+```
+
+How it works:
+- Matching is case-insensitive and ignores surrounding whitespace.
+- When a command matches, every line of its output is printed to the console even if `log4j2-cli.xml` would otherwise suppress logs.
+- The same output is also written to a timestamped transcript file under `DMTOOLS_CLI_LOG_DIR` (default: `.dmtools-logs/cli`).
+- In `--debug` mode the console output is already visible, so the filter only avoids duplication there; the transcript file is still written.
+
+This covers commands executed both as Teammate `cliCommands` and via the `cli_execute_command` MCP tool from JavaScript actions.
+
 ### Integration Credentials
 
 | Integration | Required Variables | Optional Variables |

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -232,10 +233,36 @@ public class CommandLineUtils {
         // Merge stdout and stderr so all output is captured
         processBuilder.redirectErrorStream(true);
 
+        // DMTOOLS_CLI_LOG_FILTER allows selectively teeing a command's full output to
+        // both the console and a transcript file, even when log4j is configured to
+        // discard logs (e.g. log4j2-cli.xml with Root=OFF). This is useful for making
+        // long-running agent commands (run-agent.sh, cursor-agent, etc.) visible
+        // without enabling all CLI tool logging.
+        PropertyReader propertyReader = new PropertyReader();
+        String[] cliLogFilters = propertyReader.getCliLogFilter();
+        boolean shouldTeeCliOutput = matchesCliLogFilter(command, cliLogFilters);
+        Path teeLogFile = shouldTeeCliOutput ? resolveFullOutputLogFile(timestamp, uniqueId) : null;
+        BufferedWriter teeWriter = null;
+        if (teeLogFile != null) {
+            try {
+                Path parent = teeLogFile.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+                teeWriter = Files.newBufferedWriter(teeLogFile);
+                teeWriter.write("Command: " + SecurityUtils.maskCommand(command) + System.lineSeparator());
+                teeWriter.write("Working directory: " + (workingDirectory != null ? workingDirectory.getAbsolutePath() : System.getProperty("user.dir")) + System.lineSeparator());
+                teeWriter.write("----" + System.lineSeparator());
+            } catch (IOException e) {
+                logger.warn("Failed to initialize CLI log filter transcript {}: {}", teeLogFile, e.getMessage());
+                teeWriter = null;
+            }
+        }
+
         Process process = processBuilder.start();
 
         // Drain stdout/stderr in real-time so the process doesn't block on a full pipe
-        boolean verboseCommandOutputLogging = new PropertyReader().isJsToolCallLoggingEnabled();
+        boolean verboseCommandOutputLogging = propertyReader.isJsToolCallLoggingEnabled();
         // Path a full, untruncated transcript would be written to IF this command's
         // output ends up exceeding the logging cap (computed upfront, from the same
         // timestamp/uniqueId used for the temp script, so the truncation notice can
@@ -269,6 +296,25 @@ public class CommandLineUtils {
                 }
 
                 output.append(line).append(System.lineSeparator());
+
+                // Tee matched CLI output to console and file independently of log4j.
+                // Console output is skipped when log4j is already printing, to avoid
+                // duplicate lines in --debug mode.
+                if (shouldTeeCliOutput) {
+                    if (!logger.isInfoEnabled()) {
+                        System.out.println(line);
+                    }
+                    if (teeWriter != null) {
+                        try {
+                            teeWriter.write(line);
+                            teeWriter.newLine();
+                        } catch (IOException e) {
+                            logger.warn("Failed to write CLI log filter transcript line: {}", e.getMessage());
+                            teeWriter = null;
+                        }
+                    }
+                }
+
                 if (lineConsumer != null) {
                     try {
                         lineConsumer.accept(line);
@@ -299,6 +345,26 @@ public class CommandLineUtils {
             persistFullOutput(fullOutputLogFile, command, workingDirectory, output.toString(), lineCount, exitCode);
         }
 
+        // Finalize the CLI log filter transcript, if any.
+        if (shouldTeeCliOutput) {
+            if (teeWriter != null) {
+                try {
+                    teeWriter.write("----" + System.lineSeparator());
+                    teeWriter.write("Exit code: " + exitCode + System.lineSeparator());
+                    teeWriter.close();
+                } catch (IOException e) {
+                    logger.warn("Failed to close CLI log filter transcript: {}", e.getMessage());
+                }
+            }
+            if (teeLogFile != null) {
+                if (logger.isInfoEnabled()) {
+                    logger.info("CLI log filter transcript written to: {}", teeLogFile.toAbsolutePath());
+                } else {
+                    System.out.println("CLI log filter transcript written to: " + teeLogFile.toAbsolutePath());
+                }
+            }
+        }
+
         // Propagate non-zero exit codes so callers are not silently misled.
         // Thrown as CliCommandFailedException (an IOException subtype) so existing
         // callers that only catch IOException/Exception see no behavior change, while
@@ -321,6 +387,23 @@ public class CommandLineUtils {
             return null;
         }
         return Paths.get(logDirProperty).resolve(timestamp + "-" + uniqueId + ".log");
+    }
+
+    /**
+     * Checks whether the given command matches any substring configured in
+     * {@code DMTOOLS_CLI_LOG_FILTER}. Matching is case-insensitive.
+     */
+    static boolean matchesCliLogFilter(String command, String[] filters) {
+        if (command == null || filters == null || filters.length == 0) {
+            return false;
+        }
+        String lowerCommand = command.toLowerCase();
+        for (String filter : filters) {
+            if (filter != null && !filter.isBlank() && lowerCommand.contains(filter.toLowerCase())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -461,6 +461,33 @@ public class PropertyReader {
     return getValue("DMTOOLS_CLI_LOG_DIR", ".dmtools-logs/cli");
   }
 
+  /**
+   * Comma-separated list of substrings that, when found in a CLI command, force the
+   * command's full output to be written both to the console and to a transcript file.
+   * This works independently of the active log4j configuration, so it is useful when
+   * CLI logging is otherwise suppressed (e.g. {@code log4j2-cli.xml} with Root=OFF).
+   * <p>
+   * Example: {@code DMTOOLS_CLI_LOG_FILTER=run-agent,cursor-agent,dmtools run}
+   * <p>
+   * Matching is case-insensitive and ignores surrounding whitespace. An empty or
+   * unset value disables the filter.
+   */
+  public String[] getCliLogFilter() {
+    String value = getValue("DMTOOLS_CLI_LOG_FILTER");
+    if (value == null || value.isBlank()) {
+      return new String[0];
+    }
+    String[] parts = value.split(",");
+    List<String> trimmed = new ArrayList<>();
+    for (String part : parts) {
+      String pattern = part.trim();
+      if (!pattern.isEmpty()) {
+        trimmed.add(pattern);
+      }
+    }
+    return trimmed.toArray(new String[0]);
+  }
+
   public boolean isXrayCacheGetRequestsEnabled() {
     String value = getValue("XRAY_CACHE_GET_REQUESTS_ENABLED");
     if (value == null) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
@@ -363,6 +363,107 @@ class CommandLineUtilsTest {
     }
 
     @Test
+    void testMatchesCliLogFilter_CaseInsensitiveSubstring() {
+        assertTrue(CommandLineUtils.matchesCliLogFilter("agents/scripts/run-agent.sh prompt", new String[]{"run-agent"}));
+        assertTrue(CommandLineUtils.matchesCliLogFilter("cursor-agent --model auto", new String[]{"cursor-agent"}));
+        assertTrue(CommandLineUtils.matchesCliLogFilter("dmtools run agents/story.json", new String[]{"dmtools run"}));
+        assertTrue(CommandLineUtils.matchesCliLogFilter("RUN-AGENT upper case", new String[]{"run-agent"}));
+    }
+
+    @Test
+    void testMatchesCliLogFilter_MultipleFilters() {
+        assertTrue(CommandLineUtils.matchesCliLogFilter("run-agent", new String[]{"cursor-agent", "run-agent"}));
+        assertFalse(CommandLineUtils.matchesCliLogFilter("some other command", new String[]{"run-agent", "cursor-agent"}));
+    }
+
+    @Test
+    void testMatchesCliLogFilter_EmptyOrNullFilters() {
+        assertFalse(CommandLineUtils.matchesCliLogFilter("run-agent", new String[0]));
+        assertFalse(CommandLineUtils.matchesCliLogFilter("run-agent", null));
+        assertFalse(CommandLineUtils.matchesCliLogFilter(null, new String[]{"run-agent"}));
+    }
+
+    @Test
+    void testMatchesCliLogFilter_IgnoresBlankFilters() {
+        assertTrue(CommandLineUtils.matchesCliLogFilter("run-agent", new String[]{" ", "run-agent"}));
+        assertFalse(CommandLineUtils.matchesCliLogFilter("run-agent", new String[]{" ", ""}));
+    }
+
+    @Test
+    void testRunCommand_CliLogFilterMatch_WritesTranscriptFile() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("cli-log-filter-logs");
+        try {
+            PropertyReader.setOverrides(Map.of(
+                    "DMTOOLS_CLI_LOG_DIR", logDir.toString(),
+                    "DMTOOLS_CLI_LOG_FILTER", "run-agent-test-marker"
+            ));
+
+            String result = CommandLineUtils.runCommand("echo run-agent-test-marker-output");
+            assertTrue(result.contains("run-agent-test-marker-output"));
+
+            assertTrue(Files.isDirectory(logDir), "Log dir should have been created");
+            try (var files = Files.list(logDir)) {
+                java.util.List<Path> written = files.toList();
+                assertEquals(1, written.size(), "Exactly one CLI log filter transcript should be written");
+                String content = Files.readString(written.get(0));
+                assertTrue(content.contains("run-agent-test-marker-output"),
+                        "Transcript should contain the command output");
+                assertTrue(content.contains("run-agent-test-marker"),
+                        "Transcript header should contain the matched command");
+                assertTrue(content.contains("Exit code: 0"));
+            }
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testRunCommand_CliLogFilterNoMatch_DoesNotWriteTranscriptFile() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("cli-log-filter-logs-2");
+        try {
+            PropertyReader.setOverrides(Map.of(
+                    "DMTOOLS_CLI_LOG_DIR", logDir.toString(),
+                    "DMTOOLS_CLI_LOG_FILTER", "run-agent"
+            ));
+
+            CommandLineUtils.runCommand("echo some-unrelated-output");
+
+            assertFalse(Files.exists(logDir), "No transcript should be created when command does not match filter");
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testRunCommand_CliLogFilterMatch_LogDirDisabled_DoesNotWriteFile() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        Path logDir = tempDir.resolve("cli-log-filter-logs-3");
+        try {
+            PropertyReader.setOverrides(Map.of(
+                    "DMTOOLS_CLI_LOG_DIR", "",
+                    "DMTOOLS_CLI_LOG_FILTER", "run-agent"
+            ));
+
+            CommandLineUtils.runCommand("echo run-agent-output");
+
+            assertFalse(Files.exists(logDir), "No transcript should be written when DMTOOLS_CLI_LOG_DIR is empty");
+        } finally {
+            PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
     void testRunCommand_UntruncatedOutput_DoesNotWriteLogFile() throws IOException, InterruptedException {
         String os = System.getProperty("os.name").toLowerCase();
         if (os.contains("win")) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/PropertyReaderCoverageTest.java
@@ -166,6 +166,30 @@ class PropertyReaderCoverageTest {
     }
 
     @Test
+    @DisplayName("getCliLogFilter() returns empty array when unset")
+    void testGetCliLogFilterEmptyByDefault() {
+        assertEquals(0, propertyReader.getCliLogFilter().length);
+    }
+
+    @Test
+    @DisplayName("getCliLogFilter() parses comma-separated values and trims whitespace")
+    void testGetCliLogFilterParsesCommaSeparatedValues() {
+        override("DMTOOLS_CLI_LOG_FILTER", "run-agent, cursor-agent ,dmtools run");
+
+        String[] filters = propertyReader.getCliLogFilter();
+        assertArrayEquals(new String[]{"run-agent", "cursor-agent", "dmtools run"}, filters);
+    }
+
+    @Test
+    @DisplayName("getCliLogFilter() ignores empty tokens")
+    void testGetCliLogFilterIgnoresEmptyTokens() {
+        override("DMTOOLS_CLI_LOG_FILTER", "run-agent,, ,cursor-agent");
+
+        String[] filters = propertyReader.getCliLogFilter();
+        assertArrayEquals(new String[]{"run-agent", "cursor-agent"}, filters);
+    }
+
+    @Test
     @DisplayName("findProjectRoot() falls back to user.dir when no Gradle markers exist")
     void testProjectRootFallbackWithoutGradleMarkers(@TempDir Path tempDir) throws IOException {
         // Temp dirs have no settings.gradle ancestor, so findProjectRoot() falls back to user.dir


### PR DESCRIPTION
Introduces `DMTOOLS_CLI_LOG_FILTER` env variable that accepts a comma-separated list of substrings.

When a CLI command contains any of these substrings, its full output is written both to the console (bypassing log4j when it is off) and to a transcript file under `DMTOOLS_CLI_LOG_DIR`.

This makes long-running agent commands like `run-agent.sh` visible without enabling all CLI tool logging via `--debug`.

### Usage example
```bash
DMTOOLS_CLI_LOG_FILTER=run-agent,cursor-agent,dmtools run ./dmtools.sh run agents/story_development.json
```

### Changes
- Added `PropertyReader.getCliLogFilter()` to parse the env variable
- Updated `CommandLineUtils.runCommand()` to tee matched output to `System.out` + transcript file
- Added unit tests for filter matching and transcript file behavior

All `dmtools-core` unit tests pass.