### PR TITLE
feat(github): add native PR review MCP tools (submit/list/dismiss)

### DIFF
--- a/dmtools-ai-docs/SKILL.md
+++ b/dmtools-ai-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dmtools
-description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 331+ MCP tools for Jira, Azure DevOps, GitHub, GitLab, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
+description: Comprehensive documentation and assistance for DMTools - an enterprise dark-factory orchestrator with 334+ MCP tools for Jira, Azure DevOps, GitHub, GitLab, Figma, Confluence, Teams, and test automation. Use when working with DMTools, configuring integrations, developing JavaScript agents, generating test cases, building reports (ReportGenerator/ReportVisualizer), creating CLI agent workflows (Teammate/CliAgent), or setting up CI/CD run tracing (ciRunUrl) for Teammate/Expert/TestCasesGenerator/CliAgent jobs.
 license: Apache-2.0
 compatibility:
   - Java 17+
@@ -14,7 +14,7 @@ metadata:
 
 # DMtools Development Assistant
 
-DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 331+ MCP tools for reusable delivery automation.
+DMTools is an enterprise dark-factory orchestrator that integrates with multiple platforms and provides 334+ MCP tools for reusable delivery automation.
 
 ## 🔧 FIRST-TIME SETUP (DO THIS PROACTIVELY)
 
@@ -180,7 +180,7 @@ See [Installation Guide](references/installation/README.md#️-configuration-set
 
 ### Common Commands
 ```bash
-dmtools list                          # List all 331+ MCP tools
+dmtools list                          # List all 334+ MCP tools
 dmtools jira_get_ticket PROJ-123      # Get Jira ticket
 dmtools run agents/config.json        # Run configuration
 dmtools run agents/config.json --ciRunUrl "https://ci.example.com/runs/42"  # With CI tracing
@@ -189,7 +189,7 @@ dmtools run agents/config.json "${ENCODED_CONFIG}" --inputJql "key=PROJ-1"  # Wi
 
 ## Core Capabilities
 
-### 331+ MCP Tools Available
+### 334+ MCP Tools Available
 
 **Complete Reference**: [references/mcp-tools/README.md](references/mcp-tools/README.md) - Auto-generated from actual DMtools build
 
@@ -200,7 +200,7 @@ Current breakdown (20 integrations):
 - **Teams Auth** (3 tools): Teams authentication flows
 - **Confluence** (24 tools): Page management, search, content access, attachments, inline comments
 - **ADO** (38 tools): Azure DevOps work items, queries, comments, attachments, pull requests, code review threads
-- **GitHub** (35 tools): Pull requests, issues, comments, workflows
+- **GitHub** (38 tools): Pull requests, issues, comments, workflows
 - **GitLab** (30 tools): Merge requests, issues, CI/CD pipelines
 - **Bitbucket** (1 tool): Pull request operations
 - **Figma** (22 tools): Design extraction, icons, layers, styles, components
@@ -269,11 +269,11 @@ function action(params) {
 | | [ReportVisualizer](references/jobs/README.md#reportvisualizer) | Render an existing report JSON as interactive HTML |
 | | [KBProcessingJob](references/jobs/README.md#kbprocessingjob) | Process source material into knowledge-base artifacts |
 | **Agents** | [Agent Best Practices](references/agents/best-practices.md) | **⚠️ CRITICAL**: Patterns and lessons learned |
-| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 331+ MCP tools |
+| | [JavaScript Agents](references/agents/javascript-agents.md) | GraalJS development with 334+ MCP tools |
 | | [Teammate Configs](references/agents/teammate-configs.md) | JSON-based AI workflows (CLI safety v1.7.133+) |
 | | [CLI Integration](references/agents/cli-integration.md) | Cursor, Claude, Copilot, Gemini CLI agents |
 | **Testing** | [Test Generation](references/test-generation/xray-manual.md) | Xray test case creation |
-| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 331+ tools (20 integrations) |
+| **MCP Tools** | [MCP Tools Reference](references/mcp-tools/README.md) | Auto-generated list of 334+ tools (20 integrations) |
 | **CI/CD** | [GitHub Actions](references/workflows/github-actions-teammate.md) | Automated ticket processing + CI run tracing |
 
 ## ⚠️ CRITICAL: JSON Configuration "name" Field

--- a/dmtools-ai-docs/references/mcp-tools/README.md
+++ b/dmtools-ai-docs/references/mcp-tools/README.md
@@ -3,7 +3,7 @@
 Complete reference for all MCP tools available in DMtools.
 
 **Total Integrations**: 20
-**Total Tools**: 292
+**Total Tools**: 295
 
 *Auto-generated from `dmtools list` on: 2026-07-22 19:14:18*
 
@@ -33,7 +33,7 @@ dmtools <tool_name> [arguments]
 | **FIGMA** | 22 | [figma-tools.md](figma-tools.md) |
 | **FILE** | 5 | [file-tools.md](file-tools.md) |
 | **GEMINI** | 2 | [gemini-tools.md](gemini-tools.md) |
-| **GITHUB** | 35 | [github-tools.md](github-tools.md) |
+| **GITHUB** | 38 | [github-tools.md](github-tools.md) |
 | **GITLAB** | 30 | [gitlab-tools.md](gitlab-tools.md) |
 | **JIRA** | 69 | [jira-tools.md](jira-tools.md) |
 | **KB** | 5 | [kb-tools.md](kb-tools.md) |

--- a/dmtools-ai-docs/references/mcp-tools/github-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/github-tools.md
@@ -1,6 +1,6 @@
 # GITHUB MCP Tools
 
-**Total Tools**: 35
+**Total Tools**: 38
 
 ## Quick Reference
 
@@ -32,6 +32,7 @@ const result = github_list_prs_filtered(...);
 | `github_create_commit_status` | Create a commit status (the colored dot in PR checks). Use state=pending when AI analysis starts, success/failure/error when complete. The 'context' field acts as the status name and must be unique per check. | `workspace` (string, **required**)<br>`context` (string, optional)<br>`description` (string, optional)<br>`state` (string, **required**)<br>`repository` (string, **required**)<br>`sha` (string, **required**)<br>`targetUrl` (string, optional) |
 | `github_delete_pr_comment` | Delete a comment on a GitHub pull request or issue by its comment ID. | `repository` (string, **required**)<br>`commentId` (string, **required**)<br>`workspace` (string, **required**) |
 | `github_delete_release_asset` | Delete a GitHub release asset by its asset ID. Use github_list_release_assets to find asset IDs. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`assetId` (string, **required**) |
+| `github_dismiss_pr_review` | Dismiss a previously submitted GitHub pull request review (e.g. clear a REQUEST_CHANGES decision once the issues have been fixed and a new review approves). Requires repository admin rights, or being listed as allowed to dismiss reviews, on protected branches. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`reviewId` (string, **required**)<br>`message` (string, **required**) |
 | `github_get_commit_check_runs` | Get all check runs (CI/CD status checks) for a commit SHA in a GitHub repository. Returns details about each check including status, conclusion, and output. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`commitSha` (string, **required**) |
 | `github_get_commits_from_branches` | Fetch commits from all branches whose name matches a given regex pattern, aggregated and de-duplicated. Useful for collecting commits from feature/*, release/* or similar groups of branches without specifying each branch individually. | `branchNameRegex` (string, **required**)<br>`workspace` (string, **required**)<br>`repository` (string, **required**)<br>`since` (string, optional) |
 | `github_get_job_logs` | Get the raw text logs for a specific GitHub Actions job. Returns the complete log output from all steps in the job. | `repository` (string, **required**)<br>`jobId` (string, **required**)<br>`workspace` (string, **required**) |
@@ -48,6 +49,7 @@ const result = github_list_prs_filtered(...);
 | `github_get_workflow_run_logs` | Download and extract complete logs for all jobs in a GitHub Actions workflow run. Returns full untruncated log content from the ZIP archive GitHub provides. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`runId` (string, **required**) |
 | `github_list_prs` | List pull requests in a GitHub repository by state. State can be 'open', 'closed', or 'merged'. Returns first page (up to 100) of pull requests. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`state` (string, **required**) |
 | `github_list_prs_filtered` | List pull requests in a GitHub repository filtered by a regex pattern on the PR title. Fetches all PRs matching the given state and returns only those whose title matches the regex. Useful for large repos to narrow down results without loading entire history. | `titleRegex` (string, **required**)<br>`workspace` (string, **required**)<br>`state` (string, **required**)<br>`repository` (string, **required**) |
+| `github_list_pr_reviews` | List all formal reviews (APPROVE/REQUEST_CHANGES/COMMENT decisions submitted via github_submit_pr_review or by human reviewers) for a GitHub pull request, in chronological order. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
 | `github_list_release_assets` | List all assets attached to a GitHub release. Returns a JSON array of asset objects including id, name, size, and browser_download_url. | `repository` (string, **required**)<br>`releaseId` (string, **required**)<br>`workspace` (string, **required**) |
 | `github_list_workflow_runs` | List GitHub Actions workflow runs for a repository, optionally filtered by status or specific workflow file. Use status='failure' to get all failed runs. | `workspace` (string, **required**)<br>`perPage` (number, optional)<br>`created` (string, optional)<br>`page` (number, optional)<br>`repository` (string, **required**)<br>`workflowId` (string, optional)<br>`status` (string, optional) |
 | `github_merge_pr` | Merge a GitHub pull request. Supports merge, squash, and rebase merge methods. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`commitMessage` (string, optional)<br>`mergeMethod` (string, optional)<br>`commitTitle` (string, optional) |
@@ -55,6 +57,7 @@ const result = github_list_prs_filtered(...);
 | `github_reply_to_pr_thread` | Reply to an existing inline code review comment thread in a GitHub pull request. Use the comment ID of the root comment (or any comment) in the thread as inReplyToId. | `workspace` (string, **required**)<br>`text` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`inReplyToId` (string, **required**) |
 | `github_repository_dispatch` | Trigger a GitHub repository dispatch event. Workflows listening to 'on: repository_dispatch' with the matching event_type will be triggered. | `workspace` (string, **required**)<br>`eventType` (string, **required**)<br>`clientPayload` (string, optional)<br>`repository` (string, **required**) |
 | `github_resolve_pr_thread` | Resolve a review thread in a GitHub pull request. Requires the thread's GraphQL node ID, which can be obtained from github_get_pr_review_threads (the 'id' field of each thread). | `threadId` (string, **required**) |
+| `github_submit_pr_review` | Submit a formal GitHub pull request review (a native reviewer decision, distinct from labels/comments). event=APPROVE marks the PR as approved by this reviewer; event=REQUEST_CHANGES formally blocks the PR (visible as 'Changes requested', and enforced by branch protection rules requiring approvals) until a new review or github_dismiss_pr_review clears it; event=COMMENT leaves a review without approving or blocking. 'body' is required for REQUEST_CHANGES and COMMENT. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`event` (string, **required**)<br>`body` (string, optional) |
 | `github_test` | Test GitHub connectivity by fetching the current user's profile | None |
 | `github_trigger_workflow` | Trigger a specific GitHub Actions workflow by filename (workflow dispatch). The workflow must have 'on: workflow_dispatch' configured. | `workspace` (string, **required**)<br>`ref` (string, optional)<br>`repository` (string, **required**)<br>`workflowId` (string, **required**)<br>`inputs` (string, optional) |
 | `github_update_check_run` | Update an existing GitHub Check Run — set it to completed with success/failure conclusion, update summary and detailed text. Call this after github_create_check_run to finalize the check. | `conclusion` (string, optional)<br>`summary` (string, optional)<br>`workspace` (string, **required**)<br>`checkRunId` (string, **required**)<br>`text` (string, optional)<br>`repository` (string, **required**)<br>`title` (string, optional)<br>`status` (string, **required**) |
@@ -341,6 +344,44 @@ dmtools github_delete_release_asset "value" "value"
 ```javascript
 // In JavaScript agent
 const result = github_delete_release_asset("repository", "workspace");
+```
+
+---
+
+### `github_dismiss_pr_review`
+
+Dismiss a previously submitted GitHub pull request review (e.g. clear a REQUEST_CHANGES decision once the issues have been fixed and a new review approves). Requires repository admin rights, or being listed as allowed to dismiss reviews, on protected branches.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - The GitHub owner/organization name
+  - Example: `IstiN`
+
+- **`repository`** (string) 🔴 Required
+  - The GitHub repository name
+  - Example: `dmtools`
+
+- **`pullRequestId`** (string) 🔴 Required
+  - The pull request number
+  - Example: `74`
+
+- **`reviewId`** (string) 🔴 Required
+  - The ID of the review to dismiss (from github_list_pr_reviews or the response of github_submit_pr_review)
+  - Example: `1234567`
+
+- **`message`** (string) 🔴 Required
+  - The reason for dismissing this review
+  - Example: `Superseded — issues fixed and re-reviewed as APPROVE.`
+
+**Example:**
+```bash
+dmtools github_dismiss_pr_review "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = github_dismiss_pr_review("workspace", "repository");
 ```
 
 ---
@@ -845,6 +886,36 @@ const result = github_list_prs_filtered("titleRegex", "workspace");
 
 ---
 
+### `github_list_pr_reviews`
+
+List all formal reviews (APPROVE/REQUEST_CHANGES/COMMENT decisions submitted via github_submit_pr_review or by human reviewers) for a GitHub pull request, in chronological order.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - The GitHub owner/organization name
+  - Example: `IstiN`
+
+- **`repository`** (string) 🔴 Required
+  - The GitHub repository name
+  - Example: `dmtools`
+
+- **`pullRequestId`** (string) 🔴 Required
+  - The pull request number
+  - Example: `74`
+
+**Example:**
+```bash
+dmtools github_list_pr_reviews "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = github_list_pr_reviews("workspace", "repository");
+```
+
+---
+
 ### `github_list_release_assets`
 
 List all assets attached to a GitHub release. Returns a JSON array of asset objects including id, name, size, and browser_download_url.
@@ -1087,6 +1158,44 @@ dmtools github_resolve_pr_thread "value"
 ```javascript
 // In JavaScript agent
 const result = github_resolve_pr_thread("threadId");
+```
+
+---
+
+### `github_submit_pr_review`
+
+Submit a formal GitHub pull request review (a native reviewer decision, distinct from labels/comments). event=APPROVE marks the PR as approved by this reviewer; event=REQUEST_CHANGES formally blocks the PR (visible as 'Changes requested', and enforced by branch protection rules requiring approvals) until a new review or github_dismiss_pr_review clears it; event=COMMENT leaves a review without approving or blocking. 'body' is required for REQUEST_CHANGES and COMMENT.
+
+**Parameters:**
+
+- **`workspace`** (string) 🔴 Required
+  - The GitHub owner/organization name
+  - Example: `IstiN`
+
+- **`repository`** (string) 🔴 Required
+  - The GitHub repository name
+  - Example: `dmtools`
+
+- **`pullRequestId`** (string) 🔴 Required
+  - The pull request number
+  - Example: `74`
+
+- **`event`** (string) 🔴 Required
+  - The review decision: APPROVE, REQUEST_CHANGES, or COMMENT
+  - Example: `REQUEST_CHANGES`
+
+- **`body`** (string) ⚪ Optional
+  - The review's summary text. Required for REQUEST_CHANGES and COMMENT.
+  - Example: `Blocking issues found, please address before merge.`
+
+**Example:**
+```bash
+dmtools github_submit_pr_review "value" "value"
+```
+
+```javascript
+// In JavaScript agent
+const result = github_submit_pr_review("workspace", "repository");
 ```
 
 ---

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/github/GitHub.java
@@ -1492,6 +1492,79 @@ public abstract class GitHub extends AbstractRestClient implements SourceCode, U
     }
 
     @MCPTool(
+            name = "github_submit_pr_review",
+            description = "Submit a formal GitHub pull request review (a native reviewer decision, distinct from labels/comments). event=APPROVE marks the PR as approved by this reviewer; event=REQUEST_CHANGES formally blocks the PR (visible as 'Changes requested', and enforced by branch protection rules requiring approvals) until a new review or github_dismiss_pr_review clears it; event=COMMENT leaves a review without approving or blocking. 'body' is required for REQUEST_CHANGES and COMMENT.",
+            integration = "github",
+            category = "pull_requests"
+    )
+    public String submitPullRequestReview(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request number", required = true, example = "74")
+            String pullRequestId,
+            @MCPParam(name = "event", description = "The review decision: APPROVE, REQUEST_CHANGES, or COMMENT", required = true, example = "REQUEST_CHANGES")
+            String event,
+            @MCPParam(name = "body", description = "The review's summary text. Required for REQUEST_CHANGES and COMMENT.", required = false, example = "Blocking issues found, please address before merge.")
+            String body) throws IOException {
+        String path = path(String.format("repos/%s/%s/pulls/%s/reviews", workspace, repository, pullRequestId));
+        GenericRequest postRequest = new GenericRequest(this, path);
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("event", event);
+        if (body != null && !body.trim().isEmpty()) {
+            requestBody.put("body", body);
+        }
+        postRequest.setBody(requestBody.toString());
+        return post(postRequest);
+    }
+
+    @MCPTool(
+            name = "github_list_pr_reviews",
+            description = "List all formal reviews (APPROVE/REQUEST_CHANGES/COMMENT decisions submitted via github_submit_pr_review or by human reviewers) for a GitHub pull request, in chronological order.",
+            integration = "github",
+            category = "pull_requests"
+    )
+    public String listPullRequestReviews(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request number", required = true, example = "74")
+            String pullRequestId) throws IOException {
+        String path = path(String.format("repos/%s/%s/pulls/%s/reviews", workspace, repository, pullRequestId));
+        GenericRequest getRequest = new GenericRequest(this, path);
+        String response = execute(getRequest);
+        return response != null ? response : "[]";
+    }
+
+    @MCPTool(
+            name = "github_dismiss_pr_review",
+            description = "Dismiss a previously submitted GitHub pull request review (e.g. clear a REQUEST_CHANGES decision once the issues have been fixed and a new review approves). Requires repository admin rights, or being listed as allowed to dismiss reviews, on protected branches.",
+            integration = "github",
+            category = "pull_requests"
+    )
+    public String dismissPullRequestReview(
+            @MCPParam(name = "workspace", description = "The GitHub owner/organization name", required = true, example = "IstiN")
+            String workspace,
+            @MCPParam(name = "repository", description = "The GitHub repository name", required = true, example = "dmtools")
+            String repository,
+            @MCPParam(name = "pullRequestId", description = "The pull request number", required = true, example = "74")
+            String pullRequestId,
+            @MCPParam(name = "reviewId", description = "The ID of the review to dismiss (from github_list_pr_reviews or the response of github_submit_pr_review)", required = true, example = "1234567")
+            String reviewId,
+            @MCPParam(name = "message", description = "The reason for dismissing this review", required = true, example = "Superseded — issues fixed and re-reviewed as APPROVE.")
+            String message) throws IOException {
+        String path = path(String.format("repos/%s/%s/pulls/%s/reviews/%s/dismissals", workspace, repository, pullRequestId, reviewId));
+        GenericRequest putRequest = new GenericRequest(this, path);
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("message", message);
+        requestBody.put("event", "DISMISS");
+        putRequest.setBody(requestBody.toString());
+        return put(putRequest);
+    }
+
+    @MCPTool(
             name = "github_merge_pr",
             description = "Merge a GitHub pull request. Supports merge, squash, and rebase merge methods.",
             integration = "github",


### PR DESCRIPTION
## Summary

Adds three new GitHub-specific MCP tools that let an agent submit a **formal, native GitHub PR review decision** (Approve / Request Changes / Comment via GitHub's real Review API), list existing reviews, and dismiss a previously submitted review.

This is purely additive infrastructure at the dmtools-core level — it does not change any existing tool behavior, and does not touch the `pr_approved` label logic used by `postPRReviewComments.js` in the companion `dmtools-agents` repo.

## New tools

- `github_submit_pr_review(workspace, repository, pullRequestId, event, body)` — `POST /pulls/{pr}/reviews`. `event` is `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`; `body` required for the latter two.
- `github_list_pr_reviews(workspace, repository, pullRequestId)` — `GET /pulls/{pr}/reviews`, returns the raw JSON array of reviews (used to find a bot's own prior review to dismiss).
- `github_dismiss_pr_review(workspace, repository, pullRequestId, reviewId, message)` — `PUT /pulls/{pr}/reviews/{review_id}/dismissals`. GitHub does not support deleting a submitted review outright, only dismissing it.

Follows the existing precedent of GitHub-specific actions (like `github_merge_pr`) living directly on `GitHub.java` rather than the shared `SourceCode` interface, since GitLab/Bitbucket don't have an equivalent review-dismissal concept.

## Why

Enables a companion feature in `dmtools-agents`' `pr_review` agent: an opt-in `formalGithubReview` flag that submits a real "Request Changes" review when the AI finds blocking issues, and dismisses it once a later run approves — without altering the existing `pr_approved` label lifecycle.

## Docs

Updated `dmtools-ai-docs/references/mcp-tools/github-tools.md` and `README.md` tool counts (35 → 38 GitHub tools, 292 → 295 total) to include the three new tools.

## Testing

Could not run `./gradlew :dmtools-core:test` in this sandboxed environment (no full JDK available, only a JRE-only bundled `dmtools` install). Relying on the repo's required "Java unit tests" CI check on this PR to validate compilation and the existing test suite. No new Java unit tests were added since these are thin REST wrappers following the exact same pattern as the neighboring `addPullRequestLabel`/`removePullRequestLabel` methods, which also have no dedicated unit tests.
