### PR TITLE
fix(teammate): fail job when preCliJSAction throws an unexpected error

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -288,7 +288,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
     MermaidIndexTools mermaidIndexTools;
 
     // JavaScript bridge is now inherited from AbstractJob
-    
+
     InstructionProcessor instructionProcessor;
     AgentParamsFileWriter agentParamsFileWriter;
 
@@ -323,52 +323,52 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
     @Override
     protected void initializeStandalone() {
         logger.info("Initializing Teammate in STANDALONE mode using TeammateComponent with BasicGeminiAI");
-        
+
         // Use existing Dagger component for standalone mode
         if (teammateComponent == null) {
             logger.info("Creating new DaggerTeammateComponent for standalone mode");
             teammateComponent = DaggerTeammateComponent.create();
         }
-        
+
         logger.info("Injecting dependencies using TeammateComponent");
         teammateComponent.inject(this);
-        
+
         // Initialize instruction processor after dependencies are injected
         this.instructionProcessor = new InstructionProcessor(confluence);
         this.agentParamsFileWriter = new AgentParamsFileWriter(this.instructionProcessor);
-        
-        logger.info("Teammate standalone initialization completed - AI type: {}", 
+
+        logger.info("Teammate standalone initialization completed - AI type: {}",
                    (ai != null ? ai.getClass().getSimpleName() : "null"));
-        
+
         // TeamAssistantAgent is now automatically injected by Dagger
     }
 
     @Override
     protected void initializeServerManaged(JSONObject resolvedIntegrations) {
         logger.info("Initializing Teammate in SERVER_MANAGED mode using ServerManagedIntegrationsModule");
-        logger.info("Resolved integrations: {}", 
+        logger.info("Resolved integrations: {}",
                    (resolvedIntegrations != null ? resolvedIntegrations.length() + " integrations" : "null"));
-        
+
         // Create dynamic component with pre-resolved integrations
         try {
             logger.info("Creating ServerManagedIntegrationsModule with resolved credentials");
             ServerManagedIntegrationsModule module = new ServerManagedIntegrationsModule(resolvedIntegrations);
-            
+
             logger.info("Building ServerManagedExpertComponent for Teammate");
             ServerManagedExpertComponent component = DaggerTeammate_ServerManagedExpertComponent.builder()
                     .serverManagedIntegrationsModule(module)
                     .build();
-            
+
             logger.info("Injecting dependencies using ServerManagedExpertComponent");
             component.inject(this);
-            
+
             // Initialize instruction processor after dependencies are injected
             this.instructionProcessor = new InstructionProcessor(confluence);
             this.agentParamsFileWriter = new AgentParamsFileWriter(this.instructionProcessor);
-            
-            logger.info("Teammate server-managed initialization completed - AI type: {}", 
+
+            logger.info("Teammate server-managed initialization completed - AI type: {}",
                        (ai != null ? ai.getClass().getSimpleName() : "null"));
-            
+
             // TeamAssistantAgent is now automatically injected by Dagger with server-managed dependencies
         } catch (Exception e) {
             logger.error("Failed to initialize Teammate in server-managed mode: {}", e.getMessage(), e);
@@ -454,6 +454,12 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
         contextOrchestrator.clear();
 
         List<ResultItem> results = new ArrayList<>();
+        // Tickets whose preCliJSAction threw an *uncaught* exception (e.g. a git command failure
+        // during branch setup) — as opposed to a deliberate business-logic skip (JS explicitly
+        // returning false/{success:false} without throwing, e.g. "no PR found yet"). An uncaught
+        // exception is unexpected, so the job must fail loudly at the end instead of silently
+        // reporting overall success with a hidden per-ticket "Skipped" result.
+        List<String> unexpectedSetupFailures = new ArrayList<>();
         trackerClient.searchAndPerform(ticket -> {
             long overallStart = System.currentTimeMillis();
             logger.info("Processing ticket: {}", ticket.getKey());
@@ -487,7 +493,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                 results.add(new ResultItem(ticket.getTicketKey(), "Skipped by pre-action"));
                 return false; // Skip this ticket
             }
-            
+
             // Create and prepare ticket context
             TicketContext ticketContext = new TicketContext(trackerClient, ticket);
             ticketContext.prepareContext(true, false, expertParams.isIgnoreClonedByRelationship());
@@ -509,7 +515,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             }
             // Process content with ContextOrchestrator
             //contextOrchestrator.processFullContent(ticket.getKey(), ticketText, (UriToObject) trackerClient, uriProcessingSources, expertParams.getTicketContextDepth());
-            
+
             String textFieldsOnly = trackerClient.getTextFieldsOnly(ticket);
 
             //inputParams.setKnownInfo(inputParams.getKnownInfo());
@@ -616,6 +622,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                     String preCliJSAction = expertParams.getPreCliJSAction();
                     if (preCliJSAction != null && !preCliJSAction.trim().isEmpty()) {
                         Object preCliActionResult;
+                        boolean preCliJSActionThrew = false;
                         try {
                             preCliActionResult = js(preCliJSAction)
                                 .mcp(trackerClient, ai, confluence, null)
@@ -628,12 +635,19 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                             logger.warn("preCliJSAction threw for ticket {}, treating as setup failure (skipping CLI execution and postJSAction): {}",
                                 ticket.getKey(), e.getMessage());
                             preCliActionResult = Boolean.FALSE;
+                            preCliJSActionThrew = true;
                         }
 
                         if (isPreCliJSActionFailure(preCliActionResult)) {
                             logger.warn("preCliJSAction reported failure for ticket {} — skipping CLI execution and postJSAction; " +
                                 "the JS action is responsible for its own failure notification.", ticket.getKey());
                             results.add(new ResultItem(ticket.getTicketKey(), "Skipped: preCliJSAction reported failure"));
+                            if (preCliJSActionThrew) {
+                                // Only an uncaught exception (e.g. a git command failure) is "unexpected" —
+                                // a deliberate false/{success:false} return without throwing is a normal
+                                // business skip and must not fail the job.
+                                unexpectedSetupFailures.add(ticket.getKey());
+                            }
                             return false;
                         }
                     }
@@ -655,7 +669,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                             null,
                             CliExecutionHelper.OutputFolderPreference.LEGACY_OUTPUT_FIRST,
                             liveCliErrorState);
-                    
+
                     // Append CLI responses to knownInfo if not empty
                     StringBuilder cliResponses = cliResult.getCommandResponses();
                     if (!cliResponses.isEmpty()) {
@@ -666,7 +680,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                         }
                         inputParams.setKnownInfo(inputParams.getKnownInfo() + "\n\nCLI Execution Results:\n" + cliContent);
                     }
-                    
+
                 } catch (Exception e) {
                     logger.error("Failed to execute CLI commands for ticket {}: {}", ticket.getKey(), e.getMessage(), e);
                     // Create error result for consistent handling below. Also populate the
@@ -713,7 +727,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
                                 // Account for story tokens (same pattern as TestCasesGenerator)
                                 logger.info("Index chunking for {}: story tokens={}, system limit={}, chunk limit={}",
                                     indexName, systemTokenLimits, systemTokenLimits, tokenLimit);
-                                
+
                                 List<ChunkPreparation.Chunk> chunks = contextChunkPreparation.prepareChunks(indexData, tokenLimit);
                                 indexChunks.addAll(chunks);
                                 logger.info("Prepared {} chunks from index {} for ticket {}", chunks.size(), indexName, ticket.getKey());
@@ -795,7 +809,7 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             if (expertParams.isAttachResponseAsFile()) {
                 attachResponse(genericRequestAgent, "_final_answer.txt", response, ticket.getKey(), "text/plain");
             }
-            
+
             // Handle output based on outputType, skip publishing if outputType is 'none'
             if (outputType != Params.OutputType.none) {
                 // NEW: Check if output should be skipped (when requireCliOutputFile=true and no output file)
@@ -861,6 +875,16 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             results.add(new ResultItem(ticket.getTicketKey(), response));
             return false;
         }, inputJQL, trackerClient.getExtendedQueryFields());
+
+        // All matched tickets have been attempted (a batch run keeps processing every ticket
+        // even if one fails setup), but if any preCliJSAction threw an uncaught exception
+        // (e.g. a git command failure), the overall job must fail so the CI step actually
+        // fails instead of exiting 0 with the setup failure hidden inside a ResultItem string.
+        if (!unexpectedSetupFailures.isEmpty()) {
+            throw new RuntimeException("Teammate job aborted: preCliJSAction threw an unexpected error (e.g. a git " +
+                "command failure) for ticket(s) " + unexpectedSetupFailures + " — see the warnings logged above " +
+                "for the underlying error(s).");
+        }
         return results;
     }
 

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammatePreCliJSActionTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/teammate/TeammatePreCliJSActionTest.java
@@ -232,10 +232,12 @@ public class TeammatePreCliJSActionTest {
     }
 
     @Test
-    void testPreCliJSActionExceptionStopsCliExecution() throws Exception {
+    void testPreCliJSActionExceptionStopsCliExecutionAndFailsJob() throws Exception {
         // Regression test for the "engine ignores preCliJSAction failure" bug: when the JS action
-        // throws (e.g. because it couldn't find a PR to review/rework), the engine must NOT proceed
-        // to run CLI commands — the JS action has already posted its own failure comment.
+        // throws an *uncaught* exception (e.g. a git command failure during branch setup), the
+        // engine must NOT proceed to run CLI commands, AND the job must fail overall — an uncaught
+        // exception is unexpected (unlike a deliberate false/{success:false} return), so silently
+        // reporting job success would hide the failure from CI.
         JavaScriptExecutor throwingExecutor = mock(JavaScriptExecutor.class);
         when(throwingExecutor.mcp(any(), any(), any(), any())).thenReturn(throwingExecutor);
         when(throwingExecutor.withJobContext(any(), any(), any())).thenReturn(throwingExecutor);
@@ -258,7 +260,8 @@ public class TeammatePreCliJSActionTest {
                 mocked.when(() -> CommandLineUtils.loadEnvironmentFromFile(anyString()))
                     .thenReturn(Map.of());
 
-                assertDoesNotThrow(() -> spy.runJobImpl(params));
+                Exception thrown = assertThrows(Exception.class, () -> spy.runJobImpl(params));
+                assertTrue(thrown.getMessage().contains("TEST-1"), "failure message should mention the failing ticket");
 
                 // CLI command must NOT have been executed — the JS setup failure is a hard stop.
                 mocked.verify(() -> CommandLineUtils.runCommand(eq("echo ok"), any(), any(), any(), anyBoolean(), any(), anyInt()), never());
@@ -271,6 +274,8 @@ public class TeammatePreCliJSActionTest {
     @Test
     void testPreCliJSActionFalseReturnStopsCliExecution() throws Exception {
         // preparePRForReview.js / preCliReworkSetup.js return `false` (not throw) when no PR is found.
+        // This is an expected business-logic skip (no exception thrown), so unlike the uncaught-exception
+        // case above, the job must NOT fail overall.
         JavaScriptExecutor falseExecutor = mock(JavaScriptExecutor.class);
         when(falseExecutor.mcp(any(), any(), any(), any())).thenReturn(falseExecutor);
         when(falseExecutor.withJobContext(any(), any(), any())).thenReturn(falseExecutor);
@@ -305,6 +310,8 @@ public class TeammatePreCliJSActionTest {
     @Test
     void testPreCliJSActionSuccessFalseObjectStopsCliExecution() throws Exception {
         // preCliReworkSetup.js returns {success: false, error: ...} when setup fails but doesn't throw.
+        // Also an expected skip (no exception), so the job must NOT fail overall — only an uncaught
+        // exception (see testPreCliJSActionExceptionStopsCliExecutionAndFailsJob) does that.
         org.json.JSONObject failureResult = new org.json.JSONObject();
         failureResult.put("success", false);
         failureResult.put("error", "No Pull Request found for ticket TEST-1");


### PR DESCRIPTION
## Problem

When `preCliJSAction` throws an *uncaught* exception (e.g. a `git checkout` failure during branch setup — see the linked failing run), `Teammate.runJobImpl` catches it, logs a warning, records a `"Skipped: preCliJSAction reported failure"` `ResultItem`, and moves on to the next ticket. The job then returns normally, so the CLI process exits `0` and the GitHub Actions step shows green even though the ticket's setup actually failed.

This makes real failures (git conflicts, tool errors, etc.) invisible in CI — the only way to notice is to read the step log line by line.

## Fix

- Track ticket keys whose `preCliJSAction` threw an uncaught exception in `unexpectedSetupFailures` (as opposed to a deliberate business-logic skip, i.e. the JS action returning `false` / `{success: false}` *without* throwing — e.g. "no PR found yet to review", which must keep behaving as a silent skip).
- After all matched tickets have been processed by `searchAndPerform`, if `unexpectedSetupFailures` is non-empty, throw a `RuntimeException` listing the affected ticket(s).
- This exception propagates through `runJob` → `JobRunner.run` → `JobRunner.main`, which is uncaught there, so the JVM exits with a non-zero code — which fails the GitHub Actions step running `dmtools run ...`, instead of silently exiting 0. (Confirmed by tracing the call chain; there's no local repro that reaches the real GHA runner from a unit test.)
- The batch still attempts every matched ticket before failing (a bad ticket doesn't stop others from being processed).

## Tests

- Renamed and updated `testPreCliJSActionExceptionStopsCliExecution` → `testPreCliJSActionExceptionStopsCliExecutionAndFailsJob`: now asserts `runJobImpl` throws (previously asserted it did NOT throw — that was the bug).
- Confirmed `testPreCliJSActionFalseReturnStopsCliExecution` and `testPreCliJSActionSuccessFalseObjectStopsCliExecution` (deliberate skip, no exception) still assert no throw, with clarifying comments.