### PR TITLE
ci(bitrise): report build status to GitHub as commit status

### DIFF
--- a/.bitrise/bitrise.yml
+++ b/.bitrise/bitrise.yml
@@ -110,6 +110,18 @@ workflows:
     title: Java unit tests
     summary: Quality gates, dmtools-core unit tests, and the agents JS suite
     steps:
+      - script@1:
+          title: Report pending status to GitHub
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                curl -sS -X POST \
+                  -H "Authorization: token $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/$BITRISEIO_GIT_REPOSITORY_OWNER/$BITRISEIO_GIT_REPOSITORY_SLUG/statuses/$BITRISE_GIT_COMMIT" \
+                  -d "{\"state\":\"pending\",\"context\":\"Bitrise / Java unit tests\",\"target_url\":\"$BITRISE_BUILD_URL\",\"description\":\"Bitrise build #$BITRISE_BUILD_NUMBER running\"}" \
+                  | grep -o '"state": *"[^"]*"' | head -1 || true
+
       - git-clone@8:
           inputs:
             # Full history (clone_depth -1): the file-size gate diffs against
@@ -275,6 +287,24 @@ workflows:
             - paths: |
                 $HOME/.gradle/caches
                 $HOME/.gradle/wrapper
+
+      - script@1:
+          title: Report final status to GitHub
+          is_always_run: true
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                if [ "$BITRISE_BUILD_STATUS" = "0" ]; then
+                  STATE=success; DESC="Bitrise build #$BITRISE_BUILD_NUMBER passed"
+                else
+                  STATE=failure; DESC="Bitrise build #$BITRISE_BUILD_NUMBER failed"
+                fi
+                curl -sS -X POST \
+                  -H "Authorization: token $GITHUB_TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  "https://api.github.com/repos/$BITRISEIO_GIT_REPOSITORY_OWNER/$BITRISEIO_GIT_REPOSITORY_SLUG/statuses/$BITRISE_GIT_COMMIT" \
+                  -d "{\"state\":\"$STATE\",\"context\":\"Bitrise / Java unit tests\",\"target_url\":\"$BITRISE_BUILD_URL\",\"description\":\"$DESC\"}" \
+                  | grep -o '"state": *"[^"]*"' | head -1 || true
 
   # ------------------------------------------------------------------------
   # Auto-update open PRs when main or PRs change.


### PR DESCRIPTION
## What

Bitrise is connected via webhook + deploy key, which triggers builds but does **not** post build statuses back to GitHub — nothing shows up on PRs.

This adds two script steps to the `unit-tests` workflow in `.bitrise/bitrise.yml`:

- **Report pending status** at build start
- **Report final status** (`is_always_run: true`) with `success`/`failure` and a `target_url` link to the Bitrise build

Both POST to the GitHub commit-statuses API using `GITHUB_TOKEN` (already a Bitrise Secret).

The status context is `Bitrise / Java unit tests` — deliberately distinct from the GitHub Actions `Java unit tests` check so both are visible side-by-side during the transition, and branch rulesets keep matching the Actions check.

Once Bitrise proves stable, the Actions workflow can be retired and the context renamed to just `Java unit tests`.
