### PR TITLE
fix(confluence): preserve newlines in fenced code/diagram blocks

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
@@ -189,7 +189,12 @@ public final class MarkdownToConfluenceStorage {
                     language = classAttr;
                 }
             }
-            String codeText = code != null ? code.text() : pre.text();
+            // Use wholeText() instead of text(): text() normalizes/collapses whitespace
+            // (including newlines), which corrupts multi-line code/diagram content
+            // (e.g. Mermaid diagrams become invalid because statement-separating
+            // newlines are collapsed into single spaces). wholeText() preserves the
+            // original line breaks exactly as authored.
+            String codeText = (code != null ? code.wholeText() : pre.wholeText()).strip();
 
             StringBuilder macro = new StringBuilder();
             macro.append("<ac:structured-macro ac:name=\"code\" ac:schema-version=\"1\">");

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
@@ -70,6 +70,20 @@ public class MarkdownToConfluenceStorageTest {
     }
 
     @Test
+    public void testFencedCodeBlockPreservesNewlines() {
+        // Regression test: code.text() (jsoup) collapses newlines into spaces, which
+        // corrupts multi-line content such as Mermaid diagrams (statements run
+        // together without a separator, producing invalid diagram syntax).
+        String md = "```mermaid\nflowchart TD\n    A --> B\n    B --> C\n```";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertTrue("Should contain CDATA body with preserved newlines",
+                storage.contains("<![CDATA[flowchart TD\n    A --> B\n    B --> C]]>"));
+        assertFalse("Should not collapse newlines into spaces",
+                storage.contains("flowchart TD A --> B B --> C"));
+    }
+
+    @Test
     public void testInlineCode() {
         String md = "Use `System.out.println` for output.";
         String storage = MarkdownToConfluenceStorage.toStorage(md);


### PR DESCRIPTION
## Problem

`MarkdownToConfluenceStorage.convertCodeBlocks()` used jsoup's `Element.text()` to
extract the content of fenced code blocks. `text()` normalizes/collapses whitespace,
including newlines, when extracting element text.

This corrupts any multi-line content placed inside a fenced code block once it's
converted to a Confluence `code` macro — most visibly for Mermaid diagrams, where
newlines are the statement separator:

```
flowchart TD
    A --> B
    B --> C
```

became a single line with all newlines replaced by spaces:

```
flowchart TD A --> B B --> C
```

...which is invalid Mermaid syntax (`Expecting 'SEMI', 'NEWLINE'... got 'subgraph'`
style parse errors) once copied out of Confluence or re-rendered.

Confirmed by running the shipped `dmtools.jar` directly (reflection call into
`MarkdownToConfluenceStorage.toStorage()`), not just by reading the source.

## Fix

Switch to `Element.wholeText()`, which preserves original line breaks exactly as
authored, and `strip()` only the leading/trailing whitespace so single-line code
block behavior is unchanged.

## Related but separate issue

A related bug where `Confluence.prepareBodyForConfluence()`'s HTML-mode jsoup
re-parse could destroy CDATA sections entirely (turning the whole macro empty) was
already fixed on `main` by #501 (`prepareStorageBodyForConfluence`). This PR only
addresses the remaining whitespace-collapse issue, which happens earlier, at the
source, in `MarkdownToConfluenceStorage`.

## Testing
- Added `testFencedCodeBlockPreservesNewlines` regression test.
- Ran `./gradlew :dmtools-core:test --tests MarkdownToConfluenceStorageTest --tests MarkdownConfluenceSyncTest` — all pass.
