### PR TITLE
chore(ci): reduce scheduled workflow frequency to ease runner queue

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -12,8 +12,8 @@ on:
       - ready_for_review
   schedule:
     # Fallback: auto-merge commits made via PAT still may not trigger push events
-    # in some edge cases. Poll every 5 minutes (offset to avoid the :00/:30 herd).
-    - cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *'
+    # in some edge cases. Poll every 15 minutes (offset to avoid the :00/:30 herd).
+    - cron: '7,22,37,52 * * * *'
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/sm.yml
+++ b/.github/workflows/sm.yml
@@ -4,7 +4,7 @@ run-name: "SM Agent : ${{ github.event_name == 'schedule' && 'scheduled' || 'man
 
 on:
   schedule:
-    - cron: '*/10 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Runners were piling up in queue. Root cause: no OS/runner-speed issue (`ubuntu-latest` is already the fastest free option) — instead, two scheduled workflows were firing ~430 times/day and competing with real CI jobs for the org's shared concurrent-runner slots:

- `SM Agent`: every 10 min (144 runs/day)
- `Auto-update open PRs` fallback poll: every 5 min (288 runs/day)

This PR only slows the polling cadence, no functional change:
- `SM Agent`: 10min -> 30min (144 -> 48 runs/day)
- `Auto-update PRs` schedule: 5min -> 15min (96 -> 32 runs/day). Note this cron is only a *fallback* — the primary triggers (`push` to main, `pull_request` events) are untouched, so PR branch updates still happen immediately in the normal case.

Net: ~350 fewer scheduled runs/day competing for runner slots.