### PR TITLE
fix(release): remove redundant unit test run causing push race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,21 +30,18 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v5.7.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-      
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Run unit tests
-        run: ./gradlew :dmtools-core:test --no-daemon -x integrationTest
-      
+      # Unit tests are intentionally NOT re-run here: main is protected by the
+      # "Java unit tests" required status check, so any commit reachable from
+      # main has already passed them. Re-running the full suite here just adds
+      # ~5-7 minutes during which main can move forward (e.g. another PR merges),
+      # causing the final "Push changes and tag" step to be rejected as
+      # non-fast-forward.
+
       - name: Read current version
         id: current_version
         run: |
@@ -147,8 +144,21 @@ jobs:
               }
             }"
 
-          # Push to main (branch protection now satisfied)
-          git push epam main
+          # Push to main (branch protection now satisfied).
+          # Retry with rebase in case main advanced (e.g. another PR merged)
+          # between checkout and this step.
+          for attempt in 1 2 3; do
+            if git push epam main; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to push to main after $attempt attempts"
+              exit 1
+            fi
+            echo "Push rejected (main moved), rebasing and retrying ($attempt)..."
+            git fetch epam main
+            git rebase epam/main
+          done
           git push epam --tags
 
           # Clean up temp branch


### PR DESCRIPTION
## Problem
Two of the user's manual `Release DMTools` runs failed today. Root cause: `release.yml`'s `version-and-tag` job re-runs the full `./gradlew :dmtools-core:test` suite (~5-7 min) even though `main` is already protected by the `Java unit tests` required status check — meaning every commit on `main` has already passed tests before it could be merged.

That 5-7 minute window let `main` advance (e.g. another PR auto-merging) before the release workflow's final `git push epam main`, so the push was rejected as non-fast-forward and the whole release run failed.

## Fix
- Remove the redundant `Run unit tests` step (and the now-unused `Set up Java 17` step) from `version-and-tag`.
- `build-and-test.yml` (invoked later in the pipeline) already skips tests via `-x :dmtools-core:test`, so no test coverage is lost.
- Add a rebase-and-retry loop (up to 3 attempts) around the final `git push epam main` as a safety net for the (now much smaller) remaining race window.

## Verification
Triggered `Release DMTools` manually before/after: the run that failed showed the exact `! [rejected] main -> main (fetch first)` error from this race. After removing the test step, a fresh run's `version-and-tag` job completed successfully and pushed without conflict.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>