### PR TITLE
docs/fix: correct GitLab MCP tool parameter order and preserve schema order in dmtools list

### DIFF
--- a/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
+++ b/dmtools-ai-docs/references/mcp-tools/gitlab-tools.md
@@ -25,36 +25,36 @@ const result = gitlab_add_mr_label(...);
 
 | Tool Name | Description | Parameters |
 |-----------|-------------|------------|
-| `gitlab_add_inline_mr_comment` | Create a new inline code review comment on a specific file and line in a GitLab merge request. Requires base_sha, head_sha, start_sha from the MR diff refs (use gitlab_get_mr to get them from diff_refs). | `workspace` (string, **required**)<br>`line` (string, **required**)<br>`startSha` (string, **required**)<br>`filePath` (string, **required**)<br>`baseSha` (string, **required**)<br>`text` (string, **required**)<br>`headSha` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
-| `gitlab_add_mr_comment` | Add a general discussion comment to a GitLab merge request. | `workspace` (string, **required**)<br>`text` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
-| `gitlab_add_mr_label` | Add a label to a GitLab merge request. | `workspace` (string, **required**)<br>`label` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
-| `gitlab_approve_mr` | Approve a GitLab merge request. Adds your approval to the MR. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_cancel_job` | Cancel a GitLab CI job. | `repository` (string, **required**)<br>`jobId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_create_mr` | Create a GitLab merge request from a source branch into a target branch. | `removeSourceBranch` (string, optional)<br>`workspace` (string, **required**)<br>`targetBranch` (string, **required**)<br>`sourceBranch` (string, **required**)<br>`description` (string, optional)<br>`repository` (string, **required**)<br>`title` (string, **required**) |
-| `gitlab_delete_release_asset` | Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names. | `assetName` (string, **required**)<br>`workspace` (string, **required**)<br>`packageName` (string, optional)<br>`repository` (string, **required**)<br>`tagName` (string, **required**) |
-| `gitlab_download_release_asset` | Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path. | `assetName` (string, **required**)<br>`workspace` (string, **required**)<br>`targetFilePath` (string, **required**)<br>`packageName` (string, optional)<br>`repository` (string, **required**)<br>`tagName` (string, **required**) |
-| `gitlab_get_commit_statuses` | Get CI/CD statuses for a commit SHA in a GitLab project. Returns one entry per status report (e.g. posted by an external CI like Jenkins via the gitlabBuilds plugin, or GitLab's own pipeline). Equivalent of GitHub's 'check runs' for GitLab. When the same status name was reported more than once for this commit (e.g. a CI job was retried), only the most recent report per name is returned. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`commitSha` (string, **required**) |
-| `gitlab_get_job_logs` | Get GitLab CI job trace logs. | `repository` (string, **required**)<br>`jobId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr` | Get details of a specific GitLab merge request including title, description, state, author, diff_refs (base_sha, head_sha, start_sha needed for inline comments). | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr_activities` | Get all activities for a GitLab merge request. Approvals are fetched from the real GitLab Approvals API. General discussion notes are also included. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr_comments` | Get all comments for a GitLab merge request, including both inline code review comments (DiffNote) and general discussion notes. Excludes system-generated notes. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr_diff` | Get diff stats and changed files for a GitLab merge request. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr_diff_text` | Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments). | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_mr_discussions` | Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_get_or_create_release` | Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`targetCommitish` (string, optional)<br>`body` (string, optional)<br>`releaseName` (string, optional) |
-| `gitlab_get_pipeline_jobs` | List jobs for a GitLab CI pipeline. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`pipelineId` (string, **required**) |
-| `gitlab_list_mrs` | List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'. | `repository` (string, **required**)<br>`workspace` (string, **required**)<br>`state` (string, **required**) |
-| `gitlab_list_pipeline_runs` | List recent GitLab CI pipelines. Optionally filter by status, ref, and limit. | `limit` (string, optional)<br>`workspace` (string, **required**)<br>`ref` (string, optional)<br>`repository` (string, **required**)<br>`status` (string, optional) |
-| `gitlab_list_project_jobs` | List recent GitLab CI jobs for a project. | `repository` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_list_release_assets` | List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url. | `repository` (string, **required**)<br>`tagName` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_merge_mr` | Merge a GitLab merge request. Optionally provide a custom merge commit message. | `workspace` (string, **required**)<br>`mergeCommitMessage` (string, optional)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
-| `gitlab_rebase_mr` | Ask GitLab to rebase/update a merge request source branch with its target branch. | `repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`workspace` (string, **required**) |
-| `gitlab_remove_mr_label` | Remove a label from a GitLab merge request. | `workspace` (string, **required**)<br>`label` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
-| `gitlab_reply_to_mr_thread` | Reply to an existing discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions. | `workspace` (string, **required**)<br>`text` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`discussionId` (string, **required**) |
+| `gitlab_add_inline_mr_comment` | Create a new inline code review comment on a specific file and line in a GitLab merge request. Requires base_sha, head_sha, start_sha from the MR diff refs (use gitlab_get_mr to get them from diff_refs). | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`filePath` (string, **required**)<br>`line` (string, **required**)<br>`text` (string, **required**)<br>`baseSha` (string, **required**)<br>`headSha` (string, **required**)<br>`startSha` (string, **required**) |
+| `gitlab_add_mr_comment` | Add a general discussion comment to a GitLab merge request. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`text` (string, **required**) |
+| `gitlab_add_mr_label` | Add a label to a GitLab merge request. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`label` (string, **required**) |
+| `gitlab_approve_mr` | Approve a GitLab merge request. Adds your approval to the MR. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_cancel_job` | Cancel a GitLab CI job. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`jobId` (string, **required**) |
+| `gitlab_create_mr` | Create a GitLab merge request from a source branch into a target branch. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`sourceBranch` (string, **required**)<br>`targetBranch` (string, **required**)<br>`title` (string, **required**)<br>`description` (string, optional)<br>`removeSourceBranch` (string, optional) |
+| `gitlab_delete_release_asset` | Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`assetName` (string, **required**)<br>`packageName` (string, optional) |
+| `gitlab_download_release_asset` | Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`assetName` (string, **required**)<br>`targetFilePath` (string, **required**)<br>`packageName` (string, optional) |
+| `gitlab_get_commit_statuses` | Get CI/CD statuses for a commit SHA in a GitLab project. Returns one entry per status report (e.g. posted by an external CI like Jenkins via the gitlabBuilds plugin, or GitLab's own pipeline). Equivalent of GitHub's 'check runs' for GitLab. When the same status name was reported more than once for this commit (e.g. a CI job was retried), only the most recent report per name is returned. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`commitSha` (string, **required**) |
+| `gitlab_get_job_logs` | Get GitLab CI job trace logs. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`jobId` (string, **required**) |
+| `gitlab_get_mr` | Get details of a specific GitLab merge request including title, description, state, author, diff_refs (base_sha, head_sha, start_sha needed for inline comments). | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_mr_activities` | Get all activities for a GitLab merge request. Approvals are fetched from the real GitLab Approvals API. General discussion notes are also included. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_mr_comments` | Get all comments for a GitLab merge request, including both inline code review comments (DiffNote) and general discussion notes. Excludes system-generated notes. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_mr_diff` | Get diff stats and changed files for a GitLab merge request. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_mr_diff_text` | Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments). | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_mr_discussions` | Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_get_or_create_release` | Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`releaseName` (string, optional)<br>`targetCommitish` (string, optional)<br>`body` (string, optional) |
+| `gitlab_get_pipeline_jobs` | List jobs for a GitLab CI pipeline. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pipelineId` (string, **required**) |
+| `gitlab_list_mrs` | List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`state` (string, **required**) |
+| `gitlab_list_pipeline_runs` | List recent GitLab CI pipelines. Optionally filter by status, ref, and limit. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`status` (string, optional)<br>`ref` (string, optional)<br>`limit` (string, optional) |
+| `gitlab_list_project_jobs` | List recent GitLab CI jobs for a project. | `workspace` (string, **required**)<br>`repository` (string, **required**) |
+| `gitlab_list_release_assets` | List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**) |
+| `gitlab_merge_mr` | Merge a GitLab merge request. Optionally provide a custom merge commit message. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`mergeCommitMessage` (string, optional) |
+| `gitlab_rebase_mr` | Ask GitLab to rebase/update a merge request source branch with its target branch. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**) |
+| `gitlab_remove_mr_label` | Remove a label from a GitLab merge request. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`label` (string, **required**) |
+| `gitlab_reply_to_mr_thread` | Reply to an existing discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`discussionId` (string, **required**)<br>`text` (string, **required**) |
 | `gitlab_resolve_mr_thread` | Resolve (close) a review discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`pullRequestId` (string, **required**)<br>`discussionId` (string, **required**) |
 | `gitlab_test` | Test GitLab connectivity by fetching the current user's profile | None |
-| `gitlab_trigger_pipeline` | Trigger a GitLab CI pipeline for a branch or tag using the authenticated API token. | `variablesJson` (string, optional)<br>`workspace` (string, **required**)<br>`ref` (string, **required**)<br>`repository` (string, **required**) |
-| `gitlab_upload_release_asset` | Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise). | `workspace` (string, **required**)<br>`filePath` (string, **required**)<br>`assetName` (string, optional)<br>`packageName` (string, optional)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`contentType` (string, optional)<br>`overwrite` (string, optional) |
+| `gitlab_trigger_pipeline` | Trigger a GitLab CI pipeline for a branch or tag using the authenticated API token. | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`ref` (string, **required**)<br>`variablesJson` (string, optional) |
+| `gitlab_upload_release_asset` | Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise). | `workspace` (string, **required**)<br>`repository` (string, **required**)<br>`tagName` (string, **required**)<br>`filePath` (string, **required**)<br>`assetName` (string, optional)<br>`contentType` (string, optional)<br>`packageName` (string, optional)<br>`overwrite` (string, optional) |
 
 ## Detailed Parameter Information
 
@@ -68,30 +68,6 @@ Create a new inline code review comment on a specific file and line in a GitLab 
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`line`** (string) 🔴 Required
-  - Line number in the new file to comment on
-  - Example: `42`
-
-- **`startSha`** (string) 🔴 Required
-  - Start commit SHA from MR diff_refs
-  - Example: `abc123`
-
-- **`filePath`** (string) 🔴 Required
-  - Path to the file to comment on
-  - Example: `src/main/Foo.java`
-
-- **`baseSha`** (string) 🔴 Required
-  - Base commit SHA from MR diff_refs
-  - Example: `abc123`
-
-- **`text`** (string) 🔴 Required
-  - Comment text
-  - Example: `This looks wrong`
-
-- **`headSha`** (string) 🔴 Required
-  - Head commit SHA from MR diff_refs
-  - Example: `def456`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -100,10 +76,29 @@ Create a new inline code review comment on a specific file and line in a GitLab 
   - Merge request IID
   - Example: `42`
 
-**Example:**
-```bash
-dmtools gitlab_add_inline_mr_comment "value" "value"
-```
+- **`filePath`** (string) 🔴 Required
+  - Path to the file to comment on
+  - Example: `src/main/Foo.java`
+
+- **`line`** (string) 🔴 Required
+  - Line number in the new file to comment on
+  - Example: `42`
+
+- **`text`** (string) 🔴 Required
+  - Comment text
+  - Example: `This looks wrong`
+
+- **`baseSha`** (string) 🔴 Required
+  - Base commit SHA from MR diff_refs
+  - Example: `abc123`
+
+- **`headSha`** (string) 🔴 Required
+  - Head commit SHA from MR diff_refs
+  - Example: `def456`
+
+- **`startSha`** (string) 🔴 Required
+  - Start commit SHA from MR diff_refs
+  - Example: `abc123`
 
 ```javascript
 // In JavaScript agent
@@ -122,10 +117,6 @@ Add a general discussion comment to a GitLab merge request.
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`text`** (string) 🔴 Required
-  - Comment text
-  - Example: `LGTM!`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -134,10 +125,9 @@ Add a general discussion comment to a GitLab merge request.
   - Merge request IID
   - Example: `42`
 
-**Example:**
-```bash
-dmtools gitlab_add_mr_comment "value" "value"
-```
+- **`text`** (string) 🔴 Required
+  - Comment text
+  - Example: `LGTM!`
 
 ```javascript
 // In JavaScript agent
@@ -156,10 +146,6 @@ Add a label to a GitLab merge request.
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`label`** (string) 🔴 Required
-  - Label to add
-  - Example: `pr_approved`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -168,10 +154,9 @@ Add a label to a GitLab merge request.
   - Merge request IID
   - Example: `42`
 
-**Example:**
-```bash
-dmtools gitlab_add_mr_label "value" "value"
-```
+- **`label`** (string) 🔴 Required
+  - Label to add
+  - Example: `pr_approved`
 
 ```javascript
 // In JavaScript agent
@@ -186,6 +171,10 @@ Approve a GitLab merge request. Adds your approval to the MR.
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -193,15 +182,6 @@ Approve a GitLab merge request. Adds your approval to the MR.
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_approve_mr "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -216,6 +196,10 @@ Cancel a GitLab CI job.
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -223,15 +207,6 @@ Cancel a GitLab CI job.
 - **`jobId`** (string) 🔴 Required
   - GitLab job ID
   - Example: `123456`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_cancel_job "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -246,38 +221,33 @@ Create a GitLab merge request from a source branch into a target branch.
 
 **Parameters:**
 
-- **`removeSourceBranch`** (string) ⚪ Optional
-  - Remove source branch after merge
-  - Example: `true`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
-
-- **`targetBranch`** (string) 🔴 Required
-  - Target branch name
-  - Example: `main`
-
-- **`sourceBranch`** (string) 🔴 Required
-  - Source branch name
-  - Example: `feature/PROJ-123`
-
-- **`description`** (string) ⚪ Optional
-  - Merge request description
-  - Example: `Automated changes`
 
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
 
+- **`sourceBranch`** (string) 🔴 Required
+  - Source branch name
+  - Example: `feature/PROJ-123`
+
+- **`targetBranch`** (string) 🔴 Required
+  - Target branch name
+  - Example: `main`
+
 - **`title`** (string) 🔴 Required
   - Merge request title
   - Example: `PROJ-123 Implement feature`
 
-**Example:**
-```bash
-dmtools gitlab_create_mr "value" "value"
-```
+- **`description`** (string) ⚪ Optional
+  - Merge request description
+  - Example: `Automated changes`
+
+- **`removeSourceBranch`** (string) ⚪ Optional
+  - Remove source branch after merge
+  - Example: `true`
 
 ```javascript
 // In JavaScript agent
@@ -292,17 +262,9 @@ Delete a GitLab release asset by its asset name. Removes both the release link a
 
 **Parameters:**
 
-- **`assetName`** (string) 🔴 Required
-  - The name of the asset to delete, as returned by gitlab_list_release_assets.
-  - Example: `clip_123.png`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
-
-- **`packageName`** (string) ⚪ Optional
-  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
-  - Example: `release-assets`
 
 - **`repository`** (string) 🔴 Required
   - Repository name
@@ -312,10 +274,13 @@ Delete a GitLab release asset by its asset name. Removes both the release link a
   - The tag name of the release.
   - Example: `pr-attachments-storage`
 
-**Example:**
-```bash
-dmtools gitlab_delete_release_asset "value" "value"
-```
+- **`assetName`** (string) 🔴 Required
+  - The name of the asset to delete, as returned by gitlab_list_release_assets.
+  - Example: `clip_123.png`
+
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
+  - Example: `release-assets`
 
 ```javascript
 // In JavaScript agent
@@ -330,21 +295,9 @@ Download a GitLab release asset (a file published to the Generic Package Registr
 
 **Parameters:**
 
-- **`assetName`** (string) 🔴 Required
-  - The name of the asset to download, as returned by gitlab_list_release_assets.
-  - Example: `clip_123.png`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
-
-- **`targetFilePath`** (string) 🔴 Required
-  - Local file path where the downloaded asset should be saved.
-  - Example: `/tmp/downloaded_clip_123.png`
-
-- **`packageName`** (string) ⚪ Optional
-  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
-  - Example: `release-assets`
 
 - **`repository`** (string) 🔴 Required
   - Repository name
@@ -354,10 +307,17 @@ Download a GitLab release asset (a file published to the Generic Package Registr
   - The tag name of the release.
   - Example: `pr-attachments-storage`
 
-**Example:**
-```bash
-dmtools gitlab_download_release_asset "value" "value"
-```
+- **`assetName`** (string) 🔴 Required
+  - The name of the asset to download, as returned by gitlab_list_release_assets.
+  - Example: `clip_123.png`
+
+- **`targetFilePath`** (string) 🔴 Required
+  - Local file path where the downloaded asset should be saved.
+  - Example: `/tmp/downloaded_clip_123.png`
+
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.
+  - Example: `release-assets`
 
 ```javascript
 // In JavaScript agent
@@ -372,22 +332,17 @@ Get CI/CD statuses for a commit SHA in a GitLab project. Returns one entry per s
 
 **Parameters:**
 
-- **`repository`** (string) 🔴 Required
-  - Repository name
-  - Example: `myrepo`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
 
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
 - **`commitSha`** (string) 🔴 Required
   - The commit SHA to get statuses for
   - Example: `abc123...`
-
-**Example:**
-```bash
-dmtools gitlab_get_commit_statuses "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -402,6 +357,10 @@ Get GitLab CI job trace logs.
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -409,15 +368,6 @@ Get GitLab CI job trace logs.
 - **`jobId`** (string) 🔴 Required
   - GitLab job ID
   - Example: `123456`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_job_logs "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -432,6 +382,10 @@ Get details of a specific GitLab merge request including title, description, sta
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -439,15 +393,6 @@ Get details of a specific GitLab merge request including title, description, sta
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -462,6 +407,10 @@ Get all activities for a GitLab merge request. Approvals are fetched from the re
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -469,15 +418,6 @@ Get all activities for a GitLab merge request. Approvals are fetched from the re
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr_activities "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -492,6 +432,10 @@ Get all comments for a GitLab merge request, including both inline code review c
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -499,15 +443,6 @@ Get all comments for a GitLab merge request, including both inline code review c
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr_comments "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -522,6 +457,10 @@ Get diff stats and changed files for a GitLab merge request.
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -529,15 +468,6 @@ Get diff stats and changed files for a GitLab merge request.
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr_diff "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -552,6 +482,10 @@ Get the raw unified diff text for a GitLab merge request (suitable for locating 
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -559,15 +493,6 @@ Get the raw unified diff text for a GitLab merge request (suitable for locating 
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr_diff_text "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -582,6 +507,10 @@ Get all discussion threads for a GitLab merge request. Each discussion contains 
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -589,15 +518,6 @@ Get all discussion threads for a GitLab merge request. Each discussion contains 
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_get_mr_discussions "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -624,6 +544,10 @@ Find an existing GitLab release by tag, or create one if it does not exist. Usef
   - The Git tag name for the release. Reused to find an existing release.
   - Example: `pr-attachments-storage`
 
+- **`releaseName`** (string) ⚪ Optional
+  - The human-readable release name. If empty, tagName is used.
+  - Example: `PR Attachments Storage`
+
 - **`targetCommitish`** (string) ⚪ Optional
   - Optional branch or commit SHA the release's tag should point to when created (GitLab 'ref'). Required if the tag does not already exist.
   - Example: `main`
@@ -631,15 +555,6 @@ Find an existing GitLab release by tag, or create one if it does not exist. Usef
 - **`body`** (string) ⚪ Optional
   - Optional Markdown release notes/description.
   - Example: `Internal storage release for PR attachments.`
-
-- **`releaseName`** (string) ⚪ Optional
-  - The human-readable release name. If empty, tagName is used.
-  - Example: `PR Attachments Storage`
-
-**Example:**
-```bash
-dmtools gitlab_get_or_create_release "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -654,22 +569,17 @@ List jobs for a GitLab CI pipeline.
 
 **Parameters:**
 
-- **`repository`** (string) 🔴 Required
-  - Repository name
-  - Example: `myrepo`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
 
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
 - **`pipelineId`** (string) 🔴 Required
   - GitLab pipeline ID
   - Example: `123456`
-
-**Example:**
-```bash
-dmtools gitlab_get_pipeline_jobs "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -684,22 +594,17 @@ List merge requests for a GitLab project. State can be 'opened', 'closed', 'merg
 
 **Parameters:**
 
-- **`repository`** (string) 🔴 Required
-  - Repository name
-  - Example: `myrepo`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
 
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
+
 - **`state`** (string) 🔴 Required
   - MR state: opened, closed, merged, all. 'open' is also accepted as a synonym for 'opened'.
   - Example: `opened`
-
-**Example:**
-```bash
-dmtools gitlab_list_mrs "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -714,17 +619,9 @@ List recent GitLab CI pipelines. Optionally filter by status, ref, and limit.
 
 **Parameters:**
 
-- **`limit`** (string) ⚪ Optional
-  - Maximum number of pipelines to return
-  - Example: `50`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
-
-- **`ref`** (string) ⚪ Optional
-  - Branch or tag ref
-  - Example: `main`
 
 - **`repository`** (string) 🔴 Required
   - Repository name
@@ -734,10 +631,13 @@ List recent GitLab CI pipelines. Optionally filter by status, ref, and limit.
   - Pipeline status filter
   - Example: `failed`
 
-**Example:**
-```bash
-dmtools gitlab_list_pipeline_runs "value" "value"
-```
+- **`ref`** (string) ⚪ Optional
+  - Branch or tag ref
+  - Example: `main`
+
+- **`limit`** (string) ⚪ Optional
+  - Maximum number of pipelines to return
+  - Example: `50`
 
 ```javascript
 // In JavaScript agent
@@ -752,18 +652,13 @@ List recent GitLab CI jobs for a project.
 
 **Parameters:**
 
-- **`repository`** (string) 🔴 Required
-  - Repository name
-  - Example: `myrepo`
-
 - **`workspace`** (string) 🔴 Required
   - GitLab group or namespace
   - Example: `mygroup`
 
-**Example:**
-```bash
-dmtools gitlab_list_project_jobs "value" "value"
-```
+- **`repository`** (string) 🔴 Required
+  - Repository name
+  - Example: `myrepo`
 
 ```javascript
 // In JavaScript agent
@@ -778,6 +673,10 @@ List all assets (asset links) attached to a GitLab release. Returns a JSON array
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -785,15 +684,6 @@ List all assets (asset links) attached to a GitLab release. Returns a JSON array
 - **`tagName`** (string) 🔴 Required
   - The tag name of the release.
   - Example: `pr-attachments-storage`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_list_release_assets "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -812,10 +702,6 @@ Merge a GitLab merge request. Optionally provide a custom merge commit message.
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`mergeCommitMessage`** (string) ⚪ Optional
-  - Optional custom merge commit message
-  - Example: `Merge feature branch`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -824,10 +710,9 @@ Merge a GitLab merge request. Optionally provide a custom merge commit message.
   - Merge request IID
   - Example: `42`
 
-**Example:**
-```bash
-dmtools gitlab_merge_mr "value" "value"
-```
+- **`mergeCommitMessage`** (string) ⚪ Optional
+  - Optional custom merge commit message
+  - Example: `Merge feature branch`
 
 ```javascript
 // In JavaScript agent
@@ -842,6 +727,10 @@ Ask GitLab to rebase/update a merge request source branch with its target branch
 
 **Parameters:**
 
+- **`workspace`** (string) 🔴 Required
+  - GitLab group or namespace
+  - Example: `mygroup`
+
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -849,15 +738,6 @@ Ask GitLab to rebase/update a merge request source branch with its target branch
 - **`pullRequestId`** (string) 🔴 Required
   - Merge request IID
   - Example: `42`
-
-- **`workspace`** (string) 🔴 Required
-  - GitLab group or namespace
-  - Example: `mygroup`
-
-**Example:**
-```bash
-dmtools gitlab_rebase_mr "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -876,10 +756,6 @@ Remove a label from a GitLab merge request.
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`label`** (string) 🔴 Required
-  - Label to remove
-  - Example: `pr_approved`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -888,10 +764,9 @@ Remove a label from a GitLab merge request.
   - Merge request IID
   - Example: `42`
 
-**Example:**
-```bash
-dmtools gitlab_remove_mr_label "value" "value"
-```
+- **`label`** (string) 🔴 Required
+  - Label to remove
+  - Example: `pr_approved`
 
 ```javascript
 // In JavaScript agent
@@ -910,10 +785,6 @@ Reply to an existing discussion thread in a GitLab merge request. Use the discus
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`text`** (string) 🔴 Required
-  - Reply text
-  - Example: `Addressed in latest commit`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -926,10 +797,9 @@ Reply to an existing discussion thread in a GitLab merge request. Use the discus
   - Discussion thread ID
   - Example: `6a9c1750b37d57bba1079be3bbd13a...`
 
-**Example:**
-```bash
-dmtools gitlab_reply_to_mr_thread "value" "value"
-```
+- **`text`** (string) 🔴 Required
+  - Reply text
+  - Example: `Addressed in latest commit`
 
 ```javascript
 // In JavaScript agent
@@ -959,11 +829,6 @@ Resolve (close) a review discussion thread in a GitLab merge request. Use the di
 - **`discussionId`** (string) 🔴 Required
   - Discussion thread ID to resolve
   - Example: `6a9c1750b37d57bba1079be3bbd13a...`
-
-**Example:**
-```bash
-dmtools gitlab_resolve_mr_thread "value" "value"
-```
 
 ```javascript
 // In JavaScript agent
@@ -1034,18 +899,6 @@ Upload a local file as a GitLab release asset. Internally publishes the file to 
   - GitLab group or namespace
   - Example: `mygroup`
 
-- **`filePath`** (string) 🔴 Required
-  - Absolute or relative path to the local file to upload.
-  - Example: `/tmp/preview.png`
-
-- **`assetName`** (string) ⚪ Optional
-  - Optional asset filename shown in GitLab. Defaults to the local filename.
-  - Example: `clip_123.png`
-
-- **`packageName`** (string) ⚪ Optional
-  - Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.
-  - Example: `release-assets`
-
 - **`repository`** (string) 🔴 Required
   - Repository name
   - Example: `myrepo`
@@ -1054,18 +907,25 @@ Upload a local file as a GitLab release asset. Internally publishes the file to 
   - The tag name of the release returned by gitlab_get_or_create_release.
   - Example: `pr-attachments-storage`
 
+- **`filePath`** (string) 🔴 Required
+  - Absolute or relative path to the local file to upload.
+  - Example: `/tmp/preview.png`
+
+- **`assetName`** (string) ⚪ Optional
+  - Optional asset filename shown in GitLab. Defaults to the local filename.
+  - Example: `clip_123.png`
+
 - **`contentType`** (string) ⚪ Optional
   - Optional MIME type. Defaults to detected type or application/octet-stream.
   - Example: `image/png`
 
+- **`packageName`** (string) ⚪ Optional
+  - Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.
+  - Example: `release-assets`
+
 - **`overwrite`** (string) ⚪ Optional
   - If true, delete any existing asset (release link + underlying generic package file) with the same name before uploading. Defaults to false.
   - Example: `true`
-
-**Example:**
-```bash
-dmtools gitlab_upload_release_asset "value" "value"
-```
 
 ```javascript
 // In JavaScript agent

--- a/dmtools-ai-docs/references/mcp-tools/tools-raw.json
+++ b/dmtools-ai-docs/references/mcp-tools/tools-raw.json
@@ -1,7494 +1,7792 @@
-{"tools": [
-  {
-    "name": "cli_execute_command",
-    "integration": "cli",
-    "description": "Execute CLI commands from JavaScript post-actions. Base whitelist: git, gh, dmtools, npm, yarn, docker, kubectl, terraform, ansible, aws, gcloud, az. Additional commands can be enabled via CLI_ALLOWED_COMMANDS env var (comma-separated) in dmtools.env or agent envVariables, e.g. CLI_ALLOWED_COMMANDS=find,ls,cat,pytest,python3,curl,bash,run-cursor-agent.sh. Returns command output as string.",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workingDirectory": {
-          "type": "string",
-          "description": "Working directory for command execution. Defaults to repository root if not specified. Use absolute path or path relative to current directory.",
-          "example": "/path/to/repo"
-        },
-        "command": {
-          "type": "string",
-          "description": "CLI command to execute. Must start with a whitelisted command. Extend the whitelist via CLI_ALLOWED_COMMANDS in dmtools.env.",
-          "example": "git commit -m 'Automated update'"
-        }
-      },
-      "required": ["command"]
-    }
-  },
-  {
-    "name": "github_test",
-    "integration": "github",
-    "description": "Test GitHub connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "github_list_prs",
-    "integration": "github",
-    "description": "List pull requests in a GitHub repository by state. State can be 'open', 'closed', or 'merged'. Returns first page (up to 100) of pull requests.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "state": {
-          "type": "string",
-          "description": "The state of pull requests to list: 'open', 'closed', or 'merged'. 'opened' is accepted as a synonym for 'open'.",
-          "example": "open"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "state"
-      ]
-    }
-  },
-  {
-    "name": "github_list_prs_filtered",
-    "integration": "github",
-    "description": "List pull requests in a GitHub repository filtered by a regex pattern on the PR title. Fetches all PRs matching the given state and returns only those whose title matches the regex. Useful for large repos to narrow down results without loading entire history.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "titleRegex": {
-          "type": "string",
-          "description": "Java regular expression matched against the PR title (case-sensitive). Only PRs whose title contains a match are returned. Example: '^feat\\(.*\\)' or 'TICKET-\\d+'.",
-          "example": "^feat\\("
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "state": {
-          "type": "string",
-          "description": "The state of pull requests: 'open', 'closed', or 'merged'.",
-          "example": "merged"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "state",
-        "titleRegex"
-      ]
-    }
-  },
-  {
-    "name": "github_get_commits_from_branches",
-    "integration": "github",
-    "description": "Fetch commits from all branches whose name matches a given regex pattern, aggregated and de-duplicated. Useful for collecting commits from feature/*, release/* or similar groups of branches without specifying each branch individually.",
-    "category": "commits",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "branchNameRegex": {
-          "type": "string",
-          "description": "Java regular expression matched against branch names. All branches with a matching name are included. Example: '^feature/' or 'release/\\d+'.",
-          "example": "^feature/"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "since": {
-          "type": "string",
-          "description": "Optional ISO date (yyyy-MM-dd) to limit commits to those after this date.",
-          "example": "2024-01-01"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "branchNameRegex"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr",
-    "integration": "github",
-    "description": "Get details of a GitHub pull request including title, description, status, author, branches, and merge info.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_repository_dispatch",
-    "integration": "github",
-    "description": "Trigger a GitHub repository dispatch event. Workflows listening to 'on: repository_dispatch' with the matching event_type will be triggered.",
-    "category": "actions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "eventType": {
-          "type": "string",
-          "description": "The type of activity that triggers the workflow (event_type)",
-          "example": "rework"
-        },
-        "clientPayload": {
-          "type": "string",
-          "description": "Optional JSON string with payload passed to the workflow as client_payload",
-          "example": "{\"key\":\"value\"}"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "eventType"
-      ]
-    }
-  },
-  {
-    "name": "github_trigger_workflow",
-    "integration": "github",
-    "description": "Trigger a specific GitHub Actions workflow by filename (workflow dispatch). The workflow must have 'on: workflow_dispatch' configured.",
-    "category": "actions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "ref": {
-          "type": "string",
-          "description": "The branch or tag to run the workflow on (default: main)",
-          "example": "main"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workflowId": {
-          "type": "string",
-          "description": "The workflow filename or ID to trigger",
-          "example": "rework.yml"
-        },
-        "inputs": {
-          "type": "string",
-          "description": "JSON string with workflow inputs (e.g. {\"user_request\":\"...\",\"branch\":\"main\"})",
-          "example": "{\"user_request\":\"Please rework PROJ-123\"}"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "workflowId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_or_create_draft_release",
-    "integration": "github",
-    "description": "Find an existing draft release by tag or name, or create one if it does not exist. Useful for a stable PR attachment storage release.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The Git tag name for the release. Reused to find an existing draft release.",
-          "example": "pr-attachments-storage"
-        },
-        "targetCommitish": {
-          "type": "string",
-          "description": "Optional branch or commit SHA the release should point to when created.",
-          "example": "main"
-        },
-        "body": {
-          "type": "string",
-          "description": "Optional Markdown release notes/body.",
-          "example": "Internal storage release for PR attachments."
-        },
-        "releaseName": {
-          "type": "string",
-          "description": "The human-readable release name. If empty, tagName is used.",
-          "example": "PR Attachments Storage"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName"
-      ]
-    }
-  },
-  {
-    "name": "github_upload_release_asset",
-    "integration": "github",
-    "description": "Upload a local file as a GitHub release asset. Returns the uploaded asset metadata including browser_download_url. Set overwrite=true to automatically delete an existing asset with the same name before uploading.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "releaseId": {
-          "type": "string",
-          "description": "The numeric GitHub release ID returned by github_get_or_create_draft_release.",
-          "example": "323096697"
-        },
-        "filePath": {
-          "type": "string",
-          "description": "Absolute or relative path to the local file to upload.",
-          "example": "/tmp/preview.png"
-        },
-        "assetName": {
-          "type": "string",
-          "description": "Optional asset filename shown in GitHub. Defaults to the local filename.",
-          "example": "clip_123.png"
-        },
-        "label": {
-          "type": "string",
-          "description": "Optional display label for the uploaded asset.",
-          "example": "Screenshot"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "contentType": {
-          "type": "string",
-          "description": "Optional MIME type. Defaults to detected type or application/octet-stream.",
-          "example": "image/png"
-        },
-        "overwrite": {
-          "type": "string",
-          "description": "If true, delete any existing asset with the same name before uploading. Defaults to false.",
-          "example": "true"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "releaseId",
-        "filePath"
-      ]
-    }
-  },
-  {
-    "name": "github_delete_release_asset",
-    "integration": "github",
-    "description": "Delete a GitHub release asset by its asset ID. Use github_list_release_assets to find asset IDs.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "assetId": {
-          "type": "string",
-          "description": "The numeric asset ID to delete.",
-          "example": "422721847"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "assetId"
-      ]
-    }
-  },
-  {
-    "name": "github_list_release_assets",
-    "integration": "github",
-    "description": "List all assets attached to a GitHub release. Returns a JSON array of asset objects including id, name, size, and browser_download_url.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "releaseId": {
-          "type": "string",
-          "description": "The numeric GitHub release ID.",
-          "example": "323096697"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "releaseId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_comments",
-    "integration": "github",
-    "description": "Get all comments for a GitHub pull request, including both inline code review comments and general discussion comments. Results are sorted by creation date.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_conversations",
-    "integration": "github",
-    "description": "Get all review conversations (inline code comment threads) for a GitHub pull request. Groups inline code review comments into threads showing root comment and replies. Also includes general PR discussion comments as separate entries.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_activities",
-    "integration": "github",
-    "description": "Get all activities for a GitHub pull request including reviews (approvals, change requests), inline code comments, and general discussion comments.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_add_pr_comment",
-    "integration": "github",
-    "description": "Add a comment to a GitHub pull request discussion.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "text": {
-          "type": "string",
-          "description": "The comment text to add",
-          "example": "Looks good!"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "github_update_pr_comment",
-    "integration": "github",
-    "description": "Update (edit) an existing comment on a GitHub pull request or issue by its comment ID.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "commentId": {
-          "type": "string",
-          "description": "The ID of the comment to update",
-          "example": "123456789"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "text": {
-          "type": "string",
-          "description": "The new comment text (replaces existing content)",
-          "example": "✅ Analysis complete."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "commentId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "github_delete_pr_comment",
-    "integration": "github",
-    "description": "Delete a comment on a GitHub pull request or issue by its comment ID.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "commentId": {
-          "type": "string",
-          "description": "The ID of the comment to delete",
-          "example": "123456789"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "commentId"
-      ]
-    }
-  },
-  {
-    "name": "github_reply_to_pr_thread",
-    "integration": "github",
-    "description": "Reply to an existing inline code review comment thread in a GitHub pull request. Use the comment ID of the root comment (or any comment) in the thread as inReplyToId.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "text": {
-          "type": "string",
-          "description": "The reply text (Markdown supported)",
-          "example": "Fixed in the latest commit."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "inReplyToId": {
-          "type": "string",
-          "description": "The ID of the comment to reply to (from github_get_pr_conversations rootComment.id or replies[].id)",
-          "example": "123456789"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "inReplyToId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "github_add_inline_comment",
-    "integration": "github",
-    "description": "Create a new inline code review comment on a specific file and line in a GitHub pull request. To comment on a range of lines, provide both startLine and line. Side is 'RIGHT' for new code (default) or 'LEFT' for old code.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "The relative file path in the repository",
-          "example": "src/main/java/com/example/Foo.java"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "side": {
-          "type": "string",
-          "description": "Which diff side to comment on: RIGHT (new code, default) or LEFT (old code)",
-          "example": "RIGHT"
-        },
-        "line": {
-          "type": "string",
-          "description": "The line number in the file to comment on",
-          "example": "42"
-        },
-        "startLine": {
-          "type": "string",
-          "description": "For multi-line comments: the first line of the range. Must be less than line.",
-          "example": "40"
-        },
-        "text": {
-          "type": "string",
-          "description": "The comment text (Markdown supported)",
-          "example": "This should be refactored."
-        },
-        "commitId": {
-          "type": "string",
-          "description": "The SHA of the commit to comment on. If empty, uses the PR head commit.",
-          "example": "abc123def456"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "path",
-        "line",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_review_threads",
-    "integration": "github",
-    "description": "Get all review threads for a GitHub pull request via GraphQL, including each thread's node ID (needed for resolving), resolved status, file path, line, and comments. Use the returned thread 'id' with github_resolve_pr_thread.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_resolve_pr_thread",
-    "integration": "github",
-    "description": "Resolve a review thread in a GitHub pull request. Requires the thread's GraphQL node ID, which can be obtained from github_get_pr_review_threads (the 'id' field of each thread).",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"threadId": {
-        "type": "string",
-        "description": "The GraphQL node ID of the review thread to resolve (from github_get_pr_review_threads thread.id)",
-        "example": "PRRT_kwDOBQfyNc5A..."
-      }},
-      "required": ["threadId"]
-    }
-  },
-  {
-    "name": "github_get_commit_check_runs",
-    "integration": "github",
-    "description": "Get all check runs (CI/CD status checks) for a commit SHA in a GitHub repository. Returns details about each check including status, conclusion, and output.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "commitSha": {
-          "type": "string",
-          "description": "The commit SHA to get check runs for",
-          "example": "abc123..."
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "commitSha"
-      ]
-    }
-  },
-  {
-    "name": "github_create_commit_status",
-    "integration": "github",
-    "description": "Create a commit status (the colored dot in PR checks). Use state=pending when AI analysis starts, success/failure/error when complete. The 'context' field acts as the status name and must be unique per check.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "context": {
-          "type": "string",
-          "description": "Unique identifier for this status check, e.g. 'dmtools/pr-review'",
-          "example": "dmtools/pr-review"
-        },
-        "description": {
-          "type": "string",
-          "description": "Short human-readable description shown next to the status dot",
-          "example": "AI analysis in progress..."
-        },
-        "state": {
-          "type": "string",
-          "description": "The state: pending | success | failure | error",
-          "example": "pending"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "sha": {
-          "type": "string",
-          "description": "The commit SHA to set status on",
-          "example": "abc123def456..."
-        },
-        "targetUrl": {
-          "type": "string",
-          "description": "Optional URL to link from the status (e.g. CI run URL)",
-          "example": "https://github.com/owner/repo/actions/runs/123"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "sha",
-        "state"
-      ]
-    }
-  },
-  {
-    "name": "github_create_check_run",
-    "integration": "github",
-    "description": "Create a GitHub Check Run \u2014 a rich CI check with progress, annotations, and a full log visible in the PR 'Checks' tab. Use status=in_progress when starting, then call github_update_check_run to complete it.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "summary": {
-          "type": "string",
-          "description": "Markdown summary shown in the check run output panel",
-          "example": "🔍 Analysis started..."
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the check run displayed in the PR",
-          "example": "dmtools / pr-review"
-        },
-        "externalId": {
-          "type": "string",
-          "description": "Optional external identifier for this check run",
-          "example": "MAPC-6653"
-        },
-        "headSha": {
-          "type": "string",
-          "description": "The SHA of the commit to associate this check run with",
-          "example": "abc123def456..."
-        },
-        "text": {
-          "type": "string",
-          "description": "Additional details in Markdown (supports large content)",
-          "example": "Full analysis results here..."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "title": {
-          "type": "string",
-          "description": "Title shown in the check run output panel",
-          "example": "AI PR Review"
-        },
-        "status": {
-          "type": "string",
-          "description": "The status: queued | in_progress | completed",
-          "example": "in_progress"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "name",
-        "headSha"
-      ]
-    }
-  },
-  {
-    "name": "github_update_check_run",
-    "integration": "github",
-    "description": "Update an existing GitHub Check Run \u2014 set it to completed with success/failure conclusion, update summary and detailed text. Call this after github_create_check_run to finalize the check.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "conclusion": {
-          "type": "string",
-          "description": "Required when status=completed: success | failure | neutral | cancelled | skipped | timed_out | action_required",
-          "example": "success"
-        },
-        "summary": {
-          "type": "string",
-          "description": "Updated Markdown summary for the check run output panel",
-          "example": "✅ Review complete. Found 3 issues."
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "checkRunId": {
-          "type": "string",
-          "description": "The ID of the check run to update (from github_create_check_run response)",
-          "example": "1234567890"
-        },
-        "text": {
-          "type": "string",
-          "description": "Updated detailed Markdown content (full analysis, annotations etc.)",
-          "example": "## Issues Found\n..."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "title": {
-          "type": "string",
-          "description": "Updated title for the check run output panel",
-          "example": "AI PR Review \u2014 Complete"
-        },
-        "status": {
-          "type": "string",
-          "description": "The new status: in_progress | completed",
-          "example": "completed"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "checkRunId",
-        "status"
-      ]
-    }
-  },
-  {
-    "name": "github_get_workflow_run",
-    "integration": "github",
-    "description": "Get details of a specific GitHub Actions workflow run by ID. Returns status, conclusion, logs URL, and timing information.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "runId": {
-          "type": "string",
-          "description": "The workflow run ID",
-          "example": "1234567890"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "runId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_workflow_run_jobs",
-    "integration": "github",
-    "description": "Get all jobs for a specific GitHub Actions workflow run. Shows individual job statuses, steps, and logs URLs.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "runId": {
-          "type": "string",
-          "description": "The workflow run ID",
-          "example": "1234567890"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "runId"
-      ]
-    }
-  },
-  {
-    "name": "github_list_workflow_runs",
-    "integration": "github",
-    "description": "List GitHub Actions workflow runs for a repository, optionally filtered by status or specific workflow file. Use status='failure' to get all failed runs.",
-    "category": "actions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "perPage": {
-          "type": "number",
-          "description": "Number of results per page (max 100, default 30)",
-          "example": "50"
-        },
-        "created": {
-          "type": "string",
-          "description": "Filter by created date/range using GitHub search syntax, e.g. 2026-05-01..2026-05-31 or >=2026-05-01",
-          "example": "2026-05-01..2026-05-31"
-        },
-        "page": {
-          "type": "number",
-          "description": "Page number for pagination (default 1)",
-          "example": "2"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workflowId": {
-          "type": "string",
-          "description": "Optional workflow filename to filter runs (e.g. rework.yml). If omitted, returns runs for all workflows.",
-          "example": "rework.yml"
-        },
-        "status": {
-          "type": "string",
-          "description": "Filter by status: failure, success, in_progress, queued, cancelled, timed_out, action_required, neutral, skipped, stale, completed",
-          "example": "failure"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository"
-      ]
-    }
-  },
-  {
-    "name": "github_get_job_logs",
-    "integration": "github",
-    "description": "Get the raw text logs for a specific GitHub Actions job. Returns the complete log output from all steps in the job.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "jobId": {
-          "type": "string",
-          "description": "The job ID (from github_get_workflow_run_jobs)",
-          "example": "1234567890"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "jobId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_workflow_run_logs",
-    "integration": "github",
-    "description": "Download and extract complete logs for all jobs in a GitHub Actions workflow run. Returns full untruncated log content from the ZIP archive GitHub provides.",
-    "category": "actions",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "runId": {
-          "type": "string",
-          "description": "The workflow run ID",
-          "example": "22498697315"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "runId"
-      ]
-    }
-  },
-  {
-    "name": "github_add_pr_label",
-    "integration": "github",
-    "description": "Add a label to a GitHub pull request.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "label": {
-          "type": "string",
-          "description": "The label name to add to the pull request",
-          "example": "bug"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "github_remove_pr_label",
-    "integration": "github",
-    "description": "Remove a label from a GitHub pull request.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "label": {
-          "type": "string",
-          "description": "The label name to remove from the pull request",
-          "example": "bug"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "github_merge_pr",
-    "integration": "github",
-    "description": "Merge a GitHub pull request. Supports merge, squash, and rebase merge methods.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request number to merge",
-          "example": "74"
-        },
-        "commitMessage": {
-          "type": "string",
-          "description": "Extra detail to append to the merge commit message (optional)",
-          "example": "Closes #123"
-        },
-        "mergeMethod": {
-          "type": "string",
-          "description": "The merge method: 'merge' (default), 'squash', or 'rebase'",
-          "example": "squash"
-        },
-        "commitTitle": {
-          "type": "string",
-          "description": "Title for the merge commit (optional, defaults to PR title)",
-          "example": "Merge feature/my-branch into main"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_diff",
-    "integration": "github",
-    "description": "Get the diff statistics for a GitHub pull request (files changed, additions, deletions). Requires IS_READ_PULL_REQUEST_DIFF env/config to be enabled.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestID": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestID"
-      ]
-    }
-  },
-  {
-    "name": "github_get_pr_diff_text",
-    "integration": "github",
-    "description": "Get the raw unified diff text for a GitHub pull request. Requires IS_READ_PULL_REQUEST_DIFF env/config to be enabled.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The GitHub repository name",
-          "example": "dmtools"
-        },
-        "pullRequestID": {
-          "type": "string",
-          "description": "The pull request number",
-          "example": "74"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "The GitHub owner/organization name",
-          "example": "IstiN"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestID"
-      ]
-    }
-  },
-  {
-    "name": "confluence_contents_by_urls",
-    "integration": "confluence",
-    "description": "Get Confluence content by multiple URLs. Returns a list of content objects for each valid URL. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        },
-        "urlStrings": {
-          "type": "array",
-          "description": "Array of Confluence URLs to retrieve content from",
-          "example": "['https://confluence.example.com/wiki/spaces/SPACE/pages/123/Page+Title']"
-        }
-      },
-      "required": ["urlStrings"]
-    }
-  },
-  {
-    "name": "confluence_search_content_by_text",
-    "integration": "confluence",
-    "description": "Search Confluence content by text query using CQL (Confluence Query Language). Returns search results with content excerpts. Default limit is 20 if not specified.",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of search results to return. Default is 20 if not provided.",
-          "example": "10"
-        },
-        "query": {
-          "type": "string",
-          "description": "Search query text to find in Confluence content",
-          "example": "project documentation"
-        }
-      },
-      "required": ["query"]
-    }
-  },
-  {
-    "name": "confluence_content_by_id",
-    "integration": "confluence",
-    "description": "Get Confluence content by its unique content ID. Returns detailed content information including body, version, and metadata. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "contentId": {
-          "type": "string",
-          "description": "The unique content ID of the Confluence page",
-          "example": "123456"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        }
-      },
-      "required": ["contentId"]
-    }
-  },
-  {
-    "name": "confluence_content_by_title_and_space",
-    "integration": "confluence",
-    "description": "Get Confluence content by title and space key. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "The title of the Confluence page",
-          "example": "Project Documentation"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        },
-        "space": {
-          "type": "string",
-          "description": "The space key where the content is located",
-          "example": "PROJ"
-        }
-      },
-      "required": [
-        "title",
-        "space"
-      ]
-    }
-  },
-  {
-    "name": "confluence_test",
-    "integration": "confluence",
-    "description": "Test Confluence connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "confluence_get_current_user_profile",
-    "integration": "confluence",
-    "description": "Get the current user's profile information from Confluence. Returns user details for the authenticated user.",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "confluence_get_user_profile_by_id",
-    "integration": "confluence",
-    "description": "Get a specific user's profile information from Confluence by user ID. Returns user details for the specified user.",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"userId": {
-        "type": "string",
-        "description": "The account ID of the user to get profile for",
-        "example": "123456:abcdef-1234-5678-90ab-cdef12345678"
-      }},
-      "required": ["userId"]
-    }
-  },
-  {
-    "name": "confluence_get_content_attachments",
-    "integration": "confluence",
-    "description": "Get all attachments for a specific Confluence content. Returns a list of attachment objects with metadata.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"contentId": {
-        "type": "string",
-        "description": "The content ID to get attachments for",
-        "example": "123456"
-      }},
-      "required": ["contentId"]
-    }
-  },
-  {
-    "name": "confluence_find_content_by_title_and_space",
-    "integration": "confluence",
-    "description": "Find Confluence content by title and space key. Returns the first matching content or null if not found. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "The title of the content to find",
-          "example": "Project Documentation"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        },
-        "space": {
-          "type": "string",
-          "description": "The space key where to search for the content",
-          "example": "PROJ"
-        }
-      },
-      "required": [
-        "title",
-        "space"
-      ]
-    }
-  },
-  {
-    "name": "confluence_create_page",
-    "integration": "confluence",
-    "description": "Create a new Confluence page with specified title, parent, body content, and space. Returns the created content object.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "The title of the new page",
-          "example": "New Project Page"
-        },
-        "body": {
-          "type": "string",
-          "description": "The body content of the page in Confluence storage format",
-          "example": "<p>This is the page content.<\/p>"
-        },
-        "parentId": {
-          "type": "string",
-          "description": "The ID of the parent page",
-          "example": "123456"
-        },
-        "space": {
-          "type": "string",
-          "description": "The space key where to create the page",
-          "example": "PROJ"
-        }
-      },
-      "required": [
-        "title",
-        "parentId",
-        "body",
-        "space"
-      ]
-    }
-  },
-  {
-    "name": "confluence_update_page",
-    "integration": "confluence",
-    "description": "Update an existing Confluence page with new title, parent, body content, and space. Returns the updated content object.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "contentId": {
-          "type": "string",
-          "description": "The ID of the page to update",
-          "example": "123456"
-        },
-        "title": {
-          "type": "string",
-          "description": "The new title for the page",
-          "example": "Updated Project Page"
-        },
-        "body": {
-          "type": "string",
-          "description": "The new body content of the page in Confluence storage format",
-          "example": "<p>This is the updated page content.<\/p>"
-        },
-        "parentId": {
-          "type": "string",
-          "description": "The ID of the new parent page",
-          "example": "123456"
-        },
-        "space": {
-          "type": "string",
-          "description": "The space key where the page is located",
-          "example": "PROJ"
-        }
-      },
-      "required": [
-        "contentId",
-        "title",
-        "parentId",
-        "body",
-        "space"
-      ]
-    }
-  },
-  {
-    "name": "confluence_update_page_with_history",
-    "integration": "confluence",
-    "description": "Update an existing Confluence page with new content and add a history comment. Returns the updated content object.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "contentId": {
-          "type": "string",
-          "description": "The ID of the page to update",
-          "example": "123456"
-        },
-        "title": {
-          "type": "string",
-          "description": "The new title for the page",
-          "example": "Updated Project Page"
-        },
-        "body": {
-          "type": "string",
-          "description": "The new body content of the page in Confluence storage format",
-          "example": "<p>This is the updated page content.<\/p>"
-        },
-        "parentId": {
-          "type": "string",
-          "description": "The ID of the new parent page",
-          "example": "123456"
-        },
-        "space": {
-          "type": "string",
-          "description": "The space key where the page is located",
-          "example": "PROJ"
-        },
-        "historyComment": {
-          "type": "string",
-          "description": "Comment to add to the page history",
-          "example": "Updated content based on user feedback"
-        }
-      },
-      "required": [
-        "contentId",
-        "title",
-        "parentId",
-        "body",
-        "space",
-        "historyComment"
-      ]
-    }
-  },
-  {
-    "name": "confluence_get_children_by_name",
-    "integration": "confluence",
-    "description": "Get child pages of a Confluence page by space key and content name. Returns a list of child content objects. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "spaceKey": {
-          "type": "string",
-          "description": "The space key where the parent page is located",
-          "example": "PROJ"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        },
-        "contentName": {
-          "type": "string",
-          "description": "The name/title of the parent page",
-          "example": "Project Documentation"
-        }
-      },
-      "required": [
-        "spaceKey",
-        "contentName"
-      ]
-    }
-  },
-  {
-    "name": "confluence_get_children_by_id",
-    "integration": "confluence",
-    "description": "Get child pages of a Confluence page by content ID. Returns a list of child content objects. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "contentId": {
-          "type": "string",
-          "description": "The content ID of the parent page",
-          "example": "123456"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        }
-      },
-      "required": ["contentId"]
-    }
-  },
-  {
-    "name": "confluence_download_attachment",
-    "integration": "confluence",
-    "description": "Download an attachment file from Confluence to a specified directory.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "attachment": {
-          "type": "object",
-          "description": "The attachment object to download"
-        },
-        "targetDir": {
-          "type": "object",
-          "description": "The target directory to save the file",
-          "example": "/path/to/directory"
-        }
-      },
-      "required": [
-        "attachment",
-        "targetDir"
-      ]
-    }
-  },
-  {
-    "name": "confluence_download_pages",
-    "integration": "confluence",
-    "description": "Download Confluence pages and their attachments to a local folder. Recursively follows linked pages, children macros, and internal ac:link references up to the specified depth.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "urlStrings": {
-          "type": "array",
-          "description": "Array of Confluence page URLs to download",
-          "example": "['https://wiki.example.com/wiki/spaces/SPACE/pages/123/Page']"
-        },
-        "depth": {
-          "type": "number",
-          "description": "How many levels of linked/child pages to follow. Default is 1.",
-          "example": "1"
-        },
-        "downloadAttachments": {
-          "type": "boolean",
-          "description": "Whether to download page attachments. Default is true.",
-          "example": "true"
-        },
-        "outputPath": {
-          "type": "string",
-          "description": "Local folder path where pages and attachments will be saved",
-          "example": "/tmp/confluence-pages"
-        }
-      },
-      "required": [
-        "urlStrings",
-        "outputPath"
-      ]
-    }
-  },
-  {
-    "name": "confluence_find_content",
-    "integration": "confluence",
-    "description": "Find a Confluence page by title in the default space. Returns the page content if found. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Title of the Confluence page to find",
-          "example": "Project Documentation"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        }
-      },
-      "required": ["title"]
-    }
-  },
-  {
-    "name": "confluence_find_or_create",
-    "integration": "confluence",
-    "description": "Find a Confluence page by title in the default space, or create it if it doesn't exist. Returns the found or created content.",
-    "category": "content_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Title of the page to find or create",
-          "example": "Project Documentation"
-        },
-        "body": {
-          "type": "string",
-          "description": "Body content for the new page (if creation is needed)",
-          "example": "<p>This is the page content.<\/p>"
-        },
-        "parentId": {
-          "type": "string",
-          "description": "ID of the parent page for creation",
-          "example": "123456"
-        }
-      },
-      "required": [
-        "title",
-        "parentId",
-        "body"
-      ]
-    }
-  },
-  {
-    "name": "confluence_content_by_title",
-    "integration": "confluence",
-    "description": "Get Confluence content by title in the default space. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown.",
-    "category": "content_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "title": {
-          "type": "string",
-          "description": "Title of the Confluence page to get",
-          "example": "Project Documentation"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
-          "example": "md"
-        }
-      },
-      "required": ["title"]
-    }
-  },
-  {
-    "name": "teams_test",
-    "integration": "teams",
-    "description": "Test Microsoft Teams connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_chats_raw",
-    "integration": "teams",
-    "description": "List chats for the current user with topic, type, and participant information (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"limit": {
-        "type": "number",
-        "description": "Maximum number of chats (0 for all, default: 50)",
-        "example": "50"
-      }},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_chats",
-    "integration": "teams",
-    "description": "List chats showing only chat/contact names, last message (truncated to 100 chars), and date",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"limit": {
-        "type": "number",
-        "description": "Maximum number of chats (0 for all, default: 50)",
-        "example": "50"
-      }},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_recent_chats",
-    "integration": "teams",
-    "description": "Get recent chats sorted by last activity showing chat/contact names, last message with author, and date. Shows 'new: true' for unread messages. Filter by type: 'oneOnOne' for 1-on-1 chats, 'group' for group chats, 'meeting' for meeting chats, or 'all' (default). Only shows chats with activity in the last 90 days.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of recent chats (0 for all, default: 50)",
-          "example": "50"
-        },
-        "chatType": {
-          "type": "string",
-          "description": "Filter by chat type: 'oneOnOne', 'group', 'meeting', or 'all' (default: 'all')",
-          "example": "oneOnOne"
-        }
-      },
-      "required": []
-    }
-  },
-  {
-    "name": "teams_messages_by_chat_id_raw",
-    "integration": "teams",
-    "description": "Get messages from a chat by ID with optional server-side filtering. Use $filter syntax with lastModifiedDateTime: 'lastModifiedDateTime gt 2025-01-01T00:00:00Z' (returns raw JSON). Note: createdDateTime is not supported in filters.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatId": {
-          "type": "string",
-          "description": "The chat ID"
-        },
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of messages (0 for all, default: 100)",
-          "example": "100"
-        },
-        "filter": {
-          "type": "string",
-          "description": "Optional OData filter (e.g., 'lastModifiedDateTime gt 2025-01-01T00:00:00Z')",
-          "example": "lastModifiedDateTime gt 2025-01-01T00:00:00Z"
-        }
-      },
-      "required": ["chatId"]
-    }
-  },
-  {
-    "name": "teams_chat_by_name_raw",
-    "integration": "teams",
-    "description": "Find a chat by topic/name or participant name (case-insensitive partial match). Works for group chats and 1-on-1 chats. (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"chatName": {
-        "type": "string",
-        "description": "The chat topic or participant name to search for"
-      }},
-      "required": ["chatName"]
-    }
-  },
-  {
-    "name": "teams_messages_raw",
-    "integration": "teams",
-    "description": "Get messages from a chat by name (combines find + get messages) (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of messages (0 for all, default: 100)",
-          "example": "100"
-        },
-        "chatName": {
-          "type": "string",
-          "description": "The chat name to search for"
-        }
-      },
-      "required": ["chatName"]
-    }
-  },
-  {
-    "name": "teams_messages",
-    "integration": "teams",
-    "description": "Get messages from a chat with simplified output showing only: author, body, date, reactions, mentions, and attachments",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of messages (0 for all, default: 100)",
-          "example": "100"
-        },
-        "chatName": {
-          "type": "string",
-          "description": "The chat name to search for"
-        },
-        "sorting": {
-          "type": "string",
-          "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
-          "example": "desc"
-        }
-      },
-      "required": ["chatName"]
-    }
-  },
-  {
-    "name": "teams_messages_since_by_id",
-    "integration": "teams",
-    "description": "Get messages from a chat starting from a specific date (ISO 8601 format, e.g., '2025-10-08T00:00:00Z'). Returns simplified format. Uses smart pagination with early exit for performance.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatId": {
-          "type": "string",
-          "description": "The chat ID"
-        },
-        "sinceDate": {
-          "type": "string",
-          "description": "ISO 8601 date string (e.g., '2025-10-08T00:00:00Z')",
-          "example": "2025-10-08T00:00:00Z"
-        },
-        "sorting": {
-          "type": "string",
-          "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
-          "example": "desc"
-        }
-      },
-      "required": [
-        "chatId",
-        "sinceDate"
-      ]
-    }
-  },
-  {
-    "name": "teams_messages_since",
-    "integration": "teams",
-    "description": "Get messages from a chat by name starting from a specific date (ISO 8601 format). Returns simplified format. Uses smart pagination with early exit for performance.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatName": {
-          "type": "string",
-          "description": "The chat name to search for"
-        },
-        "sinceDate": {
-          "type": "string",
-          "description": "ISO 8601 date string (e.g., '2025-10-08T00:00:00Z')",
-          "example": "2025-10-08T00:00:00Z"
-        },
-        "sorting": {
-          "type": "string",
-          "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
-          "example": "desc"
-        }
-      },
-      "required": [
-        "chatName",
-        "sinceDate"
-      ]
-    }
-  },
-  {
-    "name": "teams_send_message_by_id",
-    "integration": "teams",
-    "description": "Send a message to a chat by ID (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatId": {
-          "type": "string",
-          "description": "The chat ID"
-        },
-        "content": {
-          "type": "string",
-          "description": "Message content (plain text or HTML)"
-        }
-      },
-      "required": [
-        "chatId",
-        "content"
-      ]
-    }
-  },
-  {
-    "name": "teams_send_message",
-    "integration": "teams",
-    "description": "Send a message to a chat by name or participant name (finds chat, then sends message)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatName": {
-          "type": "string",
-          "description": "The chat topic or participant name"
-        },
-        "content": {
-          "type": "string",
-          "description": "Message content (plain text or HTML)"
-        }
-      },
-      "required": [
-        "chatName",
-        "content"
-      ]
-    }
-  },
-  {
-    "name": "teams_myself_messages_raw",
-    "integration": "teams",
-    "description": "Get messages from your personal self chat (notes to yourself) with full raw data",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"limit": {
-        "type": "number",
-        "description": "Maximum number of messages (0 for all, default: 100)",
-        "example": "100"
-      }},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_myself_messages",
-    "integration": "teams",
-    "description": "Get messages from your personal self chat (notes to yourself) with simplified output",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"limit": {
-        "type": "number",
-        "description": "Maximum number of messages (0 for all, default: 100)",
-        "example": "100"
-      }},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_send_myself_message",
-    "integration": "teams",
-    "description": "Send a message to your personal self chat (notes to yourself)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"content": {
-        "type": "string",
-        "description": "Message content (plain text or HTML)"
-      }},
-      "required": ["content"]
-    }
-  },
-  {
-    "name": "teams_download_file",
-    "integration": "teams",
-    "description": "Download a file from Teams (Graph API hostedContents or SharePoint sharing URL). Auto-detects URL type and uses appropriate method.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "url": {
-          "type": "string",
-          "description": "Graph API URL or SharePoint sharing URL",
-          "example": "https://graph.microsoft.com/v1.0/chats/.../hostedContents/.../$value"
-        },
-        "outputPath": {
-          "type": "string",
-          "description": "Local file path to save to",
-          "example": "/tmp/file.ext"
-        }
-      },
-      "required": [
-        "url",
-        "outputPath"
-      ]
-    }
-  },
-  {
-    "name": "teams_get_message_hosted_contents",
-    "integration": "teams",
-    "description": "Get hosted contents (files/transcripts) for a specific message. Returns list of files with download URLs.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "chatId": {
-          "type": "string",
-          "description": "Chat ID"
-        },
-        "messageId": {
-          "type": "string",
-          "description": "Message ID"
-        }
-      },
-      "required": [
-        "chatId",
-        "messageId"
-      ]
-    }
-  },
-  {
-    "name": "teams_get_call_transcripts",
-    "integration": "teams",
-    "description": "Get transcripts for a call/meeting using Call Records API. Returns list of transcripts with download URLs.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"callId": {
-        "type": "string",
-        "description": "Call ID from the meeting"
-      }},
-      "required": ["callId"]
-    }
-  },
-  {
-    "name": "teams_search_user_drive_files",
-    "integration": "teams",
-    "description": "Search for files in a user's OneDrive (e.g., meeting transcripts/recordings). Returns list of files with download URLs.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "userId": {
-          "type": "string",
-          "description": "User ID to search OneDrive"
-        },
-        "searchQuery": {
-          "type": "string",
-          "description": "Search term (meeting name, 'transcript', '.vtt', etc.)"
-        }
-      },
-      "required": [
-        "userId",
-        "searchQuery"
-      ]
-    }
-  },
-  {
-    "name": "teams_get_recording_transcripts",
-    "integration": "teams",
-    "description": "Get transcript metadata for a recording file. Returns list of available transcripts with download URLs.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "itemId": {
-          "type": "string",
-          "description": "Item ID of the recording file"
-        },
-        "driveId": {
-          "type": "string",
-          "description": "Drive ID from the recording file"
-        }
-      },
-      "required": [
-        "driveId",
-        "itemId"
-      ]
-    }
-  },
-  {
-    "name": "teams_list_recording_transcripts",
-    "integration": "teams",
-    "description": "List available transcripts for a recording file. Returns transcript IDs that can be downloaded.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "itemId": {
-          "type": "string",
-          "description": "Recording item ID"
-        },
-        "driveId": {
-          "type": "string",
-          "description": "Drive ID"
-        }
-      },
-      "required": [
-        "driveId",
-        "itemId"
-      ]
-    }
-  },
-  {
-    "name": "teams_extract_transcript_from_sharepoint",
-    "integration": "teams",
-    "description": "Extract transcript information by parsing SharePoint HTML page. Useful for finding transcript IDs.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"webUrl": {
-        "type": "string",
-        "description": "SharePoint webUrl of the recording"
-      }},
-      "required": ["webUrl"]
-    }
-  },
-  {
-    "name": "teams_download_recording_transcript",
-    "integration": "teams",
-    "description": "Download transcript (VTT) file from a Teams recording using SharePoint API. Requires driveId, itemId, and transcriptId.",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "itemId": {
-          "type": "string",
-          "description": "Recording item ID"
-        },
-        "driveId": {
-          "type": "string",
-          "description": "Drive ID"
-        },
-        "outputPath": {
-          "type": "string",
-          "description": "Local file path to save"
-        },
-        "transcriptId": {
-          "type": "string",
-          "description": "Transcript ID (UUID)"
-        }
-      },
-      "required": [
-        "driveId",
-        "itemId",
-        "transcriptId",
-        "outputPath"
-      ]
-    }
-  },
-  {
-    "name": "teams_get_joined_teams_raw",
-    "integration": "teams",
-    "description": "List teams the user is a member of (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_get_team_channels_raw",
-    "integration": "teams",
-    "description": "Get channels in a specific team (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"teamId": {
-        "type": "string",
-        "description": "The team ID"
-      }},
-      "required": ["teamId"]
-    }
-  },
-  {
-    "name": "teams_find_team_by_name_raw",
-    "integration": "teams",
-    "description": "Find a team by display name (case-insensitive partial match) (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"teamName": {
-        "type": "string",
-        "description": "The team name to search for"
-      }},
-      "required": ["teamName"]
-    }
-  },
-  {
-    "name": "teams_find_channel_by_name_raw",
-    "integration": "teams",
-    "description": "Find a channel by name within a team (case-insensitive partial match) (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "channelName": {
-          "type": "string",
-          "description": "The channel name to search for"
-        },
-        "teamId": {
-          "type": "string",
-          "description": "The team ID"
-        }
-      },
-      "required": [
-        "teamId",
-        "channelName"
-      ]
-    }
-  },
-  {
-    "name": "teams_get_channel_messages_by_name_raw",
-    "integration": "teams",
-    "description": "Get messages from a channel by team and channel names (returns raw JSON)",
-    "category": "communication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "teamName": {
-          "type": "string",
-          "description": "The team name to search for"
-        },
-        "limit": {
-          "type": "number",
-          "description": "Maximum number of messages (0 for all, default: 100)",
-          "example": "100"
-        },
-        "channelName": {
-          "type": "string",
-          "description": "The channel name to search for"
-        }
-      },
-      "required": [
-        "teamName",
-        "channelName"
-      ]
-    }
-  },
-  {
-    "name": "gemini_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to Gemini AI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "gemini_ai_chat_with_files",
-    "integration": "ai",
-    "description": "Send a text message to Gemini AI with file attachments. Supports images, documents, and other file types for analysis and questions.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to Gemini AI",
-          "example": "What is in this image? Please analyze the document content."
-        },
-        "filePaths": {
-          "type": "array",
-          "description": "Array of file paths to attach to the message",
-          "example": "['/path/to/image.png', '/path/to/document.pdf']"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "vertex_ai_gemini_chat",
-    "integration": "ai",
-    "description": "Send a text message to Google Vertex AI Gemini (service account auth)",
-    "category": "Vertex AI",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "vertex_ai_gemini_chat_with_files",
-    "integration": "ai",
-    "description": "Send message with file attachments to Vertex AI Gemini. Supports images, documents, and other file types.",
-    "category": "Vertex AI",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to Vertex AI Gemini",
-          "example": "What is in this image? Please analyze the document content."
-        },
-        "filePaths": {
-          "type": "array",
-          "description": "Array of file paths to attach to the message",
-          "example": "['/path/to/image.png', '/path/to/document.pdf']"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "bedrock_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to AWS Bedrock AI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "bedrock_list_models",
-    "integration": "ai",
-    "description": "Get a list of available AWS Bedrock foundation models",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "dial_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to Dial AI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "dial_ai_chat_with_files",
-    "integration": "ai",
-    "description": "Send a text message to Dial AI with file attachments. Supports images and documents for analysis and questions.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to Dial AI",
-          "example": "What is in this image? Please analyze the document content."
-        },
-        "filePaths": {
-          "type": "string",
-          "description": "Comma-separated list of file paths to attach (supports images and documents)",
-          "example": "/path/to/image.png,/path/to/document.pdf"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "anthropic_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to Anthropic Claude AI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "anthropic_ai_chat_with_files",
-    "integration": "ai",
-    "description": "Send a text message to Anthropic Claude AI with file attachments. Supports images, documents, and other file types for analysis and questions.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to Anthropic Claude AI",
-          "example": "What is in this image? Please analyze the document content."
-        },
-        "filePaths": {
-          "type": "array",
-          "description": "Array of file paths to attach to the message",
-          "example": "['/path/to/image.png', '/path/to/document.pdf']"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "anthropic_list_models",
-    "integration": "ai",
-    "description": "Get a list of available anthropic foundation models",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "ollama_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to Ollama AI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "ollama_ai_chat_with_files",
-    "integration": "ai",
-    "description": "Send a text message to Ollama AI with file attachments. Supports images and other file types for analysis and questions.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to Ollama AI",
-          "example": "What is in this image? Please analyze the document content."
-        },
-        "filePaths": {
-          "type": "array",
-          "description": "Array of file paths to attach to the message",
-          "example": "['/path/to/image.png', '/path/to/document.pdf']"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "openai_ai_chat",
-    "integration": "ai",
-    "description": "Send a text message to OpenAI and get response",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"message": {
-        "type": "string",
-        "description": "Text message to send to AI"
-      }},
-      "required": ["message"]
-    }
-  },
-  {
-    "name": "openai_ai_chat_with_files",
-    "integration": "ai",
-    "description": "Send a text message to OpenAI with file attachments. Supports images for vision models (gpt-4-vision-preview, gpt-4-turbo, etc.).",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "description": "Text message to send to OpenAI",
-          "example": "What is in this image? Please analyze the content."
-        },
-        "filePaths": {
-          "type": "array",
-          "description": "Array of file paths to attach to the message (images only for vision models)",
-          "example": "['/path/to/image.png', '/path/to/photo.jpg']"
-        }
-      },
-      "required": [
-        "message",
-        "filePaths"
-      ]
-    }
-  },
-  {
-    "name": "sharepoint_get_drive_item",
-    "integration": "sharepoint",
-    "description": "Get DriveItem information from a SharePoint sharing URL. Returns metadata about the shared file including download URLs.",
-    "category": "storage",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"sharingUrl": {
-        "type": "string",
-        "description": "SharePoint sharing URL",
-        "example": "https://company-my.sharepoint.com/:v:/p/user/EabcdefGHIJ..."
-      }},
-      "required": ["sharingUrl"]
-    }
-  },
-  {
-    "name": "sharepoint_download_file",
-    "integration": "sharepoint",
-    "description": "Download a file from a SharePoint sharing URL to a local file path. Works with OneDrive and SharePoint sharing links.",
-    "category": "storage",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sharingUrl": {
-          "type": "string",
-          "description": "SharePoint sharing URL",
-          "example": "https://company-my.sharepoint.com/:v:/p/user/EabcdefGHIJ..."
-        },
-        "outputPath": {
-          "type": "string",
-          "description": "Local file path to save to",
-          "example": "/tmp/recording.mp4"
-        }
-      },
-      "required": [
-        "sharingUrl",
-        "outputPath"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_work_item",
-    "integration": "ado",
-    "description": "Get a specific Azure DevOps work item by ID with optional field filtering",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "array",
-          "description": "Optional array of fields to include in the response"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID (numeric)",
-          "example": "12345"
-        }
-      },
-      "required": ["id"]
-    }
-  },
-  {
-    "name": "ado_search_by_wiql",
-    "integration": "ado",
-    "description": "Search for work items using WIQL (Work Item Query Language)",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "array",
-          "description": "Optional array of fields to include"
-        },
-        "wiql": {
-          "type": "string",
-          "description": "WIQL query string",
-          "example": "SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = 'Bug'"
-        }
-      },
-      "required": ["wiql"]
-    }
-  },
-  {
-    "name": "ado_get_comments",
-    "integration": "ado",
-    "description": "Get all comments for a work item",
-    "category": "comment_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "ticket": {
-          "type": "object",
-          "description": "Parameter ticket"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        }
-      },
-      "required": [
-        "id",
-        "ticket"
-      ]
-    }
-  },
-  {
-    "name": "ado_post_comment",
-    "integration": "ado",
-    "description": "Post a comment to a work item",
-    "category": "comment_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "comment": {
-          "type": "string",
-          "description": "The comment text"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        }
-      },
-      "required": [
-        "id",
-        "comment"
-      ]
-    }
-  },
-  {
-    "name": "ado_assign_work_item",
-    "integration": "ado",
-    "description": "Assign a work item to a user",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "userEmail": {
-          "type": "string",
-          "description": "The user email or display name"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        }
-      },
-      "required": [
-        "id",
-        "userEmail"
-      ]
-    }
-  },
-  {
-    "name": "ado_update_description",
-    "integration": "ado",
-    "description": "Update the description of a work item",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "The new description (HTML format)"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        }
-      },
-      "required": [
-        "id",
-        "description"
-      ]
-    }
-  },
-  {
-    "name": "ado_update_tags",
-    "integration": "ado",
-    "description": "Update the tags of a work item (semicolon-separated string)",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        },
-        "tags": {
-          "type": "string",
-          "description": "Tags as semicolon-separated string (e.g., 'tag1;tag2;tag3')"
-        }
-      },
-      "required": [
-        "id",
-        "tags"
-      ]
-    }
-  },
-  {
-    "name": "ado_move_to_state",
-    "integration": "ado",
-    "description": "Move a work item to a specific state",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        },
-        "state": {
-          "type": "string",
-          "description": "The target state name",
-          "example": "Active"
-        }
-      },
-      "required": [
-        "id",
-        "state"
-      ]
-    }
-  },
-  {
-    "name": "ado_link_work_items",
-    "integration": "ado",
-    "description": "Link two work items with a relationship (e.g., Parent-Child, Related, Tested By)",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sourceId": {
-          "type": "string",
-          "description": "The source work item ID"
-        },
-        "targetId": {
-          "type": "string",
-          "description": "The target work item ID to link to"
-        },
-        "relationship": {
-          "type": "string",
-          "description": "Relationship type (e.g., 'parent', 'child', 'related', 'tested by', 'tests')",
-          "example": "parent"
-        }
-      },
-      "required": [
-        "sourceId",
-        "targetId",
-        "relationship"
-      ]
-    }
-  },
-  {
-    "name": "ado_create_work_item",
-    "integration": "ado",
-    "description": "Create a new work item in Azure DevOps",
-    "category": "work_item_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workItemType": {
-          "type": "string",
-          "description": "The work item type (Bug, Task, User Story, etc.)"
-        },
-        "project": {
-          "type": "string",
-          "description": "The project name"
-        },
-        "description": {
-          "type": "string",
-          "description": "The work item description (HTML)"
-        },
-        "fieldsJson": {
-          "type": "object",
-          "description": "Additional fields as JSON object (e.g., {\"Microsoft.VSTS.Common.Priority\": 1})"
-        },
-        "title": {
-          "type": "string",
-          "description": "The work item title"
-        }
-      },
-      "required": [
-        "project",
-        "workItemType",
-        "title"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_changelog",
-    "integration": "ado",
-    "description": "Get the complete history/changelog of a work item",
-    "category": "history",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "ticket": {
-          "type": "object",
-          "description": "Optional work item object (can be null)"
-        },
-        "id": {
-          "type": "string",
-          "description": "The work item ID"
-        }
-      },
-      "required": ["id"]
-    }
-  },
-  {
-    "name": "ado_download_attachment",
-    "integration": "ado",
-    "description": "Download an ADO work item attachment by URL and save it as a file",
-    "category": "file_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "The attachment URL to download"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "ado_get_user_by_email",
-    "integration": "ado",
-    "description": "Get user information by email address in Azure DevOps",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"email": {
-        "type": "string",
-        "description": "User email address"
-      }},
-      "required": ["email"]
-    }
-  },
-  {
-    "name": "ado_test",
-    "integration": "ado",
-    "description": "Test Azure DevOps connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "ado_get_my_profile",
-    "integration": "ado",
-    "description": "Get the current user's profile information from Azure DevOps",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "ado_list_prs",
-    "integration": "ado",
-    "description": "List pull requests in an Azure DevOps Git repository by status. Status can be 'active', 'completed', or 'abandoned'.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "status": {
-          "type": "string",
-          "description": "The status of pull requests to list: 'active', 'completed', or 'abandoned'. 'open'/'opened' accepted as synonym for 'active'.",
-          "example": "active"
-        }
-      },
-      "required": [
-        "repository",
-        "status"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pr",
-    "integration": "ado",
-    "description": "Get details of an Azure DevOps pull request including title, description, status, author, reviewers, branches, and merge info.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID (numeric)",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pr_comments",
-    "integration": "ado",
-    "description": "Get all comment threads for an Azure DevOps pull request. Each thread contains comments, file context for inline comments, and status (active, fixed, closed, etc.).",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_add_pr_comment",
-    "integration": "ado",
-    "description": "Add a general comment to an Azure DevOps pull request (creates a new thread). For inline code comments, use ado_add_inline_comment instead.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "text": {
-          "type": "string",
-          "description": "The comment text to add (Markdown supported)",
-          "example": "Looks good!"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "ado_reply_to_pr_thread",
-    "integration": "ado",
-    "description": "Reply to an existing comment thread in an Azure DevOps pull request. Use the threadId from ado_get_pr_comments.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "threadId": {
-          "type": "string",
-          "description": "The ID of the thread to reply to (from ado_get_pr_comments)",
-          "example": "42"
-        },
-        "text": {
-          "type": "string",
-          "description": "The reply text (Markdown supported)",
-          "example": "Fixed in the latest commit."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "threadId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "ado_add_inline_comment",
-    "integration": "ado",
-    "description": "Create a new inline code comment on a specific file and line range in an Azure DevOps pull request. Creates a new thread with file context.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "side": {
-          "type": "string",
-          "description": "Which diff side to comment on: 'right' (new code, default) or 'left' (old code)",
-          "example": "right"
-        },
-        "line": {
-          "type": "string",
-          "description": "The line number to comment on (1-based)",
-          "example": "42"
-        },
-        "filePath": {
-          "type": "string",
-          "description": "The relative file path in the repository (must start with /)",
-          "example": "/src/main/java/com/example/Foo.java"
-        },
-        "startLine": {
-          "type": "string",
-          "description": "For multi-line comments: the first line of the range. Must be less than or equal to line.",
-          "example": "40"
-        },
-        "text": {
-          "type": "string",
-          "description": "The comment text (Markdown supported)",
-          "example": "This should be refactored."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "filePath",
-        "line",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "ado_resolve_pr_thread",
-    "integration": "ado",
-    "description": "Resolve (close) a comment thread in an Azure DevOps pull request. Sets the thread status to 'fixed'. Other statuses: 'active', 'closed', 'byDesign', 'pending', 'wontFix'.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "threadId": {
-          "type": "string",
-          "description": "The ID of the thread to resolve (from ado_get_pr_comments)",
-          "example": "42"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "status": {
-          "type": "string",
-          "description": "The new status: 'fixed' (default/resolved), 'closed', 'byDesign', 'wontFix', 'pending', 'active'",
-          "example": "fixed"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "threadId"
-      ]
-    }
-  },
-  {
-    "name": "ado_update_pr_comment",
-    "integration": "ado",
-    "description": "Update (edit) an existing comment in a pull request thread. Requires both threadId and commentId.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "threadId": {
-          "type": "string",
-          "description": "The ID of the thread containing the comment",
-          "example": "42"
-        },
-        "commentId": {
-          "type": "string",
-          "description": "The ID of the comment to update",
-          "example": "1"
-        },
-        "text": {
-          "type": "string",
-          "description": "The new comment text (replaces existing content)",
-          "example": "Updated analysis."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "threadId",
-        "commentId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "ado_delete_pr_comment",
-    "integration": "ado",
-    "description": "Delete a comment from a pull request thread. Requires both threadId and commentId.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "threadId": {
-          "type": "string",
-          "description": "The ID of the thread containing the comment",
-          "example": "42"
-        },
-        "commentId": {
-          "type": "string",
-          "description": "The ID of the comment to delete",
-          "example": "2"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "threadId",
-        "commentId"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pr_diff",
-    "integration": "ado",
-    "description": "Get the diff/changes for an Azure DevOps pull request. Returns the list of changed files with change types.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_merge_pr",
-    "integration": "ado",
-    "description": "Complete (merge) an Azure DevOps pull request. Sets status to 'completed' with the specified merge strategy.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID to complete/merge",
-          "example": "1"
-        },
-        "commitMessage": {
-          "type": "string",
-          "description": "Optional merge commit message",
-          "example": "Merging feature branch"
-        },
-        "mergeStrategy": {
-          "type": "string",
-          "description": "The merge strategy: 'squash' (default), 'noFastForward', 'rebase', 'rebaseMerge'",
-          "example": "squash"
-        },
-        "deleteSourceBranch": {
-          "type": "string",
-          "description": "Whether to delete the source branch after merging (default: true)",
-          "example": "true"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_add_pr_label",
-    "integration": "ado",
-    "description": "Add a label (tag) to an Azure DevOps pull request.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "label": {
-          "type": "string",
-          "description": "The label name to add",
-          "example": "needs-review"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "ado_remove_pr_label",
-    "integration": "ado",
-    "description": "Remove a label (tag) from an Azure DevOps pull request. Requires the labelId (from ado_get_pr or ado_list_prs labels array).",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "labelId": {
-          "type": "string",
-          "description": "The label ID to remove (from the PR labels array, not the label name)",
-          "example": "e10671ab-..."
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "labelId"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pr_reviewers",
-    "integration": "ado",
-    "description": "Get all reviewers for an Azure DevOps pull request with their vote status. Vote: 10=approved, 5=approved with suggestions, 0=no vote, -5=waiting for author, -10=rejected.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_add_pr_reviewer",
-    "integration": "ado",
-    "description": "Add a reviewer to an Azure DevOps pull request. Optionally set their initial vote.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "reviewerId": {
-          "type": "string",
-          "description": "The reviewer's ID (GUID from ado_get_user_by_email or uniqueName)",
-          "example": "ab1c2d3e-..."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "vote": {
-          "type": "string",
-          "description": "Optional initial vote: 10=approve, 5=approve with suggestions, 0=no vote, -5=wait for author, -10=reject",
-          "example": "0"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "reviewerId"
-      ]
-    }
-  },
-  {
-    "name": "ado_set_pr_vote",
-    "integration": "ado",
-    "description": "Set the current user's vote on a pull request. Vote values: 10=approve, 5=approve with suggestions, 0=reset/no vote, -5=wait for author, -10=reject.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "reviewerId": {
-          "type": "string",
-          "description": "The reviewer's ID (GUID) \u2014 use ado_get_my_profile or ado_get_user_by_email to get it",
-          "example": "ab1c2d3e-..."
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "vote": {
-          "type": "string",
-          "description": "Vote value: 10=approve, 5=approve with suggestions, 0=reset, -5=wait for author, -10=reject",
-          "example": "10"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId",
-        "reviewerId",
-        "vote"
-      ]
-    }
-  },
-  {
-    "name": "ado_update_pr",
-    "integration": "ado",
-    "description": "Update pull request properties such as title, description, or status. Use status='abandoned' to abandon a PR, or 'active' to reactivate.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "New description for the pull request (Markdown supported)",
-          "example": "Updated description"
-        },
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        },
-        "title": {
-          "type": "string",
-          "description": "New title for the pull request",
-          "example": "Updated PR title"
-        },
-        "status": {
-          "type": "string",
-          "description": "New status: 'active' or 'abandoned'",
-          "example": "active"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pr_work_items",
-    "integration": "ado",
-    "description": "Get work items linked to an Azure DevOps pull request.",
-    "category": "pull_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "The Git repository name",
-          "example": "ai-native-sdlc-blueprint"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "The pull request ID",
-          "example": "1"
-        }
-      },
-      "required": [
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "ado_list_pipelines",
-    "integration": "ado",
-    "description": "List all pipelines defined in the ADO project.",
-    "category": "pipeline_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "ado_trigger_pipeline",
-    "integration": "ado",
-    "description": "Trigger a pipeline run in ADO. Equivalent to github_trigger_workflow.",
-    "category": "pipeline_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "branch": {
-          "type": "string",
-          "description": "The branch to run the pipeline on (e.g. 'main')"
-        },
-        "variables": {
-          "type": "string",
-          "description": "JSON object of pipeline variables, e.g. {\"myVar\":\"value\"}"
-        },
-        "pipelineId": {
-          "type": "number",
-          "description": "The pipeline ID to trigger"
-        }
-      },
-      "required": ["pipelineId"]
-    }
-  },
-  {
-    "name": "ado_list_pipeline_runs",
-    "integration": "ado",
-    "description": "List recent runs of a pipeline. Equivalent to github_list_workflow_runs.",
-    "category": "pipeline_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "top": {
-          "type": "number",
-          "description": "Number of runs to return (default 10)"
-        },
-        "pipelineId": {
-          "type": "number",
-          "description": "The pipeline ID"
-        }
-      },
-      "required": ["pipelineId"]
-    }
-  },
-  {
-    "name": "ado_get_pipeline_run",
-    "integration": "ado",
-    "description": "Get details of a specific pipeline run including state and result.",
-    "category": "pipeline_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "pipelineId": {
-          "type": "number",
-          "description": "The pipeline ID"
-        },
-        "runId": {
-          "type": "number",
-          "description": "The run ID"
-        }
-      },
-      "required": [
-        "pipelineId",
-        "runId"
-      ]
-    }
-  },
-  {
-    "name": "ado_get_pipeline_logs",
-    "integration": "ado",
-    "description": "Get combined logs for all tasks in a pipeline run (build ID). Equivalent to github_get_job_logs.",
-    "category": "pipeline_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "tailLines": {
-          "type": "number",
-          "description": "Lines to return from the end of each task log (default 200, 0 = all)"
-        },
-        "buildId": {
-          "type": "number",
-          "description": "The build/run ID returned by ado_trigger_pipeline or ado_list_pipeline_runs"
-        },
-        "taskName": {
-          "type": "string",
-          "description": "Optional: filter logs to a specific task name (case-insensitive substring match)"
-        }
-      },
-      "required": ["buildId"]
-    }
-  },
-  {
-    "name": "mermaid_index_generate",
-    "integration": "mermaid",
-    "description": "Generate Mermaid diagrams from content sources (Confluence or Jira) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure.",
-    "category": "diagram_generation",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "integration": {
-          "type": "string",
-          "description": "Integration type: 'confluence', 'jira', 'jira_xray', or 'testrail'",
-          "example": "confluence"
-        },
-        "include_patterns": {
-          "type": "array",
-          "description": "Array of include patterns. For Confluence: [\"SPACE/pages/PAGE_ID/PAGE_NAME/**\"]. For Jira: [\"JQL query\"]. For TestRail: [\"project_id=5&suite_id=3\"]",
-          "example": "[\"AINA/pages/11665522/Templates/**\"]"
-        },
-        "exclude_patterns": {
-          "type": "array",
-          "description": "Optional array of exclude patterns to filter out specific content (not used for Jira)",
-          "example": "[]"
-        },
-        "storage_path": {
-          "type": "string",
-          "description": "Base path for storing generated diagrams",
-          "example": "./mermaid-diagrams"
-        },
-        "custom_fields": {
-          "type": "array",
-          "description": "Optional array of custom field names to include in content (only for Jira integrations)",
-          "example": "[\"summary\", \"description\", \"customfield_10001\"]"
-        },
-        "include_comments": {
-          "type": "boolean",
-          "description": "Whether to include comments in content (only for Jira integrations, default: false)",
-          "example": "false"
-        }
-      },
-      "required": [
-        "integration",
-        "storage_path",
-        "include_patterns"
-      ]
-    }
-  },
-  {
-    "name": "mermaid_index_read_list",
-    "integration": "mermaid",
-    "description": "Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of ToText objects with paths and content.",
-    "category": "diagram_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "integration": {
-          "type": "string",
-          "description": "Integration type (used as subfolder name under storage path)",
-          "example": "confluence"
-        },
-        "storage_path": {
-          "type": "string",
-          "description": "Base path where diagrams are stored",
-          "example": "./mermaid-diagrams"
-        }
-      },
-      "required": [
-        "integration",
-        "storage_path"
-      ]
-    }
-  },
-  {
-    "name": "mermaid_index_read",
-    "integration": "mermaid",
-    "description": "Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of diagrams with their paths and content.",
-    "category": "diagram_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "integration": {
-          "type": "string",
-          "description": "Integration type (used as subfolder name under storage path)",
-          "example": "confluence"
-        },
-        "storage_path": {
-          "type": "string",
-          "description": "Base path where diagrams are stored",
-          "example": "./mermaid-diagrams"
-        }
-      },
-      "required": [
-        "integration",
-        "storage_path"
-      ]
-    }
-  },
-  {
-    "name": "jira_xray_test",
-    "integration": "jira_xray",
-    "description": "Test X-ray connectivity by obtaining an access token",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "jira_xray_create_precondition",
-    "integration": "jira_xray",
-    "description": "Create a Precondition issue in Xray with optional steps (converted to definition). Returns the created ticket key.",
-    "category": "xray_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "summary": {
-          "type": "string",
-          "description": "Precondition summary",
-          "example": "System is ready for testing"
-        },
-        "project": {
-          "type": "string",
-          "description": "Project key (e.g., 'TP')",
-          "example": "TP"
-        },
-        "description": {
-          "type": "string",
-          "description": "Precondition description",
-          "example": "All system components are initialized"
-        },
-        "steps": {
-          "type": "string",
-          "description": "Optional JSON array of steps in format [{\"action\": \"...\", \"data\": \"...\", \"result\": \"...\"}]. Will be converted to definition format."
-        }
-      },
-      "required": [
-        "project",
-        "summary"
-      ]
-    }
-  },
-  {
-    "name": "jira_xray_search_tickets",
-    "integration": "jira_xray",
-    "description": "Search for Jira tickets using JQL query and enrich Test/Precondition issues with X-ray test steps and preconditions. Returns list of tickets with X-ray data.",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "array",
-          "description": "Array of field names to retrieve (e.g., ['summary', 'description', 'status'])",
-          "example": "summary,description,status"
-        },
-        "searchQueryJQL": {
-          "type": "string",
-          "description": "JQL search query (e.g., 'project = TP AND issueType = Test')",
-          "example": "project = TP AND issueType = Test"
-        }
-      },
-      "required": ["searchQueryJQL"]
-    }
-  },
-  {
-    "name": "jira_xray_get_test_details",
-    "integration": "jira_xray",
-    "description": "Get test details including steps and preconditions using X-ray GraphQL API. Returns JSONObject with test details.",
-    "category": "test_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"testKey": {
-        "type": "string",
-        "description": "Jira ticket key (e.g., 'TP-909')",
-        "example": "TP-909"
-      }},
-      "required": ["testKey"]
-    }
-  },
-  {
-    "name": "jira_xray_get_test_steps",
-    "integration": "jira_xray",
-    "description": "Get test steps for a test issue using X-ray GraphQL API. Returns JSONArray of test steps.",
-    "category": "test_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"testKey": {
-        "type": "string",
-        "description": "Jira ticket key (e.g., 'TP-909')",
-        "example": "TP-909"
-      }},
-      "required": ["testKey"]
-    }
-  },
-  {
-    "name": "jira_xray_get_preconditions",
-    "integration": "jira_xray",
-    "description": "Get preconditions for a test issue using X-ray GraphQL API. Returns JSONArray of precondition objects.",
-    "category": "test_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"testKey": {
-        "type": "string",
-        "description": "Jira ticket key (e.g., 'TP-909')",
-        "example": "TP-909"
-      }},
-      "required": ["testKey"]
-    }
-  },
-  {
-    "name": "jira_xray_get_precondition_details",
-    "integration": "jira_xray",
-    "description": "Get Precondition details including definition using X-ray GraphQL API. Returns JSONObject with precondition details.",
-    "category": "test_retrieval",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"preconditionKey": {
-        "type": "string",
-        "description": "Jira ticket key (e.g., 'TP-910')",
-        "example": "TP-910"
-      }},
-      "required": ["preconditionKey"]
-    }
-  },
-  {
-    "name": "jira_xray_add_test_step",
-    "integration": "jira_xray",
-    "description": "Add a single test step to a test issue using X-ray GraphQL API. Returns JSONObject with created step details.",
-    "category": "test_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "result": {
-          "type": "string",
-          "description": "Step expected result (e.g., 'Username accepted')",
-          "example": "Username accepted"
-        },
-        "action": {
-          "type": "string",
-          "description": "Step action (e.g., 'Enter username')",
-          "example": "Enter username"
-        },
-        "issueId": {
-          "type": "string",
-          "description": "Jira issue ID (e.g., '12345')",
-          "example": "12345"
-        },
-        "data": {
-          "type": "string",
-          "description": "Step data (e.g., 'test_user')",
-          "example": "test_user"
-        }
-      },
-      "required": [
-        "issueId",
-        "action"
-      ]
-    }
-  },
-  {
-    "name": "jira_xray_add_test_steps",
-    "integration": "jira_xray",
-    "description": "Add multiple test steps to a test issue using X-ray GraphQL API. Returns JSONArray of created step objects.",
-    "category": "test_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "steps": {
-          "type": "object",
-          "description": "JSON array string of step objects, each with 'action', 'data', and 'result' fields (e.g., '[{\"action\":\"Enter username\",\"data\":\"test_user\",\"result\":\"Username accepted\"}]')",
-          "example": "[{\"action\":\"Enter username\",\"data\":\"test_user\",\"result\":\"Username accepted\"}]"
-        },
-        "issueId": {
-          "type": "string",
-          "description": "Jira issue ID (e.g., '12345')",
-          "example": "12345"
-        }
-      },
-      "required": [
-        "issueId",
-        "steps"
-      ]
-    }
-  },
-  {
-    "name": "jira_xray_add_precondition_to_test",
-    "integration": "jira_xray",
-    "description": "Add a single precondition to a test issue using X-ray GraphQL API. Returns JSONObject with result.",
-    "category": "test_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "testIssueId": {
-          "type": "string",
-          "description": "Jira issue ID of the test (e.g., '12345')",
-          "example": "12345"
-        },
-        "preconditionIssueId": {
-          "type": "string",
-          "description": "Jira issue ID of the precondition (e.g., '12346')",
-          "example": "12346"
-        }
-      },
-      "required": [
-        "testIssueId",
-        "preconditionIssueId"
-      ]
-    }
-  },
-  {
-    "name": "jira_xray_add_preconditions_to_test",
-    "integration": "jira_xray",
-    "description": "Add multiple preconditions to a test issue using X-ray GraphQL API. Returns JSONArray of results.",
-    "category": "test_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "preconditionIssueIds": {
-          "type": "object",
-          "description": "JSON array string of precondition issue IDs (e.g., '[\"12346\", \"12347\"]')",
-          "example": "[\"12346\", \"12347\"]"
-        },
-        "testIssueId": {
-          "type": "string",
-          "description": "Jira issue ID of the test (e.g., '12345')",
-          "example": "12345"
-        }
-      },
-      "required": [
-        "testIssueId",
-        "preconditionIssueIds"
-      ]
-    }
-  },
-  {
-    "name": "file_read",
-    "integration": "file",
-    "description": "Read file content from working directory (supports input/ and outputs/ folders). Returns file content as string or null if file doesn't exist or is inaccessible. All file formats supported as UTF-8 text.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"path": {
-        "type": "string",
-        "description": "File path relative to working directory or absolute path within working directory",
-        "example": "outputs/response.md"
-      }},
-      "required": ["path"]
-    }
-  },
-  {
-    "name": "file_write",
-    "integration": "file",
-    "description": "Write content to file in working directory. Creates parent directories automatically. Returns success message or null on failure.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "File path relative to working directory or absolute path within working directory",
-          "example": "inbox/raw/teams_messages/1729766400000-messages.json"
-        },
-        "content": {
-          "type": "string",
-          "description": "Content to write to the file as UTF-8 string",
-          "example": "{\"messages\": []}"
-        }
-      },
-      "required": [
-        "path",
-        "content"
-      ]
-    }
-  },
-  {
-    "name": "file_delete",
-    "integration": "file",
-    "description": "Delete file or directory from working directory. Returns success message or null on failure.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"path": {
-        "type": "string",
-        "description": "File path relative to working directory or absolute path within working directory",
-        "example": "temp/unused_file.txt"
-      }},
-      "required": ["path"]
-    }
-  },
-  {
-    "name": "file_validate_json",
-    "integration": "file",
-    "description": "Validate JSON string and return detailed error information if invalid. Returns JSON string with validation result: {\"valid\": true} for valid JSON, or {\"valid\": false, \"error\": \"error message\", \"line\": line_number, \"column\": column_number, \"position\": character_position, \"context\": \"context around error\"} for invalid JSON.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"json": {
-        "type": "string",
-        "description": "JSON string to validate",
-        "example": "{\"key\": \"value\"}"
-      }},
-      "required": ["json"]
-    }
-  },
-  {
-    "name": "file_validate_json_file",
-    "integration": "file",
-    "description": "Validate JSON file and return detailed error information if invalid. Reads file from working directory and validates its JSON content. Returns JSON string with validation result including file path.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"path": {
-        "type": "string",
-        "description": "File path relative to working directory or absolute path within working directory",
-        "example": "outputs/response.json"
-      }},
-      "required": ["path"]
-    }
-  },
-  {
-    "name": "figma_oauth2_get_auth_url",
-    "integration": "figma",
-    "description": "Generates the Figma OAuth2 authorization URL for the initial authorization code flow. Open the returned URL in a browser, authorize the app, and copy the 'code' parameter from the redirect URL. Then call figma_oauth2_exchange_code to get access and refresh tokens. Requires FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET to be configured. Optional scope can be passed explicitly or via FIGMA_SCOPE/FIGMA_OAUTH_SCOPES env variable.",
-    "category": "auth",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "redirectUri": {
-          "type": "string",
-          "description": "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback). If omitted, uses FIGMA_REDIRECT_URI env variable.",
-          "example": "http://localhost:8080/callback"
-        },
-        "state": {
-          "type": "string",
-          "description": "Random state string for CSRF protection",
-          "example": "random_state_123"
-        },
-        "scope": {
-          "type": "string",
-          "description": "Optional OAuth scope list (space-separated), e.g. file_content:read file_metadata:read. If omitted, uses FIGMA_SCOPE (or FIGMA_OAUTH_SCOPES) env or default minimal read scope.",
-          "example": "file_content:read file_metadata:read"
-        }
-      },
-      "required": []
-    }
-  },
-  {
-    "name": "figma_oauth2_exchange_code",
-    "integration": "figma",
-    "description": "Exchanges a Figma OAuth2 authorization code for access and refresh tokens. Use the code from the redirect URL after completing the browser authorization flow started by figma_oauth2_get_auth_url. Store FIGMA_OAUTH_REFRESH_TOKEN from the response in your dmtools.env to enable automatic token refresh.",
-    "category": "auth",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "redirectUri": {
-          "type": "string",
-          "description": "Same redirect URI used in figma_oauth2_get_auth_url. If omitted, uses FIGMA_REDIRECT_URI env variable.",
-          "example": "http://localhost:8080/callback"
-        },
-        "code": {
-          "type": "string",
-          "description": "Authorization code received from Figma OAuth2 redirect",
-          "example": "figma_auth_code_abc123"
-        }
-      },
-      "required": ["code"]
-    }
-  },
-  {
-    "name": "figma_test",
-    "integration": "figma",
-    "description": "Test Figma connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "figma_me",
-    "integration": "figma",
-    "description": "Gets current user information from the Figma API using the /me endpoint. Returns user details including id, handle, and email. Can also be used to verify API connectivity.",
-    "category": "user",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "figma_get_screen_source",
-    "integration": "figma",
-    "description": "Get screen source content by URL. Returns the image URL for the specified Figma design node.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"url": {
-        "type": "string",
-        "description": "Figma design URL with node-id parameter",
-        "example": "https://www.figma.com/file/abc123/Design?node-id=1%3A2"
-      }},
-      "required": ["url"]
-    }
-  },
-  {
-    "name": "figma_download_node_image",
-    "integration": "figma",
-    "description": "Download image of specific node/component. Useful for visual preview of design pieces before processing structure.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "description": "Image format: png or jpg"
-        },
-        "scale": {
-          "type": "number",
-          "description": "Scale factor: 1, 2, or 4"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL"
-        },
-        "nodeId": {
-          "type": "string",
-          "description": "Node ID to download"
-        }
-      },
-      "required": [
-        "href",
-        "nodeId"
-      ]
-    }
-  },
-  {
-    "name": "figma_download_image_of_file",
-    "integration": "figma",
-    "description": "Download image by URL as File type. Converts Figma design URL to downloadable image file.",
-    "category": "file_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL to download as image file",
-        "example": "https://www.figma.com/file/abc123/Design?node-id=1%3A2"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_get_file_structure",
-    "integration": "figma",
-    "description": "Get full JSON structure of a Figma design file by URL. Returns the complete document tree (nodes, frames, components, text, styles). Response is large by design \u2014 intended for pre-CLI artifact preparation and file output, not inline AI context. If the URL contains node-id, returns only that subtree.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Parameter href"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_get_icons",
-    "integration": "figma",
-    "description": "Find and extract all exportable visual elements (vectors, shapes, graphics, text) from Figma design by URL. Focuses on actual visual elements to avoid complex component references.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL to extract visual elements from",
-        "example": "https://www.figma.com/file/abc123/Design"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_get_image_fills",
-    "integration": "figma",
-    "description": "Get original image fill URLs for all imageRefs in a Figma file. Resolves imageRef placeholders to actual downloadable S3 URLs. Use after inspecting file structure to download original photos/images embedded by the designer.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_render_nodes",
-    "integration": "figma",
-    "description": "Render multiple Figma nodes as images in a single batched API call. Automatically batches up to 100 node IDs per request. Returns map of nodeId to render URL. Use for exporting many icons or frames efficiently.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "description": "Export format: png, jpg, svg, pdf. Default: png"
-        },
-        "nodeIds": {
-          "type": "string",
-          "description": "Comma-separated node IDs to render (e.g. '1:2,3:4,5:6')"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL"
-        }
-      },
-      "required": [
-        "href",
-        "nodeIds"
-      ]
-    }
-  },
-  {
-    "name": "figma_download_image_as_file",
-    "integration": "figma",
-    "description": "Download image as file by node ID and format. Use this after figma_get_icons to download actual icon files.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "description": "Export format",
-          "example": "png"
-        },
-        "nodeId": {
-          "type": "string",
-          "description": "Node ID to export (from figma_get_icons result)",
-          "example": "123:456"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL to extract file ID from",
-          "example": "https://www.figma.com/file/abc123/Design"
-        }
-      },
-      "required": [
-        "href",
-        "nodeId",
-        "format"
-      ]
-    }
-  },
-  {
-    "name": "figma_get_svg_content",
-    "integration": "figma",
-    "description": "Get SVG content as text by node ID. Use this after figma_get_icons to get SVG code for vector icons.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "nodeId": {
-          "type": "string",
-          "description": "Node ID to export as SVG (from figma_get_icons result)",
-          "example": "123:456"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL to extract file ID from",
-          "example": "https://www.figma.com/file/abc123/Design"
-        }
-      },
-      "required": [
-        "href",
-        "nodeId"
-      ]
-    }
-  },
-  {
-    "name": "figma_get_node_details",
-    "integration": "figma",
-    "description": "Get detailed properties for specific node(s) including colors, fonts, text, dimensions, and styles. Returns small focused response.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "nodeIds": {
-          "type": "string",
-          "description": "Comma-separated node IDs (max 10)"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL"
-        }
-      },
-      "required": [
-        "href",
-        "nodeIds"
-      ]
-    }
-  },
-  {
-    "name": "figma_get_text_content",
-    "integration": "figma",
-    "description": "Extract text content from text nodes. Returns map of nodeId to text content.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "nodeIds": {
-          "type": "string",
-          "description": "Comma-separated text node IDs (max 20)"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL"
-        }
-      },
-      "required": [
-        "href",
-        "nodeIds"
-      ]
-    }
-  },
-  {
-    "name": "figma_get_styles",
-    "integration": "figma",
-    "description": "Get design tokens (colors, text styles) defined in Figma file.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_get_layers",
-    "integration": "figma",
-    "description": "Get first-level layers (direct children) to understand structure. Returns layer names, IDs, types, sizes. Essential first step before getting details.",
-    "category": "structure_analysis",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL with node-id"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_get_layers_batch",
-    "integration": "figma",
-    "description": "Get layers for multiple nodes at once. More efficient for analyzing multiple screens/containers. Returns map of nodeId to layers.",
-    "category": "structure_analysis",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "nodeIds": {
-          "type": "string",
-          "description": "Comma-separated node IDs (max 10)"
-        },
-        "href": {
-          "type": "string",
-          "description": "Figma design URL"
-        }
-      },
-      "required": [
-        "href",
-        "nodeIds"
-      ]
-    }
-  },
-  {
-    "name": "figma_get_node_children",
-    "integration": "figma",
-    "description": "Get immediate children IDs and basic info for a node. Non-recursive, returns only direct children.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design URL with node-id"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "figma_list_team_projects",
-    "integration": "figma",
-    "description": "List all projects within a Figma team, so a team-level 'files' listing URL (which is not a single design file and cannot be passed to file-specific tools like figma_get_layers) can be broken down into browsable projects. Accepts either a raw numeric team ID or any Figma URL containing a '/team/<teamId>' path segment.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"teamIdOrUrl": {
-        "type": "string",
-        "description": "Numeric Figma team ID, or a Figma URL containing '/team/<teamId>' (e.g. a team files-listing URL)",
-        "example": "https://www.figma.com/files/1008118788610687562/team/1633438210497791577"
-      }},
-      "required": ["teamIdOrUrl"]
-    }
-  },
-  {
-    "name": "figma_list_project_files",
-    "integration": "figma",
-    "description": "List all design files within a Figma project, returning each file's key, name, and thumbnail so a specific file URL can be built for use with file-specific tools like figma_get_layers or figma_get_file_structure. Use figma_list_team_projects first to discover project IDs from a team. Accepts either a raw numeric project ID or any Figma URL containing a '/project/<projectId>' path segment.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectIdOrUrl": {
-        "type": "string",
-        "description": "Numeric Figma project ID, or a Figma URL containing '/project/<projectId>'",
-        "example": "https://www.figma.com/files/project/123456789"
-      }},
-      "required": ["projectIdOrUrl"]
-    }
-  },
-  {
-    "name": "figma_get_file_comments",
-    "integration": "figma",
-    "description": "Get all comments left on a Figma design file, including comment text, author, and creation date. Accepts either a raw Figma file key or a full Figma design file URL.",
-    "category": "content_access",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "Figma design file URL, or a raw Figma file key",
-        "example": "https://www.figma.com/file/abc123/Design"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "testrail_test",
-    "integration": "testrail",
-    "description": "Test TestRail connectivity by fetching projects",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "testrail_get_projects",
-    "integration": "testrail",
-    "description": "Get list of all projects in TestRail",
-    "category": "projects",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "testrail_get_suites",
-    "integration": "testrail",
-    "description": "Get all test suites for a TestRail project",
-    "category": "suites",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project_name": {
-        "type": "string",
-        "description": "Project name to get suites from",
-        "example": "My Project"
-      }},
-      "required": ["project_name"]
-    }
-  },
-  {
-    "name": "testrail_get_case",
-    "integration": "testrail",
-    "description": "Get a TestRail test case by ID. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML \u2014 raw HTML pasted from Google Docs/browsers can be 20-30x larger than necessary due to inline CSS styling on every tag.",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "case_id": {
-          "type": "string",
-          "description": "The test case ID (numeric, without 'C' prefix)",
-          "example": "123"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown \u2014 much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
-          "example": "markdown"
-        }
-      },
-      "required": ["case_id"]
-    }
-  },
-  {
-    "name": "testrail_get_all_cases",
-    "integration": "testrail",
-    "description": "Get ALL test cases in a project (uses pagination to retrieve all cases). Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project_name": {
-          "type": "string",
-          "description": "Project name to get all cases from",
-          "example": "My Project"
-        },
-        "format": {
-          "type": "string",
-          "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown \u2014 much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
-          "example": "markdown"
-        }
-      },
-      "required": ["project_name"]
-    }
-  },
-  {
-    "name": "testrail_search_cases",
-    "integration": "testrail",
-    "description": "Search TestRail test cases by project and optional filters. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown \u2014 much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
-          "example": "markdown"
-        },
-        "project_name": {
-          "type": "string",
-          "description": "Project name to search in",
-          "example": "My Project"
-        },
-        "section_id": {
-          "type": "string",
-          "description": "Section ID to filter by (optional)",
-          "example": "10"
-        },
-        "suite_id": {
-          "type": "string",
-          "description": "Suite ID to filter by (optional)",
-          "example": "1"
-        }
-      },
-      "required": ["project_name"]
-    }
-  },
-  {
-    "name": "testrail_get_cases_by_refs",
-    "integration": "testrail",
-    "description": "Get test cases linked to a requirement/story via refs field",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project_name": {
-          "type": "string",
-          "description": "Project name to search in",
-          "example": "My Project"
-        },
-        "refs": {
-          "type": "string",
-          "description": "Reference ID (e.g., JIRA ticket key)",
-          "example": "PROJ-123"
-        }
-      },
-      "required": [
-        "refs",
-        "project_name"
-      ]
-    }
-  },
-  {
-    "name": "testrail_create_case",
-    "integration": "testrail",
-    "description": "Create a new test case in TestRail",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "Test case description/steps (optional)",
-          "example": "1. Navigate to login page\n2. Enter credentials\n3. Click login"
-        },
-        "priority_id": {
-          "type": "string",
-          "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
-          "example": "3"
-        },
-        "project_name": {
-          "type": "string",
-          "description": "Project name",
-          "example": "My Project"
-        },
-        "title": {
-          "type": "string",
-          "description": "Test case title/summary",
-          "example": "Verify login functionality"
-        },
-        "refs": {
-          "type": "string",
-          "description": "Reference to requirement (e.g., JIRA key)",
-          "example": "PROJ-123"
-        }
-      },
-      "required": [
-        "project_name",
-        "title"
-      ]
-    }
-  },
-  {
-    "name": "testrail_create_case_detailed",
-    "integration": "testrail",
-    "description": "Create a new test case in TestRail with detailed fields (preconditions, steps, expected results, labels, type). Note: TestRail uses its own table format in text fields: |||:Col 1|:Col 2|:Col 3\\n||val1|val2|val3. Standard Markdown tables (| Col | Col |) will be auto-converted to TestRail format.",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "priority_id": {
-          "type": "string",
-          "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
-          "example": "3"
-        },
-        "refs": {
-          "type": "string",
-          "description": "Reference to requirement (e.g., JIRA key)",
-          "example": "PROJ-123"
-        },
-        "preconditions": {
-          "type": "string",
-          "description": "Preconditions (optional). For tables use TestRail format: |||:Col1|:Col2\\n||val1|val2",
-          "example": "User is logged out"
-        },
-        "type_id": {
-          "type": "string",
-          "description": "Case type ID (optional). Use testrail_get_case_types to get available types.",
-          "example": "1"
-        },
-        "label_ids": {
-          "type": "string",
-          "description": "Comma-separated label IDs (optional). Use testrail_get_labels to find IDs.",
-          "example": "7,8"
-        },
-        "expected": {
-          "type": "string",
-          "description": "Expected results (optional)",
-          "example": "User is logged in and redirected to dashboard"
-        },
-        "project_name": {
-          "type": "string",
-          "description": "Project name",
-          "example": "My Project"
-        },
-        "title": {
-          "type": "string",
-          "description": "Test case title/summary",
-          "example": "Verify login functionality"
-        },
-        "steps": {
-          "type": "string",
-          "description": "Test steps separated by double newline (optional)",
-          "example": "Navigate to login page.\\n\\nEnter username %Username%.\\n\\nClick Login button."
-        }
-      },
-      "required": [
-        "project_name",
-        "title"
-      ]
-    }
-  },
-  {
-    "name": "testrail_create_case_steps",
-    "integration": "testrail",
-    "description": "Create a TestRail test case using the 'Test Case (Steps)' template (template_id=2). Steps are provided as a JSON array: [{\"content\":\"step text\",\"expected\":\"expected result\"}, ...]. Markdown tables in step content or expected are auto-converted to HTML tables. Use testrail_get_case_types for type_id, testrail_get_labels for label_ids.",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "priority_id": {
-          "type": "string",
-          "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
-          "example": "3"
-        },
-        "refs": {
-          "type": "string",
-          "description": "Reference to requirement (e.g., JIRA key)",
-          "example": "PROJ-123"
-        },
-        "preconditions": {
-          "type": "string",
-          "description": "Preconditions text (optional)",
-          "example": "User is logged out"
-        },
-        "type_id": {
-          "type": "string",
-          "description": "Case type ID (optional). Use testrail_get_case_types to get available types.",
-          "example": "1"
-        },
-        "label_ids": {
-          "type": "string",
-          "description": "Comma-separated label IDs (optional). Use testrail_get_labels to find IDs.",
-          "example": "7,8"
-        },
-        "steps_json": {
-          "type": "string",
-          "description": "JSON array of step objects: [{\"content\":\"step\",\"expected\":\"result\"}, ...]. Markdown tables are auto-converted to HTML.",
-          "example": "[{\"content\":\"Open login page\",\"expected\":\"Login form is displayed\"},{\"content\":\"Enter credentials\",\"expected\":\"Fields populated\"}]"
-        },
-        "project_name": {
-          "type": "string",
-          "description": "Project name",
-          "example": "My Project"
-        },
-        "title": {
-          "type": "string",
-          "description": "Test case title/summary",
-          "example": "Verify login functionality"
-        }
-      },
-      "required": [
-        "project_name",
-        "title",
-        "steps_json"
-      ]
-    }
-  },
-  {
-    "name": "testrail_update_case",
-    "integration": "testrail",
-    "description": "Update a test case in TestRail",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "case_id": {
-          "type": "string",
-          "description": "The test case ID to update",
-          "example": "123"
-        },
-        "priority_id": {
-          "type": "string",
-          "description": "New priority ID (optional)",
-          "example": "3"
-        },
-        "title": {
-          "type": "string",
-          "description": "New title (optional)",
-          "example": "Updated title"
-        },
-        "refs": {
-          "type": "string",
-          "description": "New references (optional)",
-          "example": "PROJ-123"
-        }
-      },
-      "required": ["case_id"]
-    }
-  },
-  {
-    "name": "testrail_delete_case",
-    "integration": "testrail",
-    "description": "Delete a test case in TestRail by case ID",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"case_id": {
-        "type": "string",
-        "description": "The numeric test case ID to delete (without the C prefix)",
-        "example": "123"
-      }},
-      "required": ["case_id"]
-    }
-  },
-  {
-    "name": "testrail_link_to_requirement",
-    "integration": "testrail",
-    "description": "Link a test case to a requirement by updating refs field",
-    "category": "test_cases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "case_id": {
-          "type": "string",
-          "description": "The test case ID",
-          "example": "123"
-        },
-        "requirement_key": {
-          "type": "string",
-          "description": "Requirement key (e.g., JIRA ticket)",
-          "example": "PROJ-123"
-        }
-      },
-      "required": [
-        "case_id",
-        "requirement_key"
-      ]
-    }
-  },
-  {
-    "name": "testrail_get_labels",
-    "integration": "testrail",
-    "description": "Get all labels for a project in TestRail",
-    "category": "labels",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project_name": {
-        "type": "string",
-        "description": "Project name",
-        "example": "My Project"
-      }},
-      "required": ["project_name"]
-    }
-  },
-  {
-    "name": "testrail_get_label",
-    "integration": "testrail",
-    "description": "Get a single label by ID",
-    "category": "labels",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"label_id": {
-        "type": "string",
-        "description": "The label ID",
-        "example": "7"
-      }},
-      "required": ["label_id"]
-    }
-  },
-  {
-    "name": "testrail_update_label",
-    "integration": "testrail",
-    "description": "Update a label title in TestRail. Maximum 20 characters allowed.",
-    "category": "labels",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project_name": {
-          "type": "string",
-          "description": "Project name",
-          "example": "My Project"
-        },
-        "title": {
-          "type": "string",
-          "description": "New label title (max 20 characters)",
-          "example": "Release 2.0"
-        },
-        "label_id": {
-          "type": "string",
-          "description": "The label ID to update",
-          "example": "7"
-        }
-      },
-      "required": [
-        "label_id",
-        "project_name",
-        "title"
-      ]
-    }
-  },
-  {
-    "name": "testrail_get_case_types",
-    "integration": "testrail",
-    "description": "Get all available case types in TestRail (e.g., Automated, Functionality, Other)",
-    "category": "case_types",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "kb_get",
-    "integration": "kb",
-    "description": "Get last sync date for a knowledge base source. Returns ISO 8601 date string or 'Source not found' message.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "output_path": {
-          "type": "string",
-          "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
-          "example": "/path/to/knowledge-base"
-        },
-        "source_name": {
-          "type": "string",
-          "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
-          "example": "teams_chat"
-        }
-      },
-      "required": ["source_name"]
-    }
-  },
-  {
-    "name": "kb_build",
-    "integration": "kb",
-    "description": "Build or update knowledge base from input file. Processes chat messages, documentation, or any text data to create indexed, searchable knowledge base. Returns JSON with statistics.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "input_file": {
-          "type": "string",
-          "description": "Path to input file (JSON or text format). Can be JSON array of messages or plain text.",
-          "example": "/path/to/messages.json"
-        },
-        "output_path": {
-          "type": "string",
-          "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
-          "example": "/path/to/knowledge-base"
-        },
-        "date_time": {
-          "type": "string",
-          "description": "Sync date/time in ISO 8601 format (e.g., '2024-10-10T12:00:00Z')",
-          "example": "2024-10-10T12:00:00Z"
-        },
-        "source_name": {
-          "type": "string",
-          "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
-          "example": "teams_chat"
-        },
-        "clean_source": {
-          "type": "string",
-          "description": "Optional. If true, removes all existing Q/A/N from this source before processing. Use for content refresh (e.g., Confluence pages).",
-          "example": "true"
-        }
-      },
-      "required": [
-        "source_name",
-        "input_file",
-        "date_time"
-      ]
-    }
-  },
-  {
-    "name": "kb_process",
-    "integration": "kb",
-    "description": "Process input file and build KB structure WITHOUT generating AI descriptions (fast mode). Use this for bulk data processing. Run kb_aggregate later to generate descriptions.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "input_file": {
-          "type": "string",
-          "description": "Path to input file (JSON or text format). Can be JSON array of messages or plain text.",
-          "example": "/path/to/messages.json"
-        },
-        "output_path": {
-          "type": "string",
-          "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
-          "example": "/path/to/knowledge-base"
-        },
-        "date_time": {
-          "type": "string",
-          "description": "Sync date/time in ISO 8601 format (e.g., '2024-10-10T12:00:00Z')",
-          "example": "2024-10-10T12:00:00Z"
-        },
-        "source_name": {
-          "type": "string",
-          "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
-          "example": "teams_chat"
-        },
-        "clean_source": {
-          "type": "string",
-          "description": "Optional. If true, removes all existing Q/A/N from this source before processing. Use for content refresh (e.g., Confluence pages).",
-          "example": "true"
-        }
-      },
-      "required": [
-        "source_name",
-        "input_file",
-        "date_time"
-      ]
-    }
-  },
-  {
-    "name": "kb_aggregate",
-    "integration": "kb",
-    "description": "Generate AI descriptions for existing KB structure WITHOUT processing new data. Use this after kb_process to add AI-generated descriptions for people and topics.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "smart_mode": {
-          "type": "string",
-          "description": "Only regenerate descriptions if Q/A/N files have changed. Default: true",
-          "example": "true"
-        },
-        "output_path": {
-          "type": "string",
-          "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
-          "example": "/path/to/knowledge-base"
-        },
-        "source_name": {
-          "type": "string",
-          "description": "Optional: Filter to only regenerate for specific source. If null/empty, regenerates for ALL sources (recommended for description regeneration).",
-          "example": "teams_chat"
-        }
-      },
-      "required": []
-    }
-  },
-  {
-    "name": "kb_process_inbox",
-    "integration": "kb",
-    "description": "Scan inbox/raw/ folders and process all unprocessed files automatically. Files are processed in place. Returns JSON with processed and skipped file details.",
-    "category": "",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "generate_descriptions": {
-          "type": "string",
-          "description": "Generate AI descriptions after processing. Default: true",
-          "example": "true"
-        },
-        "output_path": {
-          "type": "string",
-          "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
-          "example": "/path/to/knowledge-base"
-        },
-        "smart_aggregation": {
-          "type": "string",
-          "description": "Only regenerate descriptions if Q/A/N changed. Default: true",
-          "example": "true"
-        }
-      },
-      "required": []
-    }
-  },
-  {
-    "name": "teams_auth_start",
-    "integration": "teams_auth",
-    "description": "Start device code authentication for Microsoft Teams. Returns URL and code for user to authenticate.",
-    "category": "authentication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_auth_complete",
-    "integration": "teams_auth",
-    "description": "Complete device code authentication after user approval. Polls for tokens and saves refresh token.",
-    "category": "authentication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "teams_auth_status",
-    "integration": "teams_auth",
-    "description": "Check current Microsoft Teams authentication status and configuration.",
-    "category": "authentication",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "gitlab_test",
-    "integration": "gitlab",
-    "description": "Test GitLab connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "gitlab_get_mr_comments",
-    "integration": "gitlab",
-    "description": "Get all comments for a GitLab merge request, including both inline code review comments (DiffNote) and general discussion notes. Excludes system-generated notes.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_add_mr_label",
-    "integration": "gitlab",
-    "description": "Add a label to a GitLab merge request.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "label": {
-          "type": "string",
-          "description": "Label to add",
-          "example": "pr_approved"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_remove_mr_label",
-    "integration": "gitlab",
-    "description": "Remove a label from a GitLab merge request.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "label": {
-          "type": "string",
-          "description": "Label to remove",
-          "example": "pr_approved"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_mr_activities",
-    "integration": "gitlab",
-    "description": "Get all activities for a GitLab merge request. Approvals are fetched from the real GitLab Approvals API. General discussion notes are also included.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_add_mr_comment",
-    "integration": "gitlab",
-    "description": "Add a general discussion comment to a GitLab merge request.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "text": {
-          "type": "string",
-          "description": "Comment text",
-          "example": "LGTM!"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_mr_diff",
-    "integration": "gitlab",
-    "description": "Get diff stats and changed files for a GitLab merge request.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_mr_diff_text",
-    "integration": "gitlab",
-    "description": "Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments).",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_mr",
-    "integration": "gitlab",
-    "description": "Get details of a specific GitLab merge request including title, description, state, author, diff_refs (base_sha, head_sha, start_sha needed for inline comments).",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_list_mrs",
-    "integration": "gitlab",
-    "description": "List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "state": {
-          "type": "string",
-          "description": "MR state: opened, closed, merged, all. 'open' is also accepted as a synonym for 'opened'.",
-          "example": "opened"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "state"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_create_mr",
-    "integration": "gitlab",
-    "description": "Create a GitLab merge request from a source branch into a target branch.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "removeSourceBranch": {
-          "type": "string",
-          "description": "Remove source branch after merge",
-          "example": "true"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "targetBranch": {
-          "type": "string",
-          "description": "Target branch name",
-          "example": "main"
-        },
-        "sourceBranch": {
-          "type": "string",
-          "description": "Source branch name",
-          "example": "feature/PROJ-123"
-        },
-        "description": {
-          "type": "string",
-          "description": "Merge request description",
-          "example": "Automated changes"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "title": {
-          "type": "string",
-          "description": "Merge request title",
-          "example": "PROJ-123 Implement feature"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "sourceBranch",
-        "targetBranch",
-        "title"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_mr_discussions",
-    "integration": "gitlab",
-    "description": "Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_reply_to_mr_thread",
-    "integration": "gitlab",
-    "description": "Reply to an existing discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "text": {
-          "type": "string",
-          "description": "Reply text",
-          "example": "Addressed in latest commit"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "discussionId": {
-          "type": "string",
-          "description": "Discussion thread ID",
-          "example": "6a9c1750b37d57bba1079be3bbd13a..."
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "discussionId",
-        "text"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_add_inline_mr_comment",
-    "integration": "gitlab",
-    "description": "Create a new inline code review comment on a specific file and line in a GitLab merge request. Requires base_sha, head_sha, start_sha from the MR diff refs (use gitlab_get_mr to get them from diff_refs).",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "line": {
-          "type": "string",
-          "description": "Line number in the new file to comment on",
-          "example": "42"
-        },
-        "startSha": {
-          "type": "string",
-          "description": "Start commit SHA from MR diff_refs",
-          "example": "abc123"
-        },
-        "filePath": {
-          "type": "string",
-          "description": "Path to the file to comment on",
-          "example": "src/main/Foo.java"
-        },
-        "baseSha": {
-          "type": "string",
-          "description": "Base commit SHA from MR diff_refs",
-          "example": "abc123"
-        },
-        "text": {
-          "type": "string",
-          "description": "Comment text",
-          "example": "This looks wrong"
-        },
-        "headSha": {
-          "type": "string",
-          "description": "Head commit SHA from MR diff_refs",
-          "example": "def456"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "filePath",
-        "line",
-        "text",
-        "baseSha",
-        "headSha",
-        "startSha"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_resolve_mr_thread",
-    "integration": "gitlab",
-    "description": "Resolve (close) a review discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "discussionId": {
-          "type": "string",
-          "description": "Discussion thread ID to resolve",
-          "example": "6a9c1750b37d57bba1079be3bbd13a..."
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId",
-        "discussionId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_approve_mr",
-    "integration": "gitlab",
-    "description": "Approve a GitLab merge request. Adds your approval to the MR.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_merge_mr",
-    "integration": "gitlab",
-    "description": "Merge a GitLab merge request. Optionally provide a custom merge commit message.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "mergeCommitMessage": {
-          "type": "string",
-          "description": "Optional custom merge commit message",
-          "example": "Merge feature branch"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_rebase_mr",
-    "integration": "gitlab",
-    "description": "Ask GitLab to rebase/update a merge request source branch with its target branch.",
-    "category": "merge_requests",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "pullRequestId": {
-          "type": "string",
-          "description": "Merge request IID",
-          "example": "42"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pullRequestId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_list_project_jobs",
-    "integration": "gitlab",
-    "description": "List recent GitLab CI jobs for a project.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_cancel_job",
-    "integration": "gitlab",
-    "description": "Cancel a GitLab CI job.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "jobId": {
-          "type": "string",
-          "description": "GitLab job ID",
-          "example": "123456"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "jobId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_list_pipeline_runs",
-    "integration": "gitlab",
-    "description": "List recent GitLab CI pipelines. Optionally filter by status, ref, and limit.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "limit": {
-          "type": "string",
-          "description": "Maximum number of pipelines to return",
-          "example": "50"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "ref": {
-          "type": "string",
-          "description": "Branch or tag ref",
-          "example": "main"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "status": {
-          "type": "string",
-          "description": "Pipeline status filter",
-          "example": "failed"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_trigger_pipeline",
-    "integration": "gitlab",
-    "description": "Trigger a GitLab CI pipeline for a branch or tag using the authenticated API token.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "variablesJson": {
-          "type": "string",
-          "description": "Optional JSON object of CI variables",
-          "example": "{\"CONFIG_FILE\":\"agents/story_development.json\"}"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "ref": {
-          "type": "string",
-          "description": "Branch or tag ref",
-          "example": "main"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "ref"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_pipeline_jobs",
-    "integration": "gitlab",
-    "description": "List jobs for a GitLab CI pipeline.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "pipelineId": {
-          "type": "string",
-          "description": "GitLab pipeline ID",
-          "example": "123456"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "pipelineId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_commit_statuses",
-    "integration": "gitlab",
-    "description": "Get CI/CD statuses for a commit SHA in a GitLab project. Returns one entry per status report (e.g. posted by an external CI like Jenkins via the gitlabBuilds plugin, or GitLab's own pipeline). Equivalent of GitHub's 'check runs' for GitLab. When the same status name was reported more than once for this commit (e.g. a CI job was retried), only the most recent report per name is returned.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "commitSha": {
-          "type": "string",
-          "description": "The commit SHA to get statuses for",
-          "example": "abc123..."
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "commitSha"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_job_logs",
-    "integration": "gitlab",
-    "description": "Get GitLab CI job trace logs.",
-    "category": "ci",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "jobId": {
-          "type": "string",
-          "description": "GitLab job ID",
-          "example": "123456"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "jobId"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_get_or_create_release",
-    "integration": "gitlab",
-    "description": "Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The Git tag name for the release. Reused to find an existing release.",
-          "example": "pr-attachments-storage"
-        },
-        "targetCommitish": {
-          "type": "string",
-          "description": "Optional branch or commit SHA the release's tag should point to when created (GitLab 'ref'). Required if the tag does not already exist.",
-          "example": "main"
-        },
-        "body": {
-          "type": "string",
-          "description": "Optional Markdown release notes/description.",
-          "example": "Internal storage release for PR attachments."
-        },
-        "releaseName": {
-          "type": "string",
-          "description": "The human-readable release name. If empty, tagName is used.",
-          "example": "PR Attachments Storage"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_upload_release_asset",
-    "integration": "gitlab",
-    "description": "Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise).",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "filePath": {
-          "type": "string",
-          "description": "Absolute or relative path to the local file to upload.",
-          "example": "/tmp/preview.png"
-        },
-        "assetName": {
-          "type": "string",
-          "description": "Optional asset filename shown in GitLab. Defaults to the local filename.",
-          "example": "clip_123.png"
-        },
-        "packageName": {
-          "type": "string",
-          "description": "Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.",
-          "example": "release-assets"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The tag name of the release returned by gitlab_get_or_create_release.",
-          "example": "pr-attachments-storage"
-        },
-        "contentType": {
-          "type": "string",
-          "description": "Optional MIME type. Defaults to detected type or application/octet-stream.",
-          "example": "image/png"
-        },
-        "overwrite": {
-          "type": "string",
-          "description": "If true, delete any existing asset (release link + underlying generic package file) with the same name before uploading. Defaults to false.",
-          "example": "true"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName",
-        "filePath"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_list_release_assets",
-    "integration": "gitlab",
-    "description": "List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The tag name of the release.",
-          "example": "pr-attachments-storage"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_delete_release_asset",
-    "integration": "gitlab",
-    "description": "Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "assetName": {
-          "type": "string",
-          "description": "The name of the asset to delete, as returned by gitlab_list_release_assets.",
-          "example": "clip_123.png"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "packageName": {
-          "type": "string",
-          "description": "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.",
-          "example": "release-assets"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The tag name of the release.",
-          "example": "pr-attachments-storage"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName",
-        "assetName"
-      ]
-    }
-  },
-  {
-    "name": "gitlab_download_release_asset",
-    "integration": "gitlab",
-    "description": "Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path.",
-    "category": "releases",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "assetName": {
-          "type": "string",
-          "description": "The name of the asset to download, as returned by gitlab_list_release_assets.",
-          "example": "clip_123.png"
-        },
-        "workspace": {
-          "type": "string",
-          "description": "GitLab group or namespace",
-          "example": "mygroup"
-        },
-        "targetFilePath": {
-          "type": "string",
-          "description": "Local file path where the downloaded asset should be saved.",
-          "example": "/tmp/downloaded_clip_123.png"
-        },
-        "packageName": {
-          "type": "string",
-          "description": "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.",
-          "example": "release-assets"
-        },
-        "repository": {
-          "type": "string",
-          "description": "Repository name",
-          "example": "myrepo"
-        },
-        "tagName": {
-          "type": "string",
-          "description": "The tag name of the release.",
-          "example": "pr-attachments-storage"
-        }
-      },
-      "required": [
-        "workspace",
-        "repository",
-        "tagName",
-        "assetName",
-        "targetFilePath"
-      ]
-    }
-  },
-  {
-    "name": "jira_delete_ticket",
-    "integration": "jira",
-    "description": "Delete a Jira ticket by key",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"key": {
-        "type": "string",
-        "description": "The Jira ticket key to delete",
-        "example": "PRJ-123"
-      }},
-      "required": ["key"]
-    }
-  },
-  {
-    "name": "jira_get_account_by_email",
-    "integration": "jira",
-    "description": "Gets account details by email",
-    "category": "information",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"email": {
-        "type": "string",
-        "description": "The Jira Email",
-        "example": "email@email.com"
-      }},
-      "required": ["email"]
-    }
-  },
-  {
-    "name": "jira_assign_ticket_to",
-    "integration": "jira",
-    "description": "Assigns a Jira ticket to user",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "accountId": {
-          "type": "string",
-          "description": "The Jira account ID to assign to. If you know email use first jira_get_account_by_email tools to get account ID",
-          "example": "123457:2a123456-40e8-49d6-8ddc-6852e518451f"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to assign",
-          "example": "PRJ-123"
-        }
-      },
-      "required": [
-        "key",
-        "accountId"
-      ]
-    }
-  },
-  {
-    "name": "jira_add_label",
-    "integration": "jira",
-    "description": "Adding label to specific ticket key",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to assign",
-          "example": "PRJ-123"
-        },
-        "label": {
-          "type": "string",
-          "description": "The label to be added to ticket",
-          "example": "custom_label"
-        }
-      },
-      "required": [
-        "key",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "jira_remove_label",
-    "integration": "jira",
-    "description": "Remove a label from a specific Jira ticket. Fetches current labels and removes the specified one.",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to remove label from",
-          "example": "PRJ-123"
-        },
-        "label": {
-          "type": "string",
-          "description": "The label to be removed from the ticket",
-          "example": "custom_label"
-        }
-      },
-      "required": [
-        "key",
-        "label"
-      ]
-    }
-  },
-  {
-    "name": "jira_search_by_jql",
-    "integration": "jira",
-    "description": "Search for Jira tickets using JQL and returns all results",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "jql": {
-          "type": "string",
-          "description": "JQL query string to search tickets",
-          "example": "project = DEMO AND status = Open"
-        },
-        "fields": {
-          "type": "array",
-          "description": "Optional array of field names to include in response. When omitted, the project's extended default fields are used.",
-          "example": "[\"summary\", \"status\", \"assignee\"]"
-        }
-      },
-      "required": ["jql"]
-    }
-  },
-  {
-    "name": "jira_search_with_pagination",
-    "integration": "jira",
-    "description": "[Deprecated] Search for Jira tickets using JQL with pagination support",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "jql": {
-          "type": "string",
-          "description": "JQL query string to search for tickets",
-          "example": "project = PROJ AND status = Open"
-        },
-        "fields": {
-          "type": "array",
-          "description": "Array of field names to include in the response",
-          "example": "['summary', 'status', 'assignee']"
-        },
-        "startAt": {
-          "type": "number",
-          "description": "Starting index for pagination (0-based)",
-          "example": "0"
-        }
-      },
-      "required": [
-        "jql",
-        "startAt",
-        "fields"
-      ]
-    }
-  },
-  {
-    "name": "jira_search_by_page",
-    "integration": "jira",
-    "description": "Search for Jira tickets using JQL with paging support",
-    "category": "search",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "jql": {
-          "type": "string",
-          "description": "JQL query string to search for tickets",
-          "example": "project = PROJ AND status = Open"
-        },
-        "fields": {
-          "type": "array",
-          "description": "Array of field names to include in the response",
-          "example": "['summary', 'status', 'assignee']"
-        },
-        "nextPageToken": {
-          "type": "string",
-          "description": "Next Page Token from previous response, empty by default for 1 page",
-          "example": "AasvvasasaSASdada"
-        }
-      },
-      "required": [
-        "jql",
-        "nextPageToken",
-        "fields"
-      ]
-    }
-  },
-  {
-    "name": "jira_test",
-    "integration": "jira",
-    "description": "Test Jira connectivity by fetching the current user's profile",
-    "category": "system",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "jira_get_my_profile",
-    "integration": "jira",
-    "description": "Get the current user's profile information from Jira",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "jira_get_user_profile",
-    "integration": "jira",
-    "description": "Get a specific user's profile information from Jira",
-    "category": "user_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"userId": {
-        "type": "string",
-        "description": "The user ID to get profile for"
-      }},
-      "required": ["userId"]
-    }
-  },
-  {
-    "name": "jira_get_ticket",
-    "integration": "jira",
-    "description": "Get a specific Jira ticket by key with optional field filtering",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fields": {
-          "type": "array",
-          "description": "Optional array of fields to include in the response. When omitted, the project's extended default fields are used."
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to retrieve"
-        }
-      },
-      "required": ["key"]
-    }
-  },
-  {
-    "name": "jira_get_subtasks",
-    "integration": "jira",
-    "description": "Get all subtasks of a specific Jira ticket using jql: parent = PRJ-123 and issueType in (subtask, sub-task, 'sub task')",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"key": {
-        "type": "string",
-        "description": "The parent ticket key to get subtasks for"
-      }},
-      "required": ["key"]
-    }
-  },
-  {
-    "name": "jira_post_comment_if_not_exists",
-    "integration": "jira",
-    "description": "Post a comment to a Jira ticket only if it doesn't already exist. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
-    "category": "comment_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to post comment to"
-        },
-        "comment": {
-          "type": "string",
-          "description": "The comment text to post (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
-        }
-      },
-      "required": [
-        "key",
-        "comment"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_comments",
-    "integration": "jira",
-    "description": "Get all comments for a specific Jira ticket",
-    "category": "comment_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "ticket": {
-          "type": "object",
-          "description": "Optional ticket object for cache validation"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to get comments for"
-        }
-      },
-      "required": ["key"]
-    }
-  },
-  {
-    "name": "jira_post_comment",
-    "integration": "jira",
-    "description": "Post a comment to a Jira ticket. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
-    "category": "comment_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to post comment to"
-        },
-        "comment": {
-          "type": "string",
-          "description": "The comment text to post (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
-        }
-      },
-      "required": [
-        "key",
-        "comment"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_fix_versions",
-    "integration": "jira",
-    "description": "Get all fix versions for a specific Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project": {
-        "type": "string",
-        "description": "The Jira project key to get fix versions for"
-      }},
-      "required": ["project"]
-    }
-  },
-  {
-    "name": "jira_get_components",
-    "integration": "jira",
-    "description": "Get all components for a specific Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project": {
-        "type": "string",
-        "description": "The Jira project key to get components for"
-      }},
-      "required": ["project"]
-    }
-  },
-  {
-    "name": "jira_get_project_statuses",
-    "integration": "jira",
-    "description": "Get all statuses for a specific Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project": {
-        "type": "string",
-        "description": "The Jira project key to get statuses for"
-      }},
-      "required": ["project"]
-    }
-  },
-  {
-    "name": "jira_create_ticket_with_parent",
-    "integration": "jira",
-    "description": "Create a new Jira ticket with a parent relationship",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "issueType": {
-          "type": "string",
-          "description": "The type of issue to create (e.g., Bug, Story, Task)"
-        },
-        "summary": {
-          "type": "string",
-          "description": "The ticket summary/title"
-        },
-        "project": {
-          "type": "string",
-          "description": "The Jira project key to create the ticket in"
-        },
-        "description": {
-          "type": "string",
-          "description": "The ticket description"
-        },
-        "parentKey": {
-          "type": "string",
-          "description": "The key of the parent ticket"
-        }
-      },
-      "required": [
-        "project",
-        "issueType",
-        "summary",
-        "description",
-        "parentKey"
-      ]
-    }
-  },
-  {
-    "name": "jira_create_ticket_basic",
-    "integration": "jira",
-    "description": "Create a new Jira ticket with basic fields (project, issue type, summary, description)",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "issueType": {
-          "type": "string",
-          "description": "The type of issue to create (e.g., Bug, Story, Task)"
-        },
-        "summary": {
-          "type": "string",
-          "description": "The ticket summary/title (e.g., Fix login issue)"
-        },
-        "project": {
-          "type": "string",
-          "description": "The Jira project key to create the ticket in (e.g., PROJ)"
-        },
-        "description": {
-          "type": "string",
-          "description": "The ticket description. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists"
-        }
-      },
-      "required": [
-        "project",
-        "issueType",
-        "summary",
-        "description"
-      ]
-    }
-  },
-  {
-    "name": "jira_create_ticket_with_json",
-    "integration": "jira",
-    "description": "Create a new Jira ticket with custom fields using JSON configuration",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project": {
-          "type": "string",
-          "description": "The Jira project key to create the ticket in (e.g., PROJ)"
-        },
-        "fieldsJson": {
-          "type": "object",
-          "description": "JSON object containing ticket fields in Jira format (e.g., {\"summary\": \"Ticket Summary\", \"description\": \"Ticket Description\", \"issuetype\": {\"name\": \"Task\"}, \"priority\": {\"name\": \"High\"}}), Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists"
-        }
-      },
-      "required": [
-        "project",
-        "fieldsJson"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_description",
-    "integration": "jira",
-    "description": "Update the description of a Jira ticket. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "description": {
-          "type": "string",
-          "description": "The new description text (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        }
-      },
-      "required": [
-        "key",
-        "description"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_ticket_parent",
-    "integration": "jira",
-    "description": "Update the parent of a Jira ticket. Can be used for setting up epic relationships and parent-child relationships for subtasks",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        },
-        "parentKey": {
-          "type": "string",
-          "description": "The key of the new parent ticket"
-        }
-      },
-      "required": [
-        "key",
-        "parentKey"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_ticket",
-    "integration": "jira",
-    "description": "Update a Jira ticket using JSON parameters following the standard Jira REST API format",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "params": {
-          "type": "object",
-          "description": "JSON object containing update parameters in Jira format (e.g., {\"fields\": {\"summary\": \"New Summary\", \"parent\": {\"key\": \"PROJ-123\"}}})"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        }
-      },
-      "required": [
-        "key",
-        "params"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_field",
-    "integration": "jira",
-    "description": "Update field(s) in a Jira ticket. When using field names (e.g., 'Dependencies'), updates ALL fields with that name. When using custom field IDs (e.g., 'customfield_10091'), updates only that specific field.",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string",
-          "description": "The field to update. Use field name (e.g., 'Dependencies') to update ALL fields with that name, or custom field ID (e.g., 'customfield_10091') to update specific field"
-        },
-        "value": {
-          "type": "object",
-          "description": "The new value for the field(s)"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        }
-      },
-      "required": [
-        "key",
-        "field",
-        "value"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_field_as_adf",
-    "integration": "jira",
-    "description": "Update a rich-text field in a Jira ticket using Jira API v3 and Atlassian Document Format (ADF). The value can be a plain string (wrapped into a paragraph) or a JSON object/array representing an ADF document. Required for interactive task-list checkboxes in Jira Cloud.",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string",
-          "description": "The rich-text field to update, e.g. 'description' or 'comment'"
-        },
-        "value": {
-          "type": "object",
-          "description": "Plain text or ADF JSON. Plain text is wrapped into an ADF paragraph; JSON object is sent as-is; JSON array is used as the ADF content."
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        }
-      },
-      "required": [
-        "key",
-        "field",
-        "value"
-      ]
-    }
-  },
-  {
-    "name": "jira_update_all_fields_with_name",
-    "integration": "jira",
-    "description": "Update ALL fields with the same name in a Jira ticket. Useful when there are multiple custom fields with the same display name.",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "value": {
-          "type": "object",
-          "description": "The new value for the fields"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to update"
-        },
-        "fieldName": {
-          "type": "string",
-          "description": "The user-friendly field name (e.g., 'Dependencies')"
-        }
-      },
-      "required": [
-        "key",
-        "fieldName",
-        "value"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_all_fields_with_name",
-    "integration": "jira",
-    "description": "Get all custom field IDs that have the same display name in a Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project": {
-          "type": "string",
-          "description": "The Jira project key"
-        },
-        "fieldName": {
-          "type": "string",
-          "description": "The user-friendly field name"
-        }
-      },
-      "required": [
-        "project",
-        "fieldName"
-      ]
-    }
-  },
-  {
-    "name": "jira_execute_request",
-    "integration": "jira",
-    "description": "Execute a custom HTTP GET request to Jira API with auth. Can be used to perform any jira get requests which are required auth.",
-    "category": "api_operations",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"url": {
-        "type": "string",
-        "description": "The Jira API URL to execute"
-      }},
-      "required": ["url"]
-    }
-  },
-  {
-    "name": "jira_attach_file_to_ticket",
-    "integration": "jira",
-    "description": "Attach a file to a Jira ticket from a local file path. The file will only be attached if a file with the same name doesn't already exist",
-    "category": "file_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the file to attach",
-          "example": "document.pdf"
-        },
-        "ticketKey": {
-          "type": "string",
-          "description": "The Jira ticket key to attach the file to",
-          "example": "PRJ-123"
-        },
-        "contentType": {
-          "type": "string",
-          "description": "The content type of the file (e.g., 'application/pdf', 'image/png'). If not provided, defaults to 'image/*'",
-          "example": "application/pdf"
-        },
-        "filePath": {
-          "type": "string",
-          "description": "Absolute path to the file on disk",
-          "example": "/tmp/document.pdf"
-        }
-      },
-      "required": [
-        "ticketKey",
-        "name",
-        "filePath"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_transitions",
-    "integration": "jira",
-    "description": "Get all available transitions(statuses, workflows) for a Jira ticket",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"key": {
-        "type": "string",
-        "description": "The Jira ticket key to get transitions for"
-      }},
-      "required": ["key"]
-    }
-  },
-  {
-    "name": "jira_move_to_status",
-    "integration": "jira",
-    "description": "Move a Jira ticket to a specific status (workflow, transition)",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "statusName": {
-          "type": "string",
-          "description": "The target status name"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to move"
-        }
-      },
-      "required": [
-        "key",
-        "statusName"
-      ]
-    }
-  },
-  {
-    "name": "jira_move_to_status_with_resolution",
-    "integration": "jira",
-    "description": "Move a Jira ticket to a specific status (workflow, transition) with resolution",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "statusName": {
-          "type": "string",
-          "description": "The target status name"
-        },
-        "resolution": {
-          "type": "string",
-          "description": "The resolution to set"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to move"
-        }
-      },
-      "required": [
-        "key",
-        "statusName",
-        "resolution"
-      ]
-    }
-  },
-  {
-    "name": "jira_clear_field",
-    "integration": "jira",
-    "description": "Clear (delete value) a specific field value in a Jira ticket",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "field": {
-          "type": "string",
-          "description": "The field name to clear"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to clear field from"
-        }
-      },
-      "required": [
-        "key",
-        "field"
-      ]
-    }
-  },
-  {
-    "name": "jira_set_fix_version",
-    "integration": "jira",
-    "description": "Set the fix version for a Jira ticket",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fixVersion": {
-          "type": "string",
-          "description": "The fix version name to set"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to set fix version for"
-        }
-      },
-      "required": [
-        "key",
-        "fixVersion"
-      ]
-    }
-  },
-  {
-    "name": "jira_add_fix_version",
-    "integration": "jira",
-    "description": "Add a fix version to a Jira ticket (without removing existing ones)",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fixVersion": {
-          "type": "string",
-          "description": "The fix version name to add"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to add fix version to"
-        }
-      },
-      "required": [
-        "key",
-        "fixVersion"
-      ]
-    }
-  },
-  {
-    "name": "jira_set_priority",
-    "integration": "jira",
-    "description": "Set the priority for a Jira ticket",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "priority": {
-          "type": "string",
-          "description": "The priority name to set"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to set priority for"
-        }
-      },
-      "required": [
-        "key",
-        "priority"
-      ]
-    }
-  },
-  {
-    "name": "jira_remove_fix_version",
-    "integration": "jira",
-    "description": "Remove a fix version from a Jira ticket",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "fixVersion": {
-          "type": "string",
-          "description": "The fix version name to remove"
-        },
-        "key": {
-          "type": "string",
-          "description": "The Jira ticket key to remove fix version from"
-        }
-      },
-      "required": [
-        "key",
-        "fixVersion"
-      ]
-    }
-  },
-  {
-    "name": "jira_download_attachment",
-    "integration": "jira",
-    "description": "Download a Jira attachment by URL and save it as a file",
-    "category": "file_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"href": {
-        "type": "string",
-        "description": "The attachment URL to download"
-      }},
-      "required": ["href"]
-    }
-  },
-  {
-    "name": "jira_get_fields",
-    "integration": "jira",
-    "description": "Get all available fields for a Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project": {
-        "type": "string",
-        "description": "The Jira project key to get fields for"
-      }},
-      "required": ["project"]
-    }
-  },
-  {
-    "name": "jira_get_issue_types",
-    "integration": "jira",
-    "description": "Get all available issue types for a specific Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"project": {
-        "type": "string",
-        "description": "The Jira project key to get issue types for"
-      }},
-      "required": ["project"]
-    }
-  },
-  {
-    "name": "jira_get_field_custom_code",
-    "integration": "jira",
-    "description": "Get the custom field code for a human friendly field name in a Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "project": {
-          "type": "string",
-          "description": "The Jira project key"
-        },
-        "fieldName": {
-          "type": "string",
-          "description": "The human-readable field name"
-        }
-      },
-      "required": [
-        "project",
-        "fieldName"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_issue_link_types",
-    "integration": "jira",
-    "description": "Get all available issue link types/relationships in Jira",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {},
-      "required": []
-    }
-  },
-  {
-    "name": "jira_link_issues",
-    "integration": "jira",
-    "description": "Link two Jira issues with a specific relationship type",
-    "category": "ticket_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sourceKey": {
-          "type": "string",
-          "description": "The source issue key"
-        },
-        "relationship": {
-          "type": "string",
-          "description": "The relationship type name"
-        },
-        "anotherKey": {
-          "type": "string",
-          "description": "The target issue key"
-        }
-      },
-      "required": [
-        "sourceKey",
-        "anotherKey",
-        "relationship"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_project_details",
-    "integration": "jira",
-    "description": "Get full details of a Jira project including its numeric ID, key, name, style and issue types",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectKey": {
-        "type": "string",
-        "description": "The Jira project key, e.g. TP"
-      }},
-      "required": ["projectKey"]
-    }
-  },
-  {
-    "name": "jira_get_project_issue_type_scheme",
-    "integration": "jira",
-    "description": "Get the issue type scheme (or equivalent) assigned to a Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectKey": {
-        "type": "string",
-        "description": "The Jira project key, e.g. TP"
-      }},
-      "required": ["projectKey"]
-    }
-  },
-  {
-    "name": "jira_get_project_workflow_scheme",
-    "integration": "jira",
-    "description": "Get the workflow scheme (or equivalent) assigned to a Jira project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectKey": {
-        "type": "string",
-        "description": "The Jira project key, e.g. TP"
-      }},
-      "required": ["projectKey"]
-    }
-  },
-  {
-    "name": "jira_assign_issue_type_scheme",
-    "integration": "jira",
-    "description": "Assign an issue type scheme (by its numeric ID) to a classic Jira project (by its numeric project ID). Requires Jira admin.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "issueTypeSchemeId": {
-          "type": "string",
-          "description": "Numeric ID of the issue type scheme"
-        },
-        "projectId": {
-          "type": "string",
-          "description": "Numeric ID of the target Jira project"
-        }
-      },
-      "required": [
-        "issueTypeSchemeId",
-        "projectId"
-      ]
-    }
-  },
-  {
-    "name": "jira_assign_workflow_scheme",
-    "integration": "jira",
-    "description": "Assign a workflow scheme (by its numeric ID) to a classic Jira project (by its numeric project ID). Requires Jira admin.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "projectId": {
-          "type": "string",
-          "description": "Numeric ID of the target Jira project"
-        },
-        "workflowSchemeId": {
-          "type": "string",
-          "description": "Numeric ID of the workflow scheme"
-        }
-      },
-      "required": [
-        "workflowSchemeId",
-        "projectId"
-      ]
-    }
-  },
-  {
-    "name": "jira_create_project_issue_type",
-    "integration": "jira",
-    "description": "Create a project-scoped issue type in a next-gen Jira project. Use type 'subtask' for subtasks and 'standard' for all others. Skips if the name already exists. Requires Jira admin.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the issue type, e.g. Story"
-        },
-        "description": {
-          "type": "string",
-          "description": "Optional description"
-        },
-        "projectKey": {
-          "type": "string",
-          "description": "Key of the target Jira project, e.g. TP"
-        },
-        "type": {
-          "type": "string",
-          "description": "Issue type kind: 'standard' or 'subtask'. Defaults to 'standard'."
-        }
-      },
-      "required": [
-        "projectKey",
-        "name"
-      ]
-    }
-  },
-  {
-    "name": "jira_copy_project_structure",
-    "integration": "jira",
-    "description": "Copy issue types and workflow setup from a source Jira project to a target Jira project (e.g. MYTUBE → TP)",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sourceProjectKey": {
-          "type": "string",
-          "description": "Key of the source Jira project to copy structure from, e.g. MYTUBE"
-        },
-        "targetProjectKey": {
-          "type": "string",
-          "description": "Key of the target Jira project to apply structure to, e.g. TP"
-        }
-      },
-      "required": [
-        "sourceProjectKey",
-        "targetProjectKey"
-      ]
-    }
-  },
-  {
-    "name": "jira_delete_project",
-    "integration": "jira",
-    "description": "Delete a Jira project by moving it to trash. The project key remains reserved until permanently deleted from Jira Admin > System > Trash. Set confirmDelete to 'true' to proceed.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "projectKey": {
-          "type": "string",
-          "description": "Key of the Jira project to delete, e.g. TP"
-        },
-        "confirmDelete": {
-          "type": "string",
-          "description": "Must be 'true' to confirm deletion"
-        }
-      },
-      "required": [
-        "projectKey",
-        "confirmDelete"
-      ]
-    }
-  },
-  {
-    "name": "jira_restore_project",
-    "integration": "jira",
-    "description": "Restore a Jira project that was previously moved to trash using jira_delete_project",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectKey": {
-        "type": "string",
-        "description": "Key of the trashed Jira project to restore, e.g. TP"
-      }},
-      "required": ["projectKey"]
-    }
-  },
-  {
-    "name": "jira_clone_project",
-    "integration": "jira",
-    "description": "Create a brand-new team-managed (next-gen) Jira project that mirrors the source project. Default issue types are auto-created; custom types must be added manually. To reuse an existing key, permanently delete the old project from Jira Admin > System > Trash first.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sourceProjectKey": {
-          "type": "string",
-          "description": "Key of the source project to mirror, e.g. MYTUBE"
-        },
-        "newProjectKey": {
-          "type": "string",
-          "description": "Key for the new project, e.g. TP2"
-        },
-        "newProjectName": {
-          "type": "string",
-          "description": "Name for the new project. If empty, uses source project name"
-        }
-      },
-      "required": [
-        "sourceProjectKey",
-        "newProjectKey"
-      ]
-    }
-  },
-  {
-    "name": "jira_get_project_board_config",
-    "integration": "jira",
-    "description": "Read the board column configuration (workflow) of a Jira project \u2014 returns columns with status names and categories, useful for comparing or replicating project workflow",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {"projectKey": {
-        "type": "string",
-        "description": "Key of the Jira project, e.g. MYTUBE"
-      }},
-      "required": ["projectKey"]
-    }
-  },
-  {
-    "name": "jira_setup_project_workflow",
-    "integration": "jira",
-    "description": "Set up a project's workflow using an explicit list of statuses (no source project needed). Accepts a JSON array of {name, category} objects and applies them to the target project's workflow. Valid categories: TODO, IN_PROGRESS, DONE. Works with team-managed (next-gen) Jira projects.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "projectKey": {
-          "type": "string",
-          "description": "Key of the target Jira project, e.g. TP"
-        },
-        "statusDefinitions": {
-          "type": "string",
-          "description": "JSON array of status definitions, e.g. [{\"name\":\"Backlog\",\"category\":\"TODO\"},...]. Valid categories: TODO, IN_PROGRESS, DONE."
-        }
-      },
-      "required": [
-        "projectKey",
-        "statusDefinitions"
-      ]
-    }
-  },
-  {
-    "name": "jira_sync_project_workflow",
-    "integration": "jira",
-    "description": "Sync the workflow (statuses) of a target project to exactly match the source project using Jira's bulk workflow update API. Replaces the target workflow's statuses and transitions with those from the source project. Existing issues with removed statuses are automatically migrated to the closest matching new status. Works with team-managed (next-gen) Jira projects.",
-    "category": "project_management",
-    "inputSchema": {
-      "type": "object",
-      "properties": {
-        "sourceProjectKey": {
-          "type": "string",
-          "description": "Key of the source project to copy workflow from, e.g. MYTUBE"
-        },
-        "targetProjectKey": {
-          "type": "string",
-          "description": "Key of the target project to update workflow for, e.g. TP"
-        }
-      },
-      "required": [
-        "sourceProjectKey",
-        "targetProjectKey"
-      ]
-    }
-  }
-]}
+{
+  "tools": [
+    {
+      "name": "cli_execute_command",
+      "integration": "cli",
+      "description": "Execute CLI commands from JavaScript post-actions. Base whitelist: git, gh, dmtools, npm, yarn, docker, kubectl, terraform, ansible, aws, gcloud, az. Additional commands can be enabled via CLI_ALLOWED_COMMANDS env var (comma-separated) in dmtools.env or agent envVariables, e.g. CLI_ALLOWED_COMMANDS=find,ls,cat,pytest,python3,curl,bash,run-cursor-agent.sh. Returns command output as string.",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workingDirectory": {
+            "type": "string",
+            "description": "Working directory for command execution. Defaults to repository root if not specified. Use absolute path or path relative to current directory.",
+            "example": "/path/to/repo"
+          },
+          "command": {
+            "type": "string",
+            "description": "CLI command to execute. Must start with a whitelisted command. Extend the whitelist via CLI_ALLOWED_COMMANDS in dmtools.env.",
+            "example": "git commit -m 'Automated update'"
+          }
+        },
+        "required": [
+          "command"
+        ]
+      }
+    },
+    {
+      "name": "github_test",
+      "integration": "github",
+      "description": "Test GitHub connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "github_list_prs",
+      "integration": "github",
+      "description": "List pull requests in a GitHub repository by state. State can be 'open', 'closed', or 'merged'. Returns first page (up to 100) of pull requests.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of pull requests to list: 'open', 'closed', or 'merged'. 'opened' is accepted as a synonym for 'open'.",
+            "example": "open"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "state"
+        ]
+      }
+    },
+    {
+      "name": "github_list_prs_filtered",
+      "integration": "github",
+      "description": "List pull requests in a GitHub repository filtered by a regex pattern on the PR title. Fetches all PRs matching the given state and returns only those whose title matches the regex. Useful for large repos to narrow down results without loading entire history.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "titleRegex": {
+            "type": "string",
+            "description": "Java regular expression matched against the PR title (case-sensitive). Only PRs whose title contains a match are returned. Example: '^feat\\(.*\\)' or 'TICKET-\\d+'.",
+            "example": "^feat\\("
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of pull requests: 'open', 'closed', or 'merged'.",
+            "example": "merged"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "state",
+          "titleRegex"
+        ]
+      }
+    },
+    {
+      "name": "github_get_commits_from_branches",
+      "integration": "github",
+      "description": "Fetch commits from all branches whose name matches a given regex pattern, aggregated and de-duplicated. Useful for collecting commits from feature/*, release/* or similar groups of branches without specifying each branch individually.",
+      "category": "commits",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branchNameRegex": {
+            "type": "string",
+            "description": "Java regular expression matched against branch names. All branches with a matching name are included. Example: '^feature/' or 'release/\\d+'.",
+            "example": "^feature/"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "since": {
+            "type": "string",
+            "description": "Optional ISO date (yyyy-MM-dd) to limit commits to those after this date.",
+            "example": "2024-01-01"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "branchNameRegex"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr",
+      "integration": "github",
+      "description": "Get details of a GitHub pull request including title, description, status, author, branches, and merge info.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_repository_dispatch",
+      "integration": "github",
+      "description": "Trigger a GitHub repository dispatch event. Workflows listening to 'on: repository_dispatch' with the matching event_type will be triggered.",
+      "category": "actions",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "eventType": {
+            "type": "string",
+            "description": "The type of activity that triggers the workflow (event_type)",
+            "example": "rework"
+          },
+          "clientPayload": {
+            "type": "string",
+            "description": "Optional JSON string with payload passed to the workflow as client_payload",
+            "example": "{\"key\":\"value\"}"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "eventType"
+        ]
+      }
+    },
+    {
+      "name": "github_trigger_workflow",
+      "integration": "github",
+      "description": "Trigger a specific GitHub Actions workflow by filename (workflow dispatch). The workflow must have 'on: workflow_dispatch' configured.",
+      "category": "actions",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "ref": {
+            "type": "string",
+            "description": "The branch or tag to run the workflow on (default: main)",
+            "example": "main"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow filename or ID to trigger",
+            "example": "rework.yml"
+          },
+          "inputs": {
+            "type": "string",
+            "description": "JSON string with workflow inputs (e.g. {\"user_request\":\"...\",\"branch\":\"main\"})",
+            "example": "{\"user_request\":\"Please rework PROJ-123\"}"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "workflowId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_or_create_draft_release",
+      "integration": "github",
+      "description": "Find an existing draft release by tag or name, or create one if it does not exist. Useful for a stable PR attachment storage release.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The Git tag name for the release. Reused to find an existing draft release.",
+            "example": "pr-attachments-storage"
+          },
+          "targetCommitish": {
+            "type": "string",
+            "description": "Optional branch or commit SHA the release should point to when created.",
+            "example": "main"
+          },
+          "body": {
+            "type": "string",
+            "description": "Optional Markdown release notes/body.",
+            "example": "Internal storage release for PR attachments."
+          },
+          "releaseName": {
+            "type": "string",
+            "description": "The human-readable release name. If empty, tagName is used.",
+            "example": "PR Attachments Storage"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName"
+        ]
+      }
+    },
+    {
+      "name": "github_upload_release_asset",
+      "integration": "github",
+      "description": "Upload a local file as a GitHub release asset. Returns the uploaded asset metadata including browser_download_url. Set overwrite=true to automatically delete an existing asset with the same name before uploading.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "releaseId": {
+            "type": "string",
+            "description": "The numeric GitHub release ID returned by github_get_or_create_draft_release.",
+            "example": "323096697"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "Absolute or relative path to the local file to upload.",
+            "example": "/tmp/preview.png"
+          },
+          "assetName": {
+            "type": "string",
+            "description": "Optional asset filename shown in GitHub. Defaults to the local filename.",
+            "example": "clip_123.png"
+          },
+          "label": {
+            "type": "string",
+            "description": "Optional display label for the uploaded asset.",
+            "example": "Screenshot"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Optional MIME type. Defaults to detected type or application/octet-stream.",
+            "example": "image/png"
+          },
+          "overwrite": {
+            "type": "string",
+            "description": "If true, delete any existing asset with the same name before uploading. Defaults to false.",
+            "example": "true"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "releaseId",
+          "filePath"
+        ]
+      }
+    },
+    {
+      "name": "github_delete_release_asset",
+      "integration": "github",
+      "description": "Delete a GitHub release asset by its asset ID. Use github_list_release_assets to find asset IDs.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "assetId": {
+            "type": "string",
+            "description": "The numeric asset ID to delete.",
+            "example": "422721847"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "assetId"
+        ]
+      }
+    },
+    {
+      "name": "github_list_release_assets",
+      "integration": "github",
+      "description": "List all assets attached to a GitHub release. Returns a JSON array of asset objects including id, name, size, and browser_download_url.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "releaseId": {
+            "type": "string",
+            "description": "The numeric GitHub release ID.",
+            "example": "323096697"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "releaseId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_comments",
+      "integration": "github",
+      "description": "Get all comments for a GitHub pull request, including both inline code review comments and general discussion comments. Results are sorted by creation date.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_conversations",
+      "integration": "github",
+      "description": "Get all review conversations (inline code comment threads) for a GitHub pull request. Groups inline code review comments into threads showing root comment and replies. Also includes general PR discussion comments as separate entries.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_activities",
+      "integration": "github",
+      "description": "Get all activities for a GitHub pull request including reviews (approvals, change requests), inline code comments, and general discussion comments.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_add_pr_comment",
+      "integration": "github",
+      "description": "Add a comment to a GitHub pull request discussion.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "text": {
+            "type": "string",
+            "description": "The comment text to add",
+            "example": "Looks good!"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "github_update_pr_comment",
+      "integration": "github",
+      "description": "Update (edit) an existing comment on a GitHub pull request or issue by its comment ID.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "commentId": {
+            "type": "string",
+            "description": "The ID of the comment to update",
+            "example": "123456789"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "text": {
+            "type": "string",
+            "description": "The new comment text (replaces existing content)",
+            "example": "✅ Analysis complete."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "commentId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "github_delete_pr_comment",
+      "integration": "github",
+      "description": "Delete a comment on a GitHub pull request or issue by its comment ID.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "commentId": {
+            "type": "string",
+            "description": "The ID of the comment to delete",
+            "example": "123456789"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "commentId"
+        ]
+      }
+    },
+    {
+      "name": "github_reply_to_pr_thread",
+      "integration": "github",
+      "description": "Reply to an existing inline code review comment thread in a GitHub pull request. Use the comment ID of the root comment (or any comment) in the thread as inReplyToId.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "text": {
+            "type": "string",
+            "description": "The reply text (Markdown supported)",
+            "example": "Fixed in the latest commit."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "inReplyToId": {
+            "type": "string",
+            "description": "The ID of the comment to reply to (from github_get_pr_conversations rootComment.id or replies[].id)",
+            "example": "123456789"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "inReplyToId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "github_add_inline_comment",
+      "integration": "github",
+      "description": "Create a new inline code review comment on a specific file and line in a GitHub pull request. To comment on a range of lines, provide both startLine and line. Side is 'RIGHT' for new code (default) or 'LEFT' for old code.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "The relative file path in the repository",
+            "example": "src/main/java/com/example/Foo.java"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "side": {
+            "type": "string",
+            "description": "Which diff side to comment on: RIGHT (new code, default) or LEFT (old code)",
+            "example": "RIGHT"
+          },
+          "line": {
+            "type": "string",
+            "description": "The line number in the file to comment on",
+            "example": "42"
+          },
+          "startLine": {
+            "type": "string",
+            "description": "For multi-line comments: the first line of the range. Must be less than line.",
+            "example": "40"
+          },
+          "text": {
+            "type": "string",
+            "description": "The comment text (Markdown supported)",
+            "example": "This should be refactored."
+          },
+          "commitId": {
+            "type": "string",
+            "description": "The SHA of the commit to comment on. If empty, uses the PR head commit.",
+            "example": "abc123def456"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "path",
+          "line",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_review_threads",
+      "integration": "github",
+      "description": "Get all review threads for a GitHub pull request via GraphQL, including each thread's node ID (needed for resolving), resolved status, file path, line, and comments. Use the returned thread 'id' with github_resolve_pr_thread.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_resolve_pr_thread",
+      "integration": "github",
+      "description": "Resolve a review thread in a GitHub pull request. Requires the thread's GraphQL node ID, which can be obtained from github_get_pr_review_threads (the 'id' field of each thread).",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string",
+            "description": "The GraphQL node ID of the review thread to resolve (from github_get_pr_review_threads thread.id)",
+            "example": "PRRT_kwDOBQfyNc5A..."
+          }
+        },
+        "required": [
+          "threadId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_commit_check_runs",
+      "integration": "github",
+      "description": "Get all check runs (CI/CD status checks) for a commit SHA in a GitHub repository. Returns details about each check including status, conclusion, and output.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "commitSha": {
+            "type": "string",
+            "description": "The commit SHA to get check runs for",
+            "example": "abc123..."
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "commitSha"
+        ]
+      }
+    },
+    {
+      "name": "github_create_commit_status",
+      "integration": "github",
+      "description": "Create a commit status (the colored dot in PR checks). Use state=pending when AI analysis starts, success/failure/error when complete. The 'context' field acts as the status name and must be unique per check.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "context": {
+            "type": "string",
+            "description": "Unique identifier for this status check, e.g. 'dmtools/pr-review'",
+            "example": "dmtools/pr-review"
+          },
+          "description": {
+            "type": "string",
+            "description": "Short human-readable description shown next to the status dot",
+            "example": "AI analysis in progress..."
+          },
+          "state": {
+            "type": "string",
+            "description": "The state: pending | success | failure | error",
+            "example": "pending"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "sha": {
+            "type": "string",
+            "description": "The commit SHA to set status on",
+            "example": "abc123def456..."
+          },
+          "targetUrl": {
+            "type": "string",
+            "description": "Optional URL to link from the status (e.g. CI run URL)",
+            "example": "https://github.com/owner/repo/actions/runs/123"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "sha",
+          "state"
+        ]
+      }
+    },
+    {
+      "name": "github_create_check_run",
+      "integration": "github",
+      "description": "Create a GitHub Check Run — a rich CI check with progress, annotations, and a full log visible in the PR 'Checks' tab. Use status=in_progress when starting, then call github_update_check_run to complete it.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Markdown summary shown in the check run output panel",
+            "example": "🔍 Analysis started..."
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the check run displayed in the PR",
+            "example": "dmtools / pr-review"
+          },
+          "externalId": {
+            "type": "string",
+            "description": "Optional external identifier for this check run",
+            "example": "MAPC-6653"
+          },
+          "headSha": {
+            "type": "string",
+            "description": "The SHA of the commit to associate this check run with",
+            "example": "abc123def456..."
+          },
+          "text": {
+            "type": "string",
+            "description": "Additional details in Markdown (supports large content)",
+            "example": "Full analysis results here..."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title shown in the check run output panel",
+            "example": "AI PR Review"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status: queued | in_progress | completed",
+            "example": "in_progress"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "name",
+          "headSha"
+        ]
+      }
+    },
+    {
+      "name": "github_update_check_run",
+      "integration": "github",
+      "description": "Update an existing GitHub Check Run — set it to completed with success/failure conclusion, update summary and detailed text. Call this after github_create_check_run to finalize the check.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "conclusion": {
+            "type": "string",
+            "description": "Required when status=completed: success | failure | neutral | cancelled | skipped | timed_out | action_required",
+            "example": "success"
+          },
+          "summary": {
+            "type": "string",
+            "description": "Updated Markdown summary for the check run output panel",
+            "example": "✅ Review complete. Found 3 issues."
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "checkRunId": {
+            "type": "string",
+            "description": "The ID of the check run to update (from github_create_check_run response)",
+            "example": "1234567890"
+          },
+          "text": {
+            "type": "string",
+            "description": "Updated detailed Markdown content (full analysis, annotations etc.)",
+            "example": "## Issues Found\n..."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "title": {
+            "type": "string",
+            "description": "Updated title for the check run output panel",
+            "example": "AI PR Review — Complete"
+          },
+          "status": {
+            "type": "string",
+            "description": "The new status: in_progress | completed",
+            "example": "completed"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "checkRunId",
+          "status"
+        ]
+      }
+    },
+    {
+      "name": "github_get_workflow_run",
+      "integration": "github",
+      "description": "Get details of a specific GitHub Actions workflow run by ID. Returns status, conclusion, logs URL, and timing information.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The workflow run ID",
+            "example": "1234567890"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "runId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_workflow_run_jobs",
+      "integration": "github",
+      "description": "Get all jobs for a specific GitHub Actions workflow run. Shows individual job statuses, steps, and logs URLs.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The workflow run ID",
+            "example": "1234567890"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "runId"
+        ]
+      }
+    },
+    {
+      "name": "github_list_workflow_runs",
+      "integration": "github",
+      "description": "List GitHub Actions workflow runs for a repository, optionally filtered by status or specific workflow file. Use status='failure' to get all failed runs.",
+      "category": "actions",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "perPage": {
+            "type": "number",
+            "description": "Number of results per page (max 100, default 30)",
+            "example": "50"
+          },
+          "created": {
+            "type": "string",
+            "description": "Filter by created date/range using GitHub search syntax, e.g. 2026-05-01..2026-05-31 or >=2026-05-01",
+            "example": "2026-05-01..2026-05-31"
+          },
+          "page": {
+            "type": "number",
+            "description": "Page number for pagination (default 1)",
+            "example": "2"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workflowId": {
+            "type": "string",
+            "description": "Optional workflow filename to filter runs (e.g. rework.yml). If omitted, returns runs for all workflows.",
+            "example": "rework.yml"
+          },
+          "status": {
+            "type": "string",
+            "description": "Filter by status: failure, success, in_progress, queued, cancelled, timed_out, action_required, neutral, skipped, stale, completed",
+            "example": "failure"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository"
+        ]
+      }
+    },
+    {
+      "name": "github_get_job_logs",
+      "integration": "github",
+      "description": "Get the raw text logs for a specific GitHub Actions job. Returns the complete log output from all steps in the job.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "jobId": {
+            "type": "string",
+            "description": "The job ID (from github_get_workflow_run_jobs)",
+            "example": "1234567890"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "jobId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_workflow_run_logs",
+      "integration": "github",
+      "description": "Download and extract complete logs for all jobs in a GitHub Actions workflow run. Returns full untruncated log content from the ZIP archive GitHub provides.",
+      "category": "actions",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The workflow run ID",
+            "example": "22498697315"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "runId"
+        ]
+      }
+    },
+    {
+      "name": "github_add_pr_label",
+      "integration": "github",
+      "description": "Add a label to a GitHub pull request.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "label": {
+            "type": "string",
+            "description": "The label name to add to the pull request",
+            "example": "bug"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "github_remove_pr_label",
+      "integration": "github",
+      "description": "Remove a label from a GitHub pull request.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "label": {
+            "type": "string",
+            "description": "The label name to remove from the pull request",
+            "example": "bug"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "github_merge_pr",
+      "integration": "github",
+      "description": "Merge a GitHub pull request. Supports merge, squash, and rebase merge methods.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request number to merge",
+            "example": "74"
+          },
+          "commitMessage": {
+            "type": "string",
+            "description": "Extra detail to append to the merge commit message (optional)",
+            "example": "Closes #123"
+          },
+          "mergeMethod": {
+            "type": "string",
+            "description": "The merge method: 'merge' (default), 'squash', or 'rebase'",
+            "example": "squash"
+          },
+          "commitTitle": {
+            "type": "string",
+            "description": "Title for the merge commit (optional, defaults to PR title)",
+            "example": "Merge feature/my-branch into main"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_diff",
+      "integration": "github",
+      "description": "Get the diff statistics for a GitHub pull request (files changed, additions, deletions). Requires IS_READ_PULL_REQUEST_DIFF env/config to be enabled.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestID": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestID"
+        ]
+      }
+    },
+    {
+      "name": "github_get_pr_diff_text",
+      "integration": "github",
+      "description": "Get the raw unified diff text for a GitHub pull request. Requires IS_READ_PULL_REQUEST_DIFF env/config to be enabled.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The GitHub repository name",
+            "example": "dmtools"
+          },
+          "pullRequestID": {
+            "type": "string",
+            "description": "The pull request number",
+            "example": "74"
+          },
+          "workspace": {
+            "type": "string",
+            "description": "The GitHub owner/organization name",
+            "example": "IstiN"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestID"
+        ]
+      }
+    },
+    {
+      "name": "confluence_contents_by_urls",
+      "integration": "confluence",
+      "description": "Get Confluence content by multiple URLs. Returns a list of content objects for each valid URL. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          },
+          "urlStrings": {
+            "type": "array",
+            "description": "Array of Confluence URLs to retrieve content from",
+            "example": "['https://confluence.example.com/wiki/spaces/SPACE/pages/123/Page+Title']"
+          }
+        },
+        "required": [
+          "urlStrings"
+        ]
+      }
+    },
+    {
+      "name": "confluence_search_content_by_text",
+      "integration": "confluence",
+      "description": "Search Confluence content by text query using CQL (Confluence Query Language). Returns search results with content excerpts. Default limit is 20 if not specified.",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of search results to return. Default is 20 if not provided.",
+            "example": "10"
+          },
+          "query": {
+            "type": "string",
+            "description": "Search query text to find in Confluence content",
+            "example": "project documentation"
+          }
+        },
+        "required": [
+          "query"
+        ]
+      }
+    },
+    {
+      "name": "confluence_content_by_id",
+      "integration": "confluence",
+      "description": "Get Confluence content by its unique content ID. Returns detailed content information including body, version, and metadata. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentId": {
+            "type": "string",
+            "description": "The unique content ID of the Confluence page",
+            "example": "123456"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          }
+        },
+        "required": [
+          "contentId"
+        ]
+      }
+    },
+    {
+      "name": "confluence_content_by_title_and_space",
+      "integration": "confluence",
+      "description": "Get Confluence content by title and space key. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the Confluence page",
+            "example": "Project Documentation"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space key where the content is located",
+            "example": "PROJ"
+          }
+        },
+        "required": [
+          "title",
+          "space"
+        ]
+      }
+    },
+    {
+      "name": "confluence_test",
+      "integration": "confluence",
+      "description": "Test Confluence connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "confluence_get_current_user_profile",
+      "integration": "confluence",
+      "description": "Get the current user's profile information from Confluence. Returns user details for the authenticated user.",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "confluence_get_user_profile_by_id",
+      "integration": "confluence",
+      "description": "Get a specific user's profile information from Confluence by user ID. Returns user details for the specified user.",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "The account ID of the user to get profile for",
+            "example": "123456:abcdef-1234-5678-90ab-cdef12345678"
+          }
+        },
+        "required": [
+          "userId"
+        ]
+      }
+    },
+    {
+      "name": "confluence_get_content_attachments",
+      "integration": "confluence",
+      "description": "Get all attachments for a specific Confluence content. Returns a list of attachment objects with metadata.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentId": {
+            "type": "string",
+            "description": "The content ID to get attachments for",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "contentId"
+        ]
+      }
+    },
+    {
+      "name": "confluence_find_content_by_title_and_space",
+      "integration": "confluence",
+      "description": "Find Confluence content by title and space key. Returns the first matching content or null if not found. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the content to find",
+            "example": "Project Documentation"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space key where to search for the content",
+            "example": "PROJ"
+          }
+        },
+        "required": [
+          "title",
+          "space"
+        ]
+      }
+    },
+    {
+      "name": "confluence_create_page",
+      "integration": "confluence",
+      "description": "Create a new Confluence page with specified title, parent, body content, and space. Returns the created content object.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "The title of the new page",
+            "example": "New Project Page"
+          },
+          "body": {
+            "type": "string",
+            "description": "The body content of the page in Confluence storage format",
+            "example": "<p>This is the page content.</p>"
+          },
+          "parentId": {
+            "type": "string",
+            "description": "The ID of the parent page",
+            "example": "123456"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space key where to create the page",
+            "example": "PROJ"
+          }
+        },
+        "required": [
+          "title",
+          "parentId",
+          "body",
+          "space"
+        ]
+      }
+    },
+    {
+      "name": "confluence_update_page",
+      "integration": "confluence",
+      "description": "Update an existing Confluence page with new title, parent, body content, and space. Returns the updated content object.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentId": {
+            "type": "string",
+            "description": "The ID of the page to update",
+            "example": "123456"
+          },
+          "title": {
+            "type": "string",
+            "description": "The new title for the page",
+            "example": "Updated Project Page"
+          },
+          "body": {
+            "type": "string",
+            "description": "The new body content of the page in Confluence storage format",
+            "example": "<p>This is the updated page content.</p>"
+          },
+          "parentId": {
+            "type": "string",
+            "description": "The ID of the new parent page",
+            "example": "123456"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space key where the page is located",
+            "example": "PROJ"
+          }
+        },
+        "required": [
+          "contentId",
+          "title",
+          "parentId",
+          "body",
+          "space"
+        ]
+      }
+    },
+    {
+      "name": "confluence_update_page_with_history",
+      "integration": "confluence",
+      "description": "Update an existing Confluence page with new content and add a history comment. Returns the updated content object.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentId": {
+            "type": "string",
+            "description": "The ID of the page to update",
+            "example": "123456"
+          },
+          "title": {
+            "type": "string",
+            "description": "The new title for the page",
+            "example": "Updated Project Page"
+          },
+          "body": {
+            "type": "string",
+            "description": "The new body content of the page in Confluence storage format",
+            "example": "<p>This is the updated page content.</p>"
+          },
+          "parentId": {
+            "type": "string",
+            "description": "The ID of the new parent page",
+            "example": "123456"
+          },
+          "space": {
+            "type": "string",
+            "description": "The space key where the page is located",
+            "example": "PROJ"
+          },
+          "historyComment": {
+            "type": "string",
+            "description": "Comment to add to the page history",
+            "example": "Updated content based on user feedback"
+          }
+        },
+        "required": [
+          "contentId",
+          "title",
+          "parentId",
+          "body",
+          "space",
+          "historyComment"
+        ]
+      }
+    },
+    {
+      "name": "confluence_get_children_by_name",
+      "integration": "confluence",
+      "description": "Get child pages of a Confluence page by space key and content name. Returns a list of child content objects. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "spaceKey": {
+            "type": "string",
+            "description": "The space key where the parent page is located",
+            "example": "PROJ"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          },
+          "contentName": {
+            "type": "string",
+            "description": "The name/title of the parent page",
+            "example": "Project Documentation"
+          }
+        },
+        "required": [
+          "spaceKey",
+          "contentName"
+        ]
+      }
+    },
+    {
+      "name": "confluence_get_children_by_id",
+      "integration": "confluence",
+      "description": "Get child pages of a Confluence page by content ID. Returns a list of child content objects. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contentId": {
+            "type": "string",
+            "description": "The content ID of the parent page",
+            "example": "123456"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          }
+        },
+        "required": [
+          "contentId"
+        ]
+      }
+    },
+    {
+      "name": "confluence_download_attachment",
+      "integration": "confluence",
+      "description": "Download an attachment file from Confluence to a specified directory.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "attachment": {
+            "type": "object",
+            "description": "The attachment object to download"
+          },
+          "targetDir": {
+            "type": "object",
+            "description": "The target directory to save the file",
+            "example": "/path/to/directory"
+          }
+        },
+        "required": [
+          "attachment",
+          "targetDir"
+        ]
+      }
+    },
+    {
+      "name": "confluence_download_pages",
+      "integration": "confluence",
+      "description": "Download Confluence pages and their attachments to a local folder. Recursively follows linked pages, children macros, and internal ac:link references up to the specified depth.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "urlStrings": {
+            "type": "array",
+            "description": "Array of Confluence page URLs to download",
+            "example": "['https://wiki.example.com/wiki/spaces/SPACE/pages/123/Page']"
+          },
+          "depth": {
+            "type": "number",
+            "description": "How many levels of linked/child pages to follow. Default is 1.",
+            "example": "1"
+          },
+          "downloadAttachments": {
+            "type": "boolean",
+            "description": "Whether to download page attachments. Default is true.",
+            "example": "true"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Local folder path where pages and attachments will be saved",
+            "example": "/tmp/confluence-pages"
+          }
+        },
+        "required": [
+          "urlStrings",
+          "outputPath"
+        ]
+      }
+    },
+    {
+      "name": "confluence_find_content",
+      "integration": "confluence",
+      "description": "Find a Confluence page by title in the default space. Returns the page content if found. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the Confluence page to find",
+            "example": "Project Documentation"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "confluence_find_or_create",
+      "integration": "confluence",
+      "description": "Find a Confluence page by title in the default space, or create it if it doesn't exist. Returns the found or created content.",
+      "category": "content_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the page to find or create",
+            "example": "Project Documentation"
+          },
+          "body": {
+            "type": "string",
+            "description": "Body content for the new page (if creation is needed)",
+            "example": "<p>This is the page content.</p>"
+          },
+          "parentId": {
+            "type": "string",
+            "description": "ID of the parent page for creation",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "title",
+          "parentId",
+          "body"
+        ]
+      }
+    },
+    {
+      "name": "confluence_content_by_title",
+      "integration": "confluence",
+      "description": "Get Confluence content by title in the default space. Returns content result with metadata and body information. Use format=md to convert body.storage.value to Markdown.",
+      "category": "content_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the Confluence page to get",
+            "example": "Project Documentation"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for the page body. Use 'md' or 'markdown' to convert Confluence storage format to Markdown.",
+            "example": "md"
+          }
+        },
+        "required": [
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "teams_test",
+      "integration": "teams",
+      "description": "Test Microsoft Teams connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "teams_chats_raw",
+      "integration": "teams",
+      "description": "List chats for the current user with topic, type, and participant information (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of chats (0 for all, default: 50)",
+            "example": "50"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_chats",
+      "integration": "teams",
+      "description": "List chats showing only chat/contact names, last message (truncated to 100 chars), and date",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of chats (0 for all, default: 50)",
+            "example": "50"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_recent_chats",
+      "integration": "teams",
+      "description": "Get recent chats sorted by last activity showing chat/contact names, last message with author, and date. Shows 'new: true' for unread messages. Filter by type: 'oneOnOne' for 1-on-1 chats, 'group' for group chats, 'meeting' for meeting chats, or 'all' (default). Only shows chats with activity in the last 90 days.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of recent chats (0 for all, default: 50)",
+            "example": "50"
+          },
+          "chatType": {
+            "type": "string",
+            "description": "Filter by chat type: 'oneOnOne', 'group', 'meeting', or 'all' (default: 'all')",
+            "example": "oneOnOne"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_messages_by_chat_id_raw",
+      "integration": "teams",
+      "description": "Get messages from a chat by ID with optional server-side filtering. Use $filter syntax with lastModifiedDateTime: 'lastModifiedDateTime gt 2025-01-01T00:00:00Z' (returns raw JSON). Note: createdDateTime is not supported in filters.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "description": "The chat ID"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          },
+          "filter": {
+            "type": "string",
+            "description": "Optional OData filter (e.g., 'lastModifiedDateTime gt 2025-01-01T00:00:00Z')",
+            "example": "lastModifiedDateTime gt 2025-01-01T00:00:00Z"
+          }
+        },
+        "required": [
+          "chatId"
+        ]
+      }
+    },
+    {
+      "name": "teams_chat_by_name_raw",
+      "integration": "teams",
+      "description": "Find a chat by topic/name or participant name (case-insensitive partial match). Works for group chats and 1-on-1 chats. (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatName": {
+            "type": "string",
+            "description": "The chat topic or participant name to search for"
+          }
+        },
+        "required": [
+          "chatName"
+        ]
+      }
+    },
+    {
+      "name": "teams_messages_raw",
+      "integration": "teams",
+      "description": "Get messages from a chat by name (combines find + get messages) (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          },
+          "chatName": {
+            "type": "string",
+            "description": "The chat name to search for"
+          }
+        },
+        "required": [
+          "chatName"
+        ]
+      }
+    },
+    {
+      "name": "teams_messages",
+      "integration": "teams",
+      "description": "Get messages from a chat with simplified output showing only: author, body, date, reactions, mentions, and attachments",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          },
+          "chatName": {
+            "type": "string",
+            "description": "The chat name to search for"
+          },
+          "sorting": {
+            "type": "string",
+            "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
+            "example": "desc"
+          }
+        },
+        "required": [
+          "chatName"
+        ]
+      }
+    },
+    {
+      "name": "teams_messages_since_by_id",
+      "integration": "teams",
+      "description": "Get messages from a chat starting from a specific date (ISO 8601 format, e.g., '2025-10-08T00:00:00Z'). Returns simplified format. Uses smart pagination with early exit for performance.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "description": "The chat ID"
+          },
+          "sinceDate": {
+            "type": "string",
+            "description": "ISO 8601 date string (e.g., '2025-10-08T00:00:00Z')",
+            "example": "2025-10-08T00:00:00Z"
+          },
+          "sorting": {
+            "type": "string",
+            "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
+            "example": "desc"
+          }
+        },
+        "required": [
+          "chatId",
+          "sinceDate"
+        ]
+      }
+    },
+    {
+      "name": "teams_messages_since",
+      "integration": "teams",
+      "description": "Get messages from a chat by name starting from a specific date (ISO 8601 format). Returns simplified format. Uses smart pagination with early exit for performance.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatName": {
+            "type": "string",
+            "description": "The chat name to search for"
+          },
+          "sinceDate": {
+            "type": "string",
+            "description": "ISO 8601 date string (e.g., '2025-10-08T00:00:00Z')",
+            "example": "2025-10-08T00:00:00Z"
+          },
+          "sorting": {
+            "type": "string",
+            "description": "Sort order: 'asc' for oldest first, 'desc' for newest first (default: 'desc')",
+            "example": "desc"
+          }
+        },
+        "required": [
+          "chatName",
+          "sinceDate"
+        ]
+      }
+    },
+    {
+      "name": "teams_send_message_by_id",
+      "integration": "teams",
+      "description": "Send a message to a chat by ID (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "description": "The chat ID"
+          },
+          "content": {
+            "type": "string",
+            "description": "Message content (plain text or HTML)"
+          }
+        },
+        "required": [
+          "chatId",
+          "content"
+        ]
+      }
+    },
+    {
+      "name": "teams_send_message",
+      "integration": "teams",
+      "description": "Send a message to a chat by name or participant name (finds chat, then sends message)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatName": {
+            "type": "string",
+            "description": "The chat topic or participant name"
+          },
+          "content": {
+            "type": "string",
+            "description": "Message content (plain text or HTML)"
+          }
+        },
+        "required": [
+          "chatName",
+          "content"
+        ]
+      }
+    },
+    {
+      "name": "teams_myself_messages_raw",
+      "integration": "teams",
+      "description": "Get messages from your personal self chat (notes to yourself) with full raw data",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_myself_messages",
+      "integration": "teams",
+      "description": "Get messages from your personal self chat (notes to yourself) with simplified output",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_send_myself_message",
+      "integration": "teams",
+      "description": "Send a message to your personal self chat (notes to yourself)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "string",
+            "description": "Message content (plain text or HTML)"
+          }
+        },
+        "required": [
+          "content"
+        ]
+      }
+    },
+    {
+      "name": "teams_download_file",
+      "integration": "teams",
+      "description": "Download a file from Teams (Graph API hostedContents or SharePoint sharing URL). Auto-detects URL type and uses appropriate method.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Graph API URL or SharePoint sharing URL",
+            "example": "https://graph.microsoft.com/v1.0/chats/.../hostedContents/.../$value"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Local file path to save to",
+            "example": "/tmp/file.ext"
+          }
+        },
+        "required": [
+          "url",
+          "outputPath"
+        ]
+      }
+    },
+    {
+      "name": "teams_get_message_hosted_contents",
+      "integration": "teams",
+      "description": "Get hosted contents (files/transcripts) for a specific message. Returns list of files with download URLs.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "chatId": {
+            "type": "string",
+            "description": "Chat ID"
+          },
+          "messageId": {
+            "type": "string",
+            "description": "Message ID"
+          }
+        },
+        "required": [
+          "chatId",
+          "messageId"
+        ]
+      }
+    },
+    {
+      "name": "teams_get_call_transcripts",
+      "integration": "teams",
+      "description": "Get transcripts for a call/meeting using Call Records API. Returns list of transcripts with download URLs.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "callId": {
+            "type": "string",
+            "description": "Call ID from the meeting"
+          }
+        },
+        "required": [
+          "callId"
+        ]
+      }
+    },
+    {
+      "name": "teams_search_user_drive_files",
+      "integration": "teams",
+      "description": "Search for files in a user's OneDrive (e.g., meeting transcripts/recordings). Returns list of files with download URLs.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "User ID to search OneDrive"
+          },
+          "searchQuery": {
+            "type": "string",
+            "description": "Search term (meeting name, 'transcript', '.vtt', etc.)"
+          }
+        },
+        "required": [
+          "userId",
+          "searchQuery"
+        ]
+      }
+    },
+    {
+      "name": "teams_get_recording_transcripts",
+      "integration": "teams",
+      "description": "Get transcript metadata for a recording file. Returns list of available transcripts with download URLs.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "Item ID of the recording file"
+          },
+          "driveId": {
+            "type": "string",
+            "description": "Drive ID from the recording file"
+          }
+        },
+        "required": [
+          "driveId",
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "teams_list_recording_transcripts",
+      "integration": "teams",
+      "description": "List available transcripts for a recording file. Returns transcript IDs that can be downloaded.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "Recording item ID"
+          },
+          "driveId": {
+            "type": "string",
+            "description": "Drive ID"
+          }
+        },
+        "required": [
+          "driveId",
+          "itemId"
+        ]
+      }
+    },
+    {
+      "name": "teams_extract_transcript_from_sharepoint",
+      "integration": "teams",
+      "description": "Extract transcript information by parsing SharePoint HTML page. Useful for finding transcript IDs.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "webUrl": {
+            "type": "string",
+            "description": "SharePoint webUrl of the recording"
+          }
+        },
+        "required": [
+          "webUrl"
+        ]
+      }
+    },
+    {
+      "name": "teams_download_recording_transcript",
+      "integration": "teams",
+      "description": "Download transcript (VTT) file from a Teams recording using SharePoint API. Requires driveId, itemId, and transcriptId.",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "Recording item ID"
+          },
+          "driveId": {
+            "type": "string",
+            "description": "Drive ID"
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Local file path to save"
+          },
+          "transcriptId": {
+            "type": "string",
+            "description": "Transcript ID (UUID)"
+          }
+        },
+        "required": [
+          "driveId",
+          "itemId",
+          "transcriptId",
+          "outputPath"
+        ]
+      }
+    },
+    {
+      "name": "teams_get_joined_teams_raw",
+      "integration": "teams",
+      "description": "List teams the user is a member of (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "teams_get_team_channels_raw",
+      "integration": "teams",
+      "description": "Get channels in a specific team (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "teamId": {
+            "type": "string",
+            "description": "The team ID"
+          }
+        },
+        "required": [
+          "teamId"
+        ]
+      }
+    },
+    {
+      "name": "teams_find_team_by_name_raw",
+      "integration": "teams",
+      "description": "Find a team by display name (case-insensitive partial match) (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "teamName": {
+            "type": "string",
+            "description": "The team name to search for"
+          }
+        },
+        "required": [
+          "teamName"
+        ]
+      }
+    },
+    {
+      "name": "teams_find_channel_by_name_raw",
+      "integration": "teams",
+      "description": "Find a channel by name within a team (case-insensitive partial match) (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "channelName": {
+            "type": "string",
+            "description": "The channel name to search for"
+          },
+          "teamId": {
+            "type": "string",
+            "description": "The team ID"
+          }
+        },
+        "required": [
+          "teamId",
+          "channelName"
+        ]
+      }
+    },
+    {
+      "name": "teams_get_channel_messages_by_name_raw",
+      "integration": "teams",
+      "description": "Get messages from a channel by team and channel names (returns raw JSON)",
+      "category": "communication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "teamName": {
+            "type": "string",
+            "description": "The team name to search for"
+          },
+          "limit": {
+            "type": "number",
+            "description": "Maximum number of messages (0 for all, default: 100)",
+            "example": "100"
+          },
+          "channelName": {
+            "type": "string",
+            "description": "The channel name to search for"
+          }
+        },
+        "required": [
+          "teamName",
+          "channelName"
+        ]
+      }
+    },
+    {
+      "name": "gemini_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to Gemini AI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "gemini_ai_chat_with_files",
+      "integration": "ai",
+      "description": "Send a text message to Gemini AI with file attachments. Supports images, documents, and other file types for analysis and questions.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to Gemini AI",
+            "example": "What is in this image? Please analyze the document content."
+          },
+          "filePaths": {
+            "type": "array",
+            "description": "Array of file paths to attach to the message",
+            "example": "['/path/to/image.png', '/path/to/document.pdf']"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "vertex_ai_gemini_chat",
+      "integration": "ai",
+      "description": "Send a text message to Google Vertex AI Gemini (service account auth)",
+      "category": "Vertex AI",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "vertex_ai_gemini_chat_with_files",
+      "integration": "ai",
+      "description": "Send message with file attachments to Vertex AI Gemini. Supports images, documents, and other file types.",
+      "category": "Vertex AI",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to Vertex AI Gemini",
+            "example": "What is in this image? Please analyze the document content."
+          },
+          "filePaths": {
+            "type": "array",
+            "description": "Array of file paths to attach to the message",
+            "example": "['/path/to/image.png', '/path/to/document.pdf']"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "bedrock_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to AWS Bedrock AI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "bedrock_list_models",
+      "integration": "ai",
+      "description": "Get a list of available AWS Bedrock foundation models",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "dial_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to Dial AI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "dial_ai_chat_with_files",
+      "integration": "ai",
+      "description": "Send a text message to Dial AI with file attachments. Supports images and documents for analysis and questions.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to Dial AI",
+            "example": "What is in this image? Please analyze the document content."
+          },
+          "filePaths": {
+            "type": "string",
+            "description": "Comma-separated list of file paths to attach (supports images and documents)",
+            "example": "/path/to/image.png,/path/to/document.pdf"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "anthropic_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to Anthropic Claude AI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "anthropic_ai_chat_with_files",
+      "integration": "ai",
+      "description": "Send a text message to Anthropic Claude AI with file attachments. Supports images, documents, and other file types for analysis and questions.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to Anthropic Claude AI",
+            "example": "What is in this image? Please analyze the document content."
+          },
+          "filePaths": {
+            "type": "array",
+            "description": "Array of file paths to attach to the message",
+            "example": "['/path/to/image.png', '/path/to/document.pdf']"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "anthropic_list_models",
+      "integration": "ai",
+      "description": "Get a list of available anthropic foundation models",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "ollama_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to Ollama AI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "ollama_ai_chat_with_files",
+      "integration": "ai",
+      "description": "Send a text message to Ollama AI with file attachments. Supports images and other file types for analysis and questions.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to Ollama AI",
+            "example": "What is in this image? Please analyze the document content."
+          },
+          "filePaths": {
+            "type": "array",
+            "description": "Array of file paths to attach to the message",
+            "example": "['/path/to/image.png', '/path/to/document.pdf']"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "openai_ai_chat",
+      "integration": "ai",
+      "description": "Send a text message to OpenAI and get response",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to AI"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    },
+    {
+      "name": "openai_ai_chat_with_files",
+      "integration": "ai",
+      "description": "Send a text message to OpenAI with file attachments. Supports images for vision models (gpt-4-vision-preview, gpt-4-turbo, etc.).",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Text message to send to OpenAI",
+            "example": "What is in this image? Please analyze the content."
+          },
+          "filePaths": {
+            "type": "array",
+            "description": "Array of file paths to attach to the message (images only for vision models)",
+            "example": "['/path/to/image.png', '/path/to/photo.jpg']"
+          }
+        },
+        "required": [
+          "message",
+          "filePaths"
+        ]
+      }
+    },
+    {
+      "name": "sharepoint_get_drive_item",
+      "integration": "sharepoint",
+      "description": "Get DriveItem information from a SharePoint sharing URL. Returns metadata about the shared file including download URLs.",
+      "category": "storage",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sharingUrl": {
+            "type": "string",
+            "description": "SharePoint sharing URL",
+            "example": "https://company-my.sharepoint.com/:v:/p/user/EabcdefGHIJ..."
+          }
+        },
+        "required": [
+          "sharingUrl"
+        ]
+      }
+    },
+    {
+      "name": "sharepoint_download_file",
+      "integration": "sharepoint",
+      "description": "Download a file from a SharePoint sharing URL to a local file path. Works with OneDrive and SharePoint sharing links.",
+      "category": "storage",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sharingUrl": {
+            "type": "string",
+            "description": "SharePoint sharing URL",
+            "example": "https://company-my.sharepoint.com/:v:/p/user/EabcdefGHIJ..."
+          },
+          "outputPath": {
+            "type": "string",
+            "description": "Local file path to save to",
+            "example": "/tmp/recording.mp4"
+          }
+        },
+        "required": [
+          "sharingUrl",
+          "outputPath"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_work_item",
+      "integration": "ado",
+      "description": "Get a specific Azure DevOps work item by ID with optional field filtering",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Optional array of fields to include in the response"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID (numeric)",
+            "example": "12345"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "ado_search_by_wiql",
+      "integration": "ado",
+      "description": "Search for work items using WIQL (Work Item Query Language)",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Optional array of fields to include"
+          },
+          "wiql": {
+            "type": "string",
+            "description": "WIQL query string",
+            "example": "SELECT [System.Id] FROM WorkItems WHERE [System.WorkItemType] = 'Bug'"
+          }
+        },
+        "required": [
+          "wiql"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_comments",
+      "integration": "ado",
+      "description": "Get all comments for a work item",
+      "category": "comment_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket": {
+            "type": "object",
+            "description": "Parameter ticket"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          }
+        },
+        "required": [
+          "id",
+          "ticket"
+        ]
+      }
+    },
+    {
+      "name": "ado_post_comment",
+      "integration": "ado",
+      "description": "Post a comment to a work item",
+      "category": "comment_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "string",
+            "description": "The comment text"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          }
+        },
+        "required": [
+          "id",
+          "comment"
+        ]
+      }
+    },
+    {
+      "name": "ado_assign_work_item",
+      "integration": "ado",
+      "description": "Assign a work item to a user",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userEmail": {
+            "type": "string",
+            "description": "The user email or display name"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          }
+        },
+        "required": [
+          "id",
+          "userEmail"
+        ]
+      }
+    },
+    {
+      "name": "ado_update_description",
+      "integration": "ado",
+      "description": "Update the description of a work item",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The new description (HTML format)"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          }
+        },
+        "required": [
+          "id",
+          "description"
+        ]
+      }
+    },
+    {
+      "name": "ado_update_tags",
+      "integration": "ado",
+      "description": "Update the tags of a work item (semicolon-separated string)",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          },
+          "tags": {
+            "type": "string",
+            "description": "Tags as semicolon-separated string (e.g., 'tag1;tag2;tag3')"
+          }
+        },
+        "required": [
+          "id",
+          "tags"
+        ]
+      }
+    },
+    {
+      "name": "ado_move_to_state",
+      "integration": "ado",
+      "description": "Move a work item to a specific state",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          },
+          "state": {
+            "type": "string",
+            "description": "The target state name",
+            "example": "Active"
+          }
+        },
+        "required": [
+          "id",
+          "state"
+        ]
+      }
+    },
+    {
+      "name": "ado_link_work_items",
+      "integration": "ado",
+      "description": "Link two work items with a relationship (e.g., Parent-Child, Related, Tested By)",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceId": {
+            "type": "string",
+            "description": "The source work item ID"
+          },
+          "targetId": {
+            "type": "string",
+            "description": "The target work item ID to link to"
+          },
+          "relationship": {
+            "type": "string",
+            "description": "Relationship type (e.g., 'parent', 'child', 'related', 'tested by', 'tests')",
+            "example": "parent"
+          }
+        },
+        "required": [
+          "sourceId",
+          "targetId",
+          "relationship"
+        ]
+      }
+    },
+    {
+      "name": "ado_create_work_item",
+      "integration": "ado",
+      "description": "Create a new work item in Azure DevOps",
+      "category": "work_item_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workItemType": {
+            "type": "string",
+            "description": "The work item type (Bug, Task, User Story, etc.)"
+          },
+          "project": {
+            "type": "string",
+            "description": "The project name"
+          },
+          "description": {
+            "type": "string",
+            "description": "The work item description (HTML)"
+          },
+          "fieldsJson": {
+            "type": "object",
+            "description": "Additional fields as JSON object (e.g., {\"Microsoft.VSTS.Common.Priority\": 1})"
+          },
+          "title": {
+            "type": "string",
+            "description": "The work item title"
+          }
+        },
+        "required": [
+          "project",
+          "workItemType",
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_changelog",
+      "integration": "ado",
+      "description": "Get the complete history/changelog of a work item",
+      "category": "history",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket": {
+            "type": "object",
+            "description": "Optional work item object (can be null)"
+          },
+          "id": {
+            "type": "string",
+            "description": "The work item ID"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      }
+    },
+    {
+      "name": "ado_download_attachment",
+      "integration": "ado",
+      "description": "Download an ADO work item attachment by URL and save it as a file",
+      "category": "file_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The attachment URL to download"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_user_by_email",
+      "integration": "ado",
+      "description": "Get user information by email address in Azure DevOps",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "User email address"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      }
+    },
+    {
+      "name": "ado_test",
+      "integration": "ado",
+      "description": "Test Azure DevOps connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "ado_get_my_profile",
+      "integration": "ado",
+      "description": "Get the current user's profile information from Azure DevOps",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "ado_list_prs",
+      "integration": "ado",
+      "description": "List pull requests in an Azure DevOps Git repository by status. Status can be 'active', 'completed', or 'abandoned'.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "status": {
+            "type": "string",
+            "description": "The status of pull requests to list: 'active', 'completed', or 'abandoned'. 'open'/'opened' accepted as synonym for 'active'.",
+            "example": "active"
+          }
+        },
+        "required": [
+          "repository",
+          "status"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pr",
+      "integration": "ado",
+      "description": "Get details of an Azure DevOps pull request including title, description, status, author, reviewers, branches, and merge info.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID (numeric)",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pr_comments",
+      "integration": "ado",
+      "description": "Get all comment threads for an Azure DevOps pull request. Each thread contains comments, file context for inline comments, and status (active, fixed, closed, etc.).",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_add_pr_comment",
+      "integration": "ado",
+      "description": "Add a general comment to an Azure DevOps pull request (creates a new thread). For inline code comments, use ado_add_inline_comment instead.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "text": {
+            "type": "string",
+            "description": "The comment text to add (Markdown supported)",
+            "example": "Looks good!"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "ado_reply_to_pr_thread",
+      "integration": "ado",
+      "description": "Reply to an existing comment thread in an Azure DevOps pull request. Use the threadId from ado_get_pr_comments.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string",
+            "description": "The ID of the thread to reply to (from ado_get_pr_comments)",
+            "example": "42"
+          },
+          "text": {
+            "type": "string",
+            "description": "The reply text (Markdown supported)",
+            "example": "Fixed in the latest commit."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "threadId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "ado_add_inline_comment",
+      "integration": "ado",
+      "description": "Create a new inline code comment on a specific file and line range in an Azure DevOps pull request. Creates a new thread with file context.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "side": {
+            "type": "string",
+            "description": "Which diff side to comment on: 'right' (new code, default) or 'left' (old code)",
+            "example": "right"
+          },
+          "line": {
+            "type": "string",
+            "description": "The line number to comment on (1-based)",
+            "example": "42"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "The relative file path in the repository (must start with /)",
+            "example": "/src/main/java/com/example/Foo.java"
+          },
+          "startLine": {
+            "type": "string",
+            "description": "For multi-line comments: the first line of the range. Must be less than or equal to line.",
+            "example": "40"
+          },
+          "text": {
+            "type": "string",
+            "description": "The comment text (Markdown supported)",
+            "example": "This should be refactored."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "filePath",
+          "line",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "ado_resolve_pr_thread",
+      "integration": "ado",
+      "description": "Resolve (close) a comment thread in an Azure DevOps pull request. Sets the thread status to 'fixed'. Other statuses: 'active', 'closed', 'byDesign', 'pending', 'wontFix'.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string",
+            "description": "The ID of the thread to resolve (from ado_get_pr_comments)",
+            "example": "42"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "status": {
+            "type": "string",
+            "description": "The new status: 'fixed' (default/resolved), 'closed', 'byDesign', 'wontFix', 'pending', 'active'",
+            "example": "fixed"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "threadId"
+        ]
+      }
+    },
+    {
+      "name": "ado_update_pr_comment",
+      "integration": "ado",
+      "description": "Update (edit) an existing comment in a pull request thread. Requires both threadId and commentId.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string",
+            "description": "The ID of the thread containing the comment",
+            "example": "42"
+          },
+          "commentId": {
+            "type": "string",
+            "description": "The ID of the comment to update",
+            "example": "1"
+          },
+          "text": {
+            "type": "string",
+            "description": "The new comment text (replaces existing content)",
+            "example": "Updated analysis."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "threadId",
+          "commentId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "ado_delete_pr_comment",
+      "integration": "ado",
+      "description": "Delete a comment from a pull request thread. Requires both threadId and commentId.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "threadId": {
+            "type": "string",
+            "description": "The ID of the thread containing the comment",
+            "example": "42"
+          },
+          "commentId": {
+            "type": "string",
+            "description": "The ID of the comment to delete",
+            "example": "2"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "threadId",
+          "commentId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pr_diff",
+      "integration": "ado",
+      "description": "Get the diff/changes for an Azure DevOps pull request. Returns the list of changed files with change types.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_merge_pr",
+      "integration": "ado",
+      "description": "Complete (merge) an Azure DevOps pull request. Sets status to 'completed' with the specified merge strategy.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID to complete/merge",
+            "example": "1"
+          },
+          "commitMessage": {
+            "type": "string",
+            "description": "Optional merge commit message",
+            "example": "Merging feature branch"
+          },
+          "mergeStrategy": {
+            "type": "string",
+            "description": "The merge strategy: 'squash' (default), 'noFastForward', 'rebase', 'rebaseMerge'",
+            "example": "squash"
+          },
+          "deleteSourceBranch": {
+            "type": "string",
+            "description": "Whether to delete the source branch after merging (default: true)",
+            "example": "true"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_add_pr_label",
+      "integration": "ado",
+      "description": "Add a label (tag) to an Azure DevOps pull request.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "label": {
+            "type": "string",
+            "description": "The label name to add",
+            "example": "needs-review"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "ado_remove_pr_label",
+      "integration": "ado",
+      "description": "Remove a label (tag) from an Azure DevOps pull request. Requires the labelId (from ado_get_pr or ado_list_prs labels array).",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "labelId": {
+            "type": "string",
+            "description": "The label ID to remove (from the PR labels array, not the label name)",
+            "example": "e10671ab-..."
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "labelId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pr_reviewers",
+      "integration": "ado",
+      "description": "Get all reviewers for an Azure DevOps pull request with their vote status. Vote: 10=approved, 5=approved with suggestions, 0=no vote, -5=waiting for author, -10=rejected.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_add_pr_reviewer",
+      "integration": "ado",
+      "description": "Add a reviewer to an Azure DevOps pull request. Optionally set their initial vote.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "reviewerId": {
+            "type": "string",
+            "description": "The reviewer's ID (GUID from ado_get_user_by_email or uniqueName)",
+            "example": "ab1c2d3e-..."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "vote": {
+            "type": "string",
+            "description": "Optional initial vote: 10=approve, 5=approve with suggestions, 0=no vote, -5=wait for author, -10=reject",
+            "example": "0"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "reviewerId"
+        ]
+      }
+    },
+    {
+      "name": "ado_set_pr_vote",
+      "integration": "ado",
+      "description": "Set the current user's vote on a pull request. Vote values: 10=approve, 5=approve with suggestions, 0=reset/no vote, -5=wait for author, -10=reject.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "reviewerId": {
+            "type": "string",
+            "description": "The reviewer's ID (GUID) — use ado_get_my_profile or ado_get_user_by_email to get it",
+            "example": "ab1c2d3e-..."
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "vote": {
+            "type": "string",
+            "description": "Vote value: 10=approve, 5=approve with suggestions, 0=reset, -5=wait for author, -10=reject",
+            "example": "10"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId",
+          "reviewerId",
+          "vote"
+        ]
+      }
+    },
+    {
+      "name": "ado_update_pr",
+      "integration": "ado",
+      "description": "Update pull request properties such as title, description, or status. Use status='abandoned' to abandon a PR, or 'active' to reactivate.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "New description for the pull request (Markdown supported)",
+            "example": "Updated description"
+          },
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          },
+          "title": {
+            "type": "string",
+            "description": "New title for the pull request",
+            "example": "Updated PR title"
+          },
+          "status": {
+            "type": "string",
+            "description": "New status: 'active' or 'abandoned'",
+            "example": "active"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pr_work_items",
+      "integration": "ado",
+      "description": "Get work items linked to an Azure DevOps pull request.",
+      "category": "pull_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "repository": {
+            "type": "string",
+            "description": "The Git repository name",
+            "example": "ai-native-sdlc-blueprint"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "The pull request ID",
+            "example": "1"
+          }
+        },
+        "required": [
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "ado_list_pipelines",
+      "integration": "ado",
+      "description": "List all pipelines defined in the ADO project.",
+      "category": "pipeline_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "ado_trigger_pipeline",
+      "integration": "ado",
+      "description": "Trigger a pipeline run in ADO. Equivalent to github_trigger_workflow.",
+      "category": "pipeline_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "branch": {
+            "type": "string",
+            "description": "The branch to run the pipeline on (e.g. 'main')"
+          },
+          "variables": {
+            "type": "string",
+            "description": "JSON object of pipeline variables, e.g. {\"myVar\":\"value\"}"
+          },
+          "pipelineId": {
+            "type": "number",
+            "description": "The pipeline ID to trigger"
+          }
+        },
+        "required": [
+          "pipelineId"
+        ]
+      }
+    },
+    {
+      "name": "ado_list_pipeline_runs",
+      "integration": "ado",
+      "description": "List recent runs of a pipeline. Equivalent to github_list_workflow_runs.",
+      "category": "pipeline_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "top": {
+            "type": "number",
+            "description": "Number of runs to return (default 10)"
+          },
+          "pipelineId": {
+            "type": "number",
+            "description": "The pipeline ID"
+          }
+        },
+        "required": [
+          "pipelineId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pipeline_run",
+      "integration": "ado",
+      "description": "Get details of a specific pipeline run including state and result.",
+      "category": "pipeline_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "pipelineId": {
+            "type": "number",
+            "description": "The pipeline ID"
+          },
+          "runId": {
+            "type": "number",
+            "description": "The run ID"
+          }
+        },
+        "required": [
+          "pipelineId",
+          "runId"
+        ]
+      }
+    },
+    {
+      "name": "ado_get_pipeline_logs",
+      "integration": "ado",
+      "description": "Get combined logs for all tasks in a pipeline run (build ID). Equivalent to github_get_job_logs.",
+      "category": "pipeline_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "tailLines": {
+            "type": "number",
+            "description": "Lines to return from the end of each task log (default 200, 0 = all)"
+          },
+          "buildId": {
+            "type": "number",
+            "description": "The build/run ID returned by ado_trigger_pipeline or ado_list_pipeline_runs"
+          },
+          "taskName": {
+            "type": "string",
+            "description": "Optional: filter logs to a specific task name (case-insensitive substring match)"
+          }
+        },
+        "required": [
+          "buildId"
+        ]
+      }
+    },
+    {
+      "name": "mermaid_index_generate",
+      "integration": "mermaid",
+      "description": "Generate Mermaid diagrams from content sources (Confluence or Jira) based on include/exclude patterns. Processes content recursively and stores diagrams in hierarchical file structure.",
+      "category": "diagram_generation",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "integration": {
+            "type": "string",
+            "description": "Integration type: 'confluence', 'jira', 'jira_xray', or 'testrail'",
+            "example": "confluence"
+          },
+          "include_patterns": {
+            "type": "array",
+            "description": "Array of include patterns. For Confluence: [\"SPACE/pages/PAGE_ID/PAGE_NAME/**\"]. For Jira: [\"JQL query\"]. For TestRail: [\"project_id=5&suite_id=3\"]",
+            "example": "[\"AINA/pages/11665522/Templates/**\"]"
+          },
+          "exclude_patterns": {
+            "type": "array",
+            "description": "Optional array of exclude patterns to filter out specific content (not used for Jira)",
+            "example": "[]"
+          },
+          "storage_path": {
+            "type": "string",
+            "description": "Base path for storing generated diagrams",
+            "example": "./mermaid-diagrams"
+          },
+          "custom_fields": {
+            "type": "array",
+            "description": "Optional array of custom field names to include in content (only for Jira integrations)",
+            "example": "[\"summary\", \"description\", \"customfield_10001\"]"
+          },
+          "include_comments": {
+            "type": "boolean",
+            "description": "Whether to include comments in content (only for Jira integrations, default: false)",
+            "example": "false"
+          }
+        },
+        "required": [
+          "integration",
+          "storage_path",
+          "include_patterns"
+        ]
+      }
+    },
+    {
+      "name": "mermaid_index_read_list",
+      "integration": "mermaid",
+      "description": "Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of ToText objects with paths and content.",
+      "category": "diagram_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "integration": {
+            "type": "string",
+            "description": "Integration type (used as subfolder name under storage path)",
+            "example": "confluence"
+          },
+          "storage_path": {
+            "type": "string",
+            "description": "Base path where diagrams are stored",
+            "example": "./mermaid-diagrams"
+          }
+        },
+        "required": [
+          "integration",
+          "storage_path"
+        ]
+      }
+    },
+    {
+      "name": "mermaid_index_read",
+      "integration": "mermaid",
+      "description": "Read all Mermaid diagram files (.mmd) from storage path recursively. Returns list of diagrams with their paths and content.",
+      "category": "diagram_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "integration": {
+            "type": "string",
+            "description": "Integration type (used as subfolder name under storage path)",
+            "example": "confluence"
+          },
+          "storage_path": {
+            "type": "string",
+            "description": "Base path where diagrams are stored",
+            "example": "./mermaid-diagrams"
+          }
+        },
+        "required": [
+          "integration",
+          "storage_path"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_test",
+      "integration": "jira_xray",
+      "description": "Test X-ray connectivity by obtaining an access token",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "jira_xray_create_precondition",
+      "integration": "jira_xray",
+      "description": "Create a Precondition issue in Xray with optional steps (converted to definition). Returns the created ticket key.",
+      "category": "xray_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string",
+            "description": "Precondition summary",
+            "example": "System is ready for testing"
+          },
+          "project": {
+            "type": "string",
+            "description": "Project key (e.g., 'TP')",
+            "example": "TP"
+          },
+          "description": {
+            "type": "string",
+            "description": "Precondition description",
+            "example": "All system components are initialized"
+          },
+          "steps": {
+            "type": "string",
+            "description": "Optional JSON array of steps in format [{\"action\": \"...\", \"data\": \"...\", \"result\": \"...\"}]. Will be converted to definition format."
+          }
+        },
+        "required": [
+          "project",
+          "summary"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_search_tickets",
+      "integration": "jira_xray",
+      "description": "Search for Jira tickets using JQL query and enrich Test/Precondition issues with X-ray test steps and preconditions. Returns list of tickets with X-ray data.",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Array of field names to retrieve (e.g., ['summary', 'description', 'status'])",
+            "example": "summary,description,status"
+          },
+          "searchQueryJQL": {
+            "type": "string",
+            "description": "JQL search query (e.g., 'project = TP AND issueType = Test')",
+            "example": "project = TP AND issueType = Test"
+          }
+        },
+        "required": [
+          "searchQueryJQL"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_get_test_details",
+      "integration": "jira_xray",
+      "description": "Get test details including steps and preconditions using X-ray GraphQL API. Returns JSONObject with test details.",
+      "category": "test_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "testKey": {
+            "type": "string",
+            "description": "Jira ticket key (e.g., 'TP-909')",
+            "example": "TP-909"
+          }
+        },
+        "required": [
+          "testKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_get_test_steps",
+      "integration": "jira_xray",
+      "description": "Get test steps for a test issue using X-ray GraphQL API. Returns JSONArray of test steps.",
+      "category": "test_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "testKey": {
+            "type": "string",
+            "description": "Jira ticket key (e.g., 'TP-909')",
+            "example": "TP-909"
+          }
+        },
+        "required": [
+          "testKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_get_preconditions",
+      "integration": "jira_xray",
+      "description": "Get preconditions for a test issue using X-ray GraphQL API. Returns JSONArray of precondition objects.",
+      "category": "test_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "testKey": {
+            "type": "string",
+            "description": "Jira ticket key (e.g., 'TP-909')",
+            "example": "TP-909"
+          }
+        },
+        "required": [
+          "testKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_get_precondition_details",
+      "integration": "jira_xray",
+      "description": "Get Precondition details including definition using X-ray GraphQL API. Returns JSONObject with precondition details.",
+      "category": "test_retrieval",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "preconditionKey": {
+            "type": "string",
+            "description": "Jira ticket key (e.g., 'TP-910')",
+            "example": "TP-910"
+          }
+        },
+        "required": [
+          "preconditionKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_add_test_step",
+      "integration": "jira_xray",
+      "description": "Add a single test step to a test issue using X-ray GraphQL API. Returns JSONObject with created step details.",
+      "category": "test_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "string",
+            "description": "Step expected result (e.g., 'Username accepted')",
+            "example": "Username accepted"
+          },
+          "action": {
+            "type": "string",
+            "description": "Step action (e.g., 'Enter username')",
+            "example": "Enter username"
+          },
+          "issueId": {
+            "type": "string",
+            "description": "Jira issue ID (e.g., '12345')",
+            "example": "12345"
+          },
+          "data": {
+            "type": "string",
+            "description": "Step data (e.g., 'test_user')",
+            "example": "test_user"
+          }
+        },
+        "required": [
+          "issueId",
+          "action"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_add_test_steps",
+      "integration": "jira_xray",
+      "description": "Add multiple test steps to a test issue using X-ray GraphQL API. Returns JSONArray of created step objects.",
+      "category": "test_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "steps": {
+            "type": "object",
+            "description": "JSON array string of step objects, each with 'action', 'data', and 'result' fields (e.g., '[{\"action\":\"Enter username\",\"data\":\"test_user\",\"result\":\"Username accepted\"}]')",
+            "example": "[{\"action\":\"Enter username\",\"data\":\"test_user\",\"result\":\"Username accepted\"}]"
+          },
+          "issueId": {
+            "type": "string",
+            "description": "Jira issue ID (e.g., '12345')",
+            "example": "12345"
+          }
+        },
+        "required": [
+          "issueId",
+          "steps"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_add_precondition_to_test",
+      "integration": "jira_xray",
+      "description": "Add a single precondition to a test issue using X-ray GraphQL API. Returns JSONObject with result.",
+      "category": "test_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "testIssueId": {
+            "type": "string",
+            "description": "Jira issue ID of the test (e.g., '12345')",
+            "example": "12345"
+          },
+          "preconditionIssueId": {
+            "type": "string",
+            "description": "Jira issue ID of the precondition (e.g., '12346')",
+            "example": "12346"
+          }
+        },
+        "required": [
+          "testIssueId",
+          "preconditionIssueId"
+        ]
+      }
+    },
+    {
+      "name": "jira_xray_add_preconditions_to_test",
+      "integration": "jira_xray",
+      "description": "Add multiple preconditions to a test issue using X-ray GraphQL API. Returns JSONArray of results.",
+      "category": "test_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "preconditionIssueIds": {
+            "type": "object",
+            "description": "JSON array string of precondition issue IDs (e.g., '[\"12346\", \"12347\"]')",
+            "example": "[\"12346\", \"12347\"]"
+          },
+          "testIssueId": {
+            "type": "string",
+            "description": "Jira issue ID of the test (e.g., '12345')",
+            "example": "12345"
+          }
+        },
+        "required": [
+          "testIssueId",
+          "preconditionIssueIds"
+        ]
+      }
+    },
+    {
+      "name": "file_read",
+      "integration": "file",
+      "description": "Read file content from working directory (supports input/ and outputs/ folders). Returns file content as string or null if file doesn't exist or is inaccessible. All file formats supported as UTF-8 text.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "File path relative to working directory or absolute path within working directory",
+            "example": "outputs/response.md"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    {
+      "name": "file_write",
+      "integration": "file",
+      "description": "Write content to file in working directory. Creates parent directories automatically. Returns success message or null on failure.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "File path relative to working directory or absolute path within working directory",
+            "example": "inbox/raw/teams_messages/1729766400000-messages.json"
+          },
+          "content": {
+            "type": "string",
+            "description": "Content to write to the file as UTF-8 string",
+            "example": "{\"messages\": []}"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ]
+      }
+    },
+    {
+      "name": "file_delete",
+      "integration": "file",
+      "description": "Delete file or directory from working directory. Returns success message or null on failure.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "File path relative to working directory or absolute path within working directory",
+            "example": "temp/unused_file.txt"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    {
+      "name": "file_validate_json",
+      "integration": "file",
+      "description": "Validate JSON string and return detailed error information if invalid. Returns JSON string with validation result: {\"valid\": true} for valid JSON, or {\"valid\": false, \"error\": \"error message\", \"line\": line_number, \"column\": column_number, \"position\": character_position, \"context\": \"context around error\"} for invalid JSON.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "json": {
+            "type": "string",
+            "description": "JSON string to validate",
+            "example": "{\"key\": \"value\"}"
+          }
+        },
+        "required": [
+          "json"
+        ]
+      }
+    },
+    {
+      "name": "file_validate_json_file",
+      "integration": "file",
+      "description": "Validate JSON file and return detailed error information if invalid. Reads file from working directory and validates its JSON content. Returns JSON string with validation result including file path.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "description": "File path relative to working directory or absolute path within working directory",
+            "example": "outputs/response.json"
+          }
+        },
+        "required": [
+          "path"
+        ]
+      }
+    },
+    {
+      "name": "figma_oauth2_get_auth_url",
+      "integration": "figma",
+      "description": "Generates the Figma OAuth2 authorization URL for the initial authorization code flow. Open the returned URL in a browser, authorize the app, and copy the 'code' parameter from the redirect URL. Then call figma_oauth2_exchange_code to get access and refresh tokens. Requires FIGMA_CLIENT_ID and FIGMA_CLIENT_SECRET to be configured. Optional scope can be passed explicitly or via FIGMA_SCOPE/FIGMA_OAUTH_SCOPES env variable.",
+      "category": "auth",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "redirectUri": {
+            "type": "string",
+            "description": "Redirect URI registered in your Figma OAuth app (e.g. http://localhost:8080/callback). If omitted, uses FIGMA_REDIRECT_URI env variable.",
+            "example": "http://localhost:8080/callback"
+          },
+          "state": {
+            "type": "string",
+            "description": "Random state string for CSRF protection",
+            "example": "random_state_123"
+          },
+          "scope": {
+            "type": "string",
+            "description": "Optional OAuth scope list (space-separated), e.g. file_content:read file_metadata:read. If omitted, uses FIGMA_SCOPE (or FIGMA_OAUTH_SCOPES) env or default minimal read scope.",
+            "example": "file_content:read file_metadata:read"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "figma_oauth2_exchange_code",
+      "integration": "figma",
+      "description": "Exchanges a Figma OAuth2 authorization code for access and refresh tokens. Use the code from the redirect URL after completing the browser authorization flow started by figma_oauth2_get_auth_url. Store FIGMA_OAUTH_REFRESH_TOKEN from the response in your dmtools.env to enable automatic token refresh.",
+      "category": "auth",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "redirectUri": {
+            "type": "string",
+            "description": "Same redirect URI used in figma_oauth2_get_auth_url. If omitted, uses FIGMA_REDIRECT_URI env variable.",
+            "example": "http://localhost:8080/callback"
+          },
+          "code": {
+            "type": "string",
+            "description": "Authorization code received from Figma OAuth2 redirect",
+            "example": "figma_auth_code_abc123"
+          }
+        },
+        "required": [
+          "code"
+        ]
+      }
+    },
+    {
+      "name": "figma_test",
+      "integration": "figma",
+      "description": "Test Figma connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "figma_me",
+      "integration": "figma",
+      "description": "Gets current user information from the Figma API using the /me endpoint. Returns user details including id, handle, and email. Can also be used to verify API connectivity.",
+      "category": "user",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "figma_get_screen_source",
+      "integration": "figma",
+      "description": "Get screen source content by URL. Returns the image URL for the specified Figma design node.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Figma design URL with node-id parameter",
+            "example": "https://www.figma.com/file/abc123/Design?node-id=1%3A2"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    },
+    {
+      "name": "figma_download_node_image",
+      "integration": "figma",
+      "description": "Download image of specific node/component. Useful for visual preview of design pieces before processing structure.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Image format: png or jpg"
+          },
+          "scale": {
+            "type": "number",
+            "description": "Scale factor: 1, 2, or 4"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          },
+          "nodeId": {
+            "type": "string",
+            "description": "Node ID to download"
+          }
+        },
+        "required": [
+          "href",
+          "nodeId"
+        ]
+      }
+    },
+    {
+      "name": "figma_download_image_of_file",
+      "integration": "figma",
+      "description": "Download image by URL as File type. Converts Figma design URL to downloadable image file.",
+      "category": "file_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL to download as image file",
+            "example": "https://www.figma.com/file/abc123/Design?node-id=1%3A2"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_file_structure",
+      "integration": "figma",
+      "description": "Get full JSON structure of a Figma design file by URL. Returns the complete document tree (nodes, frames, components, text, styles). Response is large by design — intended for pre-CLI artifact preparation and file output, not inline AI context. If the URL contains node-id, returns only that subtree.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Parameter href"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_icons",
+      "integration": "figma",
+      "description": "Find and extract all exportable visual elements (vectors, shapes, graphics, text) from Figma design by URL. Focuses on actual visual elements to avoid complex component references.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL to extract visual elements from",
+            "example": "https://www.figma.com/file/abc123/Design"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_image_fills",
+      "integration": "figma",
+      "description": "Get original image fill URLs for all imageRefs in a Figma file. Resolves imageRef placeholders to actual downloadable S3 URLs. Use after inspecting file structure to download original photos/images embedded by the designer.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_render_nodes",
+      "integration": "figma",
+      "description": "Render multiple Figma nodes as images in a single batched API call. Automatically batches up to 100 node IDs per request. Returns map of nodeId to render URL. Use for exporting many icons or frames efficiently.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Export format: png, jpg, svg, pdf. Default: png"
+          },
+          "nodeIds": {
+            "type": "string",
+            "description": "Comma-separated node IDs to render (e.g. '1:2,3:4,5:6')"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href",
+          "nodeIds"
+        ]
+      }
+    },
+    {
+      "name": "figma_download_image_as_file",
+      "integration": "figma",
+      "description": "Download image as file by node ID and format. Use this after figma_get_icons to download actual icon files.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Export format",
+            "example": "png"
+          },
+          "nodeId": {
+            "type": "string",
+            "description": "Node ID to export (from figma_get_icons result)",
+            "example": "123:456"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL to extract file ID from",
+            "example": "https://www.figma.com/file/abc123/Design"
+          }
+        },
+        "required": [
+          "href",
+          "nodeId",
+          "format"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_svg_content",
+      "integration": "figma",
+      "description": "Get SVG content as text by node ID. Use this after figma_get_icons to get SVG code for vector icons.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "nodeId": {
+            "type": "string",
+            "description": "Node ID to export as SVG (from figma_get_icons result)",
+            "example": "123:456"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL to extract file ID from",
+            "example": "https://www.figma.com/file/abc123/Design"
+          }
+        },
+        "required": [
+          "href",
+          "nodeId"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_node_details",
+      "integration": "figma",
+      "description": "Get detailed properties for specific node(s) including colors, fonts, text, dimensions, and styles. Returns small focused response.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "nodeIds": {
+            "type": "string",
+            "description": "Comma-separated node IDs (max 10)"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href",
+          "nodeIds"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_text_content",
+      "integration": "figma",
+      "description": "Extract text content from text nodes. Returns map of nodeId to text content.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "nodeIds": {
+            "type": "string",
+            "description": "Comma-separated text node IDs (max 20)"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href",
+          "nodeIds"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_styles",
+      "integration": "figma",
+      "description": "Get design tokens (colors, text styles) defined in Figma file.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_layers",
+      "integration": "figma",
+      "description": "Get first-level layers (direct children) to understand structure. Returns layer names, IDs, types, sizes. Essential first step before getting details.",
+      "category": "structure_analysis",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL with node-id"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_layers_batch",
+      "integration": "figma",
+      "description": "Get layers for multiple nodes at once. More efficient for analyzing multiple screens/containers. Returns map of nodeId to layers.",
+      "category": "structure_analysis",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "nodeIds": {
+            "type": "string",
+            "description": "Comma-separated node IDs (max 10)"
+          },
+          "href": {
+            "type": "string",
+            "description": "Figma design URL"
+          }
+        },
+        "required": [
+          "href",
+          "nodeIds"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_node_children",
+      "integration": "figma",
+      "description": "Get immediate children IDs and basic info for a node. Non-recursive, returns only direct children.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design URL with node-id"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "figma_list_team_projects",
+      "integration": "figma",
+      "description": "List all projects within a Figma team, so a team-level 'files' listing URL (which is not a single design file and cannot be passed to file-specific tools like figma_get_layers) can be broken down into browsable projects. Accepts either a raw numeric team ID or any Figma URL containing a '/team/<teamId>' path segment.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "teamIdOrUrl": {
+            "type": "string",
+            "description": "Numeric Figma team ID, or a Figma URL containing '/team/<teamId>' (e.g. a team files-listing URL)",
+            "example": "https://www.figma.com/files/1008118788610687562/team/1633438210497791577"
+          }
+        },
+        "required": [
+          "teamIdOrUrl"
+        ]
+      }
+    },
+    {
+      "name": "figma_list_project_files",
+      "integration": "figma",
+      "description": "List all design files within a Figma project, returning each file's key, name, and thumbnail so a specific file URL can be built for use with file-specific tools like figma_get_layers or figma_get_file_structure. Use figma_list_team_projects first to discover project IDs from a team. Accepts either a raw numeric project ID or any Figma URL containing a '/project/<projectId>' path segment.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectIdOrUrl": {
+            "type": "string",
+            "description": "Numeric Figma project ID, or a Figma URL containing '/project/<projectId>'",
+            "example": "https://www.figma.com/files/project/123456789"
+          }
+        },
+        "required": [
+          "projectIdOrUrl"
+        ]
+      }
+    },
+    {
+      "name": "figma_get_file_comments",
+      "integration": "figma",
+      "description": "Get all comments left on a Figma design file, including comment text, author, and creation date. Accepts either a raw Figma file key or a full Figma design file URL.",
+      "category": "content_access",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "Figma design file URL, or a raw Figma file key",
+            "example": "https://www.figma.com/file/abc123/Design"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "testrail_test",
+      "integration": "testrail",
+      "description": "Test TestRail connectivity by fetching projects",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "testrail_get_projects",
+      "integration": "testrail",
+      "description": "Get list of all projects in TestRail",
+      "category": "projects",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "testrail_get_suites",
+      "integration": "testrail",
+      "description": "Get all test suites for a TestRail project",
+      "category": "suites",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "type": "string",
+            "description": "Project name to get suites from",
+            "example": "My Project"
+          }
+        },
+        "required": [
+          "project_name"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_case",
+      "integration": "testrail",
+      "description": "Get a TestRail test case by ID. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML — raw HTML pasted from Google Docs/browsers can be 20-30x larger than necessary due to inline CSS styling on every tag.",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "description": "The test case ID (numeric, without 'C' prefix)",
+            "example": "123"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
+            "example": "markdown"
+          }
+        },
+        "required": [
+          "case_id"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_all_cases",
+      "integration": "testrail",
+      "description": "Get ALL test cases in a project (uses pagination to retrieve all cases). Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "type": "string",
+            "description": "Project name to get all cases from",
+            "example": "My Project"
+          },
+          "format": {
+            "type": "string",
+            "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
+            "example": "markdown"
+          }
+        },
+        "required": [
+          "project_name"
+        ]
+      }
+    },
+    {
+      "name": "testrail_search_cases",
+      "integration": "testrail",
+      "description": "Search TestRail test cases by project and optional filters. Set format='markdown' to receive preconditions/steps/expected-result HTML fields converted to clean Markdown (tables preserved as GitHub-Flavoured Markdown) instead of raw TestRail HTML.",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string",
+            "description": "Output format for HTML-bearing fields (preconditions, steps, expected results): 'html' (default, raw TestRail HTML) or 'md'/'markdown' (cleaned Markdown — much smaller and easier to read or feed to an LLM). If omitted, falls back to the TESTRAIL_DEFAULT_FORMAT env var (defaults to 'html' when unset).",
+            "example": "markdown"
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Project name to search in",
+            "example": "My Project"
+          },
+          "section_id": {
+            "type": "string",
+            "description": "Section ID to filter by (optional)",
+            "example": "10"
+          },
+          "suite_id": {
+            "type": "string",
+            "description": "Suite ID to filter by (optional)",
+            "example": "1"
+          }
+        },
+        "required": [
+          "project_name"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_cases_by_refs",
+      "integration": "testrail",
+      "description": "Get test cases linked to a requirement/story via refs field",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "type": "string",
+            "description": "Project name to search in",
+            "example": "My Project"
+          },
+          "refs": {
+            "type": "string",
+            "description": "Reference ID (e.g., JIRA ticket key)",
+            "example": "PROJ-123"
+          }
+        },
+        "required": [
+          "refs",
+          "project_name"
+        ]
+      }
+    },
+    {
+      "name": "testrail_create_case",
+      "integration": "testrail",
+      "description": "Create a new test case in TestRail",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "Test case description/steps (optional)",
+            "example": "1. Navigate to login page\n2. Enter credentials\n3. Click login"
+          },
+          "priority_id": {
+            "type": "string",
+            "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
+            "example": "3"
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Project name",
+            "example": "My Project"
+          },
+          "title": {
+            "type": "string",
+            "description": "Test case title/summary",
+            "example": "Verify login functionality"
+          },
+          "refs": {
+            "type": "string",
+            "description": "Reference to requirement (e.g., JIRA key)",
+            "example": "PROJ-123"
+          }
+        },
+        "required": [
+          "project_name",
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "testrail_create_case_detailed",
+      "integration": "testrail",
+      "description": "Create a new test case in TestRail with detailed fields (preconditions, steps, expected results, labels, type). Note: TestRail uses its own table format in text fields: |||:Col 1|:Col 2|:Col 3\\n||val1|val2|val3. Standard Markdown tables (| Col | Col |) will be auto-converted to TestRail format.",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "priority_id": {
+            "type": "string",
+            "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
+            "example": "3"
+          },
+          "refs": {
+            "type": "string",
+            "description": "Reference to requirement (e.g., JIRA key)",
+            "example": "PROJ-123"
+          },
+          "preconditions": {
+            "type": "string",
+            "description": "Preconditions (optional). For tables use TestRail format: |||:Col1|:Col2\\n||val1|val2",
+            "example": "User is logged out"
+          },
+          "type_id": {
+            "type": "string",
+            "description": "Case type ID (optional). Use testrail_get_case_types to get available types.",
+            "example": "1"
+          },
+          "label_ids": {
+            "type": "string",
+            "description": "Comma-separated label IDs (optional). Use testrail_get_labels to find IDs.",
+            "example": "7,8"
+          },
+          "expected": {
+            "type": "string",
+            "description": "Expected results (optional)",
+            "example": "User is logged in and redirected to dashboard"
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Project name",
+            "example": "My Project"
+          },
+          "title": {
+            "type": "string",
+            "description": "Test case title/summary",
+            "example": "Verify login functionality"
+          },
+          "steps": {
+            "type": "string",
+            "description": "Test steps separated by double newline (optional)",
+            "example": "Navigate to login page.\\n\\nEnter username %Username%.\\n\\nClick Login button."
+          }
+        },
+        "required": [
+          "project_name",
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "testrail_create_case_steps",
+      "integration": "testrail",
+      "description": "Create a TestRail test case using the 'Test Case (Steps)' template (template_id=2). Steps are provided as a JSON array: [{\"content\":\"step text\",\"expected\":\"expected result\"}, ...]. Markdown tables in step content or expected are auto-converted to HTML tables. Use testrail_get_case_types for type_id, testrail_get_labels for label_ids.",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "priority_id": {
+            "type": "string",
+            "description": "Priority ID: 1=Low, 2=Medium, 3=High, 4=Critical (optional, default=2)",
+            "example": "3"
+          },
+          "refs": {
+            "type": "string",
+            "description": "Reference to requirement (e.g., JIRA key)",
+            "example": "PROJ-123"
+          },
+          "preconditions": {
+            "type": "string",
+            "description": "Preconditions text (optional)",
+            "example": "User is logged out"
+          },
+          "type_id": {
+            "type": "string",
+            "description": "Case type ID (optional). Use testrail_get_case_types to get available types.",
+            "example": "1"
+          },
+          "label_ids": {
+            "type": "string",
+            "description": "Comma-separated label IDs (optional). Use testrail_get_labels to find IDs.",
+            "example": "7,8"
+          },
+          "steps_json": {
+            "type": "string",
+            "description": "JSON array of step objects: [{\"content\":\"step\",\"expected\":\"result\"}, ...]. Markdown tables are auto-converted to HTML.",
+            "example": "[{\"content\":\"Open login page\",\"expected\":\"Login form is displayed\"},{\"content\":\"Enter credentials\",\"expected\":\"Fields populated\"}]"
+          },
+          "project_name": {
+            "type": "string",
+            "description": "Project name",
+            "example": "My Project"
+          },
+          "title": {
+            "type": "string",
+            "description": "Test case title/summary",
+            "example": "Verify login functionality"
+          }
+        },
+        "required": [
+          "project_name",
+          "title",
+          "steps_json"
+        ]
+      }
+    },
+    {
+      "name": "testrail_update_case",
+      "integration": "testrail",
+      "description": "Update a test case in TestRail",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "description": "The test case ID to update",
+            "example": "123"
+          },
+          "priority_id": {
+            "type": "string",
+            "description": "New priority ID (optional)",
+            "example": "3"
+          },
+          "title": {
+            "type": "string",
+            "description": "New title (optional)",
+            "example": "Updated title"
+          },
+          "refs": {
+            "type": "string",
+            "description": "New references (optional)",
+            "example": "PROJ-123"
+          }
+        },
+        "required": [
+          "case_id"
+        ]
+      }
+    },
+    {
+      "name": "testrail_delete_case",
+      "integration": "testrail",
+      "description": "Delete a test case in TestRail by case ID",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "description": "The numeric test case ID to delete (without the C prefix)",
+            "example": "123"
+          }
+        },
+        "required": [
+          "case_id"
+        ]
+      }
+    },
+    {
+      "name": "testrail_link_to_requirement",
+      "integration": "testrail",
+      "description": "Link a test case to a requirement by updating refs field",
+      "category": "test_cases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "case_id": {
+            "type": "string",
+            "description": "The test case ID",
+            "example": "123"
+          },
+          "requirement_key": {
+            "type": "string",
+            "description": "Requirement key (e.g., JIRA ticket)",
+            "example": "PROJ-123"
+          }
+        },
+        "required": [
+          "case_id",
+          "requirement_key"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_labels",
+      "integration": "testrail",
+      "description": "Get all labels for a project in TestRail",
+      "category": "labels",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "type": "string",
+            "description": "Project name",
+            "example": "My Project"
+          }
+        },
+        "required": [
+          "project_name"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_label",
+      "integration": "testrail",
+      "description": "Get a single label by ID",
+      "category": "labels",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "label_id": {
+            "type": "string",
+            "description": "The label ID",
+            "example": "7"
+          }
+        },
+        "required": [
+          "label_id"
+        ]
+      }
+    },
+    {
+      "name": "testrail_update_label",
+      "integration": "testrail",
+      "description": "Update a label title in TestRail. Maximum 20 characters allowed.",
+      "category": "labels",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project_name": {
+            "type": "string",
+            "description": "Project name",
+            "example": "My Project"
+          },
+          "title": {
+            "type": "string",
+            "description": "New label title (max 20 characters)",
+            "example": "Release 2.0"
+          },
+          "label_id": {
+            "type": "string",
+            "description": "The label ID to update",
+            "example": "7"
+          }
+        },
+        "required": [
+          "label_id",
+          "project_name",
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "testrail_get_case_types",
+      "integration": "testrail",
+      "description": "Get all available case types in TestRail (e.g., Automated, Functionality, Other)",
+      "category": "case_types",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "kb_get",
+      "integration": "kb",
+      "description": "Get last sync date for a knowledge base source. Returns ISO 8601 date string or 'Source not found' message.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
+            "example": "/path/to/knowledge-base"
+          },
+          "source_name": {
+            "type": "string",
+            "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
+            "example": "teams_chat"
+          }
+        },
+        "required": [
+          "source_name"
+        ]
+      }
+    },
+    {
+      "name": "kb_build",
+      "integration": "kb",
+      "description": "Build or update knowledge base from input file. Processes chat messages, documentation, or any text data to create indexed, searchable knowledge base. Returns JSON with statistics.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "input_file": {
+            "type": "string",
+            "description": "Path to input file (JSON or text format). Can be JSON array of messages or plain text.",
+            "example": "/path/to/messages.json"
+          },
+          "output_path": {
+            "type": "string",
+            "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
+            "example": "/path/to/knowledge-base"
+          },
+          "date_time": {
+            "type": "string",
+            "description": "Sync date/time in ISO 8601 format (e.g., '2024-10-10T12:00:00Z')",
+            "example": "2024-10-10T12:00:00Z"
+          },
+          "source_name": {
+            "type": "string",
+            "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
+            "example": "teams_chat"
+          },
+          "clean_source": {
+            "type": "string",
+            "description": "Optional. If true, removes all existing Q/A/N from this source before processing. Use for content refresh (e.g., Confluence pages).",
+            "example": "true"
+          }
+        },
+        "required": [
+          "source_name",
+          "input_file",
+          "date_time"
+        ]
+      }
+    },
+    {
+      "name": "kb_process",
+      "integration": "kb",
+      "description": "Process input file and build KB structure WITHOUT generating AI descriptions (fast mode). Use this for bulk data processing. Run kb_aggregate later to generate descriptions.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "input_file": {
+            "type": "string",
+            "description": "Path to input file (JSON or text format). Can be JSON array of messages or plain text.",
+            "example": "/path/to/messages.json"
+          },
+          "output_path": {
+            "type": "string",
+            "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
+            "example": "/path/to/knowledge-base"
+          },
+          "date_time": {
+            "type": "string",
+            "description": "Sync date/time in ISO 8601 format (e.g., '2024-10-10T12:00:00Z')",
+            "example": "2024-10-10T12:00:00Z"
+          },
+          "source_name": {
+            "type": "string",
+            "description": "Name of the data source (e.g., 'teams_chat', 'slack_general')",
+            "example": "teams_chat"
+          },
+          "clean_source": {
+            "type": "string",
+            "description": "Optional. If true, removes all existing Q/A/N from this source before processing. Use for content refresh (e.g., Confluence pages).",
+            "example": "true"
+          }
+        },
+        "required": [
+          "source_name",
+          "input_file",
+          "date_time"
+        ]
+      }
+    },
+    {
+      "name": "kb_aggregate",
+      "integration": "kb",
+      "description": "Generate AI descriptions for existing KB structure WITHOUT processing new data. Use this after kb_process to add AI-generated descriptions for people and topics.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "smart_mode": {
+            "type": "string",
+            "description": "Only regenerate descriptions if Q/A/N files have changed. Default: true",
+            "example": "true"
+          },
+          "output_path": {
+            "type": "string",
+            "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
+            "example": "/path/to/knowledge-base"
+          },
+          "source_name": {
+            "type": "string",
+            "description": "Optional: Filter to only regenerate for specific source. If null/empty, regenerates for ALL sources (recommended for description regeneration).",
+            "example": "teams_chat"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "kb_process_inbox",
+      "integration": "kb",
+      "description": "Scan inbox/raw/ folders and process all unprocessed files automatically. Files are processed in place. Returns JSON with processed and skipped file details.",
+      "category": "",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "generate_descriptions": {
+            "type": "string",
+            "description": "Generate AI descriptions after processing. Default: true",
+            "example": "true"
+          },
+          "output_path": {
+            "type": "string",
+            "description": "Optional path to KB directory. Defaults to DMTOOLS_KB_OUTPUT_PATH env var or current directory",
+            "example": "/path/to/knowledge-base"
+          },
+          "smart_aggregation": {
+            "type": "string",
+            "description": "Only regenerate descriptions if Q/A/N changed. Default: true",
+            "example": "true"
+          }
+        },
+        "required": []
+      }
+    },
+    {
+      "name": "teams_auth_start",
+      "integration": "teams_auth",
+      "description": "Start device code authentication for Microsoft Teams. Returns URL and code for user to authenticate.",
+      "category": "authentication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "teams_auth_complete",
+      "integration": "teams_auth",
+      "description": "Complete device code authentication after user approval. Polls for tokens and saves refresh token.",
+      "category": "authentication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "teams_auth_status",
+      "integration": "teams_auth",
+      "description": "Check current Microsoft Teams authentication status and configuration.",
+      "category": "authentication",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "gitlab_test",
+      "integration": "gitlab",
+      "description": "Test GitLab connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "gitlab_get_mr_comments",
+      "integration": "gitlab",
+      "description": "Get all comments for a GitLab merge request, including both inline code review comments (DiffNote) and general discussion notes. Excludes system-generated notes.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_add_mr_label",
+      "integration": "gitlab",
+      "description": "Add a label to a GitLab merge request.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "label": {
+            "type": "string",
+            "description": "Label to add",
+            "example": "pr_approved"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_remove_mr_label",
+      "integration": "gitlab",
+      "description": "Remove a label from a GitLab merge request.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "label": {
+            "type": "string",
+            "description": "Label to remove",
+            "example": "pr_approved"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_mr_activities",
+      "integration": "gitlab",
+      "description": "Get all activities for a GitLab merge request. Approvals are fetched from the real GitLab Approvals API. General discussion notes are also included.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_add_mr_comment",
+      "integration": "gitlab",
+      "description": "Add a general discussion comment to a GitLab merge request.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "text": {
+            "type": "string",
+            "description": "Comment text",
+            "example": "LGTM!"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_mr_diff",
+      "integration": "gitlab",
+      "description": "Get diff stats and changed files for a GitLab merge request.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_mr_diff_text",
+      "integration": "gitlab",
+      "description": "Get the raw unified diff text for a GitLab merge request (suitable for locating file/line positions, e.g. for inline review comments).",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_mr",
+      "integration": "gitlab",
+      "description": "Get details of a specific GitLab merge request including title, description, state, author, diff_refs (base_sha, head_sha, start_sha needed for inline comments).",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_list_mrs",
+      "integration": "gitlab",
+      "description": "List merge requests for a GitLab project. State can be 'opened', 'closed', 'merged', or 'all'.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "state": {
+            "type": "string",
+            "description": "MR state: opened, closed, merged, all. 'open' is also accepted as a synonym for 'opened'.",
+            "example": "opened"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "state"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_create_mr",
+      "integration": "gitlab",
+      "description": "Create a GitLab merge request from a source branch into a target branch.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "sourceBranch": {
+            "type": "string",
+            "description": "Source branch name",
+            "example": "feature/PROJ-123"
+          },
+          "targetBranch": {
+            "type": "string",
+            "description": "Target branch name",
+            "example": "main"
+          },
+          "title": {
+            "type": "string",
+            "description": "Merge request title",
+            "example": "PROJ-123 Implement feature"
+          },
+          "description": {
+            "type": "string",
+            "description": "Merge request description",
+            "example": "Automated changes"
+          },
+          "removeSourceBranch": {
+            "type": "string",
+            "description": "Remove source branch after merge",
+            "example": "true"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "sourceBranch",
+          "targetBranch",
+          "title"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_mr_discussions",
+      "integration": "gitlab",
+      "description": "Get all discussion threads for a GitLab merge request. Each discussion contains notes (comments) and a resolved status. Use the discussion id with gitlab_resolve_mr_thread.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_reply_to_mr_thread",
+      "integration": "gitlab",
+      "description": "Reply to an existing discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "discussionId": {
+            "type": "string",
+            "description": "Discussion thread ID",
+            "example": "6a9c1750b37d57bba1079be3bbd13a..."
+          },
+          "text": {
+            "type": "string",
+            "description": "Reply text",
+            "example": "Addressed in latest commit"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "discussionId",
+          "text"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_add_inline_mr_comment",
+      "integration": "gitlab",
+      "description": "Create a new inline code review comment on a specific file and line in a GitLab merge request. Requires base_sha, head_sha, start_sha from the MR diff refs (use gitlab_get_mr to get them from diff_refs).",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "Path to the file to comment on",
+            "example": "src/main/Foo.java"
+          },
+          "line": {
+            "type": "string",
+            "description": "Line number in the new file to comment on",
+            "example": "42"
+          },
+          "text": {
+            "type": "string",
+            "description": "Comment text",
+            "example": "This looks wrong"
+          },
+          "baseSha": {
+            "type": "string",
+            "description": "Base commit SHA from MR diff_refs",
+            "example": "abc123"
+          },
+          "headSha": {
+            "type": "string",
+            "description": "Head commit SHA from MR diff_refs",
+            "example": "def456"
+          },
+          "startSha": {
+            "type": "string",
+            "description": "Start commit SHA from MR diff_refs",
+            "example": "abc123"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "filePath",
+          "line",
+          "text",
+          "baseSha",
+          "headSha",
+          "startSha"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_resolve_mr_thread",
+      "integration": "gitlab",
+      "description": "Resolve (close) a review discussion thread in a GitLab merge request. Use the discussion id from gitlab_get_mr_discussions.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "discussionId": {
+            "type": "string",
+            "description": "Discussion thread ID to resolve",
+            "example": "6a9c1750b37d57bba1079be3bbd13a..."
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId",
+          "discussionId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_approve_mr",
+      "integration": "gitlab",
+      "description": "Approve a GitLab merge request. Adds your approval to the MR.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_merge_mr",
+      "integration": "gitlab",
+      "description": "Merge a GitLab merge request. Optionally provide a custom merge commit message.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          },
+          "mergeCommitMessage": {
+            "type": "string",
+            "description": "Optional custom merge commit message",
+            "example": "Merge feature branch"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_rebase_mr",
+      "integration": "gitlab",
+      "description": "Ask GitLab to rebase/update a merge request source branch with its target branch.",
+      "category": "merge_requests",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pullRequestId": {
+            "type": "string",
+            "description": "Merge request IID",
+            "example": "42"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pullRequestId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_list_project_jobs",
+      "integration": "gitlab",
+      "description": "List recent GitLab CI jobs for a project.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_cancel_job",
+      "integration": "gitlab",
+      "description": "Cancel a GitLab CI job.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "jobId": {
+            "type": "string",
+            "description": "GitLab job ID",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "jobId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_list_pipeline_runs",
+      "integration": "gitlab",
+      "description": "List recent GitLab CI pipelines. Optionally filter by status, ref, and limit.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "status": {
+            "type": "string",
+            "description": "Pipeline status filter",
+            "example": "failed"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Branch or tag ref",
+            "example": "main"
+          },
+          "limit": {
+            "type": "string",
+            "description": "Maximum number of pipelines to return",
+            "example": "50"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_trigger_pipeline",
+      "integration": "gitlab",
+      "description": "Trigger a GitLab CI pipeline for a branch or tag using the authenticated API token.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "ref": {
+            "type": "string",
+            "description": "Branch or tag ref",
+            "example": "main"
+          },
+          "variablesJson": {
+            "type": "string",
+            "description": "Optional JSON object of CI variables",
+            "example": "{\"CONFIG_FILE\":\"agents/story_development.json\"}"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "ref"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_pipeline_jobs",
+      "integration": "gitlab",
+      "description": "List jobs for a GitLab CI pipeline.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "pipelineId": {
+            "type": "string",
+            "description": "GitLab pipeline ID",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "pipelineId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_commit_statuses",
+      "integration": "gitlab",
+      "description": "Get CI/CD statuses for a commit SHA in a GitLab project. Returns one entry per status report (e.g. posted by an external CI like Jenkins via the gitlabBuilds plugin, or GitLab's own pipeline). Equivalent of GitHub's 'check runs' for GitLab. When the same status name was reported more than once for this commit (e.g. a CI job was retried), only the most recent report per name is returned.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "commitSha": {
+            "type": "string",
+            "description": "The commit SHA to get statuses for",
+            "example": "abc123..."
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "commitSha"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_job_logs",
+      "integration": "gitlab",
+      "description": "Get GitLab CI job trace logs.",
+      "category": "ci",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "jobId": {
+            "type": "string",
+            "description": "GitLab job ID",
+            "example": "123456"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "jobId"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_get_or_create_release",
+      "integration": "gitlab",
+      "description": "Find an existing GitLab release by tag, or create one if it does not exist. Useful for a stable artefact storage release (mirrors github_get_or_create_draft_release). Note: GitLab releases have no draft concept; releases are visible as soon as they are created.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The Git tag name for the release. Reused to find an existing release.",
+            "example": "pr-attachments-storage"
+          },
+          "releaseName": {
+            "type": "string",
+            "description": "The human-readable release name. If empty, tagName is used.",
+            "example": "PR Attachments Storage"
+          },
+          "targetCommitish": {
+            "type": "string",
+            "description": "Optional branch or commit SHA the release's tag should point to when created (GitLab 'ref'). Required if the tag does not already exist.",
+            "example": "main"
+          },
+          "body": {
+            "type": "string",
+            "description": "Optional Markdown release notes/description.",
+            "example": "Internal storage release for PR attachments."
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_upload_release_asset",
+      "integration": "gitlab",
+      "description": "Upload a local file as a GitLab release asset. Internally publishes the file to the project's Generic Package Registry and attaches it to the release as an asset link, so it is discoverable the same way as a GitHub release asset. Returns the release link metadata including direct_asset_url. Set overwrite=true to automatically replace an existing asset with the same name before uploading (GitLab's Generic Package Registry rejects duplicate uploads with 409 Conflict otherwise).",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The tag name of the release returned by gitlab_get_or_create_release.",
+            "example": "pr-attachments-storage"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "Absolute or relative path to the local file to upload.",
+            "example": "/tmp/preview.png"
+          },
+          "assetName": {
+            "type": "string",
+            "description": "Optional asset filename shown in GitLab. Defaults to the local filename.",
+            "example": "clip_123.png"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "Optional MIME type. Defaults to detected type or application/octet-stream.",
+            "example": "image/png"
+          },
+          "packageName": {
+            "type": "string",
+            "description": "Optional Generic Package Registry package name used to group the uploaded files. Defaults to 'release-assets'.",
+            "example": "release-assets"
+          },
+          "overwrite": {
+            "type": "string",
+            "description": "If true, delete any existing asset (release link + underlying generic package file) with the same name before uploading. Defaults to false.",
+            "example": "true"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName",
+          "filePath"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_list_release_assets",
+      "integration": "gitlab",
+      "description": "List all assets (asset links) attached to a GitLab release. Returns a JSON array of link objects including id, name, url, and direct_asset_url.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The tag name of the release.",
+            "example": "pr-attachments-storage"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_delete_release_asset",
+      "integration": "gitlab",
+      "description": "Delete a GitLab release asset by its asset name. Removes both the release link and the underlying Generic Package Registry file. Use gitlab_list_release_assets to find asset names.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The tag name of the release.",
+            "example": "pr-attachments-storage"
+          },
+          "assetName": {
+            "type": "string",
+            "description": "The name of the asset to delete, as returned by gitlab_list_release_assets.",
+            "example": "clip_123.png"
+          },
+          "packageName": {
+            "type": "string",
+            "description": "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.",
+            "example": "release-assets"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName",
+          "assetName"
+        ]
+      }
+    },
+    {
+      "name": "gitlab_download_release_asset",
+      "integration": "gitlab",
+      "description": "Download a GitLab release asset (a file published to the Generic Package Registry and attached to a release) to a local file path.",
+      "category": "releases",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "workspace": {
+            "type": "string",
+            "description": "GitLab group or namespace",
+            "example": "mygroup"
+          },
+          "repository": {
+            "type": "string",
+            "description": "Repository name",
+            "example": "myrepo"
+          },
+          "tagName": {
+            "type": "string",
+            "description": "The tag name of the release.",
+            "example": "pr-attachments-storage"
+          },
+          "assetName": {
+            "type": "string",
+            "description": "The name of the asset to download, as returned by gitlab_list_release_assets.",
+            "example": "clip_123.png"
+          },
+          "targetFilePath": {
+            "type": "string",
+            "description": "Local file path where the downloaded asset should be saved.",
+            "example": "/tmp/downloaded_clip_123.png"
+          },
+          "packageName": {
+            "type": "string",
+            "description": "Optional Generic Package Registry package name the asset was uploaded under. Defaults to 'release-assets'.",
+            "example": "release-assets"
+          }
+        },
+        "required": [
+          "workspace",
+          "repository",
+          "tagName",
+          "assetName",
+          "targetFilePath"
+        ]
+      }
+    },
+    {
+      "name": "jira_delete_ticket",
+      "integration": "jira",
+      "description": "Delete a Jira ticket by key",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to delete",
+            "example": "PRJ-123"
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_account_by_email",
+      "integration": "jira",
+      "description": "Gets account details by email",
+      "category": "information",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The Jira Email",
+            "example": "email@email.com"
+          }
+        },
+        "required": [
+          "email"
+        ]
+      }
+    },
+    {
+      "name": "jira_assign_ticket_to",
+      "integration": "jira",
+      "description": "Assigns a Jira ticket to user",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "accountId": {
+            "type": "string",
+            "description": "The Jira account ID to assign to. If you know email use first jira_get_account_by_email tools to get account ID",
+            "example": "123457:2a123456-40e8-49d6-8ddc-6852e518451f"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to assign",
+            "example": "PRJ-123"
+          }
+        },
+        "required": [
+          "key",
+          "accountId"
+        ]
+      }
+    },
+    {
+      "name": "jira_add_label",
+      "integration": "jira",
+      "description": "Adding label to specific ticket key",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to assign",
+            "example": "PRJ-123"
+          },
+          "label": {
+            "type": "string",
+            "description": "The label to be added to ticket",
+            "example": "custom_label"
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "jira_remove_label",
+      "integration": "jira",
+      "description": "Remove a label from a specific Jira ticket. Fetches current labels and removes the specified one.",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to remove label from",
+            "example": "PRJ-123"
+          },
+          "label": {
+            "type": "string",
+            "description": "The label to be removed from the ticket",
+            "example": "custom_label"
+          }
+        },
+        "required": [
+          "key",
+          "label"
+        ]
+      }
+    },
+    {
+      "name": "jira_search_by_jql",
+      "integration": "jira",
+      "description": "Search for Jira tickets using JQL and returns all results",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "jql": {
+            "type": "string",
+            "description": "JQL query string to search tickets",
+            "example": "project = DEMO AND status = Open"
+          },
+          "fields": {
+            "type": "array",
+            "description": "Optional array of field names to include in response. When omitted, the project's extended default fields are used.",
+            "example": "[\"summary\", \"status\", \"assignee\"]"
+          }
+        },
+        "required": [
+          "jql"
+        ]
+      }
+    },
+    {
+      "name": "jira_search_with_pagination",
+      "integration": "jira",
+      "description": "[Deprecated] Search for Jira tickets using JQL with pagination support",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "jql": {
+            "type": "string",
+            "description": "JQL query string to search for tickets",
+            "example": "project = PROJ AND status = Open"
+          },
+          "fields": {
+            "type": "array",
+            "description": "Array of field names to include in the response",
+            "example": "['summary', 'status', 'assignee']"
+          },
+          "startAt": {
+            "type": "number",
+            "description": "Starting index for pagination (0-based)",
+            "example": "0"
+          }
+        },
+        "required": [
+          "jql",
+          "startAt",
+          "fields"
+        ]
+      }
+    },
+    {
+      "name": "jira_search_by_page",
+      "integration": "jira",
+      "description": "Search for Jira tickets using JQL with paging support",
+      "category": "search",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "jql": {
+            "type": "string",
+            "description": "JQL query string to search for tickets",
+            "example": "project = PROJ AND status = Open"
+          },
+          "fields": {
+            "type": "array",
+            "description": "Array of field names to include in the response",
+            "example": "['summary', 'status', 'assignee']"
+          },
+          "nextPageToken": {
+            "type": "string",
+            "description": "Next Page Token from previous response, empty by default for 1 page",
+            "example": "AasvvasasaSASdada"
+          }
+        },
+        "required": [
+          "jql",
+          "nextPageToken",
+          "fields"
+        ]
+      }
+    },
+    {
+      "name": "jira_test",
+      "integration": "jira",
+      "description": "Test Jira connectivity by fetching the current user's profile",
+      "category": "system",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "jira_get_my_profile",
+      "integration": "jira",
+      "description": "Get the current user's profile information from Jira",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "jira_get_user_profile",
+      "integration": "jira",
+      "description": "Get a specific user's profile information from Jira",
+      "category": "user_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "The user ID to get profile for"
+          }
+        },
+        "required": [
+          "userId"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_ticket",
+      "integration": "jira",
+      "description": "Get a specific Jira ticket by key with optional field filtering",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "array",
+            "description": "Optional array of fields to include in the response. When omitted, the project's extended default fields are used."
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to retrieve"
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_subtasks",
+      "integration": "jira",
+      "description": "Get all subtasks of a specific Jira ticket using jql: parent = PRJ-123 and issueType in (subtask, sub-task, 'sub task')",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The parent ticket key to get subtasks for"
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    {
+      "name": "jira_post_comment_if_not_exists",
+      "integration": "jira",
+      "description": "Post a comment to a Jira ticket only if it doesn't already exist. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
+      "category": "comment_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to post comment to"
+          },
+          "comment": {
+            "type": "string",
+            "description": "The comment text to post (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
+          }
+        },
+        "required": [
+          "key",
+          "comment"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_comments",
+      "integration": "jira",
+      "description": "Get all comments for a specific Jira ticket",
+      "category": "comment_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "ticket": {
+            "type": "object",
+            "description": "Optional ticket object for cache validation"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to get comments for"
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    {
+      "name": "jira_post_comment",
+      "integration": "jira",
+      "description": "Post a comment to a Jira ticket. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
+      "category": "comment_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to post comment to"
+          },
+          "comment": {
+            "type": "string",
+            "description": "The comment text to post (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
+          }
+        },
+        "required": [
+          "key",
+          "comment"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_fix_versions",
+      "integration": "jira",
+      "description": "Get all fix versions for a specific Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to get fix versions for"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_components",
+      "integration": "jira",
+      "description": "Get all components for a specific Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to get components for"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_project_statuses",
+      "integration": "jira",
+      "description": "Get all statuses for a specific Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to get statuses for"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "jira_create_ticket_with_parent",
+      "integration": "jira",
+      "description": "Create a new Jira ticket with a parent relationship",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "issueType": {
+            "type": "string",
+            "description": "The type of issue to create (e.g., Bug, Story, Task)"
+          },
+          "summary": {
+            "type": "string",
+            "description": "The ticket summary/title"
+          },
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to create the ticket in"
+          },
+          "description": {
+            "type": "string",
+            "description": "The ticket description"
+          },
+          "parentKey": {
+            "type": "string",
+            "description": "The key of the parent ticket"
+          }
+        },
+        "required": [
+          "project",
+          "issueType",
+          "summary",
+          "description",
+          "parentKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_create_ticket_basic",
+      "integration": "jira",
+      "description": "Create a new Jira ticket with basic fields (project, issue type, summary, description)",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "issueType": {
+            "type": "string",
+            "description": "The type of issue to create (e.g., Bug, Story, Task)"
+          },
+          "summary": {
+            "type": "string",
+            "description": "The ticket summary/title (e.g., Fix login issue)"
+          },
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to create the ticket in (e.g., PROJ)"
+          },
+          "description": {
+            "type": "string",
+            "description": "The ticket description. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists"
+          }
+        },
+        "required": [
+          "project",
+          "issueType",
+          "summary",
+          "description"
+        ]
+      }
+    },
+    {
+      "name": "jira_create_ticket_with_json",
+      "integration": "jira",
+      "description": "Create a new Jira ticket with custom fields using JSON configuration",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to create the ticket in (e.g., PROJ)"
+          },
+          "fieldsJson": {
+            "type": "object",
+            "description": "JSON object containing ticket fields in Jira format (e.g., {\"summary\": \"Ticket Summary\", \"description\": \"Ticket Description\", \"issuetype\": {\"name\": \"Task\"}, \"priority\": {\"name\": \"High\"}}), Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists"
+          }
+        },
+        "required": [
+          "project",
+          "fieldsJson"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_description",
+      "integration": "jira",
+      "description": "Update the description of a Jira ticket. Supports Jira markup syntax: h2. for headings, *text* for bold, {code}text{code} for inline code, * for bullet lists",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The new description text (supports Jira markup: h2. headings, *bold*, {code}code{code}, * lists)"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          }
+        },
+        "required": [
+          "key",
+          "description"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_ticket_parent",
+      "integration": "jira",
+      "description": "Update the parent of a Jira ticket. Can be used for setting up epic relationships and parent-child relationships for subtasks",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          },
+          "parentKey": {
+            "type": "string",
+            "description": "The key of the new parent ticket"
+          }
+        },
+        "required": [
+          "key",
+          "parentKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_ticket",
+      "integration": "jira",
+      "description": "Update a Jira ticket using JSON parameters following the standard Jira REST API format",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "params": {
+            "type": "object",
+            "description": "JSON object containing update parameters in Jira format (e.g., {\"fields\": {\"summary\": \"New Summary\", \"parent\": {\"key\": \"PROJ-123\"}}})"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          }
+        },
+        "required": [
+          "key",
+          "params"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_field",
+      "integration": "jira",
+      "description": "Update field(s) in a Jira ticket. When using field names (e.g., 'Dependencies'), updates ALL fields with that name. When using custom field IDs (e.g., 'customfield_10091'), updates only that specific field.",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The field to update. Use field name (e.g., 'Dependencies') to update ALL fields with that name, or custom field ID (e.g., 'customfield_10091') to update specific field"
+          },
+          "value": {
+            "type": "object",
+            "description": "The new value for the field(s)"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          }
+        },
+        "required": [
+          "key",
+          "field",
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_field_as_adf",
+      "integration": "jira",
+      "description": "Update a rich-text field in a Jira ticket using Jira API v3 and Atlassian Document Format (ADF). The value can be a plain string (wrapped into a paragraph) or a JSON object/array representing an ADF document. Required for interactive task-list checkboxes in Jira Cloud.",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The rich-text field to update, e.g. 'description' or 'comment'"
+          },
+          "value": {
+            "type": "object",
+            "description": "Plain text or ADF JSON. Plain text is wrapped into an ADF paragraph; JSON object is sent as-is; JSON array is used as the ADF content."
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          }
+        },
+        "required": [
+          "key",
+          "field",
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "jira_update_all_fields_with_name",
+      "integration": "jira",
+      "description": "Update ALL fields with the same name in a Jira ticket. Useful when there are multiple custom fields with the same display name.",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "object",
+            "description": "The new value for the fields"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to update"
+          },
+          "fieldName": {
+            "type": "string",
+            "description": "The user-friendly field name (e.g., 'Dependencies')"
+          }
+        },
+        "required": [
+          "key",
+          "fieldName",
+          "value"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_all_fields_with_name",
+      "integration": "jira",
+      "description": "Get all custom field IDs that have the same display name in a Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key"
+          },
+          "fieldName": {
+            "type": "string",
+            "description": "The user-friendly field name"
+          }
+        },
+        "required": [
+          "project",
+          "fieldName"
+        ]
+      }
+    },
+    {
+      "name": "jira_execute_request",
+      "integration": "jira",
+      "description": "Execute a custom HTTP GET request to Jira API with auth. Can be used to perform any jira get requests which are required auth.",
+      "category": "api_operations",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "The Jira API URL to execute"
+          }
+        },
+        "required": [
+          "url"
+        ]
+      }
+    },
+    {
+      "name": "jira_attach_file_to_ticket",
+      "integration": "jira",
+      "description": "Attach a file to a Jira ticket from a local file path. The file will only be attached if a file with the same name doesn't already exist",
+      "category": "file_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the file to attach",
+            "example": "document.pdf"
+          },
+          "ticketKey": {
+            "type": "string",
+            "description": "The Jira ticket key to attach the file to",
+            "example": "PRJ-123"
+          },
+          "contentType": {
+            "type": "string",
+            "description": "The content type of the file (e.g., 'application/pdf', 'image/png'). If not provided, defaults to 'image/*'",
+            "example": "application/pdf"
+          },
+          "filePath": {
+            "type": "string",
+            "description": "Absolute path to the file on disk",
+            "example": "/tmp/document.pdf"
+          }
+        },
+        "required": [
+          "ticketKey",
+          "name",
+          "filePath"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_transitions",
+      "integration": "jira",
+      "description": "Get all available transitions(statuses, workflows) for a Jira ticket",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to get transitions for"
+          }
+        },
+        "required": [
+          "key"
+        ]
+      }
+    },
+    {
+      "name": "jira_move_to_status",
+      "integration": "jira",
+      "description": "Move a Jira ticket to a specific status (workflow, transition)",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "statusName": {
+            "type": "string",
+            "description": "The target status name"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to move"
+          }
+        },
+        "required": [
+          "key",
+          "statusName"
+        ]
+      }
+    },
+    {
+      "name": "jira_move_to_status_with_resolution",
+      "integration": "jira",
+      "description": "Move a Jira ticket to a specific status (workflow, transition) with resolution",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "statusName": {
+            "type": "string",
+            "description": "The target status name"
+          },
+          "resolution": {
+            "type": "string",
+            "description": "The resolution to set"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to move"
+          }
+        },
+        "required": [
+          "key",
+          "statusName",
+          "resolution"
+        ]
+      }
+    },
+    {
+      "name": "jira_clear_field",
+      "integration": "jira",
+      "description": "Clear (delete value) a specific field value in a Jira ticket",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "description": "The field name to clear"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to clear field from"
+          }
+        },
+        "required": [
+          "key",
+          "field"
+        ]
+      }
+    },
+    {
+      "name": "jira_set_fix_version",
+      "integration": "jira",
+      "description": "Set the fix version for a Jira ticket",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fixVersion": {
+            "type": "string",
+            "description": "The fix version name to set"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to set fix version for"
+          }
+        },
+        "required": [
+          "key",
+          "fixVersion"
+        ]
+      }
+    },
+    {
+      "name": "jira_add_fix_version",
+      "integration": "jira",
+      "description": "Add a fix version to a Jira ticket (without removing existing ones)",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fixVersion": {
+            "type": "string",
+            "description": "The fix version name to add"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to add fix version to"
+          }
+        },
+        "required": [
+          "key",
+          "fixVersion"
+        ]
+      }
+    },
+    {
+      "name": "jira_set_priority",
+      "integration": "jira",
+      "description": "Set the priority for a Jira ticket",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "priority": {
+            "type": "string",
+            "description": "The priority name to set"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to set priority for"
+          }
+        },
+        "required": [
+          "key",
+          "priority"
+        ]
+      }
+    },
+    {
+      "name": "jira_remove_fix_version",
+      "integration": "jira",
+      "description": "Remove a fix version from a Jira ticket",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "fixVersion": {
+            "type": "string",
+            "description": "The fix version name to remove"
+          },
+          "key": {
+            "type": "string",
+            "description": "The Jira ticket key to remove fix version from"
+          }
+        },
+        "required": [
+          "key",
+          "fixVersion"
+        ]
+      }
+    },
+    {
+      "name": "jira_download_attachment",
+      "integration": "jira",
+      "description": "Download a Jira attachment by URL and save it as a file",
+      "category": "file_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The attachment URL to download"
+          }
+        },
+        "required": [
+          "href"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_fields",
+      "integration": "jira",
+      "description": "Get all available fields for a Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to get fields for"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_issue_types",
+      "integration": "jira",
+      "description": "Get all available issue types for a specific Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key to get issue types for"
+          }
+        },
+        "required": [
+          "project"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_field_custom_code",
+      "integration": "jira",
+      "description": "Get the custom field code for a human friendly field name in a Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "project": {
+            "type": "string",
+            "description": "The Jira project key"
+          },
+          "fieldName": {
+            "type": "string",
+            "description": "The human-readable field name"
+          }
+        },
+        "required": [
+          "project",
+          "fieldName"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_issue_link_types",
+      "integration": "jira",
+      "description": "Get all available issue link types/relationships in Jira",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {},
+        "required": []
+      }
+    },
+    {
+      "name": "jira_link_issues",
+      "integration": "jira",
+      "description": "Link two Jira issues with a specific relationship type",
+      "category": "ticket_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceKey": {
+            "type": "string",
+            "description": "The source issue key"
+          },
+          "relationship": {
+            "type": "string",
+            "description": "The relationship type name"
+          },
+          "anotherKey": {
+            "type": "string",
+            "description": "The target issue key"
+          }
+        },
+        "required": [
+          "sourceKey",
+          "anotherKey",
+          "relationship"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_project_details",
+      "integration": "jira",
+      "description": "Get full details of a Jira project including its numeric ID, key, name, style and issue types",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "The Jira project key, e.g. TP"
+          }
+        },
+        "required": [
+          "projectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_project_issue_type_scheme",
+      "integration": "jira",
+      "description": "Get the issue type scheme (or equivalent) assigned to a Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "The Jira project key, e.g. TP"
+          }
+        },
+        "required": [
+          "projectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_project_workflow_scheme",
+      "integration": "jira",
+      "description": "Get the workflow scheme (or equivalent) assigned to a Jira project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "The Jira project key, e.g. TP"
+          }
+        },
+        "required": [
+          "projectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_assign_issue_type_scheme",
+      "integration": "jira",
+      "description": "Assign an issue type scheme (by its numeric ID) to a classic Jira project (by its numeric project ID). Requires Jira admin.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "issueTypeSchemeId": {
+            "type": "string",
+            "description": "Numeric ID of the issue type scheme"
+          },
+          "projectId": {
+            "type": "string",
+            "description": "Numeric ID of the target Jira project"
+          }
+        },
+        "required": [
+          "issueTypeSchemeId",
+          "projectId"
+        ]
+      }
+    },
+    {
+      "name": "jira_assign_workflow_scheme",
+      "integration": "jira",
+      "description": "Assign a workflow scheme (by its numeric ID) to a classic Jira project (by its numeric project ID). Requires Jira admin.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectId": {
+            "type": "string",
+            "description": "Numeric ID of the target Jira project"
+          },
+          "workflowSchemeId": {
+            "type": "string",
+            "description": "Numeric ID of the workflow scheme"
+          }
+        },
+        "required": [
+          "workflowSchemeId",
+          "projectId"
+        ]
+      }
+    },
+    {
+      "name": "jira_create_project_issue_type",
+      "integration": "jira",
+      "description": "Create a project-scoped issue type in a next-gen Jira project. Use type 'subtask' for subtasks and 'standard' for all others. Skips if the name already exists. Requires Jira admin.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the issue type, e.g. Story"
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description"
+          },
+          "projectKey": {
+            "type": "string",
+            "description": "Key of the target Jira project, e.g. TP"
+          },
+          "type": {
+            "type": "string",
+            "description": "Issue type kind: 'standard' or 'subtask'. Defaults to 'standard'."
+          }
+        },
+        "required": [
+          "projectKey",
+          "name"
+        ]
+      }
+    },
+    {
+      "name": "jira_copy_project_structure",
+      "integration": "jira",
+      "description": "Copy issue types and workflow setup from a source Jira project to a target Jira project (e.g. MYTUBE → TP)",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceProjectKey": {
+            "type": "string",
+            "description": "Key of the source Jira project to copy structure from, e.g. MYTUBE"
+          },
+          "targetProjectKey": {
+            "type": "string",
+            "description": "Key of the target Jira project to apply structure to, e.g. TP"
+          }
+        },
+        "required": [
+          "sourceProjectKey",
+          "targetProjectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_delete_project",
+      "integration": "jira",
+      "description": "Delete a Jira project by moving it to trash. The project key remains reserved until permanently deleted from Jira Admin > System > Trash. Set confirmDelete to 'true' to proceed.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "Key of the Jira project to delete, e.g. TP"
+          },
+          "confirmDelete": {
+            "type": "string",
+            "description": "Must be 'true' to confirm deletion"
+          }
+        },
+        "required": [
+          "projectKey",
+          "confirmDelete"
+        ]
+      }
+    },
+    {
+      "name": "jira_restore_project",
+      "integration": "jira",
+      "description": "Restore a Jira project that was previously moved to trash using jira_delete_project",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "Key of the trashed Jira project to restore, e.g. TP"
+          }
+        },
+        "required": [
+          "projectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_clone_project",
+      "integration": "jira",
+      "description": "Create a brand-new team-managed (next-gen) Jira project that mirrors the source project. Default issue types are auto-created; custom types must be added manually. To reuse an existing key, permanently delete the old project from Jira Admin > System > Trash first.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceProjectKey": {
+            "type": "string",
+            "description": "Key of the source project to mirror, e.g. MYTUBE"
+          },
+          "newProjectKey": {
+            "type": "string",
+            "description": "Key for the new project, e.g. TP2"
+          },
+          "newProjectName": {
+            "type": "string",
+            "description": "Name for the new project. If empty, uses source project name"
+          }
+        },
+        "required": [
+          "sourceProjectKey",
+          "newProjectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_get_project_board_config",
+      "integration": "jira",
+      "description": "Read the board column configuration (workflow) of a Jira project — returns columns with status names and categories, useful for comparing or replicating project workflow",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "Key of the Jira project, e.g. MYTUBE"
+          }
+        },
+        "required": [
+          "projectKey"
+        ]
+      }
+    },
+    {
+      "name": "jira_setup_project_workflow",
+      "integration": "jira",
+      "description": "Set up a project's workflow using an explicit list of statuses (no source project needed). Accepts a JSON array of {name, category} objects and applies them to the target project's workflow. Valid categories: TODO, IN_PROGRESS, DONE. Works with team-managed (next-gen) Jira projects.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "projectKey": {
+            "type": "string",
+            "description": "Key of the target Jira project, e.g. TP"
+          },
+          "statusDefinitions": {
+            "type": "string",
+            "description": "JSON array of status definitions, e.g. [{\"name\":\"Backlog\",\"category\":\"TODO\"},...]. Valid categories: TODO, IN_PROGRESS, DONE."
+          }
+        },
+        "required": [
+          "projectKey",
+          "statusDefinitions"
+        ]
+      }
+    },
+    {
+      "name": "jira_sync_project_workflow",
+      "integration": "jira",
+      "description": "Sync the workflow (statuses) of a target project to exactly match the source project using Jira's bulk workflow update API. Replaces the target workflow's statuses and transitions with those from the source project. Existing issues with removed statuses are automatically migrated to the closest matching new status. Works with team-managed (next-gen) Jira projects.",
+      "category": "project_management",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "sourceProjectKey": {
+            "type": "string",
+            "description": "Key of the source project to copy workflow from, e.g. MYTUBE"
+          },
+          "targetProjectKey": {
+            "type": "string",
+            "description": "Key of the target project to update workflow for, e.g. TP"
+          }
+        },
+        "required": [
+          "sourceProjectKey",
+          "targetProjectKey"
+        ]
+      }
+    }
+  ]
+}

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/JsonCliOutputFormatter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/JsonCliOutputFormatter.java
@@ -4,6 +4,7 @@
 package com.github.istin.dmtools.mcp.cli;
 
 import com.github.istin.dmtools.common.utils.JSONUtils;
+import com.google.gson.GsonBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -37,7 +38,8 @@ public class JsonCliOutputFormatter implements CliOutputFormatter {
 
     @Override
     public String formatList(Map<String, Object> toolsList) {
-        return new JSONObject(toolsList).toString(2);
+        // Preserve insertion order of the schema maps (org.json.JSONObject loses it).
+        return new GsonBuilder().setPrettyPrinting().create().toJson(toolsList);
     }
 
     @Override

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/MiniCliOutputFormatter.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/mcp/cli/MiniCliOutputFormatter.java
@@ -6,6 +6,7 @@ package com.github.istin.dmtools.mcp.cli;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.utils.JSONUtils;
 import com.github.istin.dmtools.common.utils.LLMOptimizedJson;
+import com.google.gson.GsonBuilder;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
@@ -72,7 +73,7 @@ public class MiniCliOutputFormatter implements CliOutputFormatter {
 
     @Override
     public String formatList(Map<String, Object> toolsList) {
-        return safeFormat(new JSONObject(toolsList).toString());
+        return safeFormat(new GsonBuilder().create().toJson(toolsList));
     }
 
     @Override

--- a/scripts/generate-mcp-tables.sh
+++ b/scripts/generate-mcp-tables.sh
@@ -12,20 +12,28 @@ OUTPUT_DIR="$PROJECT_ROOT/dmtools-ai-docs/references/mcp-tools"
 echo "🔄 Generating MCP tools documentation as tables..."
 
 # Check if dmtools is available
-if ! command -v dmtools &> /dev/null && [ ! -f ~/.dmtools/dmtools.jar ]; then
-    echo "❌ Error: dmtools not found. Run ./buildInstallLocal.sh first"
-    exit 1
-fi
-
 # Create output directory
 mkdir -p "$OUTPUT_DIR"
 
-# Get the tools list as JSON
-echo "📥 Fetching tools from dmtools..."
-TOOLS_JSON=$(dmtools list 2>/dev/null || java -jar ~/.dmtools/dmtools.jar list 2>/dev/null || ./dmtools.sh list 2>/dev/null)
+if [ -n "$SKIP_DMTOOLS_LIST" ]; then
+    echo "⏭️  Skipping dmtools list fetch; using existing $OUTPUT_DIR/tools-raw.json"
+    if [ ! -f "$OUTPUT_DIR/tools-raw.json" ]; then
+        echo "❌ Error: $OUTPUT_DIR/tools-raw.json not found"
+        exit 1
+    fi
+else
+    if ! command -v dmtools &> /dev/null && [ ! -f ~/.dmtools/dmtools.jar ]; then
+        echo "❌ Error: dmtools not found. Run ./buildInstallLocal.sh first"
+        exit 1
+    fi
 
-# Save raw JSON for reference
-echo "$TOOLS_JSON" > "$OUTPUT_DIR/tools-raw.json"
+    # Get the tools list as JSON
+    echo "📥 Fetching tools from dmtools..."
+    TOOLS_JSON=$(dmtools list 2>/dev/null || java -jar ~/.dmtools/dmtools.jar list 2>/dev/null || ./dmtools.sh list 2>/dev/null)
+
+    # Save raw JSON for reference
+    echo "$TOOLS_JSON" > "$OUTPUT_DIR/tools-raw.json"
+fi
 
 # Create a Python script to parse and generate markdown
 cat > /tmp/parse_mcp_tools.py << 'PYTHON_SCRIPT'


### PR DESCRIPTION
Fixes the parameter order shown for GitLab MCP tools (and others) in generated docs.

**Root cause**
`JsonCliOutputFormatter.formatList()` used `new JSONObject(toolsList)`, which does not preserve `LinkedHashMap` insertion order. As a result `dmtools list` emitted schema properties in the wrong order (e.g. `repository, pullRequestId, workspace` instead of `workspace, repository, pullRequestId`), and the doc generator copied that order.

**Changes**
- Use Gson in `JsonCliOutputFormatter` and `MiniCliOutputFormatter` for `formatList` so insertion order is preserved.
- Regenerate `gitlab-tools.md` and `tools-raw.json` with the correct parameter order.
- Add `SKIP_DMTOOLS_LIST=1` option to `scripts/generate-mcp-tables.sh` so docs can be regenerated from an existing `tools-raw.json`.

After this, calling `gitlab_get_mr_discussions(workspace, repository, pullRequestId)` positionally in JS agents matches the docs.
