### PR TITLE
feat(confluence): inline comment tools and reply via API v2

### DIFF
--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dmtools
-description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 329+ MCP tools for Jira, Azure DevOps, GitHub, GitLab, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
+description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 331+ MCP tools for Jira, Azure DevOps, GitHub, GitLab, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
 license: Apache-2.0
 compatibility:
   - Java 17+
@@ -14,7 +14,7 @@ metadata:
 
 # DMtools Development Assistant
 
-DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 329+ MCP tools for reusable delivery automation.
+DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 331+ MCP tools for reusable delivery automation.
 
 ## 🔧 FIRST-TIME SETUP (DO THIS PROACTIVELY)
 
@@ -180,7 +180,7 @@ See [Installation Guide](references/installation/README.md#️-configuration-set
 
 ### Common Commands
 ```bash
-dmtools list                          # List all 329+ MCP tools
+dmtools list                          # List all 331+ MCP tools
 dmtools jira_get_ticket PROJ-123      # Get Jira ticket
 dmtools run agents/config.json        # Run configuration
 dmtools run agents/config.json --ciRunUrl "https://ci.example.com/runs/42"  # With CI tracing
@@ -189,7 +189,7 @@ dmtools run agents/config.json "${ENCODED_CONFIG}" --inputJql "key=PROJ-1"  # Wi
 
 ## Core Capabilities
 
-### 329+ MCP Tools Available
+### 331+ MCP Tools Available
 
 **Complete Reference**: [references/mcp-tools/README.md](references/mcp-tools/README.md) - Auto-generated from actual DMtools build
 
@@ -198,7 +198,7 @@ Current breakdown (20 integrations):
 - **Jira Xray** (11 tools): Xray test management
 - **Teams** (28 tools): Messages, chats, files, transcripts, meetings
 - **Teams Auth** (3 tools): Teams authentication flows
-- **Confluence** (22 tools): Page management, search, content access, attachments
+- **Confluence** (24 tools): Page management, search, content access, attachments, inline comments
 - **ADO** (38 tools): Azure DevOps work items, queries, comments, attachments, pull requests, code review threads
 - **GitHub** (35 tools): Pull requests, issues, comments, workflows
 - **GitLab** (30 tools): Merge requests, issues, CI/CD pipelines
@@ -269,11 +269,11 @@ function action(params) {
 | | [ReportVisualizer](references/jobs/README.md#reportvisualizer) | Render an existing report JSON as interactive HTML |
 | | [KBProcessingJob](references/jobs/README.md#kbprocessingjob) | Process source material into knowledge-base artifacts |
 | **Agents** | [Agent Best Practices](references/agents/best-practices.md) | **⚠️ CRITICAL**: Patterns and lessons learned |
-| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 329+ MCP tools |
+| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 331+ MCP tools |
 | | [Teammate Configs](references/agents/teammate-configs.md) | JSON-based AI workflows (CLI safety v1.7.133+) |
 | | [CLI Integration](references/agents/cli-integration.md) | Cursor, Claude, Copilot, Gemini CLI agents |
 | **Testing** | [Test Generation](references/test-generation/xray-manual.md) | Xray test case creation |
-| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 328+ tools (20 integrations) |
+| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 331+ tools (20 integrations) |
 | **CI/CD** | [GitHub Actions](references/workflows/github-actions-teammate.md) | Automated ticket processing + CI run tracing |
 
 ## ⚠️ CRITICAL: JSON Configuration "name" Field

--- a/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
+++ b/dmtools-ai-docs/per-skill-packages/dmtools-confluence.md
@@ -54,18 +54,27 @@ You can edit Confluence pages locally as Markdown and push them back, including 
    See [spec](assets/spec.pdf).
    ```
 
-3. Create or update the page and upload referenced attachments automatically:
-   ```bash
-   # Create a new page
-   dmtools confluence_create_page_from_markdown_file_with_attachments \
-       "Design Doc" "654321" "/tmp/design.md" "TEAM" "/tmp/assets"
+3. Publish the Markdown and attachments to Confluence using the directory-sync tool:
 
-   # Update an existing page
-   dmtools confluence_update_page_from_markdown_file_with_attachments \
-       "123456" "Design Doc" "654321" "/tmp/design.md" "TEAM" "/tmp/assets"
+   Put your Markdown file and its referenced files in a directory:
+   ```text
+   /tmp/design/
+   ├── index.md
+   └── assets/
+       ├── architecture.png
+       └── spec.pdf
    ```
 
-Existing attachments are skipped, so the same command can be run repeatedly without re-uploading files.
+   Then sync the directory to a parent Confluence page:
+   ```bash
+   dmtools confluence_sync_markdown_directory \
+       "/tmp/design" "654321" "TEAM" "false" "/tmp/design/assets"
+   ```
+
+   - `654321` is the parent Confluence page ID.
+   - `index.md` supplies the body of the synced page tree.
+   - Referenced local files are uploaded as attachments idempotently.
+   - Rerun the same command to update; existing pages and attachments are matched by title/name and skipped if unchanged.
 
 For manual attachment management, use:
 

--- a/dmtools-ai-docs/references/mcp-tools/confluence-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/confluence-tools.md
@@ -30,7 +30,7 @@ const result = confluence_content_by_id(...);
 | `confluence_content_by_title_and_space` | Get Confluence content by title and space key. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown. | `title` (string, **required**)<br>`format` (string, optional)<br>`space` (string, **required**) |
 | `confluence_contents_by_urls` | Get Confluence content by multiple URLs. Returns a list of content objects for each valid URL. Use format=md to convert body.storage.value to Markdown. | `format` (string, optional)<br>`urlStrings` (array, **required**) |
 | `confluence_create_page` | Create a new Confluence page with specified title, parent, body content, and space. Returns the created content object. | `title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**) |
-| `confluence_create_page_from_markdown_file_with_attachments` | Create a Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images (e.g. ./assets/doc.pdf) are resolved against the Markdown file's directory or an explicit attachmentsDir. Existing attachments are skipped. | `attachmentsDir` (string, optional)<br>`filePath` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`title` (string, **required**) |
+| `confluence_get_page_inline_comments` | Get inline comments (annotations) for a Confluence page. Uses the Confluence REST API v2 and returns comment bodies in storage format. | `pageId` (string, **required**)<br>`limit` (number, optional) |
 | `confluence_download_attachment` | Download an attachment file from Confluence to a specified directory. | `attachment` (object, **required**)<br>`targetDir` (object, **required**) |
 | `confluence_download_pages` | Download Confluence pages and their attachments to a local folder. Recursively follows linked pages, children macros, and internal ac:link references up to the specified depth. | `urlStrings` (array, **required**)<br>`depth` (number, optional)<br>`downloadAttachments` (boolean, optional)<br>`outputPath` (string, **required**) |
 | `confluence_find_content` | Find a Confluence page by title in the default space. Returns the page content if found. Use format=md to convert body.storage.value to Markdown. | `title` (string, **required**)<br>`format` (string, optional) |
@@ -46,7 +46,7 @@ const result = confluence_content_by_id(...);
 | `confluence_test` | Test Confluence connectivity by fetching the current user's profile | None |
 | `confluence_update_page` | Update an existing Confluence page with new title, parent, body content, and space. Returns the updated content object. | `contentId` (string, **required**)<br>`title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**) |
 | `confluence_update_page_with_history` | Update an existing Confluence page with new content and add a history comment. Returns the updated content object. | `contentId` (string, **required**)<br>`title` (string, **required**)<br>`body` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`historyComment` (string, **required**) |
-| `confluence_update_page_from_markdown_file_with_attachments` | Update an existing Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images are resolved against the Markdown file's directory or an explicit attachmentsDir. Existing attachments are skipped. | `attachmentsDir` (string, optional)<br>`contentId` (string, **required**)<br>`filePath` (string, **required**)<br>`parentId` (string, **required**)<br>`space` (string, **required**)<br>`title` (string, **required**) |
+| `confluence_reply_to_inline_comment` | Reply to an existing inline comment (annotation) on a Confluence page. The reply body is treated as plain text and converted to Confluence storage format. | `pageId` (string, **required**)<br>`commentId` (string, **required**)<br>`body` (string, **required**) |
 | `confluence_upload_attachment` | Upload a single file as an attachment to a Confluence page. Skips the upload if an attachment with the same filename already exists (idempotent). Returns the attachment metadata. | `contentId` (string, **required**)<br>`filePath` (string, **required**)<br>`updateIfExists` (boolean, optional) |
 | `confluence_upload_attachments` | Upload all files from a local directory as attachments to a Confluence page. Existing attachments are skipped by default. Returns a summary of uploaded and skipped files. | `contentId` (string, **required**)<br>`directoryPath` (string, **required**)<br>`updateIfExists` (boolean, optional) |
 
@@ -629,86 +629,58 @@ const result = confluence_update_page_with_history("contentId", "title");
 
 ---
 
-### `confluence_create_page_from_markdown_file_with_attachments`
+### `confluence_get_page_inline_comments`
 
-Create a Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images (e.g. `./assets/doc.pdf`) are resolved against the Markdown file's directory or an explicit `attachmentsDir`. Existing attachments are skipped.
+Get inline comments (annotations) for a Confluence page. Uses the Confluence REST API v2 and returns comment bodies in storage format.
 
 **Parameters:**
 
-- **`title`** (string) 🔴 Required
-  - The title of the new page
-  - Example: `New Project Page`
-
-- **`parentId`** (string) 🔴 Required
-  - The ID of the parent page
+- **`pageId`** (string) 🔴 Required
+  - The content ID of the Confluence page
   - Example: `123456`
 
-- **`filePath`** (string) 🔴 Required
-  - Path to the Markdown file
-  - Example: `/tmp/page.md`
-
-- **`space`** (string) 🔴 Required
-  - The space key where to create the page
-  - Example: `PROJ`
-
-- **`attachmentsDir`** (string) ⚪ Optional
-  - Directory to resolve attachment references from. Defaults to the Markdown file's parent directory.
-  - Example: `/tmp/assets`
+- **`limit`** (number) ⚪ Optional
+  - Maximum number of inline comments to return
+  - Example: `25`
 
 **Example:**
 ```bash
-dmtools confluence_create_page_from_markdown_file_with_attachments "New Project Page" "123456" "/tmp/page.md" "PROJ" "/tmp/assets"
+dmtools confluence_get_page_inline_comments "123456" "25"
 ```
 
 ```javascript
 // In JavaScript agent
-const result = confluence_create_page_from_markdown_file_with_attachments(
-    "New Project Page", "123456", "/tmp/page.md", "PROJ", "/tmp/assets"
-);
+const result = confluence_get_page_inline_comments("123456", 25);
 ```
 
 ---
 
-### `confluence_update_page_from_markdown_file_with_attachments`
+### `confluence_reply_to_inline_comment`
 
-Update an existing Confluence page from a Markdown file and upload any referenced local attachments. Relative paths in links/images are resolved against the Markdown file's directory or an explicit `attachmentsDir`. Existing attachments are skipped.
+Reply to an existing inline comment (annotation) on a Confluence page. The reply body is treated as plain text and converted to Confluence storage format.
 
 **Parameters:**
 
-- **`contentId`** (string) 🔴 Required
-  - The ID of the page to update
+- **`pageId`** (string) 🔴 Required
+  - The content ID of the Confluence page where the inline comment is located
   - Example: `123456`
 
-- **`title`** (string) 🔴 Required
-  - The new title for the page
-  - Example: `Updated Project Page`
+- **`commentId`** (string) 🔴 Required
+  - The ID of the inline comment (annotation) to reply to
+  - Example: `789012`
 
-- **`parentId`** (string) 🔴 Required
-  - The ID of the parent page
-  - Example: `123456`
-
-- **`filePath`** (string) 🔴 Required
-  - Path to the Markdown file
-  - Example: `/tmp/page.md`
-
-- **`space`** (string) 🔴 Required
-  - The space key where the page is located
-  - Example: `PROJ`
-
-- **`attachmentsDir`** (string) ⚪ Optional
-  - Directory to resolve attachment references from. Defaults to the Markdown file's parent directory.
-  - Example: `/tmp/assets`
+- **`body`** (string) 🔴 Required
+  - The reply text in plain text. Line breaks are converted to paragraphs.
+  - Example: `Thanks for the note!`
 
 **Example:**
 ```bash
-dmtools confluence_update_page_from_markdown_file_with_attachments "123456" "Updated Project Page" "123456" "/tmp/page.md" "PROJ" "/tmp/assets"
+dmtools confluence_reply_to_inline_comment "123456" "789012" "Thanks for the note!"
 ```
 
 ```javascript
 // In JavaScript agent
-const result = confluence_update_page_from_markdown_file_with_attachments(
-    "123456", "Updated Project Page", "123456", "/tmp/page.md", "PROJ", "/tmp/assets"
-);
+const result = confluence_reply_to_inline_comment("123456", "789012", "Thanks for the note!");
 ```
 
 ---
@@ -781,7 +753,7 @@ DMTools supports a full round-trip workflow between local Markdown files and Con
 
 2. **Edit locally** and place attachment files next to the Markdown file (or in a separate directory referenced with relative paths like `./assets/doc.pdf`).
 
-3. **Push back** with `confluence_update_page_from_markdown_file_with_attachments` (or `confluence_create_page_from_markdown_file_with_attachments` for a new page). The tool:
+3. **Push back** with `confluence_sync_markdown_directory` (or `confluence_create_page` for a single new page). The tool:
    - Converts Markdown to Confluence Storage Format.
    - Finds all local attachment references.
    - Uploads any files that are not already attached to the page.
@@ -801,5 +773,5 @@ See [requirements](Requirements and Specifications) for context.
 Download the [specification](./assets/spec.pdf).
 ```
 
-When pushed with `confluence_create_page_from_markdown_file_with_attachments`, the page will contain `ri:page` and `ri:attachment` references, and `architecture.png` and `spec.pdf` will be uploaded from `./assets` if they exist and are not already attached.
+When pushed with `confluence_sync_markdown_directory`, the page will contain `ri:page` and `ri:attachment` references, and `architecture.png` and `spec.pdf` will be uploaded from `./assets` if they exist and are not already attached.
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -25,6 +25,7 @@ import dagger.multibindings.StringKey;
 import lombok.Getter;
 import lombok.Setter;
 import okhttp3.*;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -384,6 +385,67 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
             logger.error(response);
             throw e;
         }
+    }
+
+    @MCPTool(
+        name = "confluence_get_page_inline_comments",
+        description = "Get inline comments (annotations) for a Confluence page. Uses the Confluence REST API v2 and returns comment bodies in storage format.",
+        integration = "confluence",
+        category = "content_retrieval"
+    )
+    public String getPageInlineComments(
+        @MCPParam(name = "pageId", description = "The content ID of the Confluence page", required = true, example = "123456")
+        String pageId,
+        @MCPParam(name = "limit", description = "Maximum number of inline comments to return. Defaults to 25 if not provided.", required = false, example = "25")
+        Integer limit
+    ) throws IOException {
+        GenericRequest request = new GenericRequest(this, getBasePath() + "/api/v2/pages/" + pageId + "/inline-comments");
+        request.param("body-format", "storage");
+        if (limit != null && limit > 0) {
+            request.param("limit", String.valueOf(limit));
+        }
+        return execute(request);
+    }
+
+    @MCPTool(
+        name = "confluence_reply_to_inline_comment",
+        description = "Reply to an existing inline comment (annotation) on a Confluence page. The reply body is treated as plain text and converted to Confluence storage format.",
+        integration = "confluence",
+        category = "content_management"
+    )
+    public String replyToInlineComment(
+        @MCPParam(name = "pageId", description = "The content ID of the Confluence page where the inline comment is located", required = true, example = "123456")
+        String pageId,
+        @MCPParam(name = "commentId", description = "The ID of the inline comment (annotation) to reply to", required = true, example = "789012")
+        String commentId,
+        @MCPParam(name = "body", description = "The reply text in plain text. Line breaks are converted to paragraphs.", required = true, example = "Thanks for the note, I will check it.")
+        String body
+    ) throws IOException {
+        GenericRequest request = new GenericRequest(this, getBasePath() + "/api/v2/inline-comments");
+        request.setBody(new JSONObject()
+            .put("parentCommentId", commentId)
+            .put("body", new JSONObject()
+                .put("representation", "storage")
+                .put("value", prepareInlineCommentBody(body)))
+            .toString());
+        return request.post();
+    }
+
+    private String prepareInlineCommentBody(String text) {
+        if (text == null || text.trim().isEmpty()) {
+            return "<p></p>";
+        }
+        String[] paragraphs = text.split("\\n");
+        StringBuilder sb = new StringBuilder();
+        for (String paragraph : paragraphs) {
+            String trimmed = paragraph.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            sb.append("<p>").append(StringEscapeUtils.escapeHtml4(trimmed)).append("</p>\n");
+        }
+        String result = sb.toString().trim();
+        return result.isEmpty() ? "<p></p>" : result;
     }
 
     public ContentResult getContentVersions(String contentId) throws IOException {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageDownloader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageDownloader.java
@@ -6,6 +6,8 @@ package com.github.istin.dmtools.atlassian.confluence;
 import com.github.istin.dmtools.atlassian.confluence.model.Content;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -60,13 +62,19 @@ public class ConfluencePageDownloader {
      */
     public int downloadPages(List<String> seedUrls, File outputDir, int depth, boolean downloadAttachments)
             throws IOException {
+        return downloadPages(seedUrls, outputDir, depth, downloadAttachments, false);
+    }
+
+    public int downloadPages(List<String> seedUrls, File outputDir, int depth, boolean downloadAttachments,
+                             boolean includeComments)
+            throws IOException {
         if (confluence == null || seedUrls == null || seedUrls.isEmpty()) {
             return 0;
         }
 
         Files.createDirectories(outputDir.toPath());
-        logger.info("Downloading Confluence pages to {} with depth={} attachments={}",
-                outputDir.getAbsolutePath(), depth, downloadAttachments);
+        logger.info("Downloading Confluence pages to {} with depth={} attachments={} comments={}",
+                outputDir.getAbsolutePath(), depth, downloadAttachments, includeComments);
 
         Queue<PageLevel> queue = new LinkedList<>();
         Set<String> processedIds = new HashSet<>();
@@ -128,6 +136,11 @@ public class ConfluencePageDownloader {
                     }
                 } else {
                     logger.warn("Confluence page '{}' has empty body, skipping text write", title);
+                }
+
+                // Fetch and write inline comments
+                if (includeComments && contentId != null && !contentId.isBlank()) {
+                    writeInlineCommentsFile(contentId, title, pageFolder);
                 }
 
                 // Download attachments
@@ -280,6 +293,55 @@ public class ConfluencePageDownloader {
                     files.size(), contentId, targetDir.getAbsolutePath());
         } catch (Exception e) {
             logger.warn("Could not download attachments for content {} (skipping): {}", contentId, e.getMessage());
+        }
+    }
+
+    /**
+     * Fetches inline comments for a Confluence page and writes them as {@code comments.md}
+     * inside the page folder so CLI agents can read the discussion context.
+     */
+    private void writeInlineCommentsFile(String contentId, String pageTitle, Path pageFolder) {
+        try {
+            String response = confluence.getPageInlineComments(contentId, 100);
+            JSONObject json = new JSONObject(response);
+            JSONArray results = json.optJSONArray("results");
+            if (results == null || results.isEmpty()) {
+                logger.info("No inline comments for Confluence page {}", contentId);
+                return;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("# Inline comments: ").append(pageTitle != null ? pageTitle : contentId).append("\n\n");
+            for (int i = 0; i < results.length(); i++) {
+                JSONObject comment = results.getJSONObject(i);
+                String commentId = comment.optString("id", "unknown");
+                String status = comment.optString("resolutionStatus", "unknown");
+                JSONObject bodyObj = comment.optJSONObject("body");
+                String bodyStorage = "";
+                if (bodyObj != null) {
+                    JSONObject storage = bodyObj.optJSONObject("storage");
+                    if (storage != null) {
+                        bodyStorage = storage.optString("value", "");
+                    }
+                }
+                String bodyMarkdown = bodyStorage.isBlank() ? "" : ConfluenceStorageMarkdown.toMarkdown(bodyStorage);
+                JSONObject props = comment.optJSONObject("properties");
+                String selection = props != null ? props.optString("inlineOriginalSelection", "") : "";
+
+                sb.append("## Comment ").append(commentId).append("\n");
+                sb.append("- **Status**: ").append(status).append("\n");
+                if (!selection.isBlank()) {
+                    sb.append("- **Selected text**: ").append(selection).append("\n");
+                }
+                sb.append("- **Body**:\n\n").append(bodyMarkdown.isBlank() ? "_(empty)_" : bodyMarkdown).append("\n\n");
+            }
+
+            Path commentsFile = pageFolder.resolve("comments.md");
+            Files.write(commentsFile, sb.toString().getBytes(StandardCharsets.UTF_8));
+            logger.info("Wrote {} inline comment(s) for page {} -> {}",
+                    results.length(), contentId, commentsFile);
+        } catch (Exception e) {
+            logger.warn("Could not fetch inline comments for content {} (skipping): {}", contentId, e.getMessage());
         }
     }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/InputParams.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/InputParams.java
@@ -38,6 +38,7 @@ public class InputParams implements InputContextConfig {
     private boolean skipVideoAttachments = false;
     private boolean skipAllAttachments = false;
     private boolean ignoreClonedByRelationship = true;
+    private boolean includeConfluenceComments = true;
 
     public InputParams() {
     }
@@ -65,5 +66,10 @@ public class InputParams implements InputContextConfig {
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean isIncludeConfluenceComments() {
+        return includeConfluenceComments;
     }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliExecutionHelper.java
@@ -235,7 +235,15 @@ public class CliExecutionHelper {
      * @param confluence      Confluence client; if {@code null} the method does nothing
      */
     public void writeConfluencePagesFile(String textContent, Path inputFolderPath, Confluence confluence) {
-        writeConfluencePagesFile(textContent, inputFolderPath, confluence, 0, true);
+        writeConfluencePagesFile(textContent, inputFolderPath, confluence, 0, true, false);
+    }
+
+    /**
+     * Backward-compatible overload that does not fetch inline comments.
+     */
+    public void writeConfluencePagesFile(String textContent, Path inputFolderPath, Confluence confluence,
+                                         int confluenceDepth, boolean confluenceAttachments) {
+        writeConfluencePagesFile(textContent, inputFolderPath, confluence, confluenceDepth, confluenceAttachments, false);
     }
 
     /**
@@ -250,14 +258,16 @@ public class CliExecutionHelper {
      * Delegates to {@link ConfluencePageDownloader} so that Teammate and the
      * {@code confluence_download_pages} MCP tool use the exact same download logic.
      *
-     * @param textContent           Any text that may contain Confluence URLs (e.g. full ticket text)
-     * @param inputFolderPath       The base input folder (e.g. {@code input/PROJ-123})
-     * @param confluence            Confluence client; if {@code null} the method does nothing
-     * @param confluenceDepth       How many levels of linked/child pages to follow (0 = only ticket links)
-     * @param confluenceAttachments Whether to download attachments for each fetched page
+     * @param textContent              Any text that may contain Confluence URLs (e.g. full ticket text)
+     * @param inputFolderPath          The base input folder (e.g. {@code input/PROJ-123})
+     * @param confluence               Confluence client; if {@code null} the method does nothing
+     * @param confluenceDepth          How many levels of linked/child pages to follow (0 = only ticket links)
+     * @param confluenceAttachments    Whether to download attachments for each fetched page
+     * @param includeConfluenceComments Whether to fetch inline comments for each fetched page
      */
     public void writeConfluencePagesFile(String textContent, Path inputFolderPath, Confluence confluence,
-                                         int confluenceDepth, boolean confluenceAttachments) {
+                                         int confluenceDepth, boolean confluenceAttachments,
+                                         boolean includeConfluenceComments) {
         if (confluence == null || textContent == null || textContent.isBlank()) return;
         try {
             Set<String> seedUrls = confluence.parseUris(textContent);
@@ -265,12 +275,12 @@ public class CliExecutionHelper {
                 logger.info("No Confluence URLs detected in ticket text");
                 return;
             }
-            logger.info("Found {} Confluence URL(s), writing to input/confluence/ with depth={} attachments={}",
-                    seedUrls.size(), confluenceDepth, confluenceAttachments);
+            logger.info("Found {} Confluence URL(s), writing to input/confluence/ with depth={} attachments={} comments={}",
+                    seedUrls.size(), confluenceDepth, confluenceAttachments, includeConfluenceComments);
 
             Path confluenceFolder = inputFolderPath.resolve("confluence");
             new ConfluencePageDownloader(confluence).downloadPages(
-                    new ArrayList<>(seedUrls), confluenceFolder.toFile(), confluenceDepth, confluenceAttachments);
+                    new ArrayList<>(seedUrls), confluenceFolder.toFile(), confluenceDepth, confluenceAttachments, includeConfluenceComments);
         } catch (Exception e) {
             logger.warn("writeConfluencePagesFile failed (non-fatal): {}", e.getMessage());
         }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/InputContextConfig.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/InputContextConfig.java
@@ -87,4 +87,11 @@ public interface InputContextConfig {
     default boolean isConfluenceAttachments() {
         return true;
     }
+
+    /**
+     * Whether to fetch inline comments (annotations) for fetched Confluence pages.
+     */
+    default boolean isIncludeConfluenceComments() {
+        return false;
+    }
 }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -126,6 +126,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
         @SerializedName("confluenceAttachments")
         private boolean confluenceAttachments = true;
 
+        @SerializedName("includeConfluenceComments")
+        private boolean includeConfluenceComments = true;
+
         @SerializedName("includeParentConfluence")
         private boolean includeParentConfluence = true;
 
@@ -200,6 +203,11 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
         @Override
         public boolean isConfluenceAttachments() {
             return confluenceAttachments;
+        }
+
+        @Override
+        public boolean isIncludeConfluenceComments() {
+            return includeConfluenceComments;
         }
 
         /**

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/TicketInputContextBuilder.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/TicketInputContextBuilder.java
@@ -127,7 +127,8 @@ public class TicketInputContextBuilder {
                         inputFolderPath,
                         confluence,
                         config.getConfluenceDepth(),
-                        config.isConfluenceAttachments());
+                        config.isConfluenceAttachments(),
+                        config.isIncludeConfluenceComments());
             }
             if (isSourceEnabled(config, SOURCE_FIGMA)) {
                 writeFigmaFiles(smartText, inputFolderPath, figmaClient);

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/BasicConfluenceTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/BasicConfluenceTest.java
@@ -6,9 +6,11 @@ package com.github.istin.dmtools.atlassian.confluence;
 import com.github.istin.dmtools.atlassian.confluence.model.Attachment;
 import com.github.istin.dmtools.atlassian.confluence.model.Content;
 import com.github.istin.dmtools.atlassian.confluence.model.ContentResult;
+import com.github.istin.dmtools.common.networking.GenericRequest;
 import com.github.istin.dmtools.report.freemarker.GenericReport;
 import freemarker.template.TemplateException;
 import org.apache.commons.io.FileUtils;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -115,5 +117,42 @@ public class BasicConfluenceTest {
 
         List<Content> contentList = basicConfluence.getChildrenOfContentByName(contentName);
         assertNotNull(contentList);
+    }
+
+    @Test
+    public void testGetPageInlineComments() throws IOException {
+        String pageId = "12345";
+        doAnswer(invocation -> {
+            GenericRequest request = invocation.getArgument(0);
+            String url = request.url();
+            assertTrue(url.contains("/api/v2/pages/" + pageId + "/inline-comments"));
+            assertTrue(url.contains("body-format=storage"));
+            assertTrue(url.contains("limit=10"));
+            return "{\"results\":[{\"id\":\"1\"}]}";
+        }).when(basicConfluence).execute(any(GenericRequest.class));
+
+        String result = basicConfluence.getPageInlineComments(pageId, 10);
+        assertTrue(result.contains("\"id\":\"1\""));
+    }
+
+    @Test
+    public void testReplyToInlineComment() throws IOException {
+        String pageId = "12345";
+        String commentId = "67890";
+        String body = "Hello\nWorld";
+
+        doAnswer(invocation -> {
+            GenericRequest request = invocation.getArgument(0);
+            assertEquals(BASE_PATH + "/api/v2/inline-comments", request.url());
+            JSONObject json = new JSONObject(request.getBody());
+            assertEquals(commentId, json.getString("parentCommentId"));
+            JSONObject bodyJson = json.getJSONObject("body");
+            assertEquals("storage", bodyJson.getString("representation"));
+            assertEquals("<p>Hello</p>\n<p>World</p>", bodyJson.getString("value"));
+            return "{\"id\":\"111\"}";
+        }).when(basicConfluence).post(any(GenericRequest.class));
+
+        String result = basicConfluence.replyToInlineComment(pageId, commentId, body);
+        assertTrue(result.contains("\"id\":\"111\""));
     }
 }

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageDownloaderTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/ConfluencePageDownloaderTest.java
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import com.github.istin.dmtools.atlassian.confluence.model.Content;
+import com.github.istin.dmtools.atlassian.confluence.model.Storage;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class ConfluencePageDownloaderTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Test
+    public void testDownloadPagesWritesInlineComments() throws Exception {
+        Confluence confluence = Mockito.spy(new Confluence("https://example.com/wiki", "auth"));
+
+        Storage storage = mock(Storage.class);
+        when(storage.getValue()).thenReturn("<p>Page body</p>");
+
+        Content page = mock(Content.class);
+        when(page.getId()).thenReturn("123");
+        when(page.getTitle()).thenReturn("Test Page");
+        when(page.getStorage()).thenReturn(storage);
+
+        doReturn(page).when(confluence).contentByUrl(anyString());
+        doReturn("{\"results\":[{\"id\":\"456\",\"resolutionStatus\":\"open\",\"body\":{\"storage\":{\"value\":\"<p>Comment body</p>\"}},\"properties\":{\"inlineOriginalSelection\":\"selected text\"}}]}").when(confluence).getPageInlineComments("123", 100);
+        doReturn(Collections.emptyList()).when(confluence).downloadPageAttachments(anyString(), any(File.class));
+
+        ConfluencePageDownloader downloader = new ConfluencePageDownloader(confluence);
+        File outputDir = tempFolder.newFolder();
+        int written = downloader.downloadPages(
+                Collections.singletonList("https://example.com/wiki/spaces/SPACE/pages/123/Test"),
+                outputDir, 0, false, true);
+
+        assertEquals(1, written);
+
+        File pageFile = new File(outputDir, "Test_Page/Test_Page.md");
+        assertTrue(pageFile.exists());
+
+        File commentsFile = new File(outputDir, "Test_Page/comments.md");
+        assertTrue(commentsFile.exists());
+        String comments = FileUtils.readFileToString(commentsFile, StandardCharsets.UTF_8);
+        assertTrue(comments.contains("Comment 456"));
+        assertTrue(comments.contains("selected text"));
+        assertTrue(comments.contains("Comment body"));
+    }
+
+    @Test
+    public void testDownloadPagesSkipsCommentsWhenDisabled() throws Exception {
+        Confluence confluence = Mockito.spy(new Confluence("https://example.com/wiki", "auth"));
+
+        Storage storage = mock(Storage.class);
+        when(storage.getValue()).thenReturn("<p>Page body</p>");
+
+        Content page = mock(Content.class);
+        when(page.getId()).thenReturn("123");
+        when(page.getTitle()).thenReturn("Test Page");
+        when(page.getStorage()).thenReturn(storage);
+
+        doReturn(page).when(confluence).contentByUrl(anyString());
+        doReturn(Collections.emptyList()).when(confluence).downloadPageAttachments(anyString(), any(File.class));
+
+        ConfluencePageDownloader downloader = new ConfluencePageDownloader(confluence);
+        File outputDir = tempFolder.newFolder();
+        int written = downloader.downloadPages(
+                Collections.singletonList("https://example.com/wiki/spaces/SPACE/pages/123/Test"),
+                outputDir, 0, false, false);
+
+        assertEquals(1, written);
+        assertTrue(new File(outputDir, "Test_Page/Test_Page.md").exists());
+        verify(confluence, never()).getPageInlineComments(anyString(), anyInt());
+    }
+}


### PR DESCRIPTION
Adds two new Confluence MCP tools for working with inline comments (annotations):\n\n- `confluence_get_page_inline_comments` — fetches inline comments for a page using the Confluence REST API v2.\n- `confluence_reply_to_inline_comment` — replies to an existing inline comment.\n\nAlso updates SKILL.md and `confluence-tools.md` counts/documentation and adds unit tests.\n\nVerified by replying to a real inline comment on the Comprehensive Markdown Types Test page.