### PR TITLE
fix(teammate): pass fatal CLI error signal to postJSAction

### DIFF
--- a/dmtools-ai-docs/references/agents/teammate-configs.md
+++ b/dmtools-ai-docs/references/agents/teammate-configs.md
@@ -189,6 +189,8 @@ function action(params) {
 | `params.response` | String | AI response (`null` in preJSAction, filled in postJSAction) |
 | `params.initiator` | String | User who triggered the job |
 | `params.inputFolderPath` | String | Absolute path to input folder (preCliJSAction only) |
+| `params.currentCliHasFatalError` | Boolean | `true` if the CLI command batch failed with a non-zero exit code (postJSAction and timerJSAction only; `false` when no `cliCommands` are configured) |
+| `params.currentCliErrorMessage` | String | Error message from the last fatal CLI failure, or `null` if none (postJSAction and timerJSAction only) |
 
 ### Instruction Sources
 
@@ -278,6 +280,7 @@ This solves the `ConfigurationMerger` limitation: when you override a config wit
 | `cliCommands` | Array | - | CLI commands to execute | `["./cicd/scripts/run-cursor-agent.sh"]` |
 | `preCliJSAction` | String | - | JS script path executed **after** input folder is created but **before** CLI commands run. Receives `params.inputFolderPath` (absolute path). Use to write extra files into the input folder. Errors in this script are logged but do NOT stop CLI execution. | `"agents/js/extendInputFolder.js"` |
 | `timerJSAction` | String | - | JS script path executed **periodically in a background thread** while CLI commands are running. Receives the same params as `postJSAction` + `params.currentCliOutput` (accumulated stdout so far), plus `params.currentCliHasFatalError` (boolean) and `params.currentCliErrorMessage` (string, may be null) — set as soon as a CLI command fails with a non-zero exit code, so retry logic can distinguish a real, non-retryable failure from a transient interruption. Use for side-effects like auto-committing, posting progress, or sending notifications. Errors are logged and never abort CLI execution. | `"agents/js/autoCommit.js"` |
+| `postJSAction` | String | - | JS script path executed **after** CLI execution (if any) and AI processing complete. Also receives `params.currentCliHasFatalError` (boolean) and `params.currentCliErrorMessage` (string, may be null), reflecting the final CLI outcome — use this to skip PR creation or notify differently on a fatal CLI failure. | `"agents/js/developTicketAndCreatePR.js"` |
 | `timerIntervalSeconds` | Integer | `60` | Interval in seconds between `timerJSAction` executions. Timer starts after the first interval elapses. Has no effect when `timerJSAction` is not set or when value is ≤ 0. | `300` |
 | `skipAIProcessing` | Boolean | `false` | Skip AI processing when using CLI agents | `true` |
 | `requireCliOutputFile` | Boolean | `true` | **NEW v1.7.133**: Require `output/response.md` before updating fields (strict mode prevents data loss) | `true` (recommended) |

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -772,6 +772,9 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                 response = genericRequestAgent.run(genericRequesAgentParams);
             }
             AtomicReference<Exception> postJsError = new AtomicReference<>();
+            // cliResult is null when no cliCommands are configured; treat that as no fatal error.
+            boolean cliHasFatalError = cliResult != null && cliResult.hasFatalError();
+            String cliErrorMessage = cliResult != null ? cliResult.getLastErrorMessage() : null;
             CliExecutionHelper.runWithTimer(timerRunnable, timerIntervalSeconds, () -> {
                 try {
                     js(expertParams.getPostJSAction())
@@ -779,6 +782,8 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                         .withJobContext(expertParams, ticket, response)
                         .with(TrackerParams.INITIATOR, initiator)
                         .with("systemRequest", systemRequestCommentAlias)
+                        .with("currentCliHasFatalError", cliHasFatalError)
+                        .with("currentCliErrorMessage", cliErrorMessage)
                         .execute();
                 } catch (Exception e) {
                     postJsError.set(e);

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateRunJobFlowCoverageTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammateRunJobFlowCoverageTest.java
@@ -15,6 +15,7 @@ import com.github.istin.dmtools.common.model.IAttachment;
 import com.github.istin.dmtools.common.model.ITicket;
 import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.tracker.TrackerClient;
+import com.github.istin.dmtools.common.utils.CliCommandFailedException;
 import com.github.istin.dmtools.common.utils.CommandLineUtils;
 import com.github.istin.dmtools.context.ContextOrchestrator;
 import com.github.istin.dmtools.context.UriToObjectFactory;
@@ -844,6 +845,53 @@ public class TeammateRunJobFlowCoverageTest {
 
         assertTrue(teammate.jsCalls.contains("agents/js/timer.js"),
                 "timerJSAction must be executed at least once during a long CLI command");
+    }
+
+    @Test
+    void testPostJSActionReceivesFatalCliErrorSignal() throws Exception {
+        JavaScriptExecutor postExecutor = mock(JavaScriptExecutor.class);
+        when(postExecutor.mcp(any(), any(), any(), any())).thenReturn(postExecutor);
+        when(postExecutor.withJobContext(any(), any(), any())).thenReturn(postExecutor);
+        when(postExecutor.with(anyString(), any())).thenReturn(postExecutor);
+        when(postExecutor.execute()).thenReturn(null);
+        teammate.scriptedExecutors.put("agents/js/post.js", postExecutor);
+
+        params.setCliCommands(new String[]{"claude --model invalid-model"});
+        params.setPostJSAction("agents/js/post.js");
+
+        String originalUserDir = System.getProperty("user.dir");
+        try {
+            System.setProperty("user.dir", tempDir.toString());
+
+            try (MockedStatic<CommandLineUtils> mocked = mockStatic(CommandLineUtils.class)) {
+                mocked.when(() -> CommandLineUtils.runCommand(anyString(), any(), any(), any(), anyBoolean(), any(), anyInt()))
+                        .thenThrow(new CliCommandFailedException("claude --model invalid-model", 1,
+                                "API Error: 400 ValidationException: invalid model identifier"));
+                mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
+                        .thenReturn(Map.of());
+
+                List<ResultItem> results = teammate.runJobImpl(params);
+                assertEquals(1, results.size());
+            }
+        } finally {
+            System.setProperty("user.dir", originalUserDir);
+        }
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Object> valueCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(postExecutor, atLeastOnce()).with(keyCaptor.capture(), valueCaptor.capture());
+
+        Map<String, Object> capturedParams = new HashMap<>();
+        List<String> keys = keyCaptor.getAllValues();
+        List<Object> values = valueCaptor.getAllValues();
+        for (int i = 0; i < keys.size(); i++) {
+            capturedParams.put(keys.get(i), values.get(i));
+        }
+
+        assertEquals(Boolean.TRUE, capturedParams.get("currentCliHasFatalError"),
+                "postJSAction must be told the CLI command batch failed fatally");
+        assertNotNull(capturedParams.get("currentCliErrorMessage"));
+        assertTrue(((String) capturedParams.get("currentCliErrorMessage")).contains("ValidationException"));
     }
 
     // ---- additional branch coverage ----


### PR DESCRIPTION
## Summary
`timerJSAction` already receives `params.currentCliHasFatalError` / `params.currentCliErrorMessage` (added in #453), but `postJSAction` does not receive any CLI outcome signal at all. This means a `postJSAction` script (e.g. one that creates a PR or posts a notification) has no way to detect that the preceding CLI command batch failed fatally and adjust its behavior (e.g. skip PR creation, post an error notification instead).

## Changes
- `Teammate.java`: pass `currentCliHasFatalError` (boolean) and `currentCliErrorMessage` (String, nullable) to `postJSAction`, derived from the final `cliResult` (`false`/`null` when no `cliCommands` are configured — matches existing `timerJSAction` semantics).
- Docs (`teammate-configs.md`): document the two new params in the JS context table and in the `postJSAction` config row.
- Test (`TeammateRunJobFlowCoverageTest.java`): added a test asserting `postJSAction` is invoked with `currentCliHasFatalError=true` and the expected error message when the CLI command fails with a non-zero exit code.

## Testing
- Unable to run the Gradle build in this environment. The change is additive (two new params passed to an existing JS invocation) and doesn't alter existing control flow; a new unit test covers the new behavior for review/CI.