### PR TITLE
fix(confluence): don't misparse same-space page titles as SPACE:Title links

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorage.java
@@ -305,7 +305,17 @@ public final class MarkdownToConfluenceStorage {
                 String spaceKey = null;
                 String title = href;
                 int colonIndex = href.indexOf(':');
-                if (colonIndex > 0) {
+                // Only treat "SPACE:Title" as an explicit cross-space reference when
+                // the colon is immediately followed by the title with no space, e.g.
+                // "PROJ:Home". A same-space page whose OWN title merely starts with a
+                // single word + colon (e.g. "Recommendations: Some Feature") always has
+                // a space after the colon (normal punctuation), so requiring no space
+                // there disambiguates the two cases without breaking the legacy
+                // "SPACE:Title" syntax (see testPageLinkWithSpaceKey). Without this
+                // check, such a page title got misparsed as a link into a
+                // non-existent "Recommendations" space, producing a broken Confluence
+                // link that rendered as a "create this page" prompt instead.
+                if (colonIndex > 0 && colonIndex + 1 < href.length() && !Character.isWhitespace(href.charAt(colonIndex + 1))) {
                     String candidateSpace = href.substring(0, colonIndex);
                     if (isValidSpaceKey(candidateSpace)) {
                         spaceKey = candidateSpace;

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownToConfluenceStorageTest.java
@@ -144,6 +144,22 @@ public class MarkdownToConfluenceStorageTest {
     }
 
     @Test
+    public void testPageLinkToSameSpaceTitleStartingWithWordAndColonIsNotMisparsedAsSpaceKey() {
+        // Regression test: a same-space page whose own title is "SingleWord: Rest of title"
+        // (e.g. "Recommendations: Primary Biospecimen QC at Accessioning") must NOT be
+        // misinterpreted as an explicit "SPACE:Title" cross-space reference just because
+        // the first word before the colon happens to look like a valid space key. Real
+        // page titles always have a space after the colon, unlike the legacy "PROJ:Home"
+        // syntax (no space after colon) — see testPageLinkWithSpaceKey.
+        String md = "See [Recommendations](Recommendations: Primary Biospecimen QC at Accessioning).";
+        String storage = MarkdownToConfluenceStorage.toStorage(md);
+
+        assertFalse("Should not contain a bogus ri:space-key", storage.contains("ri:space-key="));
+        assertTrue("Should keep the whole string as the content title",
+                storage.contains("ri:content-title=\"Recommendations: Primary Biospecimen QC at Accessioning\""));
+    }
+
+    @Test
     public void testLocalImageConvertedToAttachment() {
         String md = "![architecture.png](architecture.png)";
         String storage = MarkdownToConfluenceStorage.toStorage(md);


### PR DESCRIPTION
## Problem
`MarkdownToConfluenceStorage.convertLinks()` splits a Markdown link href on the first colon and treats the prefix as an explicit Confluence space key whenever it matches `[A-Za-z][A-Za-z0-9]*` (`isValidSpaceKey`), regardless of what follows the colon.

A same-space target page whose own title happens to be a single word immediately followed by a colon (e.g. "Recommendations: Some Feature") triggers a false positive: the prefix "Recommendations" passes the regex, so the link gets rendered as `ri:space-key="Recommendations"` (a space that doesn't exist) instead of keeping the whole string as `ri:content-title`. Confluence can't resolve the non-existent space, so it renders the link as a broken "create this page" prompt instead of a working page reference.

Found while investigating a real discovery-agent report where a generated "Pages produced this run" table had a broken link to a page titled "Recommendations: Primary Biospecimen QC at Accessioning".

## Fix
Only treat the prefix as an explicit space key when the colon is immediately followed by the rest of the href with **no whitespace** — the legacy `SPACE:Title` syntax (e.g. `PROJ:Home`) never has a space after the colon, while real page titles shaped like "Word: Rest of title" always do. This disambiguates the two cases without breaking the existing explicit space-key syntax.

## Testing
- Added `testPageLinkToSameSpaceTitleStartingWithWordAndColonIsNotMisparsedAsSpaceKey` regression test.
- Ran the full `MarkdownToConfluenceStorageTest` suite: 24/24 passing, including the pre-existing `testPageLinkWithSpaceKey` (confirms `PROJ:Home` still works).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>