### PR TITLE
fix(release): explicitly trigger release site manifest update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,6 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
       - name: Download CLI Package
@@ -600,7 +601,22 @@ jobs:
             skill/skill-install.sh
             skill/skill-install.ps1
             skill/skill-checksums.sha256
-      
+
+      - name: Trigger release site data update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Explicitly dispatch update-release-site.yml instead of relying on
+          # the "release: published" event to cascade: GitHub does not run
+          # downstream workflows for events produced by a token whose identity
+          # collapses to the default GITHUB_TOKEN (github-actions[bot]), which
+          # is what happens here even when GITHUB_TOKEN is overridden with
+          # PAT_TOKEN above. A direct `gh workflow run` call is a normal API
+          # request and always works with actions: write permission.
+          gh workflow run update-release-site.yml \
+            --repo "${{ github.repository }}" \
+            -f version="v${{ needs.version-and-tag.outputs.version }}"
+
       - name: Summary
         run: |
           echo "## 🎉 Unified Release Created Successfully!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/update-release-site.yml
+++ b/.github/workflows/update-release-site.yml
@@ -26,6 +26,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   update-site-data:
@@ -35,7 +36,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: main
-          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 1
 
       - name: Configure Git
@@ -53,43 +53,51 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Prepare release notes (release event)
-        if: github.event_name == 'release'
+      - name: Prepare release notes
         env:
           RELEASE_BODY: ${{ github.event.release.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          VERSION="${{ steps.inputs.outputs.version }}"
           mkdir -p release-site-tmp
-          python3 -c "import os; open('release-site-tmp/release_notes.md','w',encoding='utf-8').write(os.environ['RELEASE_BODY'] or '')"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            python3 -c "import os; open('release-site-tmp/release_notes.md','w',encoding='utf-8').write(os.environ.get('RELEASE_BODY') or '')"
+          elif [ -n "${{ inputs.release_notes_file }}" ] && [ -f "${{ inputs.release_notes_file }}" ]; then
+            cp "${{ inputs.release_notes_file }}" release-site-tmp/release_notes.md
+          else
+            # Fall back to fetching the release body via the API so a manual
+            # workflow_dispatch (e.g. triggered right after `gh release create`)
+            # doesn't need any local files checked out.
+            gh release view "$VERSION" --repo "${{ github.repository }}" --json body -q .body > release-site-tmp/release_notes.md
+          fi
 
-      - name: Download checksums asset (release event)
-        if: github.event_name == 'release'
+      - name: Download checksums asset
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.inputs.outputs.version }}"
           mkdir -p release-site-tmp
-          gh release download "$VERSION" \
-            --repo "${{ github.repository }}" \
-            --pattern "dmtools-checksums.sha256" \
-            --dir release-site-tmp
+          if [ -n "${{ inputs.checksums_file }}" ] && [ -f "${{ inputs.checksums_file }}" ]; then
+            cp "${{ inputs.checksums_file }}" release-site-tmp/dmtools-checksums.sha256
+          else
+            gh release download "$VERSION" \
+              --repo "${{ github.repository }}" \
+              --pattern "dmtools-checksums.sha256" \
+              --dir release-site-tmp \
+              --clobber
+          fi
 
       - name: Generate site data
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            NOTES="release-site-tmp/release_notes.md"
-            SUMS="release-site-tmp/dmtools-checksums.sha256"
-          else
-            NOTES="${{ inputs.release_notes_file }}"
-            SUMS="${{ inputs.checksums_file }}"
-          fi
-
           python3 .github/scripts/generate-release-site-data.py \
             --version "${{ steps.inputs.outputs.version }}" \
-            --release-notes "$NOTES" \
-            --checksums "$SUMS" \
+            --release-notes "release-site-tmp/release_notes.md" \
+            --checksums "release-site-tmp/dmtools-checksums.sha256" \
             --site-url "https://dmtools.lab.epam.com"
 
       - name: Commit and push changes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git add landing/public/cli-manifest.json landing/src/data/releases.json
           if git diff --cached --quiet; then
@@ -109,4 +117,10 @@ jobs:
             --body "Automated release site data update for ${VERSION}." \
             --base main \
             --head "$BRANCH" \
+            --repo "${{ github.repository }}" || true
+          # Enable auto-merge so this data-only PR lands as soon as the
+          # required "Java unit tests" check passes, without manual action.
+          gh pr merge "$BRANCH" \
+            --squash \
+            --auto \
             --repo "${{ github.repository }}" || true


### PR DESCRIPTION
## Problem

Users installing DMTools via `install.sh` were getting outdated versions.
`https://dmtools.lab.epam.com/cli-manifest.json` (the source of truth used
by the install scripts to avoid GitHub API rate limits) was stuck reporting
`v1.7.245` as latest, even though `v1.7.246`-`v1.7.249` had already been
released.

## Root cause

`update-release-site.yml` is only wired to `on: release: types: [published]`.
The release itself is created by `release.yml`'s "Create Unified Release"
step using `softprops/action-gh-release` with `GITHUB_TOKEN` overridden to
`secrets.PAT_TOKEN` (comment: *"so the release:published event fires"*).

However, checking `gh api repos/epam/dm.ai/releases/tags/v1.7.249 -q
.author.login` shows the release is attributed to `github-actions[bot]` —
the identity of the default `GITHUB_TOKEN`. GitHub does not cascade
`release:published` → other workflow runs for events produced under that
identity. As a result, `update-release-site.yml` has **never actually
auto-triggered** since it was added (only 2 historical runs, both manual
`workflow_dispatch`).

## Fix

- `release.yml`: after creating the unified release, explicitly call
  `gh workflow run update-release-site.yml -f version=vX.Y.Z`. A direct
  `workflow_dispatch` API call is not subject to the event-cascading
  restriction, so it reliably fires with the default `GITHUB_TOKEN` +
  `actions: write`.
- `update-release-site.yml`: made the `workflow_dispatch` path
  self-sufficient — it now fetches the release body/checksums via
  `gh release view` / `gh release download` when no local file is
  present, so it behaves the same whether triggered by the `release`
  event or dispatched manually/automatically.
- The data-update PR it opens now has `--auto` merge enabled so it lands
  as soon as the required "Java unit tests" check passes, instead of
  waiting for a human to click merge.
- Dropped the now-unnecessary `PAT_TOKEN` checkout (pushing a new branch
  + opening a PR only needs `contents: write` from the default token).

## Immediate fix

Manually re-ran `update-release-site.yml` for `v1.7.249` to unstick the
manifest right away (independent of this PR merging).

## Testing

- Validated both workflow YAML files parse (`python3 -c "import yaml; ..."`).
- Manually dispatched the fixed workflow logic path for v1.7.249 and
  confirmed `cli-manifest.json` now reports the correct latest version.
