### PR TITLE
ci: trigger landing deploy when release-site-data PR merges

### DIFF
--- a/.github/workflows/deploy-landing-on-site-data-merge.yml
+++ b/.github/workflows/deploy-landing-on-site-data-merge.yml
@@ -1,0 +1,29 @@
+name: Deploy Landing After Site Data Merge
+
+# update-release-site.yml opens a "chore/release-site-data-*" PR and enables
+# auto-merge; GitHub completes that merge asynchronously once required checks
+# pass. That completion does not reliably fire deploy-landing.yml's `push`
+# trigger (observed: v1.7.250 through v1.7.257 all merged cli-manifest.json
+# updates without a matching push-triggered deploy run), so the live
+# cli-manifest.json served from dmtools.lab.epam.com can lag behind main by
+# several releases, which in turn makes install.sh report a stale version.
+# Explicitly (re-)trigger the deploy once the PR actually merges instead of
+# relying on that push trigger for this specific PR flow.
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  trigger-deploy:
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'chore/release-site-data-')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger landing page deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run deploy-landing.yml --repo "${{ github.repository }}" --ref main


### PR DESCRIPTION
## Problem
`install.sh` fetches the latest CLI version from `https://dmtools.lab.epam.com/cli-manifest.json` instead of the GitHub Releases API (to avoid rate limits). That manifest is only correct once `deploy-landing.yml` redeploys GitHub Pages.

Observed: `update-release-site.yml` opens a `chore/release-site-data-*` PR per release and enables auto-merge. Those PRs merged fine (#500, #502, #504, #515, #516, #521, #537 for v1.7.250...v1.7.257), but none of those merges triggered `deploy-landing.yml`'s `push` trigger (verified via `gh run list` / check-runs on the merge commits - no "Build landing page" check run at all). The last push-triggered deploy before this fix was for #498 (v1.7.249), so the live manifest was stuck at v1.7.254 for almost a week while releases kept shipping, making `install.sh` report a stale version right after a release was published.

## Fix
Add a workflow that listens for `pull_request: closed` on branches matching `chore/release-site-data-*` and, once merged, explicitly runs `gh workflow run deploy-landing.yml`. This no longer depends on the push path-filter trigger behaving a particular way for auto-merged PRs.

## Verification
- Manually re-triggered `deploy-landing.yml` to fix the currently-stale live manifest; `https://dmtools.lab.epam.com/cli-manifest.json` now correctly reports v1.7.257.
- This PR's fix will keep it in sync automatically for future releases.