### PR TITLE
fix(confluence): match markdown-synced child pages by stable source path, not H1 title

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSync.java
@@ -5,6 +5,7 @@ package com.github.istin.dmtools.atlassian.confluence;
 
 import com.github.istin.dmtools.atlassian.confluence.model.Attachment;
 import com.github.istin.dmtools.atlassian.confluence.model.Content;
+import com.github.istin.dmtools.atlassian.confluence.model.Storage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
@@ -171,9 +172,10 @@ public class MarkdownConfluenceSync {
             String processed = processMarkdownLinks(markdown, rootDir, fileNode.file, pathToTitle);
             Set<String> fileReferenced = MarkdownToConfluenceStorage.extractAttachmentReferences(processed);
             String storage = MarkdownToConfluenceStorage.toStorage(processed);
+            String sourceRelPath = relativePath(rootDir, fileNode.file);
 
             Content page = findOrCreateChildPage(fileNode.title, node.contentId, space,
-                    MarkdownToConfluenceStorage.toStorage("<p>Placeholder</p>"));
+                    MarkdownToConfluenceStorage.toStorage("<p>Placeholder</p>"), sourceRelPath);
 
             baseDir = resolveAttachmentsDir(fileNode.file, attachmentsDir);
             List<String> fileUploadedAttachmentNames = attachmentHelper.uploadReferencedAttachments(
@@ -186,13 +188,18 @@ public class MarkdownConfluenceSync {
             }
             storage = appendAttachmentLinks(storage, extraAttachmentNames);
             storage = preserveAnchors(page.getId(), storage);
+            storage = appendSourceMarker(storage, sourceRelPath);
             pageOps.updatePage(page.getId(), fileNode.title, node.contentId, storage, space, "");
             fileNode.contentId = page.getId();
         }
 
         for (DirNode subdir : node.subdirs) {
+            // Folder pages are matched by title only — unlike a FileNode's title (derived
+            // from the Markdown file's own H1 heading, which the content author may
+            // legitimately reword between runs), a subdir's title is always its directory's
+            // stable basename, so title-matching alone is safe here.
             Content folderPage = findOrCreateChildPage(subdir.title, node.contentId, space,
-                    MarkdownToConfluenceStorage.toStorage("<p>" + MarkdownToConfluenceStorage.escapeXml(subdir.title) + "</p>"));
+                    MarkdownToConfluenceStorage.toStorage("<p>" + MarkdownToConfluenceStorage.escapeXml(subdir.title) + "</p>"), null);
             subdir.contentId = folderPage.getId();
             subdir.parentId = node.contentId;
             syncDirNode(subdir, rootDir, pathToTitle, space, attachmentsDir);
@@ -223,8 +230,61 @@ public class MarkdownConfluenceSync {
         return uploadedAttachmentNames;
     }
 
-    private Content findOrCreateChildPage(String title, String parentId, String space, String placeholderBody) throws IOException {
+    /**
+     * Marker prefix embedded (as an HTML comment) at the end of a FileNode page's storage
+     * body, identifying the Markdown source file (path relative to the sync root) that
+     * produced it — e.g. {@code <!-- dmtools:source-path=recommendations.md -->}.
+     *
+     * Why this exists: a FileNode page's TITLE is derived from the Markdown file's own H1
+     * heading ({@link #extractTitle}), not from its filename — so the content author is free
+     * to reword that heading between runs (e.g. "# Recommendations" → "# Recommendations &
+     * Next Steps"). {@link #findOrCreateChildPage} used to match existing children by exact
+     * title equality only, so any such reword silently created a BRAND NEW duplicate page
+     * instead of updating the existing one for the same source file — while the filename
+     * (and hence the file's identity/purpose) never changed. This marker gives
+     * findOrCreateChildPage a title-independent, stable match key instead.
+     */
+    private static final String SOURCE_MARKER_PREFIX = "<!-- dmtools:source-path=";
+    private static final String SOURCE_MARKER_SUFFIX = " -->";
+    private static final Pattern SOURCE_MARKER_PATTERN = Pattern.compile(
+            Pattern.quote(SOURCE_MARKER_PREFIX) + "(.*?)" + Pattern.quote(SOURCE_MARKER_SUFFIX));
+
+    private static String appendSourceMarker(String storageBody, String sourceRelPath) {
+        if (sourceRelPath == null) {
+            return storageBody;
+        }
+        return storageBody + "\n" + SOURCE_MARKER_PREFIX + sourceRelPath + SOURCE_MARKER_SUFFIX;
+    }
+
+    private static String extractSourceMarker(String storageBody) {
+        if (storageBody == null) {
+            return null;
+        }
+        Matcher matcher = SOURCE_MARKER_PATTERN.matcher(storageBody);
+        return matcher.find() ? matcher.group(1) : null;
+    }
+
+    /**
+     * Finds an existing child page to update, or creates a new one.
+     *
+     * @param sourceRelPath the Markdown source file's path relative to the sync root, used
+     *   as a title-independent match key (see {@link #SOURCE_MARKER_PREFIX}'s docblock) — or
+     *   {@code null} for nodes whose title is already guaranteed stable across runs (e.g.
+     *   folder/subdir pages, whose title is always the directory's own basename), in which
+     *   case matching falls back to title equality only.
+     */
+    private Content findOrCreateChildPage(String title, String parentId, String space, String placeholderBody,
+                                          String sourceRelPath) throws IOException {
         List<Content> children = pageOps.getChildren(parentId);
+        if (sourceRelPath != null) {
+            for (Content child : children) {
+                Storage childStorage = child.getStorage();
+                String childBody = childStorage != null ? childStorage.getValue() : null;
+                if (sourceRelPath.equals(extractSourceMarker(childBody))) {
+                    return child;
+                }
+            }
+        }
         for (Content child : children) {
             if (title.equals(child.getTitle())) {
                 return child;

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/atlassian/confluence/MarkdownConfluenceSyncTest.java
@@ -41,7 +41,9 @@ public class MarkdownConfluenceSyncTest {
         final Map<String, String> parentsById = new HashMap<>();
         final Map<String, String> titlesById = new HashMap<>();
         final Map<String, String> bodiesById = new HashMap<>();
+        final Map<String, List<String>> childrenByParent = new HashMap<>();
         final List<String[]> updateCalls = new ArrayList<>(); // {contentId, title, parentId, body}
+        final List<String> createCalls = new ArrayList<>(); // titles, in creation order
         int nextId = 1000;
 
         @Override
@@ -49,7 +51,10 @@ public class MarkdownConfluenceSyncTest {
             String id = String.valueOf(nextId++);
             parentsById.put(id, parentId);
             titlesById.put(id, title);
-            return contentFor(id, title, parentId);
+            bodiesById.put(id, body);
+            childrenByParent.computeIfAbsent(parentId, k -> new ArrayList<>()).add(id);
+            createCalls.add(title);
+            return contentFor(id, title, parentId, body);
         }
 
         @Override
@@ -57,12 +62,29 @@ public class MarkdownConfluenceSyncTest {
             updateCalls.add(new String[]{contentId, title, parentId, body});
             parentsById.put(contentId, parentId);
             titlesById.put(contentId, title);
-            return contentFor(contentId, title, parentId);
+            bodiesById.put(contentId, body);
+            return contentFor(contentId, title, parentId, body);
         }
 
         @Override
         public List<Content> getChildren(String contentId) {
-            return new ArrayList<>();
+            List<Content> result = new ArrayList<>();
+            for (String childId : childrenByParent.getOrDefault(contentId, new ArrayList<>())) {
+                result.add(contentFor(childId, titlesById.get(childId), parentsById.get(childId), bodiesById.get(childId)));
+            }
+            return result;
+        }
+
+        /**
+         * Pre-seeds an existing child page (e.g. simulating a page left over from a
+         * previous {@code syncDirectory} run) directly, without going through
+         * {@link #createPage}.
+         */
+        void seedChild(String id, String parentId, String title, String body) {
+            parentsById.put(id, parentId);
+            titlesById.put(id, title);
+            bodiesById.put(id, body);
+            childrenByParent.computeIfAbsent(parentId, k -> new ArrayList<>()).add(id);
         }
 
         @Override
@@ -236,6 +258,76 @@ public class MarkdownConfluenceSyncTest {
             String[] childUpdate = pageOps.updateCalls.get(1);
             assertEquals("child page's parent must be the root page (555), not the grandparent",
                     "555", childUpdate[2]);
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_childFile_rewordedH1OnRerun_updatesSamePageInsteadOfDuplicating() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            // Run 1: recommendations.md has one H1 heading.
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+            FileUtils.write(new File(tempDir, "recommendations.md"), "# Recommendations\ncontent v1", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.parentsById.put("555", "999");
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertEquals("exactly one child page created on the first run", 1, pageOps.createCalls.size());
+            String childId = pageOps.childrenByParent.get("555").get(0);
+
+            // Run 2: the SAME source file (recommendations.md) now has a reworded H1 — the
+            // filename/identity of the document hasn't changed, only its title text. Before
+            // the fix, findOrCreateChildPage matched purely by exact title equality, so this
+            // would silently create a SECOND "Recommendations & Next Steps" child page
+            // instead of updating the existing one.
+            FileUtils.write(new File(tempDir, "recommendations.md"), "# Recommendations & Next Steps\ncontent v2", "UTF-8");
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertEquals("re-run with a reworded H1 must NOT create a second child page",
+                    1, pageOps.createCalls.size());
+            assertEquals("exactly one child page must still exist under the root",
+                    1, pageOps.childrenByParent.get("555").size());
+            assertEquals("the existing page (by id) must be the one updated, not a new one",
+                    childId, pageOps.childrenByParent.get("555").get(0));
+            assertEquals("the existing page's title must be renamed to the new heading",
+                    "Recommendations & Next Steps", pageOps.titlesById.get(childId));
+            assertTrue("the updated body must contain the new content",
+                    pageOps.bodiesById.get(childId).contains("content v2"));
+        } finally {
+            FileUtils.deleteDirectory(tempDir);
+        }
+    }
+
+    @Test
+    public void syncDirectory_childFile_legacyPageWithoutMarker_stillMatchesByTitleOnFirstPostFixSync() throws IOException {
+        File tempDir = newTempDir();
+        try {
+            // Simulates a page created by a pre-fix version of this sync (no source-path
+            // marker in its body yet) — the very first sync after upgrading must still find
+            // it via the old title-matching fallback (not create a duplicate), and from then
+            // on it carries the marker for future reworded-H1 reruns to match reliably.
+            FileUtils.write(new File(tempDir, "index.md"), "# Landing page", "UTF-8");
+            FileUtils.write(new File(tempDir, "recommendations.md"), "# Recommendations\ncontent v1", "UTF-8");
+
+            FakePageOperations pageOps = new FakePageOperations();
+            pageOps.parentsById.put("555", "999");
+            pageOps.titlesById.put("555", "TICKET-123 Some feature");
+            pageOps.seedChild("2000", "555", "Recommendations", "<p>legacy body, no marker</p>");
+
+            MarkdownConfluenceSync sync = new MarkdownConfluenceSync(new NoopAttachmentHelper(), pageOps);
+            sync.syncDirectory(tempDir, "555", "SPACE", false, null);
+
+            assertEquals("must update the pre-existing legacy page, not create a new one",
+                    0, pageOps.createCalls.size());
+            assertEquals("2000", pageOps.updateCalls.get(pageOps.updateCalls.size() - 1)[0]);
+            assertTrue("the marker must now be present for future reworded-H1 reruns to match",
+                    pageOps.bodiesById.get("2000").contains("dmtools:source-path=recommendations.md"));
         } finally {
             FileUtils.deleteDirectory(tempDir);
         }


### PR DESCRIPTION
## Problem
The discovery agent's Confluence sync (`confluence_sync_markdown_directory`) was creating **duplicate near-identical child pages** on re-runs (e.g. two "Recommendations", two "Discovery Plan", two "Source Distillate" pages).

## Root cause
`MarkdownConfluenceSync.extractTitle()` derives a synced child page's Confluence title from the markdown file's **first H1 heading**, not from its filename. The discovery agent's own `output_rules.md` deliberately keeps filenames stable across re-runs specifically so pages get updated instead of duplicated — but the CLI agent legitimately rewords the H1 heading text between runs (e.g. "Recommendations" -> "Recommendations & Next Steps"). `findOrCreateChildPage()` matched existing children by **exact title equality only**, so any reworded H1 caused it to miss the existing page and create a new one.

## Fix
- Embed a hidden `<!-- dmtools:source-path=<relPath> --></tp> marker at the end of each file-derived child page's storage body (added after markdown->storage conversion so it isn't mangled).
- `findOrCreateChildPage()` now first tries to match existing children by this marker (title-independent), falling back to the old title-equality matching only when no marker match is found — this preserves compatibility with pre-fix legacy pages (first post-fix sync still finds them by title, then tags them with the marker) and with folder/subdir pages (whose titles are always the stable directory basename, never H1-derived, so they pass `sourceRelPath = null` and are unaffected).
- No new Confluence REST API calls needed — reuses `body.storage` already fetched by the existing `getChildren` call.

## Testing
Added two regression tests to `MarkdownConfluenceSyncTest`:
1. `syncDirectory_childFile_rewordedH1OnRerun_updatesSamePageInsteadOfDuplicating` — reproduces the bug (fails without the fix) and proves a rewritten H1 on the same source file now updates the same page instead of creating a duplicate.
2. `syncDirectory_childFile_legacyPageWithoutMarker_stillMatchesByTitleOnFirstPostFixSync` — proves backward compatibility with pages created before this fix (no marker yet).

Ran `./gradlew :dmtools-core:test --tests "*MarkdownConfluenceSyncTest*"` — all 11 tests pass.