### PR TITLE
fix(cli): tee console output for lines beyond maxLinesToLog when DMTOOLS_CLI_LOG_FILTER matches

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/CommandLineUtils.java
@@ -282,9 +282,17 @@ public class CommandLineUtils {
                 // session); otherwise once DMTOOLS_JS_LOG_TOOL_CALLS is not set, only the first
                 // maxLinesToLog lines are logged and a single truncation notice follows.
                 boolean withinCap = maxLinesToLog < 0 || loggedLineCount < maxLinesToLog;
+                // Whether THIS line was actually emitted to console by log4j — used below to
+                // decide whether the CLI-log-filter tee also needs to print it, so lines beyond
+                // maxLinesToLog (which log4j silently drops) are not lost when log4j itself is
+                // enabled (e.g. --debug mode). Checking logger.isInfoEnabled() alone is not
+                // enough here: it reflects the logger's configured level, not whether THIS
+                // specific line passed the maxLinesToLog cap above.
+                boolean loggedByLog4jThisLine = false;
                 if (verboseCommandOutputLogging || withinCap) {
                     logger.info(line);
                     loggedLineCount++;
+                    loggedByLog4jThisLine = logger.isInfoEnabled();
                 } else if (!truncationNoticeLogged) {
                     if (fullOutputLogFile != null) {
                         logger.info("... output truncated after {} line(s); full output will be saved to {} ...",
@@ -298,10 +306,12 @@ public class CommandLineUtils {
                 output.append(line).append(System.lineSeparator());
 
                 // Tee matched CLI output to console and file independently of log4j.
-                // Console output is skipped when log4j is already printing, to avoid
-                // duplicate lines in --debug mode.
+                // Console output is skipped only when log4j ALREADY printed this exact line
+                // (see loggedByLog4jThisLine above), to avoid duplicate lines in --debug mode —
+                // but lines beyond maxLinesToLog (which log4j drops even in --debug mode) must
+                // still reach the console when DMTOOLS_CLI_LOG_FILTER matched.
                 if (shouldTeeCliOutput) {
-                    if (!logger.isInfoEnabled()) {
+                    if (!loggedByLog4jThisLine) {
                         System.out.println(line);
                     }
                     if (teeWriter != null) {

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/common/utils/CommandLineUtilsTest.java
@@ -3,11 +3,15 @@
 
 package com.github.istin.dmtools.common.utils;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -505,6 +509,49 @@ class CommandLineUtilsTest {
             assertFalse(Files.exists(logDir), "No log file should be written when DMTOOLS_CLI_LOG_DIR is empty");
         } finally {
             PropertyReader.clearOverrides();
+        }
+    }
+
+    @Test
+    void testRunCommand_CliLogFilterMatch_Log4jInfoEnabled_StillTeesLinesBeyondCap() throws IOException, InterruptedException {
+        String os = System.getProperty("os.name").toLowerCase();
+        if (os.contains("win")) {
+            return;
+        }
+        // Reproduces the ai-teammate `dmtools --debug run ...` setup: log4j INFO logging is
+        // enabled (as in --debug mode) AND DMTOOLS_CLI_LOG_FILTER matches the command. Lines
+        // beyond maxLinesToLog are dropped by log4j (see the cap above), so the CLI-log-filter
+        // tee must still print them to System.out — checking only logger.isInfoEnabled()
+        // (which is level-wide, not per-line) previously caused the tee to also skip them,
+        // silently losing all output past the cap even though the filter matched.
+        var loggerContext = (org.apache.logging.log4j.core.LoggerContext) org.apache.logging.log4j.LogManager.getContext(false);
+        Configurator.setLevel(CommandLineUtils.class.getName(), Level.INFO);
+        try {
+            Path testFile = tempDir.resolve("beyond-cap.txt");
+            Files.writeString(testFile, "L1\nL2\nL3\nL4\nL5\n");
+
+            PropertyReader.setOverrides(Map.of("DMTOOLS_CLI_LOG_FILTER", "beyond-cap"));
+
+            PrintStream originalOut = System.out;
+            ByteArrayOutputStream capturedOut = new ByteArrayOutputStream();
+            System.setOut(new PrintStream(capturedOut));
+            try {
+                // maxLinesToLog=2 guarantees L3/L4/L5 are beyond the cap and thus never
+                // reach the console via logger.info(line).
+                CommandLineUtils.runCommand(
+                        "cat " + testFile.toAbsolutePath(), null, Map.of(), null, false, null, 2);
+            } finally {
+                System.setOut(originalOut);
+            }
+
+            String consoleOutput = capturedOut.toString();
+            assertTrue(consoleOutput.contains("L4") && consoleOutput.contains("L5"),
+                    "Lines beyond maxLinesToLog must still be teed to console when "
+                            + "DMTOOLS_CLI_LOG_FILTER matches, even with log4j INFO enabled");
+        } finally {
+            PropertyReader.clearOverrides();
+            Configurator.setLevel(CommandLineUtils.class.getName(), (Level) null);
+            loggerContext.updateLoggers();
         }
     }
 }


### PR DESCRIPTION
## Bug

When `DMTOOLS_CLI_LOG_FILTER` matches a command, the CLI-output tee is supposed to print the command's live output to console (independent of log4j), so long-running commands stay visible in CI job consoles.

The tee's guard checked `!logger.isInfoEnabled()` — i.e. the logger's **global configured level** — to decide whether it needed to also print via `System.out.println`. But `logger.info(line)` is only actually called for a given line while `withinCap` is true (line index < `maxLinesToLog`, default 50, unless `DMTOOLS_JS_LOG_TOOL_CALLS=true`). In any environment where log4j INFO is enabled (e.g. `dmtools --debug run ...`, as used by ai-teammate CI), `logger.isInfoEnabled()` is always `true`, so the tee's console print was **never** invoked — even for lines beyond the cap that log4j itself silently drops.

Net effect: for any command matching `DMTOOLS_CLI_LOG_FILTER`, only the first ~50 lines of output ever reached the live console; everything after was dropped by both log4j and the tee. The full transcript was still correctly written to the CLI-log-filter file, so this only affected live console visibility (e.g. long-running `pr_rework`/`story_development` CI jobs going silent after ~50 lines).

## Fix

Track a per-line `loggedByLog4jThisLine` flag reflecting whether log4j actually emitted *this specific line* (`(verboseCommandOutputLogging || withinCap) && logger.isInfoEnabled()`), and use that instead of the global `logger.isInfoEnabled()` to decide whether the tee must also print the line.

## Testing

Added `testRunCommand_CliLogFilterMatch_Log4jInfoEnabled_StillTeesLinesBeyondCap`, which:
- Sets the `CommandLineUtils` logger to `Level.INFO` via `Configurator` (simulating --debug mode)
- Runs a command with `maxLinesToLog=2` producing 5 lines
- Asserts lines beyond the cap (L4/L5) still appear in console output

Verified TDD RED→GREEN: confirmed the test fails without the fix (stashed), and passes with it. Also ran full `CommandLineUtilsTest` suite plus every test class referencing `CommandLineUtils` (`TeammateRunJobFlowCoverageTest`, `TeammateTimerJSActionTest`, `TeammateCliIntegrationTest`, `TeammatePreCliJSActionTest`, `CliExecutionHelperTest`, `CliAgentTest`) — all pass, no regressions.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>