### PR TITLE
fix(confluence): harden inline comment anchor restoration (heading repair + safe fallback matching)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserver.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserver.java
@@ -41,6 +41,20 @@ public final class InlineCommentAnchorPreserver {
     private static final Pattern LEFTOVER_OPEN_PATTERN = Pattern.compile("\\[\\[ic:[0-9a-fA-F-]{36}\\]\\]");
     private static final Pattern STRIP_TAGS_PATTERN = Pattern.compile("<[^>]+>");
 
+    /** Minimum anchor-text length eligible for the fallback text-match. */
+    static final int MIN_FALLBACK_ANCHOR_LENGTH = 4;
+
+    /** Markdown structural prefixes stripped before the fallback text-match:
+     *  heading hashes, list bullets/numbers, blockquotes (possibly chained). */
+    private static final Pattern MD_STRUCTURAL_PREFIX = Pattern.compile(
+            "^(?:#{1,6}\\s+|[-*+]\\s+|\\d+[.)]\\s+|>\\s*)+");
+
+    /** A paragraph consisting solely of a marker whose content starts with heading
+     *  hashes — the signature of a placeholder that wrapped a Markdown heading prefix
+     *  and broke heading conversion. */
+    private static final Pattern BROKEN_HEADING_PATTERN = Pattern.compile(
+            "<p>\\s*(<ac:inline-comment-marker\\s+ac:ref=\"[^\"]+\"[^>]*>)\\s*(#{1,6})\\s+([\\s\\S]*?)(</ac:inline-comment-marker>)\\s*</p>");
+
     private InlineCommentAnchorPreserver() {
     }
 
@@ -98,6 +112,11 @@ public final class InlineCommentAnchorPreserver {
         pm.appendTail(sb);
         body = sb.toString();
 
+        // 1b. Repair headings broken by placeholders that wrapped the heading's Markdown
+        //     prefix: a paragraph consisting solely of a marker whose content starts with
+        //     heading hashes never became an <hN> during conversion — restore it.
+        body = repairMarkerWrappedHeadings(body);
+
         // 2. Text-match fallback for anchors from the old body that didn't make it over.
         for (Anchor anchor : oldAnchors == null ? List.<Anchor>of() : oldAnchors) {
             if (anchor == null || anchor.ref == null || anchor.text == null) {
@@ -106,9 +125,15 @@ public final class InlineCommentAnchorPreserver {
             if (body.contains("ac:ref=\"" + anchor.ref + "\"")) {
                 continue;
             }
-            body = wrapFirstOccurrence(body, escapeXml(anchor.text), anchor.ref);
+            String normalized = stripMarkdownStructuralPrefix(anchor.text);
+            // Too short selections (e.g. a stray "h2." from legacy markup) match random
+            // fragments — better to leave the comment orphaned than mis-anchor it.
+            if (normalized.length() < MIN_FALLBACK_ANCHOR_LENGTH) {
+                continue;
+            }
+            body = wrapFirstOccurrence(body, escapeXml(normalized), anchor.ref);
             if (!body.contains("ac:ref=\"" + anchor.ref + "\"")) {
-                body = wrapFirstOccurrence(body, anchor.text, anchor.ref);
+                body = wrapFirstOccurrence(body, normalized, anchor.ref);
             }
         }
 
@@ -118,17 +143,78 @@ public final class InlineCommentAnchorPreserver {
         return body;
     }
 
+    /**
+     * Converts a paragraph that consists solely of an inline comment marker whose content
+     * starts with Markdown heading hashes into a proper heading element. This happens when
+     * a {@code [[ic:REF]]...[[/ic]]} placeholder wrapped the heading's {@code ## } prefix in
+     * the agent's Markdown — the line no longer parsed as a heading.
+     */
+    static String repairMarkerWrappedHeadings(String storageBody) {
+        if (storageBody == null || storageBody.indexOf("inline-comment-marker") == -1) {
+            return storageBody;
+        }
+        Matcher m = BROKEN_HEADING_PATTERN.matcher(storageBody);
+        StringBuffer sb = new StringBuffer();
+        while (m.find()) {
+            int level = m.group(2).length();
+            String replacement = "<h" + level + ">" + m.group(1) + m.group(3) + m.group(4) + "</h" + level + ">";
+            m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Removes Markdown structural prefixes (heading hashes, list markers, blockquotes)
+     * from an anchor text so the fallback text-match works against the rendered content.
+     */
+    static String stripMarkdownStructuralPrefix(String text) {
+        if (text == null) {
+            return "";
+        }
+        return MD_STRUCTURAL_PREFIX.matcher(text).replaceFirst("").trim();
+    }
+
     private static String wrapFirstOccurrence(String body, String needle, String ref) {
         if (needle == null || needle.isEmpty()) {
             return body;
         }
-        int idx = body.indexOf(needle);
-        if (idx == -1) {
-            return body;
+        int from = 0;
+        while (true) {
+            int idx = body.indexOf(needle, from);
+            if (idx == -1) {
+                return body;
+            }
+            if (isWordBoundary(body, idx, needle.length())) {
+                return body.substring(0, idx)
+                        + "<ac:inline-comment-marker ac:ref=\"" + ref + "\">" + needle + "</ac:inline-comment-marker>"
+                        + body.substring(idx + needle.length());
+            }
+            from = idx + 1;
         }
-        return body.substring(0, idx)
-                + "<ac:inline-comment-marker ac:ref=\"" + ref + "\">" + needle + "</ac:inline-comment-marker>"
-                + body.substring(idx + needle.length());
+    }
+
+    /**
+     * Word-boundary check for the fallback text-match: the characters surrounding the
+     * candidate occurrence must not be letters or digits (or a tag-open that would place
+     * the match inside an attribute). Prevents short selections from latching onto
+     * unrelated longer words or markup.
+     */
+    private static boolean isWordBoundary(String body, int idx, int length) {
+        if (idx > 0) {
+            char before = body.charAt(idx - 1);
+            if (Character.isLetterOrDigit(before) || before == '"' || before == '<' || before == '=') {
+                return false;
+            }
+        }
+        int after = idx + length;
+        if (after < body.length()) {
+            char c = body.charAt(after);
+            if (Character.isLetterOrDigit(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String escapeXml(String text) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserverTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/InlineCommentAnchorPreserverTest.java
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2024 EPAM Systems, Inc.
+
+package com.github.istin.dmtools.atlassian.confluence;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link InlineCommentAnchorPreserver} — the heading-repair and
+ * fallback text-match hardening.
+ */
+public class InlineCommentAnchorPreserverTest {
+
+    private static final String REF_A = "a40ec14d-0d73-4f55-9a69-7026900b6623";
+    private static final String REF_B = "11111111-2222-3333-4444-555555555555";
+
+    // -------------------------------------------------------------------------
+    // Heading repair (placeholder wrapped the Markdown heading prefix)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void repairsMarkerWrappedHeadingParagraph() {
+        String body = "<p><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">## Purpose</ac:inline-comment-marker></p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body, List.of());
+        assertEquals("<h2><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Purpose</ac:inline-comment-marker></h2>", result);
+    }
+
+    @Test
+    public void repairsHeadingLevels() {
+        String body = "<p><ac:inline-comment-marker ac:ref=\"" + REF_A + "\"># Top</ac:inline-comment-marker></p>"
+                + "<p>middle</p>"
+                + "<p><ac:inline-comment-marker ac:ref=\"" + REF_B + "\">#### Deep</ac:inline-comment-marker></p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body, List.of());
+        assertTrue(result.contains("<h1><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Top</ac:inline-comment-marker></h1>"));
+        assertTrue(result.contains("<h4><ac:inline-comment-marker ac:ref=\"" + REF_B + "\">Deep</ac:inline-comment-marker></h4>"));
+        assertTrue(result.contains("<p>middle</p>"));
+    }
+
+    @Test
+    public void doesNotTouchMarkersInsideProperHeadings() {
+        String body = "<h2><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Purpose</ac:inline-comment-marker></h2>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body, List.of());
+        assertEquals(body, result);
+    }
+
+    @Test
+    public void doesNotTouchParagraphsWithTextAroundMarker() {
+        String body = "<p>Prefix <ac:inline-comment-marker ac:ref=\"" + REF_A + "\">## Purpose</ac:inline-comment-marker> suffix</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body, List.of());
+        assertEquals(body, result);
+    }
+
+    @Test
+    public void placeholderWrappingHeadingIsRepairedEndToEnd() {
+        String body = "<p>" + "[[ic:" + REF_A + "]]" + "## Purpose" + "[[/ic]]" + "</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body, List.of());
+        assertEquals("<h2><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Purpose</ac:inline-comment-marker></h2>", result);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fallback text-match hardening
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void stripsMarkdownHeadingPrefixBeforeFallbackMatch() {
+        String body = "<h2>Purpose</h2><p>content</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "## Purpose")));
+        assertTrue(result.contains("<h2><ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Purpose</ac:inline-comment-marker></h2>"));
+    }
+
+    @Test
+    public void stripsListAndQuotePrefixesBeforeFallbackMatch() {
+        String body = "<ul><li>Item one</li></ul>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "- Item one")));
+        assertTrue(result.contains("ac:ref=\"" + REF_A + "\""));
+    }
+
+    @Test
+    public void skipsTooShortSelections() {
+        String body = "<p>some h2. text with h2. inside</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "h2.")));
+        assertFalse("3-char selection must not be anchored", result.contains("inline-comment-marker"));
+    }
+
+    @Test
+    public void respectsWordBoundaries() {
+        String body = "<p>Purposedriven text</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "Purpose")));
+        assertFalse("substring inside a longer word must not match", result.contains("inline-comment-marker"));
+    }
+
+    @Test
+    public void findsLaterOccurrenceWhenFirstFailsBoundary() {
+        String body = "<p>Purposes are many. Purpose matters.</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "Purpose")));
+        assertTrue(result.contains("<ac:inline-comment-marker ac:ref=\"" + REF_A + "\">Purpose</ac:inline-comment-marker> matters."));
+    }
+
+    @Test
+    public void doesNotMatchInsideTagAttributes() {
+        String body = "<ac:link><ri:page ri:content-title=\"Purpose\"/></ac:link><p>real text</p>";
+        String result = InlineCommentAnchorPreserver.restoreAnchors(body,
+                List.of(new InlineCommentAnchorPreserver.Anchor(REF_A, "Purpose")));
+        assertFalse("attribute value must not be wrapped", result.contains("inline-comment-marker"));
+    }
+}


### PR DESCRIPTION
Follow-up to #494 — two failure modes observed on a live rerun where the agent iterated over a page that previously had tracker markup:

## 1. Placeholder wrapped the Markdown heading prefix

The agent kept the `[[ic:REF]]` placeholder around the *whole* heading line including the `## ` prefix (`[[ic:REF]]## Purpose[[/ic]]`). The line then failed to parse as a heading and became a paragraph; after placeholder→marker conversion the page had `<p><ac:inline-comment-marker>## Purpose</ac:inline-comment-marker></p>` — a visible plain-text heading with a comment anchored to literal hashes.

`restoreAnchors` now repairs paragraphs consisting solely of a marker whose content starts with heading hashes: `<p><marker>## Title</marker></p>` → `<h2><marker>Title</marker></h2>` (any level 1–6).

## 2. Fallback text-match was too naive

- A legacy 3-char selection (`h2.`, from an earlier tracker-markup era of the page) could latch onto unrelated fragments.
- Selections carrying Markdown structural prefixes (`## Purpose`, `- Item one`) never matched the rendered text (the hashes/bullets are gone from the storage body).

The fallback now:
- strips Markdown structural prefixes (heading hashes, list bullets/numbers, blockquotes) before matching — `## Purpose` matches `Purpose` inside `<h2>Purpose</h2>`;
- skips selections shorter than 4 chars — better orphaned than mis-anchored;
- enforces word boundaries — no match inside longer words (`Purpose` does not match `Purposedriven`) or inside tag attributes; later occurrences are tried when the first fails the boundary check.

## Tests

11 new cases in `InlineCommentAnchorPreserverTest` (heading repair incl. end-to-end placeholder path, prefix stripping, min-length, word boundaries, attribute protection). The `atlassian.confluence` package passes.