### PR TITLE
ci: auto-merge release site data PRs

### DIFF
--- a/.github/workflows/release-site-data-auto-merge.yml
+++ b/.github/workflows/release-site-data-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Release site data auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: release-site-data-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  release-site-data-auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.title, 'chore(release): update site data for') &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false
+    steps:
+      - name: Enable auto-merge for release site data PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          # Use PAT so that the subsequent auto-merge commit triggers push events
+          # (merges performed via GITHUB_TOKEN do not trigger further workflows).
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
Adds a workflow that automatically enables squash auto-merge for site-data update PRs created by `github-actions[bot]` (e.g. `chore(release): update site data for vX.Y.Z`).

Mirrors the existing `dependabot-auto-merge.yml` pattern, including the use of `PAT_TOKEN` so that the merge commit triggers further push-based workflows.

This prevents future stale release-data PRs (like #518) from piling up when newer release PRs land first.