### PR TITLE
fix(context): prevent OutOfMemoryError on large binary attachments (mp4) in FileToTextTransformer

### DIFF
--- a/dmtools-core/src/main/java/com/github/istin/dmtools/ai/ChunkPreparation.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/ai/ChunkPreparation.java
@@ -7,6 +7,8 @@ import com.github.istin.dmtools.common.model.ToText;
 import com.github.istin.dmtools.common.utils.PropertyReader;
 import lombok.Data;
 import lombok.Getter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +17,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class ChunkPreparation {
+    private static final Logger logger = LogManager.getLogger(ChunkPreparation.class);
+
     // Configuration fields
     @Getter
     private final int tokenLimit;
@@ -107,6 +111,8 @@ public class ChunkPreparation {
      */
     private boolean tryAddFile(File file, ChunkAccumulator current) {
         if (file.length() > maxSingleFileSize) {
+            logger.warn("Skipping file {} ({} bytes): exceeds PROMPT_CHUNK_MAX_SINGLE_FILE_SIZE_MB limit of {} bytes",
+                    file.getName(), file.length(), maxSingleFileSize);
             return true; // Skip this file but don't create new chunk
         }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/common/utils/PropertyReader.java
@@ -888,6 +888,7 @@ public class PropertyReader {
   private static final long DEFAULT_PROMPT_CHUNK_MAX_SINGLE_FILE_SIZE = 4 * 1024 * 1024; // 5MB
   private static final long DEFAULT_PROMPT_CHUNK_MAX_TOTAL_FILES_SIZE = 4 * 1024 * 1024; // 5MB
   private static final int DEFAULT_PROMPT_CHUNK_MAX_FILES = 10;
+  private static final long DEFAULT_FILE_TO_TEXT_MAX_TEXT_FILE_SIZE = 4 * 1024 * 1024; // 4MB
 
   /**
    * Gets the maximum token limit for AI model
@@ -952,6 +953,25 @@ public class PropertyReader {
       return Integer.parseInt(value);
     } catch (NumberFormatException e) {
       return DEFAULT_PROMPT_CHUNK_MAX_FILES;
+    }
+  }
+
+  /**
+   * Gets the maximum size in bytes for a file to be read into memory as text
+   * by FileToTextTransformer. Larger files are passed as file references instead
+   * (OOM protection). Configured via {@code FILE_TO_TEXT_MAX_FILE_SIZE_MB}.
+   * @return maximum text file size in bytes, default is 4MB
+   */
+  public long getFileToTextMaxTextFileSize() {
+    String value = getValue("FILE_TO_TEXT_MAX_FILE_SIZE_MB");
+    if (value == null || value.trim().isEmpty()) {
+      return DEFAULT_FILE_TO_TEXT_MAX_TEXT_FILE_SIZE;
+    }
+    try {
+      // Convert MB to bytes
+      return Long.parseLong(value.trim()) * 1024 * 1024;
+    } catch (NumberFormatException e) {
+      return DEFAULT_FILE_TO_TEXT_MAX_TEXT_FILE_SIZE;
     }
   }
 

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/context/FileToTextTransformer.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/context/FileToTextTransformer.java
@@ -4,6 +4,7 @@
 package com.github.istin.dmtools.context;
 
 import com.github.istin.dmtools.common.model.IAttachment;
+import com.github.istin.dmtools.common.utils.PropertyReader;
 import com.github.istin.dmtools.context.converter.DocxToImagesConverter;
 import com.github.istin.dmtools.context.converter.FileConverter;
 import com.github.istin.dmtools.context.converter.PptxToImagesConverter;
@@ -26,7 +27,14 @@ public class FileToTextTransformer {
 
     private static final Set<String> BINARY_EXTENSIONS = Set.of(
             "pdf", "csv", "doc", "docx", "xls", "xlsx",
-            "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp"
+            "jpg", "jpeg", "png", "gif", "bmp", "tiff", "webp",
+            // Video files - must be passed as file references, never read into memory as text
+            "mp4", "m4v", "mov", "webm", "avi", "mkv", "wmv", "flv", "mpg", "mpeg", "3gp",
+            // Audio files
+            "mp3", "wav", "ogg", "m4a", "flac", "aac",
+            // Archives and other binary formats
+            "zip", "tar", "gz", "tgz", "bz2", "7z", "rar", "jar",
+            "exe", "dll", "so", "dmg", "iso", "bin", "psd", "heic", "heif"
     );
     
     // Office document extensions that can be converted to images
@@ -64,10 +72,21 @@ public class FileToTextTransformer {
             return transformPdf(file);
         }
 
-        // Return null for binary files
+        // Return null for binary files (they are passed as file references downstream)
         if (BINARY_EXTENSIONS.stream().anyMatch(ext -> fileName.endsWith("." + ext))) {
             return null;
         }
+
+        // Guard against reading very large files into memory as text (OOM protection).
+        // Oversized files are passed as file references downstream instead.
+        long maxTextFileSize = new PropertyReader().getFileToTextMaxTextFileSize();
+        if (file.length() > maxTextFileSize) {
+            logger.warn("File {} ({} bytes) exceeds max text file size of {} bytes, " +
+                            "skipping text extraction and passing it as a file reference",
+                    file.getName(), file.length(), maxTextFileSize);
+            return null;
+        }
+
         // Read text files
         return List.of(new TransformationResult(file.getName() + "\n" + FileUtils.readFileToString(file, "UTF-8"), null));
     }

--- a/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
+++ b/dmtools-core/src/main/java/com/github/istin/dmtools/teammate/Teammate.java
@@ -526,13 +526,24 @@ public class Teammate extends AbstractJob<Teammate.TeammateParams, List<ResultIt
             int systemTokenLimits = contextChunkPreparation.getTokenLimit();
             int tokenLimit = (systemTokenLimits - requestTokens)/2;
             logger.info("GENERATION TOKEN LIMIT: " + tokenLimit);
-            contextOrchestrator.setTokenLimit(tokenLimit);
-            contextOrchestrator.processUrisInContent(textFieldsOnly, uriProcessingSources, 1);
-            contextOrchestrator.processUrisInContent(attachments, uriProcessingSources, 1);
-            List<ChunkPreparation.Chunk> chunksContext = contextOrchestrator.summarize();
-            contextOrchestrator.clear();
-            chunksContext.addAll(contextChunkPreparation.prepareChunks(ticketContext.getComments(), tokenLimit));
-            chunksContext.addAll(contextChunkPreparation.prepareChunks(ticketContext.getExtraTickets(), tokenLimit));
+            List<ChunkPreparation.Chunk> chunksContext = new ArrayList<>();
+            if (!expertParams.isSkipAIProcessing()) {
+                contextOrchestrator.setTokenLimit(tokenLimit);
+                contextOrchestrator.processUrisInContent(textFieldsOnly, uriProcessingSources, 1);
+                contextOrchestrator.processUrisInContent(attachments, uriProcessingSources, 1);
+                chunksContext = contextOrchestrator.summarize();
+                contextOrchestrator.clear();
+                chunksContext.addAll(contextChunkPreparation.prepareChunks(ticketContext.getComments(), tokenLimit));
+                chunksContext.addAll(contextChunkPreparation.prepareChunks(ticketContext.getExtraTickets(), tokenLimit));
+            } else {
+                // With skipAIProcessing=true the response comes from CLI execution, not from
+                // GenericRequestAgent, so context chunks are never consumed. Attachments are
+                // delivered to the CLI agent via the input folder (TicketInputContextBuilder),
+                // hence downloading + transforming them here is pure overhead and risks OOM
+                // on large binaries (e.g. mp4 read into a String).
+                logger.info("skipAIProcessing=true: skipping context/attachment chunk building; " +
+                        "attachments are delivered to the CLI agent via the input folder");
+            }
 
             // Process hooks as context first
             String[] hooksAsContext = expertParams.getHooksAsContext();

--- a/dmtools-core/src/test/java/com/github/istin/dmtools/context/FileToTextTransformerTest.java
+++ b/dmtools-core/src/test/java/com/github/istin/dmtools/context/FileToTextTransformerTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -97,6 +99,62 @@ class FileToTextTransformerTest {
 
         List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(xlsFile.toFile());
         assertNull(results);
+    }
+
+    @Test
+    void testTransformBinaryVideoFile() throws Exception {
+        Path mp4File = tempDir.resolve("recording.mp4");
+        Files.write(mp4File, new byte[]{1, 2, 3, 4}); // Dummy binary content
+
+        List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(mp4File.toFile());
+        assertNull(results);
+    }
+
+    @Test
+    void testTransformBinaryVideoMovFile() throws Exception {
+        Path movFile = tempDir.resolve("recording.mov");
+        Files.write(movFile, new byte[]{1, 2, 3, 4});
+
+        List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(movFile.toFile());
+        assertNull(results);
+    }
+
+    @Test
+    void testTransformBinaryArchiveFile() throws Exception {
+        Path zipFile = tempDir.resolve("archive.zip");
+        Files.write(zipFile, new byte[]{1, 2, 3, 4});
+
+        List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(zipFile.toFile());
+        assertNull(results);
+    }
+
+    @Test
+    void testTransformLargeTextFileReturnsNull() throws Exception {
+        // OOM guard: files larger than FILE_TO_TEXT_MAX_FILE_SIZE_MB (default 4MB)
+        // must not be read into memory as text - null means "pass as file reference"
+        Path largeFile = tempDir.resolve("large.txt");
+        byte[] chunk = new byte[1024 * 1024]; // 1MB
+        Arrays.fill(chunk, (byte) 'a');
+        try (OutputStream os = Files.newOutputStream(largeFile)) {
+            for (int i = 0; i < 5; i++) { // 5MB total > default 4MB limit
+                os.write(chunk);
+            }
+        }
+
+        List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(largeFile.toFile());
+        assertNull(results);
+    }
+
+    @Test
+    void testTransformSmallTextFileStillReadAsText() throws Exception {
+        Path textFile = tempDir.resolve("notes.log");
+        String content = "some log output";
+        Files.writeString(textFile, content);
+
+        List<FileToTextTransformer.TransformationResult> results = FileToTextTransformer.transform(textFile.toFile());
+        assertNotNull(results);
+        assertEquals(1, results.size());
+        assertTrue(results.get(0).text().contains(content));
     }
 
     @Test


### PR DESCRIPTION
## Problem

`Teammate` job crashed on tickets with video attachments:

```
java.lang.OutOfMemoryError: Java heap space
    at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:2773)
    at com.github.istin.dmtools.context.FileToTextTransformer.transform(FileToTextTransformer.java:72)
    at com.github.istin.dmtools.context.ContextOrchestrator.processFullContent(ContextOrchestrator.java:69)
```

Two compounding causes:

1. `.mp4` (and any video/audio/archive) attachments were **not** in `BINARY_EXTENSIONS`, so after a successful download the transformer fell through to `FileUtils.readFileToString(file, "UTF-8")` and tried to load a multi-hundred-MB video into a `String`. With several large attachments processed on a 10-thread pool, the heap blew up.
2. The job config used `skipAIProcessing: true` (CLI execution mode), where context chunks are **never consumed** — the response comes from the external CLI agent, and attachments are delivered to it via the input folder (`TicketInputContextBuilder`). The whole download+transform pipeline ran as dead work and crashed before CLI execution even started.

## Fix

**`Teammate`** — when `skipAIProcessing=true`, skip the context/attachment chunk-building block entirely (`processUrisInContent` for text fields + attachments, `summarize`, comments/extra-tickets chunking). Its only consumer is the `GenericRequestAgent` call in the non-skip branch. Attachments still get downloaded into the CLI input folder by `TicketInputContextBuilder` (`includeAttachments` / `skipVideoAttachments` filters unchanged).

**`FileToTextTransformer`** (protects the AI-processing path too):
- `BINARY_EXTENSIONS` extended with video (`mp4`, `m4v`, `mov`, `webm`, `avi`, `mkv`, ...), audio (`mp3`, `wav`, `ogg`, ...) and archive/binary (`zip`, `tar`, `gz`, `jar`, `dmg`, ...) extensions → they return `null`, so `ContextOrchestrator` stores the `File` itself and it reaches AI as a file attachment (same established path as images).
- New size guard: files larger than **`FILE_TO_TEXT_MAX_FILE_SIZE_MB`** (default **4MB**) are never read into a `String` — they are passed as file references instead. Protects against OOM from any oversized/unknown-format file.

**`PropertyReader`** — typed getter `getFileToTextMaxTextFileSize()` for the new env var (follows existing `PROMPT_CHUNK_*` pattern).

**`ChunkPreparation`** — log a warning when a file is skipped for exceeding `PROMPT_CHUNK_MAX_SINGLE_FILE_SIZE_MB` (previously silent).

## Tests

`FileToTextTransformerTest`: +5 tests (mp4/mov/zip → file reference, 5MB text file → file reference instead of OOM, small text file still inlined). All 15 tests pass; `teammate`/`context`/`ai` package suites green (the 3 `PropertyReaderTest` failures are pre-existing env-dependent ones, also failing on clean `main`).