### PR TITLE
fix(confluence): stop updatePage from emptying code/diagram macros (CDATA loss)

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/Confluence.java
@@ -559,7 +559,16 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         @MCPParam(name = "historyComment", description = "Comment to add to the page history", required = true, example = "Updated content based on user feedback")
         String historyComment
     ) throws IOException {
-        body = prepareBodyForConfluence(body);
+        // Bodies produced by MarkdownToConfluenceStorage contain ac:structured-macro
+        // elements with CDATA plain-text bodies (code blocks, diagrams). The generic
+        // prepareBodyForConfluence re-parses the whole body through Jsoup's HTML parser,
+        // which destroys those CDATA sections — use the macro-preserving variant for
+        // storage-format bodies.
+        if (body.contains("<ac:structured-macro")) {
+            body = prepareStorageBodyForConfluence(body);
+        } else {
+            body = prepareBodyForConfluence(body);
+        }
         logger.info("{} {} {} {} {} {}", contentId, title, parentId, body, space, historyComment);
         Content oldContent = new Content(new GenericRequest(this, path("content/" + contentId + "?expand=version")).execute());
 
@@ -600,6 +609,20 @@ public class Confluence extends AtlassianRestClient implements UriToObject {
         body = body.replaceAll("<br>", "\n").replaceAll("<br/>", "\n");
         body = HtmlCleaner.convertLinksUrlsToConfluenceFormat(body);
         return body;
+    }
+
+    /**
+     * Variant of {@link #prepareBodyForConfluence(String)} for bodies that already
+     * contain Confluence storage-format macros ({@code ac:structured-macro} with
+     * CDATA plain-text bodies — e.g. produced by {@link MarkdownToConfluenceStorage}).
+     * The generic variant re-parses the whole body through Jsoup's HTML parser, which
+     * destroys CDATA sections and empties code/diagram macros; this variant performs
+     * the same normalizations without re-serializing macro elements.
+     */
+    @NotNull
+    public static String prepareStorageBodyForConfluence(String body) {
+        String prepared = body.replaceAll("<br>", "\n").replaceAll("<br/>", "\n");
+        return HtmlCleaner.convertLinksUrlsToConfluenceFormatPreservingCdata(prepared);
     }
 
     public static String macroHTML(String body) {

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlCleaner.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/HtmlCleaner.java
@@ -114,6 +114,39 @@ public class HtmlCleaner {
         return doc.body().html();
     }
 
+    /**
+     * Same normalization as {@link #convertLinksUrlsToConfluenceFormat(String)} but safe
+     * for bodies containing Confluence storage-format macros: Jsoup's HTML parsing
+     * destroys CDATA sections inside {@code <ac:plain-text-body>} elements (emptying
+     * code/diagram macros), so macro elements are masked out before parsing and
+     * restored afterwards, untouched.
+     */
+    public static String convertLinksUrlsToConfluenceFormatPreservingCdata(String body) {
+        java.util.List<String> masked = new java.util.ArrayList<>();
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("<ac:structured-macro\\b[\\s\\S]*?</ac:structured-macro>")
+                .matcher(body);
+        StringBuffer sb = new StringBuffer();
+        int i = 0;
+        while (m.find()) {
+            String token = "DMTOOLS_MACRO_" + i + "_TOKEN";
+            masked.add(m.group(0));
+            m.appendReplacement(sb, java.util.regex.Matcher.quoteReplacement(
+                    "<span data-dmtools-macro=\"" + token + "\"></span>"));
+            i++;
+        }
+        m.appendTail(sb);
+        if (masked.isEmpty()) {
+            return convertLinksUrlsToConfluenceFormat(body);
+        }
+        String parsed = convertLinksUrlsToConfluenceFormat(sb.toString());
+        for (int j = 0; j < masked.size(); j++) {
+            parsed = parsed.replace("<span data-dmtools-macro=\"DMTOOLS_MACRO_" + j + "_TOKEN\"></span>",
+                    java.util.regex.Matcher.quoteReplacement(masked.get(j)));
+        }
+        return parsed;
+    }
+
     private static final Set<String> SIZE_RELATED_ATTRIBUTES = Set.of(
             "width", "height", "min-width", "min-height", "max-width", "max-height",
             "margin", "margin-top", "margin-right", "margin-bottom", "margin-left",

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlCleanerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/HtmlCleanerTest.java
@@ -27,4 +27,40 @@ public class HtmlCleanerTest extends TestCase {
         assertEquals(expectedOutput, convertedOutput);
     }
 
+
+    public void testPreservingCdata_keepsCodeMacroContent() {
+        String body = "<h1>Title</h1>"
+                + "<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\">"
+                + "<ac:parameter ac:name=\"language\">mermaid</ac:parameter>"
+                + "<ac:plain-text-body><![CDATA[flowchart TD\nA --> B]]></ac:plain-text-body>"
+                + "</ac:structured-macro>"
+                + "<p>after <a href=\"https://example.com\">link</a></p>";
+        String result = HtmlCleaner.convertLinksUrlsToConfluenceFormatPreservingCdata(body);
+        assertTrue("CDATA content must survive",
+                result.contains("<![CDATA[flowchart TD\nA --> B]]>"));
+        assertTrue("link must still be processed",
+                result.contains("https://example.com"));
+        assertFalse("masking token must not leak", result.contains("DMTOOLS_MACRO_"));
+    }
+
+    public void testPreservingCdata_noMacros_behavesLikePlainConversion() {
+        String body = "<p>hello <a href=\"https://example.com\">link</a></p>";
+        String result = HtmlCleaner.convertLinksUrlsToConfluenceFormatPreservingCdata(body);
+        assertTrue(result.contains("hello"));
+        assertTrue(result.contains("https://example.com"));
+    }
+
+    public void testPlainConversion_destroysCdata_regressionDocumentation() {
+        // Documents WHY the preserving variant exists: Jsoup HTML parsing converts the
+        // CDATA section into a bogus comment, so the macro body is no longer a CDATA
+        // section — Confluence then stores the macro as EMPTY.
+        String body = "<ac:structured-macro ac:name=\"code\">"
+                + "<ac:plain-text-body><![CDATA[graph TD\nA --> B]]></ac:plain-text-body>"
+                + "</ac:structured-macro>";
+        String result = HtmlCleaner.convertLinksUrlsToConfluenceFormat(body);
+        assertFalse("real CDATA markers must be gone after plain conversion",
+                result.contains("<![CDATA["));
+        assertTrue("text degrades into a bogus comment",
+                result.contains("<!--[CDATA["));
+    }
 }


### PR DESCRIPTION
## Problem

Pages published via `confluence_sync_markdown_directory` showed **empty code macros** — mermaid diagrams, dependency graphs and JSON anchors arrived on the page with no content, even though the storage body logged right before the PUT contained the full `<ac:plain-text-body><![CDATA[...]]></ac:plain-text-body>`.

Root cause: `Confluence.updatePage` routes every body through `prepareBodyForConfluence` → `HtmlCleaner.convertLinksUrlsToConfluenceFormat`, which re-parses the whole body with Jsoup's HTML parser. Jsoup converts CDATA sections into bogus comments (`<!--[CDATA[...]]-->`), so the macro arrives without a real CDATA section and Confluence stores it empty. Verified with a standalone Jsoup reproduction.

## Change

- New `HtmlCleaner.convertLinksUrlsToConfluenceFormatPreservingCdata`: masks `ac:structured-macro` elements out before the Jsoup pass and restores them byte-for-byte afterwards; bodies without macros use the existing path.
- `Confluence.updatePage` uses the preserving variant (via new `prepareStorageBodyForConfluence`) when the body contains `ac:structured-macro` elements; plain bodies keep the existing behavior.

## Tests

`HtmlCleanerTest`: CDATA content survives the preserving variant (links still processed, no token leakage), no-macro parity with the plain variant, and a regression test documenting the plain variant's CDATA destruction. `common.utils`, `atlassian`, `mcp` packages pass.