### PR TITLE
feat(landing): publish the agents reference at /agents/

### DIFF
--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # The /agents pages render from the agents submodule.
+          submodules: true
 
       - name: Set up Node
         uses: actions/setup-node@v7

--- a/landing/src/content.config.ts
+++ b/landing/src/content.config.ts
@@ -27,4 +27,17 @@ const docs = defineCollection({
   }),
 });
 
-export const collections = { docs };
+/**
+ * The agent reference, read from the agents submodule: one generated page per
+ * agent config (human description embedded, plus the auto-extracted actions,
+ * artifacts and parameters reference).
+ */
+const agentDocs = defineCollection({
+  loader: glob({
+    base: '../agents/docs/agents/generated',
+    pattern: ['*.md'],
+    generateId: ({ entry }) => entry.replace(/\.md$/i, '').toLowerCase(),
+  }),
+});
+
+export const collections = { docs, agentDocs };

--- a/landing/src/data/content.ts
+++ b/landing/src/data/content.ts
@@ -129,6 +129,7 @@ export const navLinks: NavLink[] = [
   { label: 'FAQ', href: '#faq' },
   // The rendered docs, not the folder listing on GitHub.
   { label: 'Docs', href: `${basePath}docs/` },
+  { label: 'Agents', href: `${basePath}agents/` },
   { label: 'Releases', href: `${basePath}releases/` },
 ];
 
@@ -145,6 +146,7 @@ export const footerColumns: FooterColumn[] = [
       { label: 'Configuration', href: `${basePath}docs/references/configuration/` },
       { label: 'MCP tools', href: `${basePath}docs/references/mcp-tools/` },
       { label: 'Jobs and agents', href: `${basePath}docs/references/jobs/` },
+      { label: 'Agents reference', href: `${basePath}agents/` },
     ],
   },
   {

--- a/landing/src/layouts/AgentDoc.astro
+++ b/landing/src/layouts/AgentDoc.astro
@@ -1,0 +1,246 @@
+---
+// Layout for /agents/* — same typography and SEO treatment as the docs pages,
+// but with the agents collection behind the sidebar instead of the reference
+// docs nav.
+import '../styles/tokens.css';
+import '../styles/base.css';
+import '../styles/sections.css';
+import '../styles/docs.css';
+import '../styles/a11y.css';
+
+import Analytics from '../components/Analytics.astro';
+import Brand from '../components/Brand.astro';
+import { meta, basePath, REPO, organization, lastModified } from '../data/content';
+import { agentHrefOf, agentTitleOf, groupAgents } from '../lib/agentDocs';
+import { getCollection } from 'astro:content';
+import type { MarkdownHeading } from 'astro';
+
+interface Props {
+  title: string;
+  description: string;
+  /** Agent config name without .json; empty string for the agents index. */
+  id: string;
+  headings?: MarkdownHeading[];
+  /** The agent JSON this page was generated from. */
+  sourcePath?: string;
+}
+
+const { title, description, id, headings = [], sourcePath } = Astro.props;
+
+const isRoot = id === '';
+const canonical = isRoot
+  ? new URL(`${basePath}agents/`, Astro.site).href
+  : new URL(agentHrefOf(id, basePath), Astro.site).href;
+const siteHome = new URL(basePath, Astro.site).href;
+
+const agents = await getCollection('agentDocs');
+const groups = groupAgents(agents);
+
+const toc = headings.filter((h) => h.depth === 2 || h.depth === 3);
+
+const crumbs = [
+  { label: 'DMTools', href: basePath },
+  { label: 'Agents', href: `${basePath}agents/` },
+  ...(isRoot ? [] : [{ label: title, href: canonical }]),
+];
+
+const schema = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'TechArticle',
+      '@id': `${canonical}#article`,
+      headline: title,
+      description,
+      inLanguage: meta.lang,
+      dateModified: lastModified,
+      url: canonical,
+      isPartOf: { '@id': `${siteHome}#website` },
+      about: { '@id': `${siteHome}#dmtools` },
+      publisher: {
+        '@type': 'Organization',
+        '@id': `${siteHome}#organization`,
+        name: organization.name,
+        url: organization.url,
+      },
+    },
+    {
+      '@type': 'BreadcrumbList',
+      '@id': `${canonical}#breadcrumbs`,
+      itemListElement: crumbs.map((crumb, i) => ({
+        '@type': 'ListItem',
+        position: i + 1,
+        name: crumb.label,
+        item: new URL(crumb.href, Astro.site).href,
+      })),
+    },
+  ],
+};
+---
+
+<!DOCTYPE html>
+<html lang={meta.lang} data-theme="night">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <title>{title} — DMTools agents</title>
+  <meta name="description" content={description} />
+  <link rel="canonical" href={canonical} />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content={meta.siteName} />
+  <meta property="og:title" content={`${title} — DMTools agents`} />
+  <meta property="og:description" content={description} />
+  <meta property="og:url" content={canonical} />
+
+  <meta name="theme-color" content={meta.themeColor} />
+  <link rel="icon" href={`${basePath}assets/favicon.svg`} type="image/svg+xml" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@300;400;600;700;900&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+  <script is:inline>
+    (function () {
+      try {
+        var stored = localStorage.getItem('dmtools-theme');
+        if (stored) document.documentElement.dataset.theme = stored;
+      } catch (e) { /* private mode keeps the default */ }
+    })();
+  </script>
+
+  <Analytics />
+
+  <script type="application/ld+json" set:html={JSON.stringify(schema)} is:inline />
+</head>
+
+<body class="docs">
+  <a class="skip-link" href="#doc">Skip to content</a>
+
+  <header class="nav docs__bar">
+    <div class="docs__barInner">
+      <Brand href={basePath} label="DMTools — back to the landing page" />
+      <span class="docs__barTag">Agents</span>
+
+      <div class="docs__barActions">
+        <a class="docs__barLink" href={`${basePath}docs/`}>Docs</a>
+        <a class="docs__barLink" href={REPO} target="_blank" rel="noopener">GitHub</a>
+        <a class="btn btn--sm nav__cta" href={`${basePath}#install`}>Install DMTools</a>
+        <button class="docs__menuBtn" id="docs-menu" type="button"
+                aria-label="Open agents menu" aria-expanded="false" aria-controls="docs-side">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true">
+            <path d="M3 6h18M3 12h18M3 18h18"></path>
+          </svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <div class="docs__shell">
+    <aside class="docs__side" id="docs-side">
+      <nav aria-label="Agents">
+        <div class="docs__group">
+          <p class="docs__groupTitle">Agents</p>
+          <ul class="docs__list">
+            <li>
+              <a
+                class="docs__link"
+                href={`${basePath}agents/`}
+                aria-current={isRoot ? 'page' : undefined}
+              >Overview</a>
+            </li>
+          </ul>
+        </div>
+        {groups.map((group) => (
+          <div class="docs__group">
+            <p class="docs__groupTitle">{group.label}</p>
+            <ul class="docs__list">
+              {group.items.map((item) => (
+                <li>
+                  <a
+                    class="docs__link"
+                    href={agentHrefOf(item.id, basePath)}
+                    aria-current={item.id === id ? 'page' : undefined}
+                  >{agentTitleOf(item)}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </nav>
+    </aside>
+
+    <main class="docs__main" id="doc">
+      <nav class="docs__crumbs" aria-label="Breadcrumb">
+        {crumbs.map((crumb, i) => (
+          <>
+            {i > 0 && <span aria-hidden="true">/</span>}
+            {i === crumbs.length - 1
+              ? <span aria-current="page">{crumb.label}</span>
+              : <a href={crumb.href}>{crumb.label}</a>}
+          </>
+        ))}
+      </nav>
+
+      <article class="prose">
+        <slot />
+      </article>
+
+      {sourcePath && (
+        <footer class="docs__foot">
+          <a class="textlink" href={`${REPO}/blob/main/agents/${sourcePath}`} target="_blank" rel="noopener">
+            View the agent config on GitHub →
+          </a>
+          <p class="docs__footNote">
+            Generated from <code>agents/{sourcePath}</code> and its human doc — edit either and the page follows.
+            Last updated <time datetime={lastModified}>{lastModified}</time>.
+          </p>
+        </footer>
+      )}
+    </main>
+
+    {toc.length > 1 && (
+      <aside class="docs__toc" aria-label="On this page">
+        <p class="docs__groupTitle">On this page</p>
+        <ul class="docs__tocList">
+          {toc.map((h) => (
+            <li class={`docs__tocItem docs__tocItem--${h.depth}`}>
+              <a href={`#${h.slug}`}>{h.text}</a>
+            </li>
+          ))}
+        </ul>
+      </aside>
+    )}
+  </div>
+
+  <footer class="docs__pageFoot">
+    <div class="docs__barInner">
+      <p>© 2026 EPAM Systems, Inc. DMTools is open source software, Apache 2.0.</p>
+      <a class="docs__barLink" href={`${REPO}/tree/main/agents`} target="_blank" rel="noopener">Agents source</a>
+    </div>
+  </footer>
+
+  <script>
+    const btn = document.getElementById('docs-menu');
+    const side = document.getElementById('docs-side');
+
+    if (btn && side) {
+      btn.addEventListener('click', () => {
+        const open = document.body.classList.toggle('is-nav-open');
+        btn.setAttribute('aria-expanded', String(open));
+        btn.setAttribute('aria-label', open ? 'Close agents menu' : 'Open agents menu');
+      });
+
+      side.addEventListener('click', (event) => {
+        if (!(event.target as Element).closest('a')) return;
+        document.body.classList.remove('is-nav-open');
+        btn.setAttribute('aria-expanded', 'false');
+      });
+    }
+
+    document.querySelector('.docs__link[aria-current="page"]')
+      ?.scrollIntoView({ block: 'center' });
+  </script>
+</body>
+</html>

--- a/landing/src/lib/agentDocs.ts
+++ b/landing/src/lib/agentDocs.ts
@@ -1,0 +1,74 @@
+import type { CollectionEntry } from 'astro:content';
+
+export type AgentDoc = CollectionEntry<'agentDocs'>;
+
+/** One page per agent config: /agents/<name>/. */
+export const agentHrefOf = (id: string, base: string): string => `${base}agents/${id}/`;
+
+/**
+ * The generated page's H1 is the job class plus the config file name
+ * ("Teammate (`story_solution.json`)") — the agent name is the useful title.
+ */
+export function agentTitleOf(doc: AgentDoc): string {
+  return doc.id.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * First real paragraph after the H1 — the human description embedded from
+ * docs/agents/<name>.md. Used for index cards and the meta description.
+ */
+export function agentSummaryOf(doc: AgentDoc): string {
+  const body = (doc.body ?? '')
+    .replace(/^#\s+.+$/m, '')
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/^\s*[|>#-].*$/gm, '');
+
+  const paragraph = body.split(/\n\s*\n/).map((p) => p.trim()).find((p) => p.length > 40);
+  if (!paragraph) return '';
+
+  const flat = paragraph
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return flat.length > 200 ? `${flat.slice(0, 197).trimEnd()}…` : flat;
+}
+
+/** Group agents by their name prefix (story_*, bug_*, pr_*, …) for the index. */
+export interface AgentGroup {
+  label: string;
+  items: AgentDoc[];
+}
+
+const GROUP_LABELS: Record<string, string> = {
+  story: 'Story workflows',
+  bug: 'Bug workflows',
+  pr: 'Pull request workflows',
+  test: 'Test automation',
+  recover: 'Recovery',
+  retry: 'Recovery',
+};
+
+function groupLabel(id: string): string {
+  const prefix = id.split('_')[0];
+  return GROUP_LABELS[prefix] ?? 'Other agents';
+}
+
+export function groupAgents(docs: AgentDoc[]): AgentGroup[] {
+  const groups = new Map<string, AgentDoc[]>();
+  const sorted = [...docs].sort((a, b) => a.id.localeCompare(b.id));
+  for (const doc of sorted) {
+    const label = groupLabel(doc.id);
+    if (!groups.has(label)) groups.set(label, []);
+    groups.get(label)!.push(doc);
+  }
+  const order = ['Story workflows', 'Bug workflows', 'Pull request workflows', 'Test automation', 'Recovery'];
+  return [...groups.entries()]
+    .sort(([a], [b]) => {
+      const ia = order.indexOf(a);
+      const ib = order.indexOf(b);
+      return (ia === -1 ? order.length : ia) - (ib === -1 ? order.length : ib) || a.localeCompare(b);
+    })
+    .map(([label, items]) => ({ label, items }));
+}

--- a/landing/src/pages/agents/[slug].astro
+++ b/landing/src/pages/agents/[slug].astro
@@ -1,0 +1,29 @@
+---
+import { getCollection, render } from 'astro:content';
+import AgentDoc from '../../layouts/AgentDoc.astro';
+import { agentTitleOf, agentSummaryOf } from '../../lib/agentDocs';
+
+export async function getStaticPaths() {
+  const agents = await getCollection('agentDocs');
+  return agents.map((doc) => ({ params: { slug: doc.id }, props: { doc } }));
+}
+
+const { doc } = Astro.props;
+const { Content, headings } = await render(doc);
+
+const title = agentTitleOf(doc);
+const summary = agentSummaryOf(doc);
+
+const description = summary
+  || `${title} — a DMTools delivery agent: what it does, what it reads and writes, and every parameter it accepts.`;
+---
+
+<AgentDoc
+  title={title}
+  description={description}
+  id={doc.id}
+  headings={headings}
+  sourcePath={`${doc.id}.json`}
+>
+  <Content />
+</AgentDoc>

--- a/landing/src/pages/agents/index.astro
+++ b/landing/src/pages/agents/index.astro
@@ -1,0 +1,48 @@
+---
+import { getCollection } from 'astro:content';
+import AgentDoc from '../../layouts/AgentDoc.astro';
+import { agentHrefOf, agentTitleOf, agentSummaryOf, groupAgents } from '../../lib/agentDocs';
+
+const agents = await getCollection('agentDocs');
+const groups = groupAgents(agents);
+const total = agents.length;
+const summaries = new Map(agents.map((doc) => [doc.id, agentSummaryOf(doc)]));
+---
+
+<AgentDoc
+  title="Agents"
+  description={`Every DMTools delivery agent — what it does, what it reads and writes, and every parameter it accepts. ${total} agents, rendered from the agents repository.`}
+  id=""
+  headings={[]}
+>
+  <h1>DMTools agents</h1>
+  <p>
+    Every delivery agent in the DMTools fleet — story development, PR review and rework,
+    test automation, recovery and housekeeping. Each page lists what the agent reads and
+    writes, its side effects, and every parameter it accepts.
+  </p>
+  <p>
+    Rendered from the
+    <a href="https://github.com/epam/dm.ai/tree/main/agents" target="_blank" rel="noopener">agents repository</a>:
+    the human-written description and the auto-extracted reference stay in sync with the
+    agent configs by a coverage test.
+  </p>
+
+  <h2 id="all-agents">All {total} agents</h2>
+
+  <div class="docs__index" not-prose>
+    {groups.map((group) => (
+      <section class="docs__indexGroup">
+        <h3 class="docs__indexTitle">{group.label}</h3>
+        <ul class="docs__indexList">
+          {group.items.map((item) => (
+            <li>
+              <a class="docs__indexLink" href={agentHrefOf(item.id, import.meta.env.BASE_URL)}>{agentTitleOf(item)}</a>
+              {summaries.get(item.id) && <p class="docs__indexDesc">{summaries.get(item.id)}</p>}
+            </li>
+          ))}
+        </ul>
+      </section>
+    ))}
+  </div>
+</AgentDoc>

--- a/landing/src/pages/sitemap.xml.ts
+++ b/landing/src/pages/sitemap.xml.ts
@@ -2,6 +2,8 @@ import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
 import { basePath, lastModified } from '../data/content';
 import { hrefOf } from '../lib/docs';
+import { agentHrefOf } from '../lib/agentDocs';
+import releases from '../data/releases.json';
 
 /**
  * One page today. This grows a URL per reference document once the docs in
@@ -16,6 +18,17 @@ export const GET: APIRoute = async ({ site }) => {
   const docs = await getCollection('docs');
   const docUrls = [...new Set(docs.map((doc) => new URL(hrefOf(doc.id, basePath), site).href))]
     .sort();
+
+  const agents = await getCollection('agentDocs');
+  const agentUrls = [
+    new URL(`${basePath}agents/`, site).href,
+    ...agents.map((doc) => new URL(agentHrefOf(doc.id, basePath), site).href),
+  ].sort();
+
+  const releaseUrls = [
+    new URL(`${basePath}releases/`, site).href,
+    ...releases.map((r) => new URL(`${basePath}releases/${r.version}/`, site).href),
+  ].sort();
 
   // pricing.md is listed because nothing on the site links to it.
   const body = `<?xml version="1.0" encoding="UTF-8"?>
@@ -37,6 +50,18 @@ ${docUrls.map((loc) => `  <url>
     <lastmod>${lastModified}</lastmod>
     <changefreq>monthly</changefreq>
     <priority>${loc.endsWith('/docs/') ? '0.9' : '0.7'}</priority>
+  </url>`).join('\n')}
+${agentUrls.map((loc) => `  <url>
+    <loc>${loc}</loc>
+    <lastmod>${lastModified}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>${loc.endsWith('/agents/') ? '0.8' : '0.6'}</priority>
+  </url>`).join('\n')}
+${releaseUrls.map((loc) => `  <url>
+    <loc>${loc}</loc>
+    <lastmod>${lastModified}</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>${loc.endsWith('/releases/') ? '0.8' : '0.6'}</priority>
   </url>`).join('\n')}
 </urlset>
 `;


### PR DESCRIPTION
## What

New **/agents/** section on dmtools.lab.epam.com rendering the agents submodule documentation:

- `GET /agents/` — index grouped by workflow (Story / Bug / Pull request / Test automation / Recovery) with per-agent summaries.
- `GET /agents/<name>/` — one page per agent config: the human-written description plus the auto-extracted reference (actions, file reads/writes, side effects, customParams).
- Same SEO/GEO treatment as /docs/: TechArticle + BreadcrumbList JSON-LD, canonical URLs, sitemap entries (sitemap now also covers /releases/ pages).
- Nav and footer links added.
- `deploy-landing.yml` now checks out submodules so `agents/docs/agents/generated/` is present at build time.

Depends on the agents-repo docs being present on the submodule commit that `main` points to — after IstiN/dmtools-agents#370 merges, bump the submodule pointer to publish the full content.

## Verify

`npm run build` in `landing/` — 167 pages (61 agent pages) built successfully.