### PR TITLE
fix(landing): lowercase agent prompt-link casing to fix broken deploy

### DIFF
--- a/landing/src/lib/remark-agent-links.mjs
+++ b/landing/src/lib/remark-agent-links.mjs
@@ -19,7 +19,10 @@ export function remarkAgentLinks({ base, agentsRepoUrl }) {
       if (node.type === 'link' && typeof node.url === 'string') {
         const snapshot = node.url.match(snapshotRe);
         if (snapshot) {
-          node.url = `${base}agents/${snapshot[1]}/prompt/`;
+          // Agent doc/snapshot ids are lowercased by the content collection
+          // loaders (see content.config.ts), so the site route is always
+          // lowercase regardless of the original file's casing.
+          node.url = `${base}agents/${snapshot[1].toLowerCase()}/prompt/`;
         } else {
           const repoPath = node.url.match(agentsRepoRe);
           if (repoPath) {


### PR DESCRIPTION
Fixes a post-merge deploy failure of #488: `check-links.mjs` caught 3 broken internal links because `remarkAgentLinks` preserved the original (mixed-case) snapshot filename when building `/agents/<name>/prompt/` links, while the actual route is always lowercased by the content collection loaders in `content.config.ts`.

Affected agents: `createRepoTasks`, `createRepoTasksMulti`, `restoreDescription`.

Verified locally: `npm run build` now reports `✅ 14359 internal links OK across dist/` (0 broken).