### PR TITLE
chore(ci): consolidate PR-triggered jobs onto fewer runners

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,11 @@ name: Coverage
 # It is intentionally a standalone workflow (not part of build-and-test.yml) so it
 # runs in parallel with the release pipeline and can never block a release.
 #
+# Runs only on push to main / manual dispatch — NOT on pull_request. The badge is
+# only ever published from main, so re-running the full test suite again on every
+# PR push (duplicating unit-tests.yml's "Java unit tests" job) bought nothing but
+# an extra ~4 min runner slot per PR event.
+#
 # The badge SVGs land on `main` via a small auto-merge PR: the "Protect main"
 # ruleset requires the "Java unit tests" status check, so a direct push from a
 # workflow is rejected. The PR gets the required check from unit-tests.yml,
@@ -19,8 +24,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened]
   # Manual trigger, e.g. to refresh the badge after an auto-merged PR (squash
   # merges created by the GitHub Actions bot do not fire the push trigger).
   workflow_dispatch:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,17 +5,33 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  quality-gate:
-    name: Quality gate
+  # Quality gate, Java unit tests, and the agents JS suite used to be three
+  # separate jobs (= three concurrently-requested runners per PR push, all
+  # competing for the org's shared runner pool). They're merged into one job
+  # on one runner, run sequentially. This job's `name:` stays "Java unit
+  # tests" because that literal string is the required status check in the
+  # "Protect main" branch ruleset — do not rename it without also updating
+  # the ruleset.
+  #
+  # Quality-gate and agents-JS-tests steps keep `continue-on-error: true` so
+  # a failure there is visible (annotated, non-zero step, workflow summary)
+  # but does NOT fail this job / block merge — preserving the exact
+  # pre-merge semantics these two checks had as independent, non-required
+  # jobs before this consolidation.
+  test:
+    name: Java unit tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository with submodules
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          submodules: recursive
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js (for jscpd)
         uses: actions/setup-node@v7
@@ -25,7 +41,9 @@ jobs:
       - name: Install jscpd
         run: npm install -g jscpd@5.0.11
 
-      - name: Check Java file sizes
+      - name: 'Quality gate: check Java file sizes'
+        id: quality_gate_file_sizes
+        continue-on-error: true
         run: |
           MAX_LINES=2800
           FAILED=0
@@ -49,7 +67,9 @@ jobs:
             exit 1
           fi
 
-      - name: Check code duplication against baseline
+      - name: 'Quality gate: check code duplication against baseline'
+        id: quality_gate_duplication
+        continue-on-error: true
         run: |
           jscpd --min-tokens 50 --min-lines 5 --reporters json --output /tmp/jscpd-check dmtools-core/src/main/java/ >/dev/null 2>&1 || true
           CURRENT=$(python3 -c '
@@ -71,17 +91,6 @@ jobs:
           echo "Current duplication: $CURRENT%"
           echo "Baseline: $BASELINE%"
           python3 -c "import sys; sys.exit(0 if float('$CURRENT') <= float('$BASELINE') else 1)"
-
-  test:
-    name: Java unit tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
 
       - name: Set up Java 17
         uses: actions/setup-java@v5.7.0
@@ -110,33 +119,7 @@ jobs:
           reporter: java-junit
           fail-on-error: false
 
-  dmtools-agents-js-tests:
-    name: DMTools Agents JS unit tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      checks: write
-
-    steps:
-      - name: Checkout repository with submodules
-        uses: actions/checkout@v7
-        with:
-          submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Java 17
-        uses: actions/setup-java@v5.7.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-
-      - name: Configure Git for tests
-        run: |
-          git config --global user.name "dm.ai"
-          git config --global user.email "dm.ai@epam.com"
-
-      - name: Build DMTools shadow JAR
+      - name: Build DMTools shadow JAR (for agents JS tests)
         run: ./gradlew :dmtools-core:shadowJar --no-daemon
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,14 +131,17 @@ jobs:
           echo "Installed DMTools CLI:"
           java -jar "$HOME/.dmtools/dmtools.jar" --version
 
-      - name: Run DMTools Agents JS unit tests
+      - name: 'Agents JS tests: run'
         id: agents_tests
+        continue-on-error: true
         run: |
           cd agents
           ../dmtools.sh run js/unit-tests/run_all.json > ../agents-test-output.json 2>&1 || true
           cat ../agents-test-output.json
 
-      - name: Validate agents test results
+      - name: 'Agents JS tests: validate results'
+        id: agents_tests_validate
+        continue-on-error: true
         run: |
           PASSED=$(grep -oE '"passed"\s*:\s*[0-9]+' agents-test-output.json | tail -1 | grep -oE '[0-9]+')
           FAILED=$(grep -oE '"failed"\s*:\s*[0-9]+' agents-test-output.json | tail -1 | grep -oE '[0-9]+')
@@ -167,4 +153,25 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             echo "Some agents JS tests failed. See output above for details."
             exit 1
+          fi
+
+      - name: Summary of advisory (non-blocking) checks
+        if: always()
+        run: |
+          fail=0
+          check() {
+            local label="$1" outcome="$2"
+            if [ "$outcome" = "failure" ]; then
+              echo "❌ $label: FAILED (advisory — did not block this required check)" >> "$GITHUB_STEP_SUMMARY"
+              fail=1
+            else
+              echo "✅ $label: passed" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+          check "Quality gate: file sizes" "${{ steps.quality_gate_file_sizes.outcome }}"
+          check "Quality gate: duplication" "${{ steps.quality_gate_duplication.outcome }}"
+          check "Agents JS tests: run" "${{ steps.agents_tests.outcome }}"
+          check "Agents JS tests: validate" "${{ steps.agents_tests_validate.outcome }}"
+          if [ "$fail" -ne 0 ]; then
+            echo "::warning::One or more advisory checks failed — see step summary for details."
           fi


### PR DESCRIPTION
Follow-up to #491 (scheduled-workflow frequency reduction). This targets the per-PR-push runner burst directly.

**Before**: every PR push requested up to 6 concurrent runners: `quality-gate`, `Java unit tests`, `DMTools Agents JS unit tests` (3 separate jobs in `unit-tests.yml`), `JaCoCo coverage badge` (`coverage.yml`, which re-ran the *entire* test suite a second time), `OWASP dependency check`, `CodeQL`.

**After**:
- `unit-tests.yml`: the 3 jobs are merged into a single sequential job on one runner. Job keeps the name `Java unit tests` (the literal required status check in the `Protect main` ruleset — verified via `gh api repos/epam/dm.ai/rulesets/14832498`). Quality-gate and agents-JS-test steps use `continue-on-error: true`, so failures stay visible in the job's step summary/annotations but do **not** newly block merges — preserving exactly the current (non-required) semantics of those two checks.
- `coverage.yml`: dropped the `pull_request` trigger. The badge is only ever published on `push` to `main` (existing `if:` guard in the publish step) — running the full test suite again per PR bought nothing.

**Net effect per PR push**: ~6 requested runners -> ~3 (Java unit tests, OWASP, CodeQL), and one fewer full ~4min duplicate test run.

Validated the rewritten workflow YAML parses correctly (`node -e "require('yaml').parse(...)"`). `merge-trigger.yml` only depends on the *workflow* name `"Unit Tests"` + run conclusion, not job names, so it is unaffected.