### PR TITLE
feat(teammate): select 'confluence' cliPromptsByTracker key when contentOutput routes to Confluence

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/cliagent/CliAgent.java
@@ -185,7 +185,8 @@ public class CliAgent extends AbstractJob<CliAgentParams, List<ResultItem>> {
                     params.getCliCommands(),
                     params.getCliPrompt(),
                     params.getCliPromptsConfig(),
-                    params.getCliPromptsByTracker());
+                    params.getCliPromptsByTracker(),
+                    params.getCustomParams());
 
             ensureOutputFolder(workingDirectory);
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliCommandBuilder.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/CliCommandBuilder.java
@@ -32,6 +32,41 @@ public class CliCommandBuilder {
     }
 
     /**
+     * Pseudo-tracker key used in {@code cliPromptsByTracker} for prompts that produce
+     * Confluence (Markdown) output. Selected when the job routes its generated content
+     * exclusively to Confluence via {@code customParams.contentOutput.target = "confluence"},
+     * regardless of the configured {@code DEFAULT_TRACKER}.
+     */
+    public static final String TRACKER_CONFLUENCE = "confluence";
+
+    /**
+     * Resolves the tracker key used to select tracker-specific CLI prompts.
+     * <p>
+     * When {@code customParams.contentOutput.target} is {@code "confluence"} (content is
+     * published only to a Confluence page, not to the tracker field) and the agent declares
+     * {@code cliPromptsByTracker.confluence} prompts, the {@code "confluence"} key wins over
+     * the configured tracker so the CLI agent produces Markdown instead of tracker-specific
+     * markup. In all other cases (no contentOutput routing, target "both", or no confluence
+     * prompts declared) the configured tracker type is kept, preserving existing behavior.
+     */
+    public static String resolvePromptTrackerType(Map<String, String[]> cliPromptsByTracker,
+                                                  String trackerType,
+                                                  Map<String, Object> customParams) {
+        if (customParams != null) {
+            Object contentOutput = customParams.get("contentOutput");
+            if (contentOutput instanceof Map) {
+                Object target = ((Map<?, ?>) contentOutput).get("target");
+                if (TRACKER_CONFLUENCE.equals(target)
+                        && cliPromptsByTracker != null
+                        && cliPromptsByTracker.containsKey(TRACKER_CONFLUENCE)) {
+                    return TRACKER_CONFLUENCE;
+                }
+            }
+        }
+        return trackerType;
+    }
+
+    /**
      * Resolves the effective CLI prompts by merging base {@code cliPrompts} with tracker-specific
      * prompts from {@code cliPromptsByTracker} when a matching tracker type is configured.
      */
@@ -75,7 +110,25 @@ public class CliCommandBuilder {
     public String[] buildCommands(String[] cliCommands, String cliPrompt, String[] cliPrompts,
                                    Map<String, String[]> cliPromptsByTracker) throws IOException {
         return buildCommands(cliCommands, cliPrompt,
-                CliPromptsConfig.fromStrings(cliPrompts), cliPromptsByTracker);
+                CliPromptsConfig.fromStrings(cliPrompts), cliPromptsByTracker, null);
+    }
+
+    /**
+     * Builds the final CLI commands for execution.
+     *
+     * @param cliCommands       base CLI commands from the job config
+     * @param cliPrompt         single base CLI prompt (may be null)
+     * @param cliPrompts        array of CLI prompts (may be null)
+     * @param cliPromptsByTracker tracker-specific prompts (may be null)
+     * @param customParams      job custom params (may be null); used to detect
+     *                          {@code contentOutput.target = "confluence"} routing
+     * @return commands with aggregated prompt appended, or original commands if no prompt provided
+     */
+    public String[] buildCommands(String[] cliCommands, String cliPrompt, String[] cliPrompts,
+                                   Map<String, String[]> cliPromptsByTracker,
+                                   Map<String, Object> customParams) throws IOException {
+        return buildCommands(cliCommands, cliPrompt,
+                CliPromptsConfig.fromStrings(cliPrompts), cliPromptsByTracker, customParams);
     }
 
     /**
@@ -89,11 +142,29 @@ public class CliCommandBuilder {
      */
     public String[] buildCommands(String[] cliCommands, String cliPrompt, CliPromptsConfig cliPrompts,
                                    Map<String, String[]> cliPromptsByTracker) throws IOException {
+        return buildCommands(cliCommands, cliPrompt, cliPrompts, cliPromptsByTracker, null);
+    }
+
+    /**
+     * Builds the final CLI commands for execution using the structured prompt config.
+     *
+     * @param cliCommands       base CLI commands from the job config
+     * @param cliPrompt         single base CLI prompt (may be null)
+     * @param cliPrompts        structured CLI prompts config (may be null)
+     * @param cliPromptsByTracker tracker-specific prompts (may be null)
+     * @param customParams      job custom params (may be null); used to detect
+     *                          {@code contentOutput.target = "confluence"} routing
+     * @return commands with aggregated prompt appended, or original commands if no prompt provided
+     */
+    public String[] buildCommands(String[] cliCommands, String cliPrompt, CliPromptsConfig cliPrompts,
+                                   Map<String, String[]> cliPromptsByTracker,
+                                   Map<String, Object> customParams) throws IOException {
         if (cliCommands == null || cliCommands.length == 0) {
             return cliCommands;
         }
 
         String trackerType = configuration != null ? configuration.getDefaultTracker() : null;
+        trackerType = resolvePromptTrackerType(cliPromptsByTracker, trackerType, customParams);
         String[] flatPrompts = cliPrompts != null ? cliPrompts.toStringArray() : null;
         String[] mergedCliPrompts = resolveCliPrompts(flatPrompts, cliPromptsByTracker, trackerType);
         if (mergedCliPrompts != flatPrompts) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -598,7 +598,8 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                             cliCommands,
                             expertParams.getCliPrompt(),
                             expertParams.getCliPrompts(),
-                            expertParams.getCliPromptsByTracker());
+                            expertParams.getCliPromptsByTracker(),
+                            expertParams.getCustomParams());
 
                     // Create input context for CLI commands via shared builder
                     TicketInputContextBuilder contextBuilder = new TicketInputContextBuilder(instructionProcessor);

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateCliPromptsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateCliPromptsTest.java
@@ -231,6 +231,61 @@ class TeammateCliPromptsTest {
     }
 
     // -------------------------------------------------------------------------
+    // resolvePromptTrackerType — contentOutput.target = "confluence" routing
+    // -------------------------------------------------------------------------
+
+    @Test
+    void testResolvePromptTrackerType_ConfluenceTargetSelectsConfluenceKey() {
+        Map<String, String[]> byTracker = Map.of(
+                "jira", new String[]{"jira1"},
+                "confluence", new String[]{"conf1"});
+        Map<String, Object> customParams = Map.of("contentOutput", Map.of("target", "confluence"));
+        String result = CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira", customParams);
+        assertEquals("confluence", result);
+    }
+
+    @Test
+    void testResolvePromptTrackerType_KeepsTrackerWhenNoConfluenceKeyDeclared() {
+        Map<String, String[]> byTracker = Map.of("jira", new String[]{"jira1"});
+        Map<String, Object> customParams = Map.of("contentOutput", Map.of("target", "confluence"));
+        String result = CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira", customParams);
+        assertEquals("jira", result);
+    }
+
+    @Test
+    void testResolvePromptTrackerType_KeepsTrackerForBothTarget() {
+        Map<String, String[]> byTracker = Map.of(
+                "jira", new String[]{"jira1"},
+                "confluence", new String[]{"conf1"});
+        Map<String, Object> customParams = Map.of("contentOutput", Map.of("target", "both"));
+        String result = CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira", customParams);
+        assertEquals("jira", result);
+    }
+
+    @Test
+    void testResolvePromptTrackerType_KeepsTrackerWithoutContentOutput() {
+        Map<String, String[]> byTracker = Map.of(
+                "jira", new String[]{"jira1"},
+                "confluence", new String[]{"conf1"});
+        assertEquals("jira", CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira", null));
+        assertEquals("jira", CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira", Map.of()));
+        assertEquals("jira", CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira",
+                Map.of("contentOutput", Map.of("target", "jira_field"))));
+    }
+
+    @Test
+    void testResolvePromptTrackerType_ConfluenceKeyDrivesPromptSelection() {
+        String[] base = {"base1"};
+        Map<String, String[]> byTracker = Map.of(
+                "jira", new String[]{"jira1"},
+                "confluence", new String[]{"conf1"});
+        String tracker = CliCommandBuilder.resolvePromptTrackerType(byTracker, "jira",
+                Map.of("contentOutput", Map.of("target", "confluence")));
+        String[] result = Teammate.resolveCliPrompts(base, byTracker, tracker);
+        assertArrayEquals(new String[]{"base1", "conf1"}, result);
+    }
+
+    // -------------------------------------------------------------------------
     // Structured cliPrompts (new format)
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Agents using `cliPromptsByTracker` always resolve tracker-specific prompts from `DEFAULT_TRACKER`. When a job routes its generated content exclusively to Confluence (`customParams.contentOutput.target: 'confluence'`, see dmtools-agents `js/common/contentOutput.js`), the CLI agent still receives the tracker markup transform (e.g. Jira wiki markup: `h2.`, `{code}`, `{{...}}`), and the published Confluence page ends up unrenderable since the Confluence Markdown sync expects real Markdown.

## Change

`CliCommandBuilder` gains `resolvePromptTrackerType()`: when `customParams.contentOutput.target == 'confluence'` **and** the agent declares a `cliPromptsByTracker.confluence` key, tracker prompts are selected by the `'confluence'` key instead of the configured default tracker. Otherwise behavior is unchanged (including `target: 'both'`, which still needs tracker markup for the tracker field).

Both call sites now pass `customParams`:
- `Teammate` (covers direct `dmtools run agents/config.json` without an encoded config)
- `CliAgent`

Companion dmtools-agents change adds the generic `instructions/tracker/confluence_markup_transform.md` prompt and the `confluence` key to content-producing agent configs.

## Tests

New cases in `TeammateCliPromptsTest` covering: confluence selection, fallback when no confluence key declared, `both` target, absent/null contentOutput, and end-to-end prompt selection.