### PR TITLE
feat(confluence): preserve inline comment anchors across Markdown sync body replacements

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -674,10 +674,22 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         @MCPParam(name = "deleteOrphans", description = "Whether to delete child pages not present in the directory tree", required = false, example = "false")
         Boolean deleteOrphans,
         @MCPParam(name = "attachmentsDir", description = "Optional directory containing referenced attachments. Defaults to the Markdown file's directory.", required = false, example = "/path/to/attachments")
-        String attachmentsDir
+        String attachmentsDir,
+        @MCPParam(name = "preserveInlineComments", description = "Whether to carry inline comment anchors over from the existing page bodies (default: true). When enabled, ac:inline-comment-marker elements are re-applied after the body is replaced, and [[ic:REF]]...[[/ic]] placeholders in the Markdown are converted into real markers.", required = false, example = "true")
+        Boolean preserveInlineComments
     ) throws IOException {
         MarkdownConfluenceSync sync = new MarkdownConfluenceSync(getAttachmentHelper(), new ConfluencePageOperations(this));
-        return sync.syncDirectory(new File(directory), parentId, space, deleteOrphans != null && deleteOrphans, attachmentsDir);
+        return sync.syncDirectory(new File(directory), parentId, space, deleteOrphans != null && deleteOrphans, attachmentsDir,
+                preserveInlineComments == null || preserveInlineComments);
+    }
+
+    /**
+     * Java-facing overload without {@code preserveInlineComments} (defaults to true).
+     * Kept for source compatibility with pre-existing callers.
+     */
+    public String syncMarkdownDirectory(String directory, String parentId, String space,
+                                        Boolean deleteOrphans, String attachmentsDir) throws IOException {
+        return syncMarkdownDirectory(directory, parentId, space, deleteOrphans, attachmentsDir, Boolean.TRUE);
     }
 
     private ConfluenceAttachmentHelper attachmentHelper;

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserver.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserver.java
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Preserves Confluence inline comment anchors ({@code <ac:inline-comment-marker ac:ref="...">})
+ * across page body replacements.
+ *
+ * <p>Any REST body update that drops these marker elements orphans the corresponding inline
+ * comments: they stay in the API but disappear from the page UI. When a page is republished
+ * from generated Markdown (e.g. via {@link MarkdownConfluenceSync}), the markers are lost
+ * unless they are carried over explicitly.</p>
+ *
+ * <p>Strategy:</p>
+ * <ol>
+ *   <li>Agents may carry anchors through Markdown as literal
+ *   {@code [[ic:REF]]anchored text[[/ic]]} placeholders (HTML comments do not survive the
+ *   Markdown→storage conversion; literal tags do). These are converted back into real
+ *   markers unconditionally — Confluence resolves the ref to the comment.</li>
+ *   <li>For markers present in the OLD storage body but missing from the new one, the
+ *   anchored plain text is matched in the new body (raw and XML-escaped variants) and
+ *   re-wrapped with the original ref.</li>
+ *   <li>Any leftover placeholder tags are stripped so they never render visibly.</li>
+ * </ol>
+ */
+public final class InlineCommentAnchorPreserver {
+
+    public static final String PLACEHOLDER_OPEN_PREFIX = "[[ic:";
+    public static final String PLACEHOLDER_CLOSE = "[[/ic]]";
+
+    private static final Pattern MARKER_PATTERN = Pattern.compile(
+            "<ac:inline-comment-marker\\s+ac:ref=\"([^\"]+)\"[^>]*>([\\s\\S]*?)</ac:inline-comment-marker>");
+    private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile(
+            "\\[\\[ic:([0-9a-fA-F-]{36})\\]\\]([\\s\\S]*?)\\[\\[/ic\\]\\]");
+    private static final Pattern LEFTOVER_OPEN_PATTERN = Pattern.compile("\\[\\[ic:[0-9a-fA-F-]{36}\\]\\]");
+    private static final Pattern STRIP_TAGS_PATTERN = Pattern.compile("<[^>]+>");
+
+    private InlineCommentAnchorPreserver() {
+    }
+
+    /**
+     * An inline comment anchor: the marker ref (resolves to the comment) and the plain
+     * text it wraps.
+     */
+    public static final class Anchor {
+        public final String ref;
+        public final String text;
+
+        public Anchor(String ref, String text) {
+            this.ref = ref;
+            this.text = text;
+        }
+    }
+
+    /**
+     * Extracts inline comment markers from a storage-format body.
+     * Nested tags inside the anchored text are stripped — anchors are plain text.
+     */
+    public static List<Anchor> extractMarkers(String storageBody) {
+        List<Anchor> anchors = new ArrayList<>();
+        if (storageBody == null) {
+            return anchors;
+        }
+        Matcher m = MARKER_PATTERN.matcher(storageBody);
+        while (m.find()) {
+            String text = STRIP_TAGS_PATTERN.matcher(m.group(2)).replaceAll("");
+            if (!m.group(1).isEmpty() && !text.trim().isEmpty()) {
+                anchors.add(new Anchor(m.group(1), text));
+            }
+        }
+        return anchors;
+    }
+
+    /**
+     * Restores inline comment anchors in a fresh storage body. See the class javadoc for
+     * the strategy. Returns the (possibly unchanged) body.
+     */
+    public static String restoreAnchors(String newStorageBody, List<Anchor> oldAnchors) {
+        if (newStorageBody == null) {
+            return null;
+        }
+        String body = newStorageBody;
+
+        // 1. Agent-preserved placeholders → real markers (unconditional: Confluence
+        //    resolves the ref to the comment even if the old body had no marker).
+        Matcher pm = PLACEHOLDER_PATTERN.matcher(body);
+        StringBuffer sb = new StringBuffer();
+        while (pm.find()) {
+            pm.appendReplacement(sb, Matcher.quoteReplacement(
+                    "<ac:inline-comment-marker ac:ref=\"" + pm.group(1) + "\">" + pm.group(2) + "</ac:inline-comment-marker>"));
+        }
+        pm.appendTail(sb);
+        body = sb.toString();
+
+        // 2. Text-match fallback for anchors from the old body that didn't make it over.
+        for (Anchor anchor : oldAnchors == null ? List.<Anchor>of() : oldAnchors) {
+            if (anchor == null || anchor.ref == null || anchor.text == null) {
+                continue;
+            }
+            if (body.contains("ac:ref=\"" + anchor.ref + "\"")) {
+                continue;
+            }
+            body = wrapFirstOccurrence(body, escapeXml(anchor.text), anchor.ref);
+            if (!body.contains("ac:ref=\"" + anchor.ref + "\"")) {
+                body = wrapFirstOccurrence(body, anchor.text, anchor.ref);
+            }
+        }
+
+        // 3. Strip leftover placeholder tags so they never render as visible text.
+        body = LEFTOVER_OPEN_PATTERN.matcher(body).replaceAll("");
+        body = body.replace(PLACEHOLDER_CLOSE, "");
+        return body;
+    }
+
+    private static String wrapFirstOccurrence(String body, String needle, String ref) {
+        if (needle == null || needle.isEmpty()) {
+            return body;
+        }
+        int idx = body.indexOf(needle);
+        if (idx == -1) {
+            return body;
+        }
+        return body.substring(0, idx)
+                + "<ac:inline-comment-marker ac:ref=\"" + ref + "\">" + needle + "</ac:inline-comment-marker>"
+                + body.substring(idx + needle.length());
+    }
+
+    private static String escapeXml(String text) {
+        return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
+    }
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
@@ -46,6 +46,7 @@ public class MarkdownConfluenceSync {
 
     private final ConfluenceAttachmentHelper attachmentHelper;
     private final PageOperations pageOps;
+    private boolean preserveInlineComments = true;
 
     /**
      * Callbacks for Confluence page CRUD operations.
@@ -74,6 +75,23 @@ public class MarkdownConfluenceSync {
      */
     public String syncDirectory(File rootDir, String parentId, String space,
                                 boolean deleteOrphans, String attachmentsDir) throws IOException {
+        return syncDirectory(rootDir, parentId, space, deleteOrphans, attachmentsDir, true);
+    }
+
+    /**
+     * Synchronizes a local directory tree to a Confluence page subtree.
+     *
+     * @param preserveInlineComments when true (default via the 5-arg overload), inline
+     *   comment anchors ({@code ac:inline-comment-marker}) from each existing page body are
+     *   carried over into the freshly converted body before it replaces the old one, and
+     *   {@code [[ic:REF]]...[[/ic]]} placeholders in the Markdown are converted into real
+     *   markers — otherwise every sync would orphan the page's inline comments
+     *   (they remain in the API but disappear from the page UI).
+     */
+    public String syncDirectory(File rootDir, String parentId, String space,
+                                boolean deleteOrphans, String attachmentsDir,
+                                boolean preserveInlineComments) throws IOException {
+        this.preserveInlineComments = preserveInlineComments;
         DirNode root = buildDirTree(rootDir);
         Map<String, String> pathToTitle = buildPathToTitleMap(rootDir, root);
         Set<String> expectedTitles = new HashSet<>(pathToTitle.values());
@@ -143,6 +161,7 @@ public class MarkdownConfluenceSync {
 
         List<String> uploadedAttachmentNames = uploadDirectoryAttachments(node, referencedAttachmentNames);
         folderBody = appendAttachmentLinks(folderBody, uploadedAttachmentNames);
+        folderBody = preserveAnchors(node.contentId, folderBody);
         pageOps.updatePage(node.contentId, node.title,
                 node.parentId != null ? node.parentId : node.contentId,
                 folderBody, space, "");
@@ -166,6 +185,7 @@ public class MarkdownConfluenceSync {
                 }
             }
             storage = appendAttachmentLinks(storage, extraAttachmentNames);
+            storage = preserveAnchors(page.getId(), storage);
             pageOps.updatePage(page.getId(), fileNode.title, node.contentId, storage, space, "");
             fileNode.contentId = page.getId();
         }
@@ -363,6 +383,32 @@ public class MarkdownConfluenceSync {
         }
         File parent = markdownFile.getParentFile();
         return parent != null ? parent : new File(".");
+    }
+
+    /**
+     * Carries inline comment anchors over from the page's current body into the freshly
+     * converted one. Non-fatal: any failure (page just created, lookup error) leaves the
+     * new body unchanged.
+     */
+    private String preserveAnchors(String contentId, String newStorageBody) {
+        if (!preserveInlineComments || contentId == null || newStorageBody == null) {
+            return newStorageBody;
+        }
+        try {
+            Content existing = pageOps.getContent(contentId);
+            String oldBody = (existing != null && existing.getStorage() != null)
+                    ? existing.getStorage().getValue() : null;
+            String restored = InlineCommentAnchorPreserver.restoreAnchors(
+                    newStorageBody, InlineCommentAnchorPreserver.extractMarkers(oldBody));
+            if (!restored.equals(newStorageBody)) {
+                logger.info("Preserved inline comment anchors on page {}", contentId);
+            }
+            return restored;
+        } catch (Exception e) {
+            logger.warn("Failed to preserve inline comment anchors for page {} — continuing without preservation: {}",
+                    contentId, e.getMessage());
+            return newStorageBody;
+        }
     }
 
     private static String appendAttachmentLinks(String storageBody, List<String> attachmentNames) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
@@ -17,7 +17,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Regression coverage for {@link MarkdownConfluenceSync#syncDirectory}, in particular two
@@ -38,6 +40,7 @@ public class MarkdownConfluenceSyncTest {
     private static class FakePageOperations implements MarkdownConfluenceSync.PageOperations {
         final Map<String, String> parentsById = new HashMap<>();
         final Map<String, String> titlesById = new HashMap<>();
+        final Map<String, String> bodiesById = new HashMap<>();
         final List<String[]> updateCalls = new ArrayList<>(); // {contentId, title, parentId, body}
         int nextId = 1000;
 
@@ -71,16 +74,24 @@ public class MarkdownConfluenceSyncTest {
         public Content getContent(String contentId) throws IOException {
             String parentId = parentsById.get(contentId);
             String title = titlesById.containsKey(contentId) ? titlesById.get(contentId) : "existing";
-            return contentFor(contentId, title, parentId);
+            return contentFor(contentId, title, parentId, bodiesById.get(contentId));
         }
 
         private Content contentFor(String id, String title, String parentId) {
+            return contentFor(id, title, parentId, null);
+        }
+
+        private Content contentFor(String id, String title, String parentId, String body) {
             JSONObject json = new JSONObject();
             json.put("id", id);
             json.put("title", title);
             if (parentId != null) {
                 JSONObject ancestor = new JSONObject().put("id", parentId);
                 json.put("ancestors", new org.json.JSONArray().put(ancestor));
+            }
+            if (body != null) {
+                json.put("body", new JSONObject().put("storage",
+                        new JSONObject().put("value", body).put("representation", "storage")));
             }
             return new Content(json);
         }
@@ -225,6 +236,100 @@ public class MarkdownConfluenceSyncTest {
             String[] childUpdate = pageOps.updateCalls.get(1);
             assertEquals("child page's parent must be the root page (555), not the grandparent",
                     "555", childUpdate[2]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    private static final String REF_A = "a40ec14d-0d73-4f55-9a69-7026900b6623";
+
+    @Test
+    public void syncDirectory_preservesInlineCommentMarker_fromExistingBody() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            // New content still contains the anchored text but no marker (Markdown never
+            // carries one) — the sync must re-wrap the text with the original marker.
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing\n\n- Item one\n- Item two\n", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+            pageOps.bodiesById.put("555",
+                    "<ul><li><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Item one</ac:inline-comment-marker></li><li>Item two</li></ul>");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            String updatedBody = pageOps.updateCalls.get(0)[3];
+            assertTrue("marker with original ref must be re-applied around the anchor text",
+                    updatedBody.contains("<ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Item one</ac:inline-comment-marker>"));
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_convertsPlaceholderInMarkdown_intoRealMarker() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"),
+                    "# Landing\n\n- [[ic:" + REF_A + "]]Item one[[/ic]]\n", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+            pageOps.bodiesById.put("555", "<p>old body without markers</p>");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            String updatedBody = pageOps.updateCalls.get(0)[3];
+            assertTrue("placeholder must become a real marker",
+                    updatedBody.contains("<ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Item one</ac:inline-comment-marker>"));
+            assertFalse("no leftover placeholder tags", updatedBody.contains("[[ic:"));
+            assertFalse("no leftover placeholder close tags", updatedBody.contains("[[/ic]]"));
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_preserveInlineCommentsFalse_leavesPlaceholdersUntouched() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"),
+                    "# Landing\n\n- [[ic:" + REF_A + "]]Item one[[/ic]]\n", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+            pageOps.bodiesById.put("555",
+                    "<ul><li><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Item one</ac:inline-comment-marker></li></ul>");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null, false);
+
+            String updatedBody = pageOps.updateCalls.get(0)[3];
+            assertFalse("marker must NOT be re-applied when preservation is disabled",
+                    updatedBody.contains("ac:inline-comment-marker"));
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_anchorTextGone_doesNotFailSync() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing\n\n- completely new content\n", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+            pageOps.bodiesById.put("555",
+                    "<ul><li><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Item one</ac:inline-comment-marker></li></ul>");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            String updatedBody = pageOps.updateCalls.get(0)[3];
+            assertFalse(updatedBody.contains("ac:inline-comment-marker"));
         } finally {
             FileUtils.deleteDirectory(tempDir);
         }


### PR DESCRIPTION
## Problem

`confluence_sync_markdown_directory` replaces page bodies wholesale. This drops every `<ac:inline-comment-marker ac:ref="...">` element from the storage body, which orphans the page's inline comments: they remain in the API but disappear from the page UI (known Atlassian Cloud limitation — e.g. atlassian/atlassian-mcp-server#54). Every consumer of the sync tool is affected, including discovery publishing and the `contentOutput` flows in dmtools-agents.

Verified empirically against a live Confluence Cloud test page: reinserting a marker with the original `ac:ref` re-anchors the comment — Confluence accepts and renders it.

## Change

New `InlineCommentAnchorPreserver` + integration into `MarkdownConfluenceSync` (enabled by default, before every page body update):

1. **`[[ic:REF]]...[[/ic]]` placeholders** in the Markdown are converted back into real `ac:inline-comment-marker` elements. (HTML comments don't survive the Markdown→storage conversion; literal tags do — both verified against Confluence Cloud.) Agents carrying content through Markdown can thus keep comment anchors across rewrites.
2. **Text-match fallback**: markers present in the existing page body but missing from the new content are re-applied around their anchored text (raw and XML-escaped variants tried).
3. **Cleanup**: leftover placeholder tags are stripped so they never render as visible text.
4. Comments whose anchored text genuinely disappeared stay orphaned (semantically honest) and never fail the sync — preservation errors are non-fatal.

Opt out per call via the new optional `preserveInlineComments` parameter on `confluence_sync_markdown_directory` (default `true`). A 5-arg overload of `Confluence.syncMarkdownDirectory` keeps source compatibility for existing Java callers.

## Tests

`MarkdownConfluenceSyncTest` (FakePageOperations extended to seed page bodies): text-match preservation, placeholder→marker conversion, disabled-flag behavior, anchor-text-gone case. `atlassian.*` and `mcp.*` packages pass.