### PR TITLE
fix(landing): rewrite agents-repo links + internal link check in build

### DIFF
--- a/landing/astro.config.mjs
+++ b/landing/astro.config.mjs
@@ -12,6 +12,7 @@ const here = fileURLToPath(new URL('.', import.meta.url));
 const REPO_ROOT = resolve(here, '..');
 const DOCS_ROOT = resolve(REPO_ROOT, 'dmtools-ai-docs');
 const REPO_URL = 'https://github.com/epam/dm.ai';
+const AGENTS_REPO_URL = 'https://github.com/IstiN/dmtools-agents';
 
 /**
  * The published address differs per repository — a fork publishes to its own
@@ -49,7 +50,7 @@ export default defineConfig({
       remarkPlugins: [
         // Agent snapshot links must be rewritten before the generic doc-link
         // resolver turns them into (broken) GitHub blob URLs.
-        remarkAgentLinks({ base: pathname }),
+        remarkAgentLinks({ base: pathname, agentsRepoUrl: AGENTS_REPO_URL }),
         remarkDocLinks({
           docsRoot: DOCS_ROOT,
           repoRoot: REPO_ROOT,

--- a/landing/package.json
+++ b/landing/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && node scripts/check-links.mjs",
     "preview": "astro preview",
     "check": "astro check"
   },

--- a/landing/scripts/check-links.mjs
+++ b/landing/scripts/check-links.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Internal link checker for the built site.
+ *
+ * Crawls dist/**.html, collects href/src attributes, and fails the build when
+ * a site-internal link does not resolve to a file in dist/. External links
+ * (http/mailto/…) and fragment-only links are skipped — this catches the
+ * "repo-relative path leaked onto the site" class of bug, not the open web.
+ *
+ * Usage: node scripts/check-links.mjs [distDir] [basePath]
+ *   distDir  defaults to dist
+ *   basePath defaults to / (must match the build base, e.g. /repo/ on GitHub
+ *            Pages project sites)
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join, resolve, sep } from 'node:path';
+
+const distDir = resolve(process.argv[2] || 'dist');
+const base = (process.argv[3] || '/').replace(/\/?$/, '/');
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (entry.endsWith('.html')) yield full;
+  }
+}
+
+const ATTR_RE = /(?:href|src)="([^"]+)"/g;
+const missing = new Map(); // url -> [source files]
+let checked = 0;
+
+for (const file of walk(distDir)) {
+  const html = readFileSync(file, 'utf8');
+  for (const match of html.matchAll(ATTR_RE)) {
+    const url = match[1];
+    if (/^([a-z][a-z0-9+.-]*:|\/\/|#|mailto:)/i.test(url)) continue;
+    if (!url.startsWith(base)) continue; // not a site-internal link
+
+    const path = url.slice(base.length).split('#')[0].split('?')[0];
+    if (!path) continue; // the root itself
+
+    checked++;
+    const asFile = join(distDir, path);
+    const asDirIndex = join(distDir, path.replace(/\/?$/, '/'), 'index.html');
+    if (!existsSync(asFile) && !existsSync(asDirIndex)) {
+      if (!missing.has(url)) missing.set(url, []);
+      missing.get(url).push(file.split(sep).slice(-3).join('/'));
+    }
+  }
+}
+
+if (missing.size > 0) {
+  console.error(`❌ ${missing.size} broken internal link(s):`);
+  for (const [url, sources] of missing) {
+    console.error(`  ${url}`);
+    console.error(`    referenced from: ${sources.slice(0, 5).join(', ')}${sources.length > 5 ? '…' : ''}`);
+  }
+  process.exit(1);
+}
+
+console.log(`✅ ${checked} internal links OK across dist/`);

--- a/landing/src/lib/remark-agent-links.mjs
+++ b/landing/src/lib/remark-agent-links.mjs
@@ -7,15 +7,24 @@
  * The Markdown stays repository-correct — on GitHub the link opens the
  * snapshot file; on the site it opens the rendered prompt page.
  */
-export function remarkAgentLinks({ base }) {
+export function remarkAgentLinks({ base, agentsRepoUrl }) {
   const snapshotRe = /^(?:\.\.\/)*agents\/snapshots\/([a-zA-Z0-9_]+)\.md$/;
+  // Any other repo-relative link into the agents submodule (human docs, JS
+  // sources) — these are repository paths, so they go to the agents repo on
+  // GitHub; on the site they would 404.
+  const agentsRepoRe = /^(?:\.\.\/)*agents\/(.+)$/;
 
   return () => (tree) => {
     const visit = (node) => {
       if (node.type === 'link' && typeof node.url === 'string') {
-        const match = node.url.match(snapshotRe);
-        if (match) {
-          node.url = `${base}agents/${match[1]}/prompt/`;
+        const snapshot = node.url.match(snapshotRe);
+        if (snapshot) {
+          node.url = `${base}agents/${snapshot[1]}/prompt/`;
+        } else {
+          const repoPath = node.url.match(agentsRepoRe);
+          if (repoPath) {
+            node.url = `${agentsRepoUrl}/blob/main/${repoPath[1]}`;
+          }
         }
       }
       if (node.children) node.children.forEach(visit);


### PR DESCRIPTION
- **Fix:** `Human doc: agents/docs/agents/<name>.md` links on agent pages 404ed — repo-relative agents paths now rewrite to the agents repo on GitHub.\n- **New:** `scripts/check-links.mjs` crawls `dist/` after every build and fails on broken internal links (14,359 links currently pass). Runs inside `npm run build`, so the deploy workflow enforces it automatically.