### PR TITLE
chore: update agents submodule and release site data for v1.7.244

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,7 +549,10 @@ jobs:
       - name: Create Unified Release
         uses: softprops/action-gh-release@v3
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT_TOKEN so the release:published event fires and triggers
+          # the Update Release Site Data workflow (events from GITHUB_TOKEN
+          # do not trigger downstream workflows).
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         with:
           tag_name: v${{ needs.version-and-tag.outputs.version }}
           name: "DMTools v${{ needs.version-and-tag.outputs.version }}"

--- a/.github/workflows/update-release-site.yml
+++ b/.github/workflows/update-release-site.yml
@@ -99,4 +99,14 @@ jobs:
 
           VERSION="${{ steps.inputs.outputs.version }}"
           git commit -m "chore(release): update site data for ${VERSION}"
-          git push origin main
+          # Push to a transient branch and open a PR so the change goes through
+          # the required status checks on main instead of bypassing them.
+          BRANCH="chore/release-site-data-${VERSION}"
+          git checkout -b "$BRANCH"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): update site data for ${VERSION}" \
+            --body "Automated release site data update for ${VERSION}." \
+            --base main \
+            --head "$BRANCH" \
+            --repo "${{ github.repository }}" || true

--- a/landing/src/sections/Nav.astro
+++ b/landing/src/sections/Nav.astro
@@ -1,21 +1,34 @@
 ---
 import Brand from '../components/Brand.astro';
-import { navLinks } from '../data/content';
+import { navLinks, basePath } from '../data/content';
 
 const docsLink = navLinks.find((link) => link.label === 'Docs');
+
+// On non-home pages the in-page anchor links (e.g. #problem) do not exist,
+// so turn them into links back to the homepage anchors. The homepage is
+// recognised by pathname matching the base path (/ or /repo/).
+const pathname = Astro.url.pathname;
+const isHome = pathname === basePath || pathname === `${basePath}index.html`;
+
+function navHref(link: typeof navLinks[0]) {
+  if (link.external) return link.href;
+  if (isHome || link.href.startsWith(basePath)) return link.href;
+  // Absolute path link for a hash-only anchor on another page.
+  return `${basePath}${link.href.replace(/^\//, '')}`;
+}
 ---
 
 <header class="nav" id="nav">
   <div class="nav__inner">
     <div class="nav__left">
-      <Brand href="#top" label="DMTools by EPAM — back to top" />
+      <Brand href={isHome ? '#top' : basePath} label="DMTools by EPAM — back to top" />
     </div>
 
     <nav class="nav__links" id="nav-links" aria-label="Sections">
       {navLinks.map((link) => (
         <a
           class="nav__link"
-          href={link.href}
+          href={navHref(link)}
           target={link.external ? '_blank' : undefined}
           rel={link.external ? 'noopener' : undefined}
         >{link.label}</a>
@@ -39,7 +52,7 @@ const docsLink = navLinks.find((link) => link.label === 'Docs');
         </span>
       </button>
 
-      <a class="btn btn--sm nav__cta" href="#install">Install DMTools</a>
+      <a class="btn btn--sm nav__cta" href={isHome ? '#install' : `${basePath}#install`}>Install DMTools</a>
 
       <a class="nav__search" href="https://github.com/epam/dm.ai" target="_blank" rel="noopener" aria-label="DMTools on GitHub">
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
- Bumps the `agents` submodule to IstiN/dmtools-agents#367 (discovery inline comments support).\n- Fixes nav links on non-home pages (e.g. /releases/): in-page anchor links now resolve to the homepage anchors when the current page is not the homepage.\n- Switches release creation to PAT_TOKEN so the `Update Release Site Data` workflow runs automatically after future releases.\n\nThe v1.7.244 manifest and release data will be generated by running the `Update Release Site Data` workflow, not committed manually.\n\nAfter merge: run `Update Release Site Data` manually for v1.7.244 to populate https://dmtools.lab.epam.com/releases/.